### PR TITLE
src/main.cpp: set desktop file name to avoid a broken icon under KDE Wayland

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -198,6 +198,9 @@ int main(int argc, char **argv)
 	}
 
 	a.setApplicationName( TEXSTUDIO );
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)) && defined(Q_OS_LINUX)
+	a.setDesktopFileName("texstudio");
+#endif
 	a.init(cmdLine); // Initialization takes place only if there is no other instance running.
 
 	QObject::connect(&a, SIGNAL(messageReceived(const QString &)),


### PR DESCRIPTION
This fixes the missing icon in the title bar.

Before:
![grafik](https://user-images.githubusercontent.com/3226457/45927881-e5403980-bf3a-11e8-9b87-4dea8cd05b4c.png)

After:
![grafik](https://user-images.githubusercontent.com/3226457/45928359-8c749f00-bf42-11e8-8fee-8e5feac2ba6c.png)


