### PR TITLE
 Avoid spinlock and UI block while compiling files 

### DIFF
--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -2448,6 +2448,7 @@ void ProcessX::onFinished(int error)
 		readFromStandardError();
 	}
 	ended = true;
+	emit finishedProcess();
 }
 
 #ifdef PROFILE_PROCESSES

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -294,6 +294,7 @@ signals:
 	void processNotification(const QString &message);
 	void standardOutputRead(const QString &data);
 	void standardErrorRead(const QString &data);
+	void finishedProcess();
 private slots:
 	void onStarted();
 	void onError(QProcess::ProcessError error);


### PR DESCRIPTION
This commit makes UI responsive while compiling, and allows to continue typing.