### PR TITLE
Fix tooltip preview of inline math when it is preceded by other text

### DIFF
--- a/src/latexeditorview.cpp
+++ b/src/latexeditorview.cpp
@@ -2245,7 +2245,12 @@ bool LatexEditorView::showMathEnvPreview(QDocumentCursor cursor, QString command
 {
     QStringList envAliases = document->lp.environmentAliases.values(environment);
 	if (((command == "\\begin" || command == "\\end") && envAliases.contains("math")) || command == "\\[" || command == "\\]" || command == "$") {
-		while (!cursor.atLineStart() && cursor.nextChar() != '\\') {
+		while (!cursor.atLineStart()) {
+			QChar nc = cursor.nextChar();
+
+			if (nc == '\\' || nc == '$') {
+				break;
+			}
 			cursor.movePosition(1, QDocumentCursor::PreviousCharacter);
 		}
 		QString text = parenthizedTextSelection(cursor).selectedText();


### PR DESCRIPTION
At the moment TexStudio does not handle correctly inline math that is preceded by other text on the same line. For example if we have the following line of inline math
abc $1+2$ cba
then hovering the mouse over the opening or closing dollar sign ($) will not invoke the preview tooptip.
The problem is caused by the fact that LatexEditorView::showMathEnvPreview does not detect correctly the starting position of the inline math text. The proposed patch fixes this issue.

Please note that previewing old-style display math (surrounded by double-dollar signs, like $$1+2$$ ) still does not work, but fixing it is more of an enhancement than a simple bugfix.