### PR TITLE
Only insert \caption{} once

### DIFF
--- a/src/insertgraphics.cpp
+++ b/src/insertgraphics.cpp
@@ -357,13 +357,14 @@ QString InsertGraphics::getFormattedFilename(const QString filename) const
 QString InsertGraphics::getCaptionLabelString(const InsertGraphicsConfig &conf) const
 {
 	QString s;
-	if (!conf.caption.isEmpty() || !conf.shortCaption.isEmpty()) {
+	bool captionProvided = !conf.caption.isEmpty() || !conf.shortCaption.isEmpty();
+	if (captionProvided) {
 		s.append("\\caption");
 		if (!conf.shortCaption.isEmpty()) s.append("[" + conf.shortCaption + "]");
 		s.append("{" + conf.caption + "}\n");
 	}
 	if (!conf.label.isEmpty()) {
-		if (conf.caption.isEmpty()) s.append("\\caption{}\n");
+		if (!captionProvided) s.append("\\caption{}\n");
 		s.append("\\label{" + conf.label + "}\n");
 	}
 	return s;


### PR DESCRIPTION
When using the "Insert Graphic" wizard, if only a short caption is
provided, TeXStudio currently inserts an extra, empty \caption{}.

This happens because inserting a label requires a caption and tries to
add it if the caption is empty. Of course, in the case that only a short
caption is provided, we end up with two \caption{}s.

By checking that both the long and short caption is empty, we make sure
only one caption is inserted.