### PR TITLE
Convert UTC time to local time in PDFInfoDock.

### DIFF
--- a/src/pdfviewer/PDFDocks.cpp
+++ b/src/pdfviewer/PDFDocks.cpp
@@ -227,7 +227,7 @@ void PDFInfoDock::fillInfo()
 		const int id = keys.indexOf(date);
 		if (id != -1) {
 			list->addItem(date + ":");
-			list->addItem(doc->date(date).toString(Qt::SystemLocaleDate));
+			list->addItem(doc->date(date).toLocalTime().toString(Qt::SystemLocaleDate));
 			++i;
 			keys.removeAt(id);
 		}


### PR DESCRIPTION
To fix the mismatch of 'CreationDate' between pdf file and PDFInfoDock.