### PR TITLE
Added \gram to siunitx.cwl

### DIFF
--- a/completion/siunitx.cwl
+++ b/completion/siunitx.cwl
@@ -74,6 +74,7 @@ number-angle-product=
 \gibi
 \giga
 \GPa#*
+\gram
 \gray
 \GW#*
 \hartree


### PR DESCRIPTION
Although '\kilogram' is the SI unit, '\gram' is needed to form deduced units like '\milli\gram'.