### PR TITLE
minor fixes in biblatex.cwl

### DIFF
--- a/completion/biblatex.cwl
+++ b/completion/biblatex.cwl
@@ -33,6 +33,8 @@
 \newrefsegment
 \DeclareBibliographyCategory{category}
 \addtocategory{category}{bibid}
+\defbibenvironment{name}{begincode%text}{endcode%text}{itemcode%text}
+\defbibheading{name}[title%text]{code}
 \defbibheading{name}{code}
 \defbibnote{name}{text}
 \defbibfilter{name}{code}


### PR DESCRIPTION
In accordance with [biblatex package v3.12 manual](http://mirror.macomnet.net/pub/CTAN/macros/latex/contrib/biblatex/doc/biblatex.pdf) :

1. Added missing `\defbibenvironment` macro
2. Fixed missing optional argument in `\defbibheading` 
