### PR TITLE
Fontenc in quickstart

### DIFF
--- a/src/quickdocumentdialog.cpp
+++ b/src/quickdocumentdialog.cpp
@@ -29,8 +29,8 @@ qreal convertLatexLengthToMetre(const qreal &length, const QString &unit)
 }
 
 //options for the configmanager
-QStringList QuickDocumentDialog::otherClassList, QuickDocumentDialog::otherPaperList, QuickDocumentDialog::otherInputEncodingList, QuickDocumentDialog::otherBabelOptionsList, QuickDocumentDialog::otherOptionsList;
-QString QuickDocumentDialog::document_class, QuickDocumentDialog::typeface_size, QuickDocumentDialog::paper_size, QuickDocumentDialog::document_encoding, QuickDocumentDialog::babel_language, QuickDocumentDialog::author;
+QStringList QuickDocumentDialog::otherClassList, QuickDocumentDialog::otherPaperList, QuickDocumentDialog::otherInputEncodingList, QuickDocumentDialog::otherFontEncodingList, QuickDocumentDialog::otherBabelOptionsList, QuickDocumentDialog::otherOptionsList;
+QString QuickDocumentDialog::document_class, QuickDocumentDialog::typeface_size, QuickDocumentDialog::paper_size, QuickDocumentDialog::document_encoding, QuickDocumentDialog::font_encoding, QuickDocumentDialog::babel_language, QuickDocumentDialog::author;
 bool QuickDocumentDialog::ams_packages, QuickDocumentDialog::makeidx_package, QuickDocumentDialog::graphicx_package;
 double geometryPageWidth, geometryPageHeight, geometryMarginLeft, geometryMarginRight, geometryMarginTop, geometryMarginBottom;
 QString geometryPageWidthUnit, geometryPageHeightUnit, geometryMarginLeftUnit, geometryMarginRightUnit, geometryMarginTopUnit, geometryMarginBottomUnit;
@@ -53,6 +53,7 @@ QuickDocumentDialog::QuickDocumentDialog(QWidget *parent, const QString &name)
 	ui.comboBoxSize->addItem("12pt");
 	connect(ui.pushButtonPaper , SIGNAL(clicked()), SLOT(addUserPaper()));
 	connect(ui.pushButtonInputEncoding , SIGNAL(clicked()), SLOT(addUserInputEncoding()));
+	connect(ui.pushButtonFontEncoding , SIGNAL(clicked()), SLOT(addUserFontEncoding()));
 	connect(ui.pushButtonBabel, SIGNAL(clicked()), SLOT(addBabelOption()));
 	connect(ui.pushButtonOptions , SIGNAL(clicked()), SLOT(addUserOptions()));
 	ui.listWidgetOptions->setSelectionMode(QAbstractItemView::ExtendedSelection);
@@ -100,8 +101,14 @@ QString QuickDocumentDialog::getNewDocumentText()
 	tag += opt + QString("]{");
 	tag += ui.comboBoxClass->currentText() + QString("}");
 	tag += QString("\n");
-	if (ui.comboBoxInputEncoding->currentText() != "NONE") tag += QString("\\usepackage[") + ui.comboBoxInputEncoding->currentText() + QString("]{inputenc}");
-	tag += QString("\n");
+	if (ui.comboBoxInputEncoding->currentText() != "NONE") {
+		tag += QString("\\usepackage[") + ui.comboBoxInputEncoding->currentText() + QString("]{inputenc}");
+		tag += QString("\n");
+	}
+	if (ui.comboBoxFontEncoding->currentText() != "NONE") {
+		tag += QString("\\usepackage[") + ui.comboBoxFontEncoding->currentText() + QString("]{fontenc}");
+		tag += QString("\n");
+	}
 	if (ui.comboBoxInputEncoding->currentText().startsWith("utf8x"))
 		tag += QString("\\usepackage{ucs}\n");
 	if (ui.comboBoxBabel->currentText() != "NONE")
@@ -144,12 +151,14 @@ void QuickDocumentDialog::registerOptions(ConfigManagerInterface &configManager)
 	configManager.registerOption("Tools/User Class", &otherClassList);
 	configManager.registerOption("Tools/User Paper", &otherPaperList);
 	configManager.registerOption("Tools/User Encoding", &otherInputEncodingList);
+	configManager.registerOption("Tools/User Font Encoding", &otherFontEncodingList);
 	configManager.registerOption("Tools/User Babel Options", &otherBabelOptionsList);
 	configManager.registerOption("Tools/User Options", &otherOptionsList);
 	configManager.registerOption("Quick/Class", &document_class, "article");
 	configManager.registerOption("Quick/Typeface", &typeface_size, "10pt");
 	configManager.registerOption("Quick/Papersize", &paper_size, "a4paper");
-    configManager.registerOption("Quick/Encoding", &document_encoding, "utf8");
+	configManager.registerOption("Quick/Encoding", &document_encoding, "utf8");
+	configManager.registerOption("Quick/FontEncoding", &font_encoding, "T1");
 	configManager.registerOption("Quick/Babel", &babel_language, "NONE");
 	configManager.registerOption("Quick/AMS", &ams_packages, true);
 	configManager.registerOption("Quick/MakeIndex", &makeidx_package, false);
@@ -239,11 +248,44 @@ void QuickDocumentDialog::Init()
 	ui.comboBoxInputEncoding->addItem("NONE");
 	if (!otherInputEncodingList.isEmpty()) ui.comboBoxInputEncoding->addItems(otherInputEncodingList);
 
+	ui.comboBoxFontEncoding->clear();
+	ui.comboBoxFontEncoding->addItem("OT1");
+	ui.comboBoxFontEncoding->addItem("OT2");
+	ui.comboBoxFontEncoding->addItem("OT3");
+	ui.comboBoxFontEncoding->addItem("OT4");
+	ui.comboBoxFontEncoding->addItem("OT5");
+	ui.comboBoxFontEncoding->addItem("OT6");
+	ui.comboBoxFontEncoding->addItem("T1");
+	ui.comboBoxFontEncoding->addItem("T2A");
+	ui.comboBoxFontEncoding->addItem("T2B");
+	ui.comboBoxFontEncoding->addItem("T2C");
+	ui.comboBoxFontEncoding->addItem("T3");
+	ui.comboBoxFontEncoding->addItem("T4");
+	ui.comboBoxFontEncoding->addItem("T5");
+	ui.comboBoxFontEncoding->addItem("T6");
+	ui.comboBoxFontEncoding->addItem("T7");
+	ui.comboBoxFontEncoding->addItem("TS1");
+	ui.comboBoxFontEncoding->addItem("TS3");
+	ui.comboBoxFontEncoding->addItem("X2");
+	ui.comboBoxFontEncoding->addItem("OML");
+	ui.comboBoxFontEncoding->addItem("OMS");
+	ui.comboBoxFontEncoding->addItem("OMX");
+	ui.comboBoxFontEncoding->addItem("C..");
+	ui.comboBoxFontEncoding->addItem("E..");
+	ui.comboBoxFontEncoding->addItem("L..");
+	ui.comboBoxFontEncoding->addItem("LY1");
+	ui.comboBoxFontEncoding->addItem("LV1");
+	ui.comboBoxFontEncoding->addItem("LGR");
+	ui.comboBoxFontEncoding->addItem("PD1");
+	ui.comboBoxFontEncoding->addItem("PU");
+	ui.comboBoxFontEncoding->addItem("U");
+	ui.comboBoxFontEncoding->addItem("NONE");
+	if (!otherFontEncodingList.isEmpty()) ui.comboBoxFontEncoding->addItems(otherFontEncodingList);
+
 	ui.comboBoxBabel->clear();
 	ui.comboBoxBabel->addItem("NONE");
 	ui.comboBoxBabel->addItems(babelLanguages);
 	if (!otherBabelOptionsList.isEmpty()) ui.comboBoxBabel->addItems(otherBabelOptionsList);
-
 
 	ui.listWidgetOptions->clear();
 	ui.listWidgetOptions->addItem("landscape");
@@ -267,6 +309,7 @@ void QuickDocumentDialog::Init()
 	configManagerInterface->linkOptionToDialogWidget(&typeface_size, ui.comboBoxSize);
 	configManagerInterface->linkOptionToDialogWidget(&paper_size, ui.comboBoxPaper);
 	configManagerInterface->linkOptionToDialogWidget(&document_encoding, ui.comboBoxInputEncoding);
+	configManagerInterface->linkOptionToDialogWidget(&font_encoding, ui.comboBoxFontEncoding);
 	configManagerInterface->linkOptionToDialogWidget(&babel_language, ui.comboBoxBabel);
 	configManagerInterface->linkOptionToDialogWidget(&ams_packages, ui.checkBoxAMS);
 	configManagerInterface->linkOptionToDialogWidget(&makeidx_package, ui.checkBoxIDX);
@@ -457,6 +500,17 @@ void QuickDocumentDialog::addUserInputEncoding()
 	dialog.addVariable(&newoption, tr("New:"));
 	if (dialog.exec() && !newoption.isEmpty()) {
 		otherInputEncodingList.append(newoption);
+		Init();
+	}
+}
+
+void QuickDocumentDialog::addUserFontEncoding()
+{
+	QString newoption;
+	UniversalInputDialog dialog;
+	dialog.addVariable(&newoption, tr("New:"));
+	if (dialog.exec() && !newoption.isEmpty()) {
+		otherFontEncodingList.append(newoption);
 		Init();
 	}
 }

--- a/src/quickdocumentdialog.cpp
+++ b/src/quickdocumentdialog.cpp
@@ -29,7 +29,7 @@ qreal convertLatexLengthToMetre(const qreal &length, const QString &unit)
 }
 
 //options for the configmanager
-QStringList QuickDocumentDialog::otherClassList, QuickDocumentDialog::otherPaperList, QuickDocumentDialog::otherEncodingList, QuickDocumentDialog::otherBabelOptionsList, QuickDocumentDialog::otherOptionsList;
+QStringList QuickDocumentDialog::otherClassList, QuickDocumentDialog::otherPaperList, QuickDocumentDialog::otherInputEncodingList, QuickDocumentDialog::otherBabelOptionsList, QuickDocumentDialog::otherOptionsList;
 QString QuickDocumentDialog::document_class, QuickDocumentDialog::typeface_size, QuickDocumentDialog::paper_size, QuickDocumentDialog::document_encoding, QuickDocumentDialog::babel_language, QuickDocumentDialog::author;
 bool QuickDocumentDialog::ams_packages, QuickDocumentDialog::makeidx_package, QuickDocumentDialog::graphicx_package;
 double geometryPageWidth, geometryPageHeight, geometryMarginLeft, geometryMarginRight, geometryMarginTop, geometryMarginBottom;
@@ -52,7 +52,7 @@ QuickDocumentDialog::QuickDocumentDialog(QWidget *parent, const QString &name)
 	ui.comboBoxSize->addItem("11pt");
 	ui.comboBoxSize->addItem("12pt");
 	connect(ui.pushButtonPaper , SIGNAL(clicked()), SLOT(addUserPaper()));
-	connect(ui.pushButtonEncoding , SIGNAL(clicked()), SLOT(addUserEncoding()));
+	connect(ui.pushButtonInputEncoding , SIGNAL(clicked()), SLOT(addUserInputEncoding()));
 	connect(ui.pushButtonBabel, SIGNAL(clicked()), SLOT(addBabelOption()));
 	connect(ui.pushButtonOptions , SIGNAL(clicked()), SLOT(addUserOptions()));
 	ui.listWidgetOptions->setSelectionMode(QAbstractItemView::ExtendedSelection);
@@ -100,9 +100,9 @@ QString QuickDocumentDialog::getNewDocumentText()
 	tag += opt + QString("]{");
 	tag += ui.comboBoxClass->currentText() + QString("}");
 	tag += QString("\n");
-	if (ui.comboBoxEncoding->currentText() != "NONE") tag += QString("\\usepackage[") + ui.comboBoxEncoding->currentText() + QString("]{inputenc}");
+	if (ui.comboBoxInputEncoding->currentText() != "NONE") tag += QString("\\usepackage[") + ui.comboBoxInputEncoding->currentText() + QString("]{inputenc}");
 	tag += QString("\n");
-	if (ui.comboBoxEncoding->currentText().startsWith("utf8x"))
+	if (ui.comboBoxInputEncoding->currentText().startsWith("utf8x"))
 		tag += QString("\\usepackage{ucs}\n");
 	if (ui.comboBoxBabel->currentText() != "NONE")
 		tag += QString("\\usepackage[%1]{babel}\n").arg(ui.comboBoxBabel->currentText());
@@ -143,7 +143,7 @@ void QuickDocumentDialog::registerOptions(ConfigManagerInterface &configManager)
 {
 	configManager.registerOption("Tools/User Class", &otherClassList);
 	configManager.registerOption("Tools/User Paper", &otherPaperList);
-	configManager.registerOption("Tools/User Encoding", &otherEncodingList);
+	configManager.registerOption("Tools/User Encoding", &otherInputEncodingList);
 	configManager.registerOption("Tools/User Babel Options", &otherBabelOptionsList);
 	configManager.registerOption("Tools/User Options", &otherOptionsList);
 	configManager.registerOption("Quick/Class", &document_class, "article");
@@ -217,27 +217,27 @@ void QuickDocumentDialog::Init()
 	ui.comboBoxPaper->addItem("executivepaper");
 	if (!otherPaperList.isEmpty()) ui.comboBoxPaper->addItems(otherPaperList);
 
-	ui.comboBoxEncoding->clear();
-	ui.comboBoxEncoding->addItem("latin1");
-	ui.comboBoxEncoding->addItem("latin2");
-	ui.comboBoxEncoding->addItem("latin3");
-	ui.comboBoxEncoding->addItem("latin5");
-	ui.comboBoxEncoding->addItem("utf8");
-	ui.comboBoxEncoding->addItem("utf8x");
-	ui.comboBoxEncoding->addItem("ascii");
-	ui.comboBoxEncoding->addItem("decmulti");
-	ui.comboBoxEncoding->addItem("cp850");
-	ui.comboBoxEncoding->addItem("cp852");
-	ui.comboBoxEncoding->addItem("cp437");
-	ui.comboBoxEncoding->addItem("cp437de");
-	ui.comboBoxEncoding->addItem("cp865");
-	ui.comboBoxEncoding->addItem("applemac");
-	ui.comboBoxEncoding->addItem("next");
-	ui.comboBoxEncoding->addItem("ansinew");
-	ui.comboBoxEncoding->addItem("cp1252");
-	ui.comboBoxEncoding->addItem("cp1250");
-	ui.comboBoxEncoding->addItem("NONE");
-	if (!otherEncodingList.isEmpty()) ui.comboBoxEncoding->addItems(otherEncodingList);
+	ui.comboBoxInputEncoding->clear();
+	ui.comboBoxInputEncoding->addItem("latin1");
+	ui.comboBoxInputEncoding->addItem("latin2");
+	ui.comboBoxInputEncoding->addItem("latin3");
+	ui.comboBoxInputEncoding->addItem("latin5");
+	ui.comboBoxInputEncoding->addItem("utf8");
+	ui.comboBoxInputEncoding->addItem("utf8x");
+	ui.comboBoxInputEncoding->addItem("ascii");
+	ui.comboBoxInputEncoding->addItem("decmulti");
+	ui.comboBoxInputEncoding->addItem("cp850");
+	ui.comboBoxInputEncoding->addItem("cp852");
+	ui.comboBoxInputEncoding->addItem("cp437");
+	ui.comboBoxInputEncoding->addItem("cp437de");
+	ui.comboBoxInputEncoding->addItem("cp865");
+	ui.comboBoxInputEncoding->addItem("applemac");
+	ui.comboBoxInputEncoding->addItem("next");
+	ui.comboBoxInputEncoding->addItem("ansinew");
+	ui.comboBoxInputEncoding->addItem("cp1252");
+	ui.comboBoxInputEncoding->addItem("cp1250");
+	ui.comboBoxInputEncoding->addItem("NONE");
+	if (!otherInputEncodingList.isEmpty()) ui.comboBoxInputEncoding->addItems(otherInputEncodingList);
 
 	ui.comboBoxBabel->clear();
 	ui.comboBoxBabel->addItem("NONE");
@@ -266,7 +266,7 @@ void QuickDocumentDialog::Init()
 	configManagerInterface->linkOptionToDialogWidget(&document_class, ui.comboBoxClass);
 	configManagerInterface->linkOptionToDialogWidget(&typeface_size, ui.comboBoxSize);
 	configManagerInterface->linkOptionToDialogWidget(&paper_size, ui.comboBoxPaper);
-	configManagerInterface->linkOptionToDialogWidget(&document_encoding, ui.comboBoxEncoding);
+	configManagerInterface->linkOptionToDialogWidget(&document_encoding, ui.comboBoxInputEncoding);
 	configManagerInterface->linkOptionToDialogWidget(&babel_language, ui.comboBoxBabel);
 	configManagerInterface->linkOptionToDialogWidget(&ams_packages, ui.checkBoxAMS);
 	configManagerInterface->linkOptionToDialogWidget(&makeidx_package, ui.checkBoxIDX);
@@ -450,13 +450,13 @@ void QuickDocumentDialog::addUserPaper()
 	}
 }
 
-void QuickDocumentDialog::addUserEncoding()
+void QuickDocumentDialog::addUserInputEncoding()
 {
 	QString newoption;
 	UniversalInputDialog dialog;
 	dialog.addVariable(&newoption, tr("New:"));
 	if (dialog.exec() && !newoption.isEmpty()) {
-		otherEncodingList.append(newoption);
+		otherInputEncodingList.append(newoption);
 		Init();
 	}
 }

--- a/src/quickdocumentdialog.h
+++ b/src/quickdocumentdialog.h
@@ -31,7 +31,7 @@ public:
 	static QString document_encoding;
 
 private:
-	static QStringList otherClassList, otherPaperList, otherEncodingList, otherBabelOptionsList, otherOptionsList;
+	static QStringList otherClassList, otherPaperList, otherInputEncodingList, otherBabelOptionsList, otherOptionsList;
 	static QString document_class, typeface_size, paper_size, babel_language, author;
 	static bool ams_packages, makeidx_package, graphicx_package;
 	static ConfigManagerInterface* configManagerInterface;
@@ -49,7 +49,7 @@ public slots:
 private slots:
 	void addUserClass();
 	void addUserPaper();
-	void addUserEncoding();
+	void addUserInputEncoding();
 	void addBabelOption();
 	void addUserOptions();
 };

--- a/src/quickdocumentdialog.h
+++ b/src/quickdocumentdialog.h
@@ -29,9 +29,10 @@ public:
 	QString getNewDocumentText();
 
 	static QString document_encoding;
+	static QString font_encoding;
 
 private:
-	static QStringList otherClassList, otherPaperList, otherInputEncodingList, otherBabelOptionsList, otherOptionsList;
+	static QStringList otherClassList, otherPaperList, otherInputEncodingList, otherFontEncodingList, otherBabelOptionsList, otherOptionsList;
 	static QString document_class, typeface_size, paper_size, babel_language, author;
 	static bool ams_packages, makeidx_package, graphicx_package;
 	static ConfigManagerInterface* configManagerInterface;
@@ -50,6 +51,7 @@ private slots:
 	void addUserClass();
 	void addUserPaper();
 	void addUserInputEncoding();
+	void addUserFontEncoding();
 	void addBabelOption();
 	void addUserOptions();
 };

--- a/src/quickdocumentdialog.ui
+++ b/src/quickdocumentdialog.ui
@@ -99,41 +99,8 @@
          <property name="spacing">
           <number>6</number>
          </property>
-         <item row="3" column="2">
-          <widget class="QPushButton" name="pushButtonInputEncoding">
-           <property name="text">
-            <string/>
-           </property>
-           <property name="icon">
-            <iconset resource="../images.qrc">
-             <normaloff>:/images-ng/list-add.svgz</normaloff>:/images-ng/list-add.svgz</iconset>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QComboBox" name="comboBoxSize"/>
-         </item>
-         <item row="3" column="1">
-          <widget class="QComboBox" name="comboBoxInputEncoding"/>
-         </item>
-         <item row="8" column="1">
-          <widget class="QListWidget" name="listWidgetOptions"/>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="labelPaper">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Paper Size</string>
-           </property>
-          </widget>
-         </item>
          <item row="8" column="0">
-          <widget class="QLabel" name="labelOptions">
+          <widget class="QLabel" name="labelTitle">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
              <horstretch>0</horstretch>
@@ -141,12 +108,22 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Other Options</string>
+            <string>Title</string>
            </property>
           </widget>
          </item>
          <item row="7" column="1">
-          <widget class="QLineEdit" name="lineEditTitle"/>
+          <widget class="QLineEdit" name="lineEditAuthor"/>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="labelBabel">
+           <property name="text">
+            <string>Babel</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="comboBoxClass"/>
          </item>
          <item row="0" column="0">
           <widget class="QLabel" name="labelClass">
@@ -161,56 +138,14 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
-          <widget class="QComboBox" name="comboBoxPaper"/>
-         </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="comboBoxClass"/>
-         </item>
-         <item row="5" column="0">
-          <widget class="QCheckBox" name="checkBoxAMS">
-           <property name="text">
-            <string>AMS Packages</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="labelInputEncoding">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Input encoding</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="2">
-          <widget class="QPushButton" name="pushButtonPaper">
+         <item row="0" column="2">
+          <widget class="QPushButton" name="pushButtonClass">
            <property name="text">
             <string/>
            </property>
            <property name="icon">
             <iconset resource="../images.qrc">
              <normaloff>:/images-ng/list-add.svgz</normaloff>:/images-ng/list-add.svgz</iconset>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0">
-          <widget class="QLabel" name="labelAuthor">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Author</string>
            </property>
           </widget>
          </item>
@@ -227,8 +162,11 @@
            </property>
           </widget>
          </item>
-         <item row="7" column="0">
-          <widget class="QLabel" name="labelTitle">
+         <item row="3" column="1">
+          <widget class="QComboBox" name="comboBoxInputEncoding"/>
+         </item>
+         <item row="9" column="0">
+          <widget class="QLabel" name="labelOptions">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
              <horstretch>0</horstretch>
@@ -236,12 +174,12 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Title</string>
+            <string>Other Options</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="2">
-          <widget class="QPushButton" name="pushButtonClass">
+         <item row="5" column="2">
+          <widget class="QPushButton" name="pushButtonBabel">
            <property name="text">
             <string/>
            </property>
@@ -251,7 +189,10 @@
            </property>
           </widget>
          </item>
-         <item row="5" column="1">
+         <item row="1" column="1">
+          <widget class="QComboBox" name="comboBoxSize"/>
+         </item>
+         <item row="6" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_4">
            <item>
             <widget class="QCheckBox" name="checkBoxIDX">
@@ -269,10 +210,18 @@
            </item>
           </layout>
          </item>
-         <item row="6" column="1">
-          <widget class="QLineEdit" name="lineEditAuthor"/>
+         <item row="2" column="2">
+          <widget class="QPushButton" name="pushButtonPaper">
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../images.qrc">
+             <normaloff>:/images-ng/list-add.svgz</normaloff>:/images-ng/list-add.svgz</iconset>
+           </property>
+          </widget>
          </item>
-         <item row="8" column="2">
+         <item row="9" column="2">
           <widget class="QPushButton" name="pushButtonOptions">
            <property name="text">
             <string/>
@@ -283,18 +232,90 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="1">
-          <widget class="QComboBox" name="comboBoxBabel"/>
+         <item row="9" column="1">
+          <widget class="QListWidget" name="listWidgetOptions"/>
          </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="labelBabel">
+         <item row="6" column="0">
+          <widget class="QCheckBox" name="checkBoxAMS">
            <property name="text">
-            <string>Babel</string>
+            <string>AMS Packages</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="labelPaper">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Paper Size</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="QPushButton" name="pushButtonInputEncoding">
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../images.qrc">
+             <normaloff>:/images-ng/list-add.svgz</normaloff>:/images-ng/list-add.svgz</iconset>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1">
+          <widget class="QLineEdit" name="lineEditTitle"/>
+         </item>
+         <item row="5" column="1">
+          <widget class="QComboBox" name="comboBoxBabel"/>
+         </item>
+         <item row="2" column="1">
+          <widget class="QComboBox" name="comboBoxPaper"/>
+         </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="labelAuthor">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Author</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="labelInputEncoding">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Input encoding</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="labelFontEncoding">
+           <property name="text">
+            <string>Font encoding</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QComboBox" name="comboBoxFontEncoding"/>
+         </item>
          <item row="4" column="2">
-          <widget class="QPushButton" name="pushButtonBabel">
+          <widget class="QPushButton" name="pushButtonFontEncoding">
            <property name="text">
             <string/>
            </property>

--- a/src/quickdocumentdialog.ui
+++ b/src/quickdocumentdialog.ui
@@ -100,7 +100,7 @@
           <number>6</number>
          </property>
          <item row="3" column="2">
-          <widget class="QPushButton" name="pushButtonEncoding">
+          <widget class="QPushButton" name="pushButtonInputEncoding">
            <property name="text">
             <string/>
            </property>
@@ -114,7 +114,7 @@
           <widget class="QComboBox" name="comboBoxSize"/>
          </item>
          <item row="3" column="1">
-          <widget class="QComboBox" name="comboBoxEncoding"/>
+          <widget class="QComboBox" name="comboBoxInputEncoding"/>
          </item>
          <item row="8" column="1">
           <widget class="QListWidget" name="listWidgetOptions"/>
@@ -178,7 +178,7 @@
           </widget>
          </item>
          <item row="3" column="0">
-          <widget class="QLabel" name="labelEncoding">
+          <widget class="QLabel" name="labelInputEncoding">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
              <horstretch>0</horstretch>
@@ -186,7 +186,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Encoding</string>
+            <string>Input encoding</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Fixes #347.

Source of font encodings: https://www.latex-project.org/help/documentation/encguide.pdf. I'm not 100% sure if they're all relevant, so it might be necessary to cut in the list.