### PR TITLE
Hanslollo patch translation

### DIFF
--- a/src/latexcompleter.cpp
+++ b/src/latexcompleter.cpp
@@ -1816,7 +1816,7 @@ void LatexCompleter::selectionChanged(const QModelIndex &index)
 		if (cnt == 0) {
 			topic = tr("label missing!");
 		} else if (cnt > 1) {
-			topic = tr("label multiple times defined!");
+			topic = tr("label defined multiple times!");
 		} else {
 			QMultiHash<QDocumentLineHandle *, int> result = document->getLabels(value);
 			QDocumentLineHandle *mLine = result.keys().first();

--- a/src/latexeditorview.cpp
+++ b/src/latexeditorview.cpp
@@ -2370,7 +2370,7 @@ void LatexEditorView::mouseHovered(QPoint pos)
 			if (cnt == 0) {
 				mText = tr("label missing!");
 			} else if (cnt > 1) {
-				mText = tr("label multiple times defined!");
+				mText = tr("label defined multiple times!");
 			} else {
 				QMultiHash<QDocumentLineHandle *, int> result = document->getLabels(value);
 				QDocumentLineHandle *mLine = result.keys().first();
@@ -2388,7 +2388,7 @@ void LatexEditorView::mouseHovered(QPoint pos)
 		if (tk.type == Token::label) {
 			handled = true;
 			if (document->countLabels(value) > 1) {
-				QToolTip::showText(editor->mapToGlobal(editor->mapFromFrame(pos)), tr("label multiple times defined!"));
+				QToolTip::showText(editor->mapToGlobal(editor->mapFromFrame(pos)), tr("label defined multiple times!"));
 			} else {
 				int cnt = document->countRefs(value);
 				QToolTip::showText(editor->mapToGlobal(editor->mapFromFrame(pos)), tr("%n reference(s) to this label", "", cnt));


### PR DESCRIPTION
A tiny change to the warning put out when a label is _defined multiple times,_ which should now be translated correctly. For reference, just google (with quotation marks) "multiple times defined" (returns 3k results, first few are just texstudio) versus "defined multiple times" (70k results of all kinds).