### PR TITLE
Add appimage to travis upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
     os: linux
   - env: QT=qt5NoPoppler
     os: linux
+  - env: QT=qt5Release
+    os: linux
   - env: QT=qt5win
     os: linux
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,4 +59,13 @@ deploy:
     on:
       tags: true 
       condition: -f "${TRAVIS_BUILD_DIR}/texstudio-${TRAVIS_TAG}-win-portable-qt5.zip"
+  - provider: releases
+    skip_cleanup: true
+    api_key:
+      secure: DQEuiEzNzXF9EhGLmMN/SrDjinVJbMgdmEZtokY9ZPp+yLqTHcvdX4EfuzbVElz14dAOK2H4TBK2q+13ZjCzuvWdgbdb72M4lNOk7YcHmpxK4XuvhYxsY02QxO0zTHCqWhZGL87jrTlBWICEZCuvXAg7/FHry0HqSsukUmP6cCVeIB8q33+8GwOVPUjXF9kRf9UgogtFhIcS0TwwGezdngkhonxBJYgaEYgZRxMPts1Fb+7ifmtjbZwF2QUUYZQvp0dFeI8S0w0lQKP+gVxNY8CAYKnIJ/STFJA6tXCstpKL2EPjbOhgI34DYBTCg4+peFOOLbVpBlwhInOeaYF35VryjulpMsNM9LdJH9gXiSOHOr4vxnr2M4ijLssd+p2dCZ1oeG9kHfARupmtmKer8lbrPkHrD1QGiwEOnrIZqV0TrJvnXTlJDtbOJnB+43lCzsIHJ4WDTpREHq8p2XoVBljlcVac3Kl6MmY5LVNtbdwBxirWF8hheEh/K4Cxv9wzktsP20/M3wpk2VFf2qL9ZxjugtxoT92WRVuHtCvLN8Zp+ekHZuhik5ImJXvVOavCy76SpBbJhz1sSnbjM2pFy9F9dHzYkMAVEX2i1iHQJKSVl82YpaqW0QTUAdRcyRLL4KVQOYAPJp8Ne9kkRc/rhX1aVOY3kp1GzInAEAJ89vA=
+    file: 
+      - "${TRAVIS_BUILD_DIR}/texstudio-${VERSION}-x86_64.AppImage"
+    on:
+      tags: true 
+      condition: -f "${TRAVIS_BUILD_DIR}/texstudio-${VERSION}-x86_64.AppImage"
 

--- a/travis-ci/configure.sh
+++ b/travis-ci/configure.sh
@@ -17,6 +17,8 @@ elif [ $QT = qt5NoPoppler ]; then
 	qmake texstudio.pro CONFIG+=debug NO_POPPLER_PREVIEW=1
 elif [ $QT = qt4 ]; then
 	qmake texstudio.pro CONFIG+=debug
+elif [ $QT = qt5Release ]; then
+	qmake texstudio.pro CONFIG-=debug
 elif [ $QT = qt5win ]; then
 	PATH=$PATH:${MXEDIR}/usr/bin
 	$MXEDIR/usr/bin/${MXETARGET}-qmake-qt5 texstudio.pro CONFIG-=debug MXE=1

--- a/travis-ci/get-dependencies.sh
+++ b/travis-ci/get-dependencies.sh
@@ -51,7 +51,7 @@ if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
 		if [ $QT = "qt4" ]; then
 			print_info "Installing packages: QT4"
 			sudo apt-get install qt4-qmake  libpoppler-qt4-dev zlib1g-dev pkg-config libx11-dev
-		elif [ $QT = "qt5" ]; then
+		elif [ $QT = "qt5" ] || [ $QT = "qt5Release" ] ; then
 			print_info "Installing packages: QT5"
 			sudo apt-get install qtbase5-dev qt5-default qt5-qmake  libqt5svg5-dev qtscript5-dev qttools5-dev libpoppler-qt5-dev zlib1g-dev pkg-config
 		elif [ $QT = "qt5NoPoppler" ]; then

--- a/travis-ci/package.sh
+++ b/travis-ci/package.sh
@@ -83,7 +83,7 @@ cat "${TRAVIS_BUILD_DIR}/travis-ci/bintray.json"
 fi
 
 
-if [ "${QT}" = "qt5" ]; then
+if [ "${QT}" = "qt5Release" ]; then
 	print_info "Running linuxdeployqt"
 
 	make INSTALL_ROOT=appdir -j$(nproc) install ; find appdir/
@@ -117,7 +117,6 @@ if [ "${QT}" = "qt5" ]; then
 		"publish": true
 	}
 EOF
-
 
 cat "${TRAVIS_BUILD_DIR}/travis-ci/bintray.json"
 fi

--- a/travis-ci/package.sh
+++ b/travis-ci/package.sh
@@ -82,6 +82,46 @@ EOF
 cat "${TRAVIS_BUILD_DIR}/travis-ci/bintray.json"
 fi
 
+
+if [ "${QT}" = "qt5" ]; then
+	print_info "Running linuxdeployqt"
+
+	make INSTALL_ROOT=appdir -j$(nproc) install ; find appdir/
+	wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+	chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+	unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+	export VERSION=${TRAVIS_OS_NAME}-${VERSION_NAME}
+	./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -extra-plugins=iconengines/libqsvgicon.so
+	./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -appimage
+	mv "${TRAVIS_BUILD_DIR}/TeXstudio-${VERSION}-x86_64.AppImage" "texstudio-${VERSION}-x86_64.AppImage"
+
+
+	print_info "Preparing bintray.json"
+	cat > "${TRAVIS_BUILD_DIR}/travis-ci/bintray.json" <<EOF
+	{
+		"package": {
+			"name": "texstudio-linux",
+			"repo": "texstudio",
+			"subject": "sunderme"
+		},
+
+		"version": {
+			"name": "${VERSION_NAME}",
+			"released": "${RELEASE_DATE}",
+			"gpgSign": false
+		},
+		"files":
+		[
+			{"includePattern": "${TRAVIS_BUILD_DIR}/texstudio-${VERSION}-x86_64.AppImage", "uploadPattern": "texstudio-${VERSION}-x86_64.AppImage"}
+		],
+		"publish": true
+	}
+EOF
+
+
+cat "${TRAVIS_BUILD_DIR}/travis-ci/bintray.json"
+fi
+
 if [ "${QT}" = "qt5win" ]; then
 	print_info "package build into zip for win"
 	print_info "make installer"


### PR DESCRIPTION
This adds an automated appimage build to travis.
Like the windows and macos buils, since texstudio is being built it might as well be packaged and released on github as an appimage, available as soon as the other packages are.
At the moment I didn't test the push to github(but that's like the other ones you already have)
I had set up an upload to transfer.sh so I could download and test, and it seems that the images work.
I didn't include texlive, since I don't think the win/macos versions do, and I think it's better to keep them separate...