### PR TITLE
Update cwls

### DIFF
--- a/completion/amsthm.cwl
+++ b/completion/amsthm.cwl
@@ -1,17 +1,17 @@
 # amsthm
 # Ryan Reich/2007-11-03
 # http://tug.ctan.org/cgi-bin/ctanPackageInformation.py?id=amsthm
-\newtheorem{envname}{caption}#N
-\newtheorem{envname}{caption}[within]#N
-\newtheorem{envname}[numberedlike]{caption}#N
-\newtheorem*{envname}{caption}#N
-\newtheorem*{envname}{caption}[within]#N
-\newtheorem*{envname}[numberedlike]{caption}#N
+\newtheorem{envname}{heading}#N
+\newtheorem{envname}{heading}[within]#N
+\newtheorem{envname}[numberedlike]{heading}#N
+\newtheorem*{envname}{heading}#N
+\newtheorem*{envname}{heading}[within]#N
+\newtheorem*{envname}[numberedlike]{heading}#N
 \theoremstyle{style}
 \swapnumbers
 \newtheoremstyle{stylename}{spaceabove}{spacebelow}{bodyfont}{indentamt}{headfont}{headpunct}{headspace}{headspec}
 \begin{proof}
-\begin{proof}[caption]
+\begin{proof}[heading]
 \end{proof}
 \qedsymbol
 \qedhere

--- a/completion/latex-document.cwl
+++ b/completion/latex-document.cwl
@@ -165,7 +165,7 @@
 \botfigrule#*
 \cal
 \caption{text}
-\caption[short text]{text}
+\caption[short text%text]{text}
 \chapter{title}#L1
 \chapter*{title}#L1
 \chapter[short title]{title}#L1
@@ -188,7 +188,7 @@
 \descriptionlabel{code}#*
 \documentclass[keyvals]{class}
 \documentclass{class}
-\em
+\em#*
 \emph{text}
 \enlargethispage*{size}
 \enlargethispage{size}


### PR DESCRIPTION
Changes:

- short text for `\caption` to be treated as text (with spell check)
- changed arg names for theorems to be more similar with `amsthm` documentation (doc calls them heading, not caption)
- make `\em` unusual (deprecated command)