### PR TITLE
Add 2 missing images used by manual

### DIFF
--- a/texstudio.pro
+++ b/texstudio.pro
@@ -138,7 +138,7 @@ unix {
         translation/texstudio_fa.qm \
         translation/texstudio_fr.qm \
         translation/texstudio_hu.qm \
-	translation/texstudio_id_ID.qm \
+        translation/texstudio_id_ID.qm \
         translation/texstudio_it.qm \
         translation/texstudio_ja.qm \
         translation/texstudio_ko.qm \
@@ -255,7 +255,7 @@ unix {
         utilities/manual/doc8.png \
         utilities/manual/doc9.png \
         utilities/manual/configure_completion.png \
-	utilities/manual/configure_commands.png \
+        utilities/manual/configure_commands.png \
         utilities/manual/configure_customizeMenu.png \
         utilities/manual/configure_customToolbar.png \
         utilities/manual/configure_editor.png \
@@ -337,7 +337,7 @@ CONFIG(debug, debug|release) {
         src/tests/structureview_t.cpp \
         src/tests/syntaxcheck_t.cpp \
         src/tests/tablemanipulation_t.cpp \
-	src/tests/usermacro_t.cpp \
+        src/tests/usermacro_t.cpp \
         src/tests/testmanager.cpp \
         src/tests/testutil.cpp
     HEADERS += \

--- a/texstudio.pro
+++ b/texstudio.pro
@@ -268,7 +268,9 @@ unix {
         utilities/manual/thesaurus.png \
         utilities/manual/wizard_figure.png \
         utilities/manual/block_selection.png \
-        utilities/manual/spellcheck_menu.png
+        utilities/manual/spellcheck_menu.png \
+        utilities/manual/spellcheck_options.png \
+        utilities/manual/format_example.png
     INSTALLS += target \
         manual \
         utilities


### PR DESCRIPTION
There are in total 3 images used by user manual but missing in package for macOS. Issue #643 (fixed by https://github.com/texstudio-org/texstudio/commit/d7e834cbaaa25ddfb584f65e1e089fe2d608a276) reports one of them, and this pr adds the rest 2.

Other change:
 - Substitute tabs by spaces in order to unify indent symbols

PS:
 - Is it necessary to keep items in arrays of file `texstudio.pro` in *strict alphabetic order*?