### PR TITLE
Use the most recent log

### DIFF
--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -2141,9 +2141,13 @@ QString BuildManager::findFile(const QString &defaultName, const QStringList &se
             }
         }
 	}
-	if (mostRecent && mr != nullptr)
-        return mr->absoluteFilePath();
-	return "";
+	if (mostRecent && mr != nullptr) {
+        QString result = mr->absoluteFilePath();
+        delete mr;
+        return result;
+    } else {
+        return "";
+    }
 }
 
 void BuildManager::removePreviewFiles(QString elem)

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -2107,19 +2107,10 @@ QString BuildManager::findFile(const QString &defaultName, const QStringList &se
 			return defaultName;
 	}
 
+	QFileInfo fi;
 	foreach (QString p, searchPaths) {
 		if (p.startsWith('/') || p.startsWith("\\\\") || (p.length() > 2 && p[1] == ':' && (p[2] == '\\' || p[2] == '/'))) {
-			QFileInfo fi(QDir(p), base.fileName());
-			if (fi.exists()) {
-				if (mostRecent) {
-					if (mr == nullptr || mr->lastModified() < fi.lastModified()) {
-						if (mr != nullptr)
-							delete mr;
-						mr = new QFileInfo(fi);
-					}
-				} else
-					return fi.absoluteFilePath();
-			}
+			fi = QFileInfo(QDir(p), base.fileName());
 		} else {
 			// ?? seems a bit weird: if p is not an absolute path, then interpret p as directory
 			// e.g. default = /my/filename.tex
@@ -2128,18 +2119,18 @@ QString BuildManager::findFile(const QString &defaultName, const QStringList &se
 			// TODO: do we want/use this anywere or can it be removed?
 			QString absPath = base.absolutePath() + "/";
 			QString baseName = "/" + base.fileName();
-			QFileInfo fi(absPath + p + baseName);
-			if (fi.exists()) {
-				if (mostRecent) {
-					if (mr == nullptr || mr->lastModified() < fi.lastModified()) {
-						if (mr != nullptr)
-							delete mr;
-						mr = new QFileInfo(fi);
-					}
-				} else
-					return fi.absoluteFilePath();
-			}
-		}
+			fi = QFileInfo(absPath + p + baseName);
+        }
+        if (fi.exists()) {
+            if (mostRecent) {
+                if (mr == nullptr || mr->lastModified() < fi.lastModified()) {
+                    if (mr != nullptr)
+                        delete mr;
+                    mr = new QFileInfo(fi);
+                }
+            } else
+                return fi.absoluteFilePath();
+        }
 	}
 	if (mostRecent && mr != nullptr) {
 		QString result = mr->absoluteFilePath();

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -2107,8 +2107,8 @@ QString BuildManager::findFile(const QString &defaultName, const QStringList &se
 			return defaultName;
 	}
 
-	QFileInfo fi;
 	foreach (QString p, searchPaths) {
+        QFileInfo fi;
 		if (p.startsWith('/') || p.startsWith("\\\\") || (p.length() > 2 && p[1] == ':' && (p[2] == '\\' || p[2] == '/'))) {
 			fi = QFileInfo(QDir(p), base.fileName());
 		} else {

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -2099,55 +2099,55 @@ QString BuildManager::findFile(const QString &defaultName, const QStringList &se
 {
 	//TODO: merge with findResourceFile
 	QFileInfo base(defaultName);
-    QFileInfo* mr = nullptr;
+	QFileInfo* mr = nullptr;
 	if (base.exists()) {
-        if (mostRecent)
-            mr = new QFileInfo(base);
-        else
-            return defaultName;
-    }
+		if (mostRecent)
+			mr = new QFileInfo(base);
+		else
+			return defaultName;
+	}
 
 	foreach (QString p, searchPaths) {
 		if (p.startsWith('/') || p.startsWith("\\\\") || (p.length() > 2 && p[1] == ':' && (p[2] == '\\' || p[2] == '/'))) {
 			QFileInfo fi(QDir(p), base.fileName());
 			if (fi.exists()) {
-                if (mostRecent) {
-                    if (mr == nullptr || mr->lastModified() < fi.lastModified()) {
-                        if (mr != nullptr)
-                            delete mr;
-                        mr = new QFileInfo(fi);
-                    }
-                } else
-                    return fi.absoluteFilePath();
-            }
+				if (mostRecent) {
+					if (mr == nullptr || mr->lastModified() < fi.lastModified()) {
+						if (mr != nullptr)
+							delete mr;
+						mr = new QFileInfo(fi);
+					}
+				} else
+					return fi.absoluteFilePath();
+			}
 		} else {
 			// ?? seems a bit weird: if p is not an absolute path, then interpret p as directory
 			// e.g. default = /my/filename.tex
-			//      p = foo
+			//	  p = foo
 			// -->  /my/foo/filename.tex
 			// TODO: do we want/use this anywere or can it be removed?
 			QString absPath = base.absolutePath() + "/";
 			QString baseName = "/" + base.fileName();
 			QFileInfo fi(absPath + p + baseName);
-            if (fi.exists()) {
-                if (mostRecent) {
-                    if (mr == nullptr || mr->lastModified() < fi.lastModified()) {
-                        if (mr != nullptr)
-                            delete mr;
-                        mr = new QFileInfo(fi);
-                    }
-                } else
-                    return fi.absoluteFilePath();
-            }
-        }
+			if (fi.exists()) {
+				if (mostRecent) {
+					if (mr == nullptr || mr->lastModified() < fi.lastModified()) {
+						if (mr != nullptr)
+							delete mr;
+						mr = new QFileInfo(fi);
+					}
+				} else
+					return fi.absoluteFilePath();
+			}
+		}
 	}
 	if (mostRecent && mr != nullptr) {
-        QString result = mr->absoluteFilePath();
-        delete mr;
-        return result;
-    } else {
-        return "";
-    }
+		QString result = mr->absoluteFilePath();
+		delete mr;
+		return result;
+	} else {
+		return "";
+	}
 }
 
 void BuildManager::removePreviewFiles(QString elem)

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -235,7 +235,7 @@ public:
 	static QString autoRerunCommands;
 	static QString additionalSearchPaths, additionalLogPaths, additionalPdfPaths;
 
-	QString findFile(const QString &baseName, const QStringList &searchPaths);
+	QString findFile(const QString &baseName, const QStringList &searchPaths, bool mostRecent = false);
 	void addPreviewFileName(QString fn)
 	{
 		if (!previewFileNames.contains(fn))

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -6146,7 +6146,7 @@ bool Texstudio::logExists()
 	QString finame = documents.getTemporaryCompileFileName();
 	if (finame == "")
 		return false;
-	QString logFileName = buildManager.findFile(getAbsoluteFilePath(documents.getLogFileName()), splitPaths(BuildManager::resolvePaths(buildManager.additionalLogPaths)));
+	QString logFileName = buildManager.findFile(getAbsoluteFilePath(documents.getLogFileName()), splitPaths(BuildManager::resolvePaths(buildManager.additionalLogPaths)), true);
 	QFileInfo fic(logFileName);
 	if (fic.exists() && fic.isReadable()) return true;
 	else return false;
@@ -6161,7 +6161,7 @@ bool Texstudio::loadLog()
 		QMessageBox::warning(this, tr("Error"), tr("File must be saved and compiling before you can view the log"));
 		return false;
 	}
-	QString logFileName = buildManager.findFile(getAbsoluteFilePath(documents.getLogFileName()), splitPaths(BuildManager::resolvePaths(buildManager.additionalLogPaths)));
+	QString logFileName = buildManager.findFile(getAbsoluteFilePath(documents.getLogFileName()), splitPaths(BuildManager::resolvePaths(buildManager.additionalLogPaths)), true);
 	QTextCodec * codec = QTextCodec::codecForName(configManager.logFileEncoding.toLatin1());
 	return outputView->getLogWidget()->loadLogFile(logFileName, compileFileName, codec ? codec : documents.getCurrentDocument()->codec() );
 }

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -5787,7 +5787,7 @@ void Texstudio::runInternalPdfViewer(const QFileInfo &master, const QString &opt
 	QString pdfDefFile = BuildManager::parseExtendedCommandLine(pdfFile, master).first();
 	QStringList searchPaths = splitPaths(BuildManager::resolvePaths(buildManager.additionalPdfPaths));
 	searchPaths.insert(0, master.absolutePath());
-	pdfFile = buildManager.findFile(pdfDefFile, searchPaths);
+	pdfFile = buildManager.findFile(pdfDefFile, searchPaths, true);
 	if (pdfFile == "") pdfFile = pdfDefFile; //use old file name, so pdf viewer shows reasonable error message
 	int ln = 0;
 	int col = 0;


### PR DESCRIPTION
This PR addresses my concern in #661.

This works satisfactorily for viewing the log file in the following sense : if I use my standard compile command from with TXS (which puts log file in ./_build), the new log file gets used (and errors reported) even if there is a stale log file in the base dir obtained from another compilation process.

I replicated the change for locating the PDF file but cannot extensively test it as my current routine does copy the PDF back from ./_build to the base dir and thus overwrites a stale PDF.