### PR TITLE
Set dvipdfmx as default executable of DviPdf

### DIFF
--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -296,7 +296,7 @@ void BuildManager::initDefaultCommandNames()
 	registerCommand("dvips",       "dvips",        "DviPs",       "-o %.ps %.dvi", "Tools/Dvips");
 	registerCommand("dvipng",      "dvipng",       "DviPng",      "-T tight -D 120 %.dvi", "Tools/Dvipng");
 	registerCommand("ps2pdf",      "ps2pdf",       "Ps2Pdf",      "%.ps", "Tools/Ps2pdf");
-	registerCommand("dvipdf",      "dvipdf;dvipdfm",       "DviPdf",      "%.dvi", "Tools/Dvipdf");
+	registerCommand("dvipdf",      "dvipdfmx",       "DviPdf",      "%.dvi", "Tools/Dvipdf");
 	registerCommand("bibtex",      "bibtex",       "BibTeX",       ON_WIN("%") ON_NIX("%.aux"),  "Tools/Bibtex"); //miktex bibtex will stop (appears like crash in txs) if .aux is attached
 	registerCommand("bibtex8",     "bibtex8",      "BibTeX 8-Bit", ON_WIN("%") ON_NIX("%.aux"));
 	registerCommand("biber",       "biber",        "Biber" ,       "%"); //todo: correct parameter?
@@ -1501,7 +1501,7 @@ bool BuildManager::checkExpandedCommands(const ExpandedCommands &expansion)
 	// check if one command in the list is empty (expansion produced an error, e.g. txs:quick and compile is undefined
 	foreach (const CommandToRun elem, expansion.commands) {
 		if (elem.command.isEmpty()) {
-			emit processNotification(tr("Error: One command expansion invalid.") + 
+			emit processNotification(tr("Error: One command expansion invalid.") +
 			                         QString("\n    %1: %2").arg(tr("Parent Command"), elem.parentCommand) +
 			                         QString("\n    %1: %2").arg(tr("Primary Command"), expansion.primaryCommand));
 			if (!BuildManager_hadSuccessfulProcessStart) {
@@ -2003,7 +2003,7 @@ void BuildManager::latexPreviewCompleted(int status)
 		QString processedFile = p1->getFile();
 		if (processedFile.endsWith(".tex"))
 			processedFile = QDir::fromNativeSeparators(parseExtendedCommandLine("?am.tex", processedFile).first());
-			// TODO: fromNativeSeparators is a workaround to fix bug 
+			// TODO: fromNativeSeparators is a workaround to fix bug
 			// yields different dir separators depending on the context. This should be fixed (which direction?).
 			// Test (on win): switch preview between dvipng and pdflatex
 		QString fn = parseExtendedCommandLine("?am).pdf", processedFile).first();


### PR DESCRIPTION
dvipdfm was replaced with dvipdfmx, which is an extended version supporting CJK, and xdvipdfmx.

```
$ dvipdfm --version                                                      
This is xdvipdfmx Version 20170318 by the DVIPDFMx project team,
modified for TeX Live,
an extended version of DVIPDFMx, which in turn was
an extended version of dvipdfm-0.13.2c developed by Mark A. Wicks.

Copyright (C) 2002-2017 the DVIPDFMx project team
Copyright (C) 2006-2017 SIL International.

This is free software; you can redistribute it and/or modify
it under the terms of the GNU General Public License as published by
the Free Software Foundation; either version 2 of the License, or
(at your option) any later version.
$ dvipdfmx --version                                                     
This is dvipdfmx Version 20170318 by the DVIPDFMx project team,
modified for TeX Live,
an extended version of dvipdfm-0.13.2c developed by Mark A. Wicks.

Copyright (C) 2002-2017 the DVIPDFMx project team
Copyright (C) 2006-2017 SIL International.

This is free software; you can redistribute it and/or modify
it under the terms of the GNU General Public License as published by
the Free Software Foundation; either version 2 of the License, or
(at your option) any later version.
```

By trying to launch dvipdfm, dvipdfmx (xdvipdfmx) starts with the compatible mode with it.
I suppose no one use dvipdfm (or dvipdf).