### PR TITLE
Disable compile & build buttons while executing compile proccess

### DIFF
--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1644,13 +1644,17 @@ bool BuildManager::waitForProcess(ProcessX *p)
 {
 	REQUIRE_RET(!processWaitedFor, false);
 	processWaitedFor = p;
-	m_stopBuildAction->setEnabled(true);
     QEventLoop loop; //This approach avoids spinlock and high CPU usage, and allows user interaction and UI responsivness while compiling.
     connect(p, SIGNAL(finishedProcess()), &loop, SLOT(quit()));
-    loop.exec(); //exec will delay execution until the signal has arrived
+	m_stopBuildAction->setEnabled(true);
+    m_buildAction->setEnabled(false);
+    m_compileAction->setEnabled(false);
+    loop.exec(); //exec will delay execution until the signal has arrived    
 	bool result = processWaitedFor;
     processWaitedFor = nullptr;
 	m_stopBuildAction->setEnabled(false);
+    m_buildAction->setEnabled(true);
+    m_compileAction->setEnabled(true);
 	return result;
 }
 

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -269,11 +269,7 @@ BuildManager::BuildManager(): processWaitedFor(nullptr)
 #endif
 {
 	initDefaultCommandNames();
-	connect(this, SIGNAL(commandLineRequested(QString, QString *, bool *)), SLOT(commandLineRequestedDefault(QString, QString *, bool *)));
-
-	m_stopBuildAction = new QAction(getRealIcon("stop"), tr("Stop Compile"), this);
-	connect(m_stopBuildAction, SIGNAL(triggered()), this, SLOT(killCurrentProcess()));
-	m_stopBuildAction->setEnabled(false);
+    connect(this, SIGNAL(commandLineRequested(QString, QString *, bool *)), SLOT(commandLineRequestedDefault(QString, QString *, bool *)));
 }
 
 BuildManager::~BuildManager()
@@ -1645,16 +1641,12 @@ bool BuildManager::waitForProcess(ProcessX *p)
 	REQUIRE_RET(!processWaitedFor, false);
 	processWaitedFor = p;
     QEventLoop loop; //This approach avoids spinlock and high CPU usage, and allows user interaction and UI responsivness while compiling.
-    connect(p, SIGNAL(finishedProcess()), &loop, SLOT(quit()));
-	m_stopBuildAction->setEnabled(true);
-    m_buildAction->setEnabled(false);
-    m_compileAction->setEnabled(false);
+    connect(p, SIGNAL(processFinished()), &loop, SLOT(quit()));
+    emit buildRunning(true);
     loop.exec(); //exec will delay execution until the signal has arrived    
+    emit buildRunning(false);
 	bool result = processWaitedFor;
     processWaitedFor = nullptr;
-	m_stopBuildAction->setEnabled(false);
-    m_buildAction->setEnabled(true);
-    m_compileAction->setEnabled(true);
 	return result;
 }
 
@@ -2452,7 +2444,7 @@ void ProcessX::onFinished(int error)
 		readFromStandardError();
 	}
 	ended = true;
-    emit finishedProcess();
+    emit processFinished();
 }
 
 #ifdef PROFILE_PROCESSES

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -187,6 +187,8 @@ public:
 	enum SaveFilesBeforeCompiling {SFBC_ALWAYS, SFBC_ONLY_CURRENT_OR_NAMED, SFBC_ONLY_NAMED};
 	SaveFilesBeforeCompiling saveFilesBeforeCompiling;
 	bool previewRemoveBeamer, previewPrecompilePreamble;
+    QAction *m_buildAction;
+    QAction *m_compileAction;
 private slots:
 	void singleInstanceCompleted(int status);
 	void preamblePrecompileCompleted(int status);

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -139,10 +139,6 @@ public:
 
 	void checkLatexConfiguration(bool &noWarnAgain);
 
-	QAction *stopBuildAction()
-	{
-		return m_stopBuildAction;
-	}
 
 public slots:
     bool runCommand(const QString &unparsedCommandLine, const QFileInfo &mainFile, const QFileInfo &currentFile = QFileInfo(), int currentLine = 0, QString *buffer = nullptr, QTextCodec *codecForBuffer = nullptr);
@@ -187,8 +183,6 @@ public:
 	enum SaveFilesBeforeCompiling {SFBC_ALWAYS, SFBC_ONLY_CURRENT_OR_NAMED, SFBC_ONLY_NAMED};
 	SaveFilesBeforeCompiling saveFilesBeforeCompiling;
 	bool previewRemoveBeamer, previewPrecompilePreamble;
-    QAction *m_buildAction;
-    QAction *m_compileAction;
 private slots:
 	void singleInstanceCompleted(int status);
 	void preamblePrecompileCompleted(int status);
@@ -215,6 +209,7 @@ signals:
 	void beginRunningSubCommand(ProcessX *p, const QString &commandMain, const QString &subCommand, const RunCommandFlags &flags);
 	void endRunningSubCommand(ProcessX *p, const QString &commandMain, const QString &subCommand, const RunCommandFlags &flags);
 	void endRunningCommands(const QString &commandMain, bool latex, bool pdf, bool asyncPdf);
+    void buildRunning(bool c);
 private:
 
 	void initDefaultCommandNames();
@@ -248,7 +243,6 @@ public:
 	}
 
 private:
-	QAction *m_stopBuildAction;
 	QStringList previewFileNames;
 	QMap<QString, PreviewSource> previewFileNameToSource;
 	QHash<QString, QString> preambleHash;
@@ -296,7 +290,7 @@ signals:
 	void processNotification(const QString &message);
 	void standardOutputRead(const QString &data);
 	void standardErrorRead(const QString &data);
-    void finishedProcess();
+    void processFinished();
 private slots:
 	void onStarted();
 	void onError(QProcess::ProcessError error);

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -963,8 +963,12 @@ void Texstudio::setupMenus()
 
 	menu = newManagedMenu("main/tools", tr("&Tools"));
 	menu->setProperty("defaultSlot", QByteArray(SLOT(commandFromAction())));
-	newManagedAction(menu, "quickbuild", tr("&Build && View"), SLOT(commandFromAction()), (QList<QKeySequence>() << Qt::Key_F5 << Qt::Key_F1), "build")->setData(BuildManager::CMD_QUICK);
-	newManagedAction(menu, "compile", tr("&Compile"), SLOT(commandFromAction()), Qt::Key_F6, "compile")->setData(BuildManager::CMD_COMPILE);
+    QAction *buildAction = newManagedAction(menu, "quickbuild", tr("&Build && View"), SLOT(commandFromAction()), (QList<QKeySequence>() << Qt::Key_F5 << Qt::Key_F1), "build");
+    buildAction->setData(BuildManager::CMD_QUICK);
+    QAction *compileAction = newManagedAction(menu, "compile", tr("&Compile"), SLOT(commandFromAction()), Qt::Key_F6, "compile");
+    compileAction->setData(BuildManager::CMD_COMPILE);
+    buildManager.m_buildAction=buildAction;
+    buildManager.m_compileAction=compileAction;
 	newManagedAction(menu, "stopcompile", buildManager.stopBuildAction())->setText(buildManager.tr("Stop Compile")); // resetting text necessary for language updates
 	buildManager.stopBuildAction()->setParent(menu);  // actions need to be a child of the menu in order to be configurable in toolbars
 	newManagedAction(menu, "view", tr("&View"), SLOT(commandFromAction()), Qt::Key_F7, "viewer")->setData(BuildManager::CMD_VIEW);

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -963,14 +963,12 @@ void Texstudio::setupMenus()
 
 	menu = newManagedMenu("main/tools", tr("&Tools"));
 	menu->setProperty("defaultSlot", QByteArray(SLOT(commandFromAction())));
-    QAction *buildAction = newManagedAction(menu, "quickbuild", tr("&Build && View"), SLOT(commandFromAction()), (QList<QKeySequence>() << Qt::Key_F5 << Qt::Key_F1), "build");
-    buildAction->setData(BuildManager::CMD_QUICK);
-    QAction *compileAction = newManagedAction(menu, "compile", tr("&Compile"), SLOT(commandFromAction()), Qt::Key_F6, "compile");
-    compileAction->setData(BuildManager::CMD_COMPILE);
-    buildManager.m_buildAction=buildAction;
-    buildManager.m_compileAction=compileAction;
-	newManagedAction(menu, "stopcompile", buildManager.stopBuildAction())->setText(buildManager.tr("Stop Compile")); // resetting text necessary for language updates
-	buildManager.stopBuildAction()->setParent(menu);  // actions need to be a child of the menu in order to be configurable in toolbars
+    newManagedAction(menu, "quickbuild", tr("&Build && View"), SLOT(commandFromAction()), (QList<QKeySequence>() << Qt::Key_F5 << Qt::Key_F1), "build")->setData(BuildManager::CMD_QUICK);
+    newManagedAction(menu, "compile", tr("&Compile"), SLOT(commandFromAction()), Qt::Key_F6, "compile")->setData(BuildManager::CMD_COMPILE);
+    QAction *stopAction = new QAction(getRealIcon("stop"), tr("Stop Compile"), menu);
+    connect(stopAction, SIGNAL(triggered()), &buildManager, SLOT(killCurrentProcess()));
+    newManagedAction(menu, "stopcompile", stopAction)->setEnabled(false);
+    connect(&buildManager,SIGNAL(buildRunning(bool)),this,SLOT(setBuildButtonsDisabled(bool)));
 	newManagedAction(menu, "view", tr("&View"), SLOT(commandFromAction()), Qt::Key_F7, "viewer")->setData(BuildManager::CMD_VIEW);
 	newManagedAction(menu, "bibtex", tr("&Bibliography"), SLOT(commandFromAction()), Qt::Key_F8)->setData(BuildManager::CMD_BIBLIOGRAPHY);
 	newManagedAction(menu, "glossary", tr("&Glossary"), SLOT(commandFromAction()), Qt::Key_F9)->setData(BuildManager::CMD_GLOSSARY);
@@ -6887,10 +6885,10 @@ void Texstudio::viewCloseElement()
 	if (completer && completer->isVisible() && completer->close()) {
 		return;
 	}
-	if (buildManager.stopBuildAction()->isEnabled()) {
-		buildManager.stopBuildAction()->trigger();
-		return;
-	}
+    if (getManagedAction("main/tools/stopcompile")->isEnabled()) {
+        getManagedAction("main/tools/stopcompile")->trigger();
+        return;
+    }
 
 #ifndef NO_POPPLER_PREVIEW
 	// close element in focussed viewer
@@ -7737,6 +7735,13 @@ void Texstudio::fuzzBackForward()
 	rep = random() % (1 + cursorHistory->count());
 	for (int j = 0; j < rep; j++) goForward();
 #endif
+}
+
+void Texstudio::setBuildButtonsDisabled(bool c)
+{
+    getManagedAction("main/tools/stopcompile")->setEnabled(c);
+    getManagedAction("main/tools/quickbuild")->setEnabled(!c);
+    getManagedAction("main/tools/compile")->setEnabled(!c);
 }
 
 void Texstudio::fuzzCursorHistory()

--- a/src/texstudio.h
+++ b/src/texstudio.h
@@ -86,9 +86,9 @@ public slots:
 	void hideSplash(); ///< hide splash screen
 	void startupCompleted();
 	void onOtherInstanceMessage(const QString &);  ///< For messages for the single instance
-
 	void fuzzCursorHistory();
 	void fuzzBackForward();
+    void setBuildButtonsDisabled(bool c);
 
 
 protected:


### PR DESCRIPTION
This pull request wants to make noticeable for users that a compile command while a proccess is executing will have no effect, by disabling the compile buttons. They should first stop the current process.

![imagen](https://user-images.githubusercontent.com/6536835/56862027-dd4fe880-69a6-11e9-9c5c-8fbcfe06807d.png)


To achieve this, the buildManager instance needs to have a reference to the QAction buttons. I just created 2 new public attributes in the BuildManager class that are set up when the buttons are initialized in Texstudio instance. If there is any other prefered approach, using private attributes and a setter, for example, I have no problem with that.