### PR TITLE
cwl: booktabs - fix \specialrule

### DIFF
--- a/completion/booktabs.cwl
+++ b/completion/booktabs.cwl
@@ -1,5 +1,6 @@
 # mode: booktabs.sty
 # dani/2006-02-18
+# muzimuzhi/2019-07-17
 \addlinespace
 \addlinespace[space]
 \bottomrule
@@ -10,6 +11,6 @@
 \midrule
 \midrule[width]
 \morecmidrules
-\specialrule[width]{abovespace}{belowspace}
+\specialrule{width}{abovespace}{belowspace}
 \toprule
 \toprule[width]


### PR DESCRIPTION
According to doc of `booktabs` package, sec. 4, change the first argument of `\specialrule` from optional to mandatory.
![image](https://user-images.githubusercontent.com/6376638/61318581-f777c500-a837-11e9-9181-2a7014529953.png)


