### PR TITLE
[cwl] add primitive \or

### DIFF
--- a/completion/tex.cwl
+++ b/completion/tex.cwl
@@ -300,6 +300,7 @@
 \omit#*
 \openin#*
 \openout#*
+\or#*
 \outer#*
 \output#*
 \outputpenalty#*


### PR DESCRIPTION
This pr adds `\or` to `.cwl` file. 

------

Currently, tex primitive `\or` only occurs in the middle of `.cwl` lines of `\ifcase` command, but does not have its separate line. See 
https://github.com/texstudio-org/texstudio/blob/f0418e713f63174f5ea398fa4090c2a36d8b655a/completion/tex.cwl#L197-L198

Hence txs highlights `\or` as "unrecognized command". 