### PR TITLE
[cwl] fix syntax of `\colorlet` in xcolor.cwl

### DIFF
--- a/completion/xcolor.cwl
+++ b/completion/xcolor.cwl
@@ -7,7 +7,7 @@
 
 \definecolor[type]{name}{model-list}{spec-list}#s#%color
 \providecolor[type]{name}{model-list}{spec-list}#s#%color
-\colorlet[type]{name}{num-model}{color}#s#%color
+\colorlet[type]{name}[num-model]{color}#s#%color
 
 \definecolorset[type]{model-list}{head}{tail}{set-spec}#*
 \providecolorset[type]{model-list}{head}{tail}{set-spec}#*


### PR DESCRIPTION
By [user manual of `xcolor`](http://mirrors.ctan.org/macros/latex/contrib/xcolor/xcolor.pdf), sec. 2.5.2, change the third argument of `\colorlet` from mandatory to optional.

![image](https://user-images.githubusercontent.com/6376638/55920958-515f6200-5c2d-11e9-9894-d473bdc1e42a.png)
