### PR TITLE
Update babel.cwl

### DIFF
--- a/completion/babel.cwl
+++ b/completion/babel.cwl
@@ -7,7 +7,7 @@
 \begin{otherlanguage*}{language}
 \end{otherlanguage}
 \foreignlanguage{language}{text}
-\begin{hypenrules}{option}
+\begin{hyphenrules}{option}
 \end{hyphenrules}
 \languagename
 \iflanguage{language}{if true}{if false}

--- a/completion/etoolbox.cwl
+++ b/completion/etoolbox.cwl
@@ -113,7 +113,7 @@
 \gluegdef{command}{glue expression}#*
 \gpreto{hook}{code}#*
 \ifbool{bool}{true}{false}#*
-\ifboolexpr{true}{false}#*
+\ifboolexpr{expression}{true}{false}#*
 \ifcsltxprotect{true}{false}#*
 \ifcsstring{true}{false}#*
 \ifdefltxprotect{true}{false}#*


### PR DESCRIPTION
Typo for hyphenrules environment (Fixes #146) 