### PR TITLE
cwl - handle \newXXX commands better

### DIFF
--- a/completion/tex.cwl
+++ b/completion/tex.cwl
@@ -1,5 +1,7 @@
-# tex/latex mode: Tex commands
+# tex/latex mode: TeX commands
 # dani/8.1.2004
+# muzimuzhi/2019-08-20
+
 \above#*
 \abovedisplayshortskip#*
 \abovedisplayskip#*
@@ -275,14 +277,28 @@
 \newcount
 \newcount{cmd}#dS
 \newdimen
+\newdimen{cmd}#dS
+\newfam#*
+\newfam{cmd}#dS
 \newhelp#*
-\newif{cmd}#*
+\newhelp{cmd}{help text}#dS
+\newif#*
+\newif{cmd}#dS
+\newinsert#*
+\newinsert{cmd}#dS
+\newlanguage#*
+\newlanguage{cmd}#dS
 \newlinechar#*
 \newmuskip#*
+\newmuskip{cmd}#dS
 \newread#*
+\newread{cmd}#dS
 \newskip#*
+\newskip{cmd}#dS
 \newtoks#*
+\newtoks{cmd}#dS
 \newwrite#*
+\newwrite{cmd}#dS
 \noalign
 \nobreak#*
 \noexpand#*


### PR DESCRIPTION
This pr is the result of #689, and the rest part of https://github.com/texstudio-org/texstudio/commit/99cafd4f0df6c49319cdc13b9891fc7672b8cdff.

Main changes:
 - add missing plain tex commands `\newfam`, `\newhelp`, `\newinsert`, and `\newlanguage`
 - let (`newXXX`-form) commands define new commands (continued)