### PR TITLE
Fixed typo

### DIFF
--- a/completion/tikz.cwl
+++ b/completion/tikz.cwl
@@ -58,7 +58,7 @@ graphs
 fadings
 decorations
 automata
-background
+backgrounds
 calc
 calendar
 chains


### PR DESCRIPTION
The library is called `backgrounds` not `background`(note the trailing `s`)