### PR TITLE
Update physics.cwl

### DIFF
--- a/completion/physics.cwl
+++ b/completion/physics.cwl
@@ -320,15 +320,15 @@
 \vqty{expression}#m
 \vu*{expression}#m
 \vu{expression}#m
-\diagonalmatrix{matrix element 1,matrix element 2,...}#Sm
-\dmat{matrix element 1,matrix element 2,...}#Sm
-\antidiagonalmatrix{matrix element 1,matrix element 2,...}#Sm
-\admat{matrix element 1,matrix element 2,...}#Sm
-\identitymatrix{n}#Sm
-\imat{n}#Sm
-\paulimatrix{n}#Sm
-\pmat{n}#Sm
-\xmatrix{matrix element}{n}{m}#Sm
-\xmat{matrix element}{n}{m}#Sm
-\zeromatrix{n}{m}#Sm
-\zmat{n}{m}#Sm
+\diagonalmatrix{matrix element 1,matrix element 2,...}#*m
+\dmat{matrix element 1,matrix element 2,...}#*m
+\antidiagonalmatrix{matrix element 1,matrix element 2,...}#*m
+\admat{matrix element 1,matrix element 2,...}#*m
+\identitymatrix{n}#*m
+\imat{n}#*m
+\paulimatrix{n}#*m
+\pmat{n}#*m
+\xmatrix{matrix element}{n}{m}#*m
+\xmat{matrix element}{n}{m}#*m
+\zeromatrix{n}{m}#*m
+\zmat{n}{m}#*m

--- a/completion/physics.cwl
+++ b/completion/physics.cwl
@@ -320,3 +320,15 @@
 \vqty{expression}#m
 \vu*{expression}#m
 \vu{expression}#m
+\diagonalmatrix{matrix element 1,matrix element 2,...}#Sm
+\dmat{matrix element 1,matrix element 2,...}#Sm
+\antidiagonalmatrix{matrix element 1,matrix element 2,...}#Sm
+\admat{matrix element 1,matrix element 2,...}#Sm
+\identitymatrix{n}#Sm
+\imat{n}#Sm
+\paulimatrix{n}#Sm
+\pmat{n}#Sm
+\xmatrix{matrix element}{n}{m}#Sm
+\xmat{matrix element}{n}{m}#Sm
+\zeromatrix{n}{m}#Sm
+\zmat{n}{m}#Sm


### PR DESCRIPTION
There are several matrix commands (e.g., `\dmat`, `\imat`) defined in the [`physics`](http://mirror.ox.ac.uk/sites/ctan.org/macros/latex/contrib/physics/physics.pdf) package that must be surrounded by a "matrix" environment, e.g.:

```
\mqty{\imat{2}}
\mqty(\dmat{1,2,3})
\mqty(\admat{1,2,3})
```

and these have corresponding entries in the existing `physics.cwl` file:

```
\mqty(\imat{number})#m
\mqty(\dmat{matrix element 1,matrix element 2,matrix element 3,...})#m
\mqty(\admat{matrix element 1,matrix element 2,matrix element 3,...})#m
```

However, these do not "work" since the `\imat`, `\dmat` etc. are still unrecognized commands, as far as TXS is concerned. (Pardon the colours, it was just so I could identify them easier in my original document.)

![texstudio_2018-04-12_16-15-30](https://user-images.githubusercontent.com/30731072/38688161-502db55c-3e70-11e8-9ba3-7ecf7660b193.png)


Since, as far as I know, there isn't support for classification of "nested" commands to be recognized (as in this case), I propose to include the `\imat`, `\dmat` etc. commands in the cwl, but with `#S` classification so that:

1. we avoid suggesting these (`\imat`, `\dmat` etc. ) to newbies as commands to use outside of `\mqty()`, `pmatrix` environments etc., since those will give an error ;
2. while still allowing TXS to recognize these as 'valid' commands.

<img src="https://user-images.githubusercontent.com/30731072/38688515-2fe4e256-3e71-11e8-822e-d1aa481c3fdb.png" width=450px>


