### PR TITLE
Fix indentation and StructureEntry definition

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -244,7 +244,7 @@ void ShortcutDelegate::setModelData(QWidget *editor, QAbstractItemModel *model,
 				if (UtilsUi::txsConfirmWarning(QString(ConfigDialog::tr("The shortcut <%1> is already assigned to the command:")).arg(value) + "\n" + duplicate + "\n\n" + ConfigDialog::tr("Do you wish to remove the old assignment and bind the shortcut to the new command?"))) {
 					//model->setData(mil[0],"",Qt::DisplayRole);
 					foreach (QTreeWidgetItem *twi, li) {
-                        if (twi && twi->text(2) == value) twi->setText(2, "");
+						if (twi && twi->text(2) == value) twi->setText(2, "");
 					}
 				} else {
 					return;

--- a/src/qcodeedit/lib/document/qdocumentsearch.cpp
+++ b/src/qcodeedit/lib/document/qdocumentsearch.cpp
@@ -559,7 +559,7 @@ int QDocumentSearch::next(bool backward, bool all, bool again, bool allowWrapAro
 		bool replaceSelectedText = false;
 		if (m_regexp.exactMatch(m_cursor.selectedText()))  {
 			replaceSelectedText = true;
-        } else if (m_regexp.pattern().contains("(?=") || m_regexp.pattern().contains("(?!")) {
+		} else if (m_regexp.pattern().contains("(?=") || m_regexp.pattern().contains("(?!")) {
 			// special handling for lookahead: The selected text is not enough to match the regexp
 			// because the lookahead context is missing. Therefore we have to find matches to the
 			// whole line until we find the original selection. Only then, we know that the original

--- a/src/structuretreeview.h
+++ b/src/structuretreeview.h
@@ -4,7 +4,7 @@
 #include "mostQtHeaders.h"
 
 
-class StructureEntry;
+struct StructureEntry;
 class Editors;
 class LatexDocuments;
 class LatexDocument;

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -7793,7 +7793,7 @@ void Texstudio::previewLatex()
 	}
 	if (!previewc.hasSelection()) {
 		// special handling for cusor in the middle of \[ or \]
-        if (c.previousChar() == '\\' && (c.nextChar() == '[' || c.nextChar() == ']')) {
+		if (c.previousChar() == '\\' && (c.nextChar() == '[' || c.nextChar() == ']')) {
 			c.movePosition(1, QDocumentCursor::PreviousCharacter);
 			previewc = currentEditorView()->parenthizedTextSelection(c);
 		}

--- a/src/utilsSystem.cpp
+++ b/src/utilsSystem.cpp
@@ -12,7 +12,7 @@
 bool getDiskFreeSpace(const QString &path, quint64 &freeBytes)
 {
 #ifdef Q_OS_WIN
-    wchar_t* d = new wchar_t[path.size() + 1];
+	wchar_t* d = new wchar_t[path.size() + 1];
 	int len = path.toWCharArray(d);
 	d[len] = 0;
 
@@ -20,11 +20,11 @@ bool getDiskFreeSpace(const QString &path, quint64 &freeBytes)
 	freeBytesToCaller.QuadPart = 0L;
 
 	if ( !GetDiskFreeSpaceEx( d, &freeBytesToCaller, NULL, NULL ) ) {
-        delete d;
+		delete d;
 		qDebug() << "ERROR: Call to GetDiskFreeSpaceEx() failed on path" << path;
 		return false;
 	}
-    delete d;
+	delete d;
 	freeBytes = freeBytesToCaller.QuadPart;
 	return true;
 #else


### PR DESCRIPTION
Different declarations with ```struct StructureEntry``` (src/latexstructure.h line 16) and ```class StructureEntry``` (src/structuretreeview.h line 7) create an error.