### PR TITLE
manual: add missing p tag

### DIFF
--- a/utilities/manual/usermanual_en.html
+++ b/utilities/manual/usermanual_en.html
@@ -1546,7 +1546,7 @@ Each line of a cwl file defines a command. Comment lines are possible and start 
   <li><b>priorized:</b> Some packages may specify very many commands. Mark the unusual ones by the *-classifier to prevent the completer from overcrowding with rarely used commands.</li>
 </ul>
 
-<h3>4.13.4 cwl file placement</h3>
+<h3>4.13.5 cwl file placement</h3>
 <p>cwl files can be provided from three locations. If present, the user provided cwl is taken, if not built-in versions are taken. As a last resort, txs automatically generates cwls from latex styles, though these only serve to provide syntax information. Context information for arguments are not available and no completion hints are given.</p>
 <ul>
 <li><b>%appdata%\texstudio\completion\user or .config/texstudio/completion/user</b> user generated cwls</li>

--- a/utilities/manual/usermanual_en.html
+++ b/utilities/manual/usermanual_en.html
@@ -1547,7 +1547,7 @@ Each line of a cwl file defines a command. Comment lines are possible and start 
 </ul>
 
 <h3>4.13.4 cwl file placement</h3>
-cwl files can be provided from three locations. If present, the user provided cwl is taken, if not built-in versions are taken. As a last resort, txs automatically generates cwls from latex styles, though these only serve to provide syntax information. Context information for arguments are not available and no completion hints are given.
+<p>cwl files can be provided from three locations. If present, the user provided cwl is taken, if not built-in versions are taken. As a last resort, txs automatically generates cwls from latex styles, though these only serve to provide syntax information. Context information for arguments are not available and no completion hints are given.</p>
 <ul>
 <li><b>%appdata%\texstudio\completion\user or .config/texstudio/completion/user</b> user generated cwls</li>
 <li><b>built-in</b></li>


### PR DESCRIPTION
This commit fixes 
 - wrong indent of the first paragraph of (the "second") sec. 4.13.4, and
 - duplicate section numbering (two occurrences of sec. 4.13.4)


Before:
![image](https://user-images.githubusercontent.com/6376638/57291527-3845b600-70f2-11e9-87d9-a6b9f35475f2.png)


After:
![image](https://user-images.githubusercontent.com/6376638/57291485-2237f580-70f2-11e9-9049-3df5b5e44baa.png)

