### PR TITLE
Add Dutch as an option for babel in the wizard

### DIFF
--- a/src/quickdocumentdialog.cpp
+++ b/src/quickdocumentdialog.cpp
@@ -192,6 +192,7 @@ void QuickDocumentDialog::registerOptions(ConfigManagerInterface &configManager)
 QStringList babelLanguages = QStringList()
   << "arabic"
   << "czech"
+  << "dutch"
   << "english"
   << "farsi"
   << "finnish"


### PR DESCRIPTION
Quite a few people around here use LaTeX, and we promote the use of TeXstudio in our LaTeX workshops, so it would be valuable to us if it was in the default list :)