### PR TITLE
Fix error in minutes autocomplete.

### DIFF
--- a/completion/minutes.cwl
+++ b/completion/minutes.cwl
@@ -31,7 +31,7 @@ header=#text
 \begin{Vote}
 \vote{text}{yes}{no}{-}[text]
 \end{Vote}
-\decisionTheme{ref%labeldef}{title}
+\decisiontheme{ref%labeldef}{title}
 \decision{ref%ref}{text}[longText%text]
 \listofdecisions
 \begin{Argumentation}


### PR DESCRIPTION
When I originally submitted the `minutes` package's autocompletion I miscapitalized the `\decisiontheme` command.  Sorry about that!