### PR TITLE
Context menu: Add to ignore list

### DIFF
--- a/src/latexeditorview.cpp
+++ b/src/latexeditorview.cpp
@@ -2185,7 +2185,7 @@ void LatexEditorView::addSpellingActions(QMenu *menu, QString word, bool dedicat
 	QStringList suggestions = speller->suggest(word);
 	addReplaceActions(menu, suggestions, false);
 
-	QAction *act = new QAction(LatexEditorView::tr("Add to Dictionary"), menu);
+	QAction *act = new QAction(LatexEditorView::tr("Add to Ignore List"), menu);
 	connect(act, SIGNAL(triggered()), this, SLOT(spellCheckingAlwaysIgnore()));
 	if (dedicatedMenu) {
 		menu->addSeparator();


### PR DESCRIPTION
The item Add to Dictionary was misleading. 
Words are not added to the Hunspell dictionary, but to a local ignore list in
~/.config/texstudio/*.ign