### PR TITLE
Fix the open/close parenthesis for old-style display math

### DIFF
--- a/utilities/qxs/tex.qnfa
+++ b/utilities/qxs/tex.qnfa
@@ -109,9 +109,9 @@ environments in smallUsefulFunctions.cpp)
 	<sequence id="keywords/single" format="align-ampersand">&amp;</sequence>
 	
 	<context id="mathmode$$" format="numbers" transparency="true">
-		<start parenthesis="math:open$$" parenthesisWeight="50" fold="1" format="math-delimiter" >\$\$</start>
-		<stop parenthesis="math:close$$" parenthesisWeight="50" fold="1" format="math-delimiter" >\$\$</stop>
-		<stop parenthesis="math:close$$" parenthesisWeight="0" fold="1" format="math-delimiter" >^\n</stop>
+		<start parenthesis="math$$:open" parenthesisWeight="50" fold="1" format="math-delimiter" >\$\$</start>
+		<stop parenthesis="math$$:close" parenthesisWeight="50" fold="1" format="math-delimiter" >\$\$</stop>
+		<stop parenthesis="math$$:close" parenthesisWeight="0" fold="1" format="math-delimiter" >^\n</stop>
 
 		<sequence parenthesis="leftright(:open" parenthesisWeight="0" format="math-keyword">\\left\(</sequence>
 		<sequence parenthesis="leftright(:close" parenthesisWeight="0" format="math-keyword">\\right\)</sequence>


### PR DESCRIPTION
Currently TexStudio does not show correctly blocks of old-style display math enclosed in $$.
Even though the tex.qnfa specifies the blocks as foldable, they are not displayed as foldable in the editor window. Additionally the parenthesis weight for $$ is specified as 50, but in fact it is 40.
For example if one creates and opens in TexStudio a .tex file containing

$$
1+2
$$

then there will be no fold/unfold icon for this text block.
What is causing this bug is the incorrect definition of the start and stop tags for the $$ math context.
They have the attributes parenthesis="math:open$$" and parenthesis="math:close$$".
Obviously the intention of the $$ in the name was to specify a unique ID for the parenthesis tag. However the $$ is treated as a part of the parenthesis types which become open$$ and close$$. Obviously these are invalid parenthesis types so the $$ math blocks are not defined correctly.

The proposed patch fixes this issue and the old-style math blocks like the one from the above example are displayed correctly and can be folded/unfolded.