### PR TITLE
Fix the inline preview of old-style display math

### DIFF
--- a/src/latexeditorview.h
+++ b/src/latexeditorview.h
@@ -272,6 +272,7 @@ private:
 	void removeLinkOverlay();
 	bool isNonTextFormat(int format);
 	QString extractMath(QDocumentCursor cursor);
+	bool moveToCommandStart (QDocumentCursor &cursor, QString commandPrefix);
 	bool showMathEnvPreview(QDocumentCursor cursor, QString command, QString environment, QPoint pos);
 
 public slots:


### PR DESCRIPTION
Currently TexStudio does not allow preview of old-style display math. For example if one creates a tex file that contains
$$4+5$$
then hovering the mouse over the opening or closing $$ will not activate the preview. The proposed patch fixes the preview for such old-style display math.
This patch relies on a previous fix https://github.com/texstudio-org/texstudio/pull/568 which corrects the internal presentation of the opening/closing $$ brackets.
