### PR TITLE
Fix rerunnable flag of user commands

### DIFF
--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1061,7 +1061,7 @@ RunCommandFlags BuildManager::getSingleCommandFlags(const QString &subcmd) const
 	int result = 0;
 	if (similarCommandInList(subcmd, latexCommands)) result |= RCF_COMPILES_TEX;
 	if (similarCommandInList(subcmd, pdfCommands)) result |= RCF_CHANGE_PDF;
-	if (rerunnableCommands.contains(subcmd)) result |= RCF_RERUNNABLE;
+	if (similarCommandInList(subcmd, rerunnableCommands)) result |= RCF_RERUNNABLE;
 	if (stdoutCommands.contains(subcmd)) result |= RCF_SHOW_STDOUT;
 	bool isAcrobat = false;
 #ifdef Q_OS_WIN

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -26,8 +26,10 @@ Q_DECLARE_METATYPE(LatexCompileResult)
 enum RunCommandFlag {
 	RCF_SHOW_STDOUT = 1,    //bibliography command (=> show stdout)
 	RCF_COMPILES_TEX = 4, //latex command, show the log
-	RCF_RERUNNABLE = 8,   //rerun if there are errors (usually RCF_RERUNNABLE is set iff RCF_COMPILES_TEX is set, except for latexmk)
-	RCF_RERUN = 16,
+	RCF_RERUNNABLE = 8, 	// set if the command provides output information that
+				// tells you when it must be rerun. Usually RCF_RERUNNABLE
+				// is set iff RCF_COMPILES_TEX is set, except for latexmk.
+	RCF_RERUN = 16,         // User has allowed program rerun through the command settings
 	RCF_CHANGE_PDF = 32,    //pdflatex (=> lock pdf)
 	RCF_SINGLE_INSTANCE = 64,//viewer (=> start only once)
 	RCF_WAITFORFINISHED = 128


### PR DESCRIPTION
The current version of TexStudio does not handle correctly rerunnable user commands. The user command can be rerunnable only if the user command with its arguments is a substring of an built-in rerunnable command (one of the *tex commands).

For example if the builtin pdflatex command is:
pdflatex -synctex=1 -interaction=nonstopmode %.tex
then creating a custom user command
pdflatex -synctex=1 -interaction=nonstopmode -output-directory=/root/tex %.tex
cannot be rerunnable even if the user enables the "Repeat contained compilation commands" for the new command.

The proposed patch fixes this issue, but checking only the basename of the new user command, ignoring the arguments. As long as the basename matches with one of the builtin rerunnable commands, the user command is marked as rerunnable and repeating can be enabled for it.