### PR TITLE
Add padding to small PDF files (size < 1024).

### DIFF
--- a/src/pdfviewer/pdfrendermanager.cpp
+++ b/src/pdfviewer/pdfrendermanager.cpp
@@ -163,10 +163,13 @@ QSharedPointer<Poppler::Document> PDFRenderManager::loadDocument(const QString &
 				return QSharedPointer<Poppler::Document>();
 			}
 			// create document
-			if (loadStrategy == BufferedLoad || (loadStrategy == HybridLoad && queueAdministration->documentData.size() < 50000000))
+			if (loadStrategy == BufferedLoad || (loadStrategy == HybridLoad && queueAdministration->documentData.size() < 50000000)) {
+				if (queueAdministration->documentData.size() < 1024)
+					queueAdministration->documentData.append(QByteArray(1024 - queueAdministration->documentData.size(), (char) 0));
 				docPtr = Poppler::Document::loadFromData(queueAdministration->documentData, ownerPassword, userPassword);
-			else
+			} else {
 				docPtr = Poppler::Document::load(fileName, ownerPassword, userPassword);
+			}
 		}
 	} catch (std::bad_alloc) {
 		error = PopplerErrorBadAlloc;


### PR DESCRIPTION
To fix [Specific PDF not viewable in TeXstudio](https://tex.stackexchange.com/questions/486175/specific-pdf-not-viewable-in-texstudio).
This is a bug related to poppler's `MemStream` class when load PDF with `Poppler::Document::loadFromData`.