### PR TITLE
Fix a crash when undoing/redoing code with labels and other structure elements

### DIFF
--- a/src/latexdocument.cpp
+++ b/src/latexdocument.cpp
@@ -2194,30 +2194,57 @@ void LatexStructureMergerMerge::mergeChildren(StructureEntry *se, int start){
 		mergeStructure(oldChildren[i]);
 }
 
+bool LatexDocument::IsInTree (StructureEntry *se)
+{
+	Q_ASSERT(se);
+	while (se) {
+		if (se->type == StructureEntry::SE_DOCUMENT_ROOT) {
+			return true;
+		}
+		se = se->parent;
+	}
+	return false;
+}
+
 void LatexDocument::removeElementWithSignal(StructureEntry *se)
 {
+	int sendSignal = IsInTree(se);
 	int parentRow = se->getRealParentRow();
 	REQUIRE(parentRow >= 0);
-	emit removeElement(se, parentRow);
+	if (sendSignal) {
+		emit removeElement(se, parentRow);
+	}
 	se->parent->children.removeAt(parentRow);
 	se->parent = nullptr;
-	emit removeElementFinished();
+	if (sendSignal) {
+		emit removeElementFinished();
+	}
 }
 
 void LatexDocument::addElementWithSignal(StructureEntry *parent, StructureEntry *se)
 {
-	emit addElement(parent, parent->children.size());
+	int sendSignal = IsInTree(parent);
+	if (sendSignal) {
+		emit addElement(parent, parent->children.size());
+	}
 	parent->children.append(se);
 	se->parent = parent;
-	emit addElementFinished();
+	if (sendSignal) {
+		emit addElementFinished();
+	}
 }
 
 void LatexDocument::insertElementWithSignal(StructureEntry *parent, int pos, StructureEntry *se)
 {
-	emit addElement(parent, pos);
+	int sendSignal = IsInTree(parent);
+	if (sendSignal) {
+		emit addElement(parent, pos);
+	}
 	parent->children.insert(pos, se);
 	se->parent = parent;
-	emit addElementFinished();
+	if (sendSignal) {
+		emit addElementFinished();
+	}
 }
 
 void LatexDocument::moveElementWithSignal(StructureEntry *se, StructureEntry *parent, int pos)

--- a/src/latexdocument.cpp
+++ b/src/latexdocument.cpp
@@ -527,8 +527,8 @@ bool LatexDocument::patchStructure(int linenr, int count, bool recheck)
 			int i = elem.indexOf("{");
 			if (i >= 0) elem = elem.left(i);
 			ltxCommands.possibleCommands["user"].remove(elem);
-            if(cs.type==CodeSnippet::userConstruct)
-                continue;
+			if(cs.type==CodeSnippet::userConstruct)
+				continue;
 			removedUserCommands << elem;
 			//updateSyntaxCheck=true;
 		}
@@ -638,7 +638,7 @@ bool LatexDocument::patchStructure(int linenr, int count, bool recheck)
 		}
 		if (line(i).handle() == mAppendixLine && curLine != "\\appendix") {
 			oldLine = mAppendixLine;
-            mAppendixLine = nullptr;
+			mAppendixLine = nullptr;
 		}
 		/// \end{document} keyword
 		/// don't add section in structure view after passing \end{document} , this command must not contains spaces nor any additions in the same line
@@ -649,7 +649,7 @@ bool LatexDocument::patchStructure(int linenr, int count, bool recheck)
 		}
 		if (line(i).handle() == mBeyondEnd && curLine != "\\end{document}") {
 			oldLineBeyond = mBeyondEnd;
-            mBeyondEnd = nullptr;
+			mBeyondEnd = nullptr;
 		}
 
 		for (int j = 0; j < tl.length(); j++) {
@@ -736,9 +736,9 @@ bool LatexDocument::patchStructure(int linenr, int count, bool recheck)
 			Token tkCmd;
 			TokenList args;
 			QString cmd;
-            int cmdStart = Parsing::findCommandWithArgsFromTL(tl, tkCmd, args, j, parent->showCommentedElementsInStructure);
+			int cmdStart = Parsing::findCommandWithArgsFromTL(tl, tkCmd, args, j, parent->showCommentedElementsInStructure);
 			if (cmdStart < 0) break;
-            cmdStart=tkCmd.start; // from here, cmdStart is line column position of command
+			cmdStart=tkCmd.start; // from here, cmdStart is line column position of command
 			cmd = curLine.mid(tkCmd.start, tkCmd.length);
 
 			QString firstArg = Parsing::getArg(args, dlh, 0, ArgumentList::Mandatory);
@@ -748,7 +748,7 @@ bool LatexDocument::patchStructure(int linenr, int count, bool recheck)
 				completerNeedsUpdate = true;
 				//Tokens cmdName;
 				QString cmdName = Parsing::getArg(args, Token::def);
-                cmdName.replace("@","@@"); // special treatment for commandnames containing @
+				cmdName.replace("@","@@"); // special treatment for commandnames containing @
 				bool isDefWidth = true;
 				if (cmdName.isEmpty())
 					cmdName = Parsing::getArg(args, Token::defWidth);
@@ -764,33 +764,33 @@ bool LatexDocument::patchStructure(int linenr, int count, bool recheck)
 				if (!removedUserCommands.removeAll(cmdName)) {
 					addedUserCommands << cmdName;
 				}
-                QString cmdNameWithoutOptional=cmdName;
+				QString cmdNameWithoutOptional=cmdName;
 				for (int j = 0; j < optionCount; j++) {
 					if (j == 0) {
-                        if (!def){
+						if (!def){
 							cmdName.append("{%<arg1%|%>}");
-                            cmdNameWithoutOptional.append("{%<arg1%|%>}");
-                        } else
+							cmdNameWithoutOptional.append("{%<arg1%|%>}");
+						} else
 							cmdName.append("[%<opt. arg1%|%>]");
-                    } else {
-						cmdName.append(QString("{%<arg%1%>}").arg(j + 1));
-                        cmdNameWithoutOptional.append(QString("{%<arg%1%>}").arg(j + 1));
-                    }
+						} else {
+							cmdName.append(QString("{%<arg%1%>}").arg(j + 1));
+							cmdNameWithoutOptional.append(QString("{%<arg%1%>}").arg(j + 1));
+						}
 				}
 				CodeSnippet cs(cmdName);
-                cs.index = qHash(cmdName);
-                cs.snippetLength = cmdName.length();
+				cs.index = qHash(cmdName);
+				cs.snippetLength = cmdName.length();
 				if (isDefWidth)
 					cs.type = CodeSnippet::length;
 				mUserCommandList.insert(line(i).handle(), cs);
-                if(def){ // optional argument, add version without that argument as well
-                    CodeSnippet cs(cmdNameWithoutOptional);
-                    cs.index = qHash(cmdNameWithoutOptional);
-                    cs.snippetLength = cmdNameWithoutOptional.length();
-                    if (isDefWidth)
-                        cs.type = CodeSnippet::length;
-                    mUserCommandList.insert(line(i).handle(), cs);
-                }
+				if(def){ // optional argument, add version without that argument as well
+					CodeSnippet cs(cmdNameWithoutOptional);
+					cs.index = qHash(cmdNameWithoutOptional);
+					cs.snippetLength = cmdNameWithoutOptional.length();
+					if (isDefWidth)
+						cs.type = CodeSnippet::length;
+					mUserCommandList.insert(line(i).handle(), cs);
+				}
 				// remove obsolete Overlays (maybe this can be refined
 				//updateSyntaxCheck=true;
 				continue;
@@ -816,7 +816,7 @@ bool LatexDocument::patchStructure(int linenr, int count, bool recheck)
 						} else {
 							QStringList args = optionStr.split('#'); //#1;#2#3:#4 => ["",1;,2,3:,4]
 							bool hadSeparator = true;
-                            for (int i = 1; i < args.length(); i++) {
+							for (int i = 1; i < args.length(); i++) {
 								if (args[i].length() == 0) continue; //invalid
 								bool hasSeparator = (args[i].length() != 1); //only single digit variables allowed. last arg also needs a sep
 								if (!hadSeparator || !hasSeparator)
@@ -1095,65 +1095,65 @@ bool LatexDocument::patchStructure(int linenr, int count, bool recheck)
 			if (cmd.endsWith("*"))
 				cmd = cmd.left(cmd.length() - 1);
 			int level = lp.structureCommandLevel(cmd);
-            if(level<0 && cmd=="\\begin"){
-                // special treatment for \begin{frame}{title}
-                level=lp.structureCommandLevel(cmd+"{"+firstArg+"}");
-            }
+			if(level<0 && cmd=="\\begin"){
+				// special treatment for \begin{frame}{title}
+				level=lp.structureCommandLevel(cmd+"{"+firstArg+"}");
+			}
 			if (level > -1 && !firstArg.isEmpty() && tkCmd.subtype == Token::none) {
 				StructureEntry *newSection = new StructureEntry(this, StructureEntry::SE_SECTION);
 				if (mAppendixLine && indexOf(mAppendixLine) < i) newSection->setContext(StructureEntry::InAppendix);
 				if (mBeyondEnd && indexOf(mBeyondEnd) < i) newSection->setContext(StructureEntry::BeyondEnd);
-                //QString firstOptArg = Parsing::getArg(args, dlh, 0, ArgumentList::Optional);
-                QString firstOptArg = Parsing::getArg(args, Token::shorttitle);
+				//QString firstOptArg = Parsing::getArg(args, dlh, 0, ArgumentList::Optional);
+				QString firstOptArg = Parsing::getArg(args, Token::shorttitle);
 				if (!firstOptArg.isEmpty() && firstOptArg != "[]") // workaround, actually getArg should return "" for "[]"
 					firstArg = firstOptArg;
-                if(cmd=="\\begin"){
-                    // special treatment for \begin{frame}{title}
-                    firstArg = Parsing::getArg(args, dlh, 1, ArgumentList::MandatoryWithBraces,false);
-                    if(firstArg.isEmpty()){
-                        // empty frame title, maybe \frametitle is used ?
-                        delete newSection;
-                        continue;
-                    }
-                }
+				if(cmd=="\\begin"){
+					// special treatment for \begin{frame}{title}
+					firstArg = Parsing::getArg(args, dlh, 1, ArgumentList::MandatoryWithBraces,false);
+					if(firstArg.isEmpty()){
+						// empty frame title, maybe \frametitle is used ?
+						delete newSection;
+						continue;
+					}
+				}
 				newSection->title = latexToText(firstArg).trimmed();
 				newSection->level = level;
 				newSection->setLine(line(i).handle(), i);
 				newSection->columnNumber = cmdStart;
 				flatStructure << newSection;
-                                continue;
-            }
-            /// auto user command for \symbol_...
-            if(j+2<tl.length()){
-                Token tk2=tl.at(j+1);
-                if(tk2.getText()=="_"){
-                    QString txt=cmd+"_";
-                    tk2=tl.at(j+2);
-                    txt.append(tk2.getText());
-                    if(tk2.type==Token::command && j+3<tl.length()){
-                        Token tk3=tl.at(j+3);
-                        if(tk3.level==tk2.level && tk.subtype!=Token::none)
-                            txt.append(tk3.getText());
-                    }
-                    CodeSnippet cs(txt);
-                    cs.type=CodeSnippet::userConstruct;
-                    mUserCommandList.insert(line(i).handle(), cs);
-                }
-            }
-            /// auto user commands of \mathcmd{one arg} e.g. \mathsf{abc} or \overbrace{abc}
-            if(j+2<tl.length() && !firstArg.isEmpty() && lp.possibleCommands["math"].contains(cmd) ){
-                if (lp.commandDefs.contains(cmd)) {
-                    CommandDescription cd = lp.commandDefs.value(cmd);
-                    if(cd.args==1 && cd.bracketArgs==0 && cd.optionalArgs==0){
-                        QString txt=cmd+"{"+firstArg+"}";
-                        CodeSnippet cs(txt);
-                        cs.type=CodeSnippet::userConstruct;
-                        mUserCommandList.insert(line(i).handle(), cs);
-                    }
-                }
-            }
+				continue;
+			}
+			/// auto user command for \symbol_...
+			if(j+2<tl.length()){
+				Token tk2=tl.at(j+1);
+				if(tk2.getText()=="_"){
+					QString txt=cmd+"_";
+					tk2=tl.at(j+2);
+					txt.append(tk2.getText());
+					if(tk2.type==Token::command && j+3<tl.length()){
+						Token tk3=tl.at(j+3);
+						if(tk3.level==tk2.level && tk.subtype!=Token::none)
+							txt.append(tk3.getText());
+					}
+					CodeSnippet cs(txt);
+					cs.type=CodeSnippet::userConstruct;
+					mUserCommandList.insert(line(i).handle(), cs);
+				}
+			}
+			/// auto user commands of \mathcmd{one arg} e.g. \mathsf{abc} or \overbrace{abc}
+			if(j+2<tl.length() && !firstArg.isEmpty() && lp.possibleCommands["math"].contains(cmd) ){
+				if (lp.commandDefs.contains(cmd)) {
+					CommandDescription cd = lp.commandDefs.value(cmd);
+					if(cd.args==1 && cd.bracketArgs==0 && cd.optionalArgs==0){
+						QString txt=cmd+"{"+firstArg+"}";
+						CodeSnippet cs(txt);
+						cs.type=CodeSnippet::userConstruct;
+						mUserCommandList.insert(line(i).handle(), cs);
+					}
+				}
+			}
 
-        } // while(findCommandWithArgs())
+		} // while(findCommandWithArgs())
 
 		if (!oldBibs.isEmpty())
 			bibTeXFilesNeedsUpdate = true; //file name removed
@@ -1165,7 +1165,7 @@ bool LatexDocument::patchStructure(int linenr, int count, bool recheck)
 		if (syntaxChecking && languageIsLatexLike()) {
 			StackEnvironment env;
 			getEnv(i, env);
-            QDocumentLineHandle *lastHandle = nullptr;
+			QDocumentLineHandle *lastHandle = nullptr;
 			TokenStack oldRemainder;
 			if (i > 0) {
 				lastHandle = line(i - 1).handle();
@@ -1185,7 +1185,7 @@ bool LatexDocument::patchStructure(int linenr, int count, bool recheck)
 
 		for (int i = categories.size() - 1; i >= 0; i--) {
 			StructureEntry *cat = categories[i];
-            if (cat->children.isEmpty() == (cat->parent == nullptr)) continue;
+			if (cat->children.isEmpty() == (cat->parent == nullptr)) continue;
 			if (cat->children.isEmpty()) removeElementWithSignal(cat);
 			else insertElementWithSignal(baseStructure, 0, cat);
 		}
@@ -1200,7 +1200,7 @@ bool LatexDocument::patchStructure(int linenr, int count, bool recheck)
 		}
 
 		// rehighlight current cursor position
-        StructureEntry *newSection = nullptr;
+		StructureEntry *newSection = nullptr;
 		if (edView) {
 			int i = edView->editor->cursor().lineNumber();
 			if (i >= 0) {
@@ -1208,8 +1208,8 @@ bool LatexDocument::patchStructure(int linenr, int count, bool recheck)
 			}
 		}
 
-        emit structureUpdated(this, newSection);
-        //emit setHighlightedEntry(newSection);
+		emit structureUpdated(this, newSection);
+		//emit setHighlightedEntry(newSection);
 	}
 	StructureEntry *se;
 	foreach (se, MapOfTodo.values())

--- a/src/latexdocument.cpp
+++ b/src/latexdocument.cpp
@@ -2539,7 +2539,7 @@ void LatexDocuments::updateStructure()
 		model->updateElement(doc->baseStructure);
 	}
 	if (model->getSingleDocMode()) {
-        model->structureUpdated(currentDocument, nullptr);
+		model->structureUpdated(currentDocument, nullptr);
 	}
 }
 

--- a/src/latexdocument.cpp
+++ b/src/latexdocument.cpp
@@ -1179,6 +1179,28 @@ bool LatexDocument::patchStructure(int linenr, int count, bool recheck)
 			SynChecker.putLine(line(i).handle(), env, oldRemainder, true);
 		}
 	}//for each line handle
+	StructureEntry *se;
+	foreach (se, MapOfTodo.values()) {
+		removeElementWithSignal(se);
+		delete se;
+	}
+	foreach (se, MapOfBibtex.values()) {
+		removeElementWithSignal(se);
+		delete se;
+	}
+	foreach (se, MapOfBlock.values()) {
+		removeElementWithSignal(se);
+		delete se;
+	}
+	foreach (se, MapOfLabels.values()) {
+		removeElementWithSignal(se);
+		delete se;
+	}
+	foreach (se, MapOfMagicComments.values()) {
+		removeElementWithSignal(se);
+		delete se;
+	}
+	StructureEntry *newSection = nullptr;
 	if (!isHidden()) {
 		LatexStructureMergerMerge(this, lp.structureDepth(), lineNrStart, newCount)(flatStructure);
 
@@ -1202,7 +1224,6 @@ bool LatexDocument::patchStructure(int linenr, int count, bool recheck)
 		}
 
 		// rehighlight current cursor position
-		StructureEntry *newSection = nullptr;
 		if (edView) {
 			int i = edView->editor->cursor().lineNumber();
 			if (i >= 0) {
@@ -1210,24 +1231,9 @@ bool LatexDocument::patchStructure(int linenr, int count, bool recheck)
 			}
 		}
 
-		emit structureUpdated(this, newSection);
 		//emit setHighlightedEntry(newSection);
 	}
-	StructureEntry *se;
-	foreach (se, MapOfTodo.values())
-		delete se;
-
-	foreach (se, MapOfBibtex.values())
-		delete se;
-
-	foreach (se, MapOfBlock.values())
-		delete se;
-
-	foreach (se, MapOfLabels.values())
-		delete se;
-
-	foreach (se, MapOfMagicComments.values())
-		delete se;
+	emit structureUpdated(this, newSection);
 	bool updateLtxCommands = false;
 	if (!addedUsepackages.isEmpty() || !removedUsepackages.isEmpty() || !addedUserCommands.isEmpty() || !removedUserCommands.isEmpty()) {
 		bool forceUpdate = !addedUserCommands.isEmpty() || !removedUserCommands.isEmpty();
@@ -2132,23 +2138,17 @@ void LatexDocuments::hideDocInEditor(LatexEditorView *edView)
 void LatexDocument::findStructureEntryBefore(QMutableListIterator<StructureEntry *> &iter, QMultiHash<QDocumentLineHandle *, StructureEntry *> &MapOfElements, int linenr, int count)
 {
 	bool goBack = false;
-	int l = 0;
 	while (iter.hasNext()) {
 		StructureEntry *se = iter.next();
 		int realline = se->getRealLineNumber();
 		Q_ASSERT(realline >= 0);
 		if (realline >= linenr && (realline < linenr + count) ) {
-			emit removeElement(se, l);
-			iter.remove();
-			emit removeElementFinished();
 			MapOfElements.insert(se->getLineHandle(), se);
-			l--;
 		}
 		if (realline >= linenr + count) {
 			goBack = true;
 			break;
 		}
-		l++;
 	}
 	if (goBack && iter.hasPrevious()) iter.previous();
 }

--- a/src/latexdocument.cpp
+++ b/src/latexdocument.cpp
@@ -41,8 +41,8 @@ LatexDocument::LatexDocument(QObject *parent): QDocument(parent), remeberAutoRel
 	mBibItem.clear();
 	mUserCommandList.clear();
 	mMentionedBibTeXFiles.clear();
-    masterDocument = nullptr;
-    this->parent = nullptr;
+	masterDocument = nullptr;
+	this->parent = nullptr;
 
 	unclosedEnv.id = -1;
 	syntaxChecking = true;
@@ -80,11 +80,11 @@ void LatexDocument::setFileName(const QString &fileName)
 	//clear all references to old editor
 	if (this->edView) {
 		StructureEntryIterator iter(baseStructure);
-        while (iter.hasNext()) iter.next()->setLine(nullptr);
+		while (iter.hasNext()) iter.next()->setLine(nullptr);
 	}
 
 	this->setFileNameInternal(fileName);
-    this->edView = nullptr;
+	this->edView = nullptr;
 }
 
 void LatexDocument::setEditorView(LatexEditorView *edView)
@@ -191,8 +191,9 @@ QDocumentSelection LatexDocument::sectionSelection(StructureEntry *section)
 class LatexStructureMerger{
 public:
 	LatexStructureMerger (LatexDocument* document, int maxDepth):
-		document(document), parent_level(maxDepth){
-    }
+		document(document), parent_level(maxDepth)
+	{
+	}
 
 protected:
 	LatexDocument* document;
@@ -205,8 +206,9 @@ protected:
 class LatexStructureMergerMerge: public LatexStructureMerger{
 public:
 	LatexStructureMergerMerge (LatexDocument* document, int maxDepth, int linenr, int count):
-        LatexStructureMerger(document, maxDepth), linenr(linenr), count(count),flatStructure(nullptr) {
-    }
+		LatexStructureMerger(document, maxDepth), linenr(linenr), count(count), flatStructure(nullptr)
+	{
+	}
 	void operator ()(QList<StructureEntry *> &flatStructure){
 		this->flatStructure = &flatStructure;
 		parent_level.fill(document->baseStructure);
@@ -233,11 +235,11 @@ void LatexDocument::initClearStructure()
 	mRefItem.clear();
 	mMentionedBibTeXFiles.clear();
 
-    mAppendixLine = nullptr;
-    mBeyondEnd = nullptr;
+	mAppendixLine = nullptr;
+	mBeyondEnd = nullptr;
 
 
-    emit structureUpdated(this, nullptr);
+	emit structureUpdated(this, nullptr);
 
 	const int CATCOUNT = 5;
 	StructureEntry *categories[CATCOUNT] = {magicCommentList, labelList, todoList, bibTeXList, blockList};
@@ -313,8 +315,8 @@ void LatexDocument::patchStructureRemoval(QDocumentLineHandle *dlh)
 	mUsepackageList.remove(dlh);
 
 	if (dlh == mAppendixLine) {
-        updateContext(mAppendixLine, nullptr, StructureEntry::InAppendix);
-        mAppendixLine = nullptr;
+		updateContext(mAppendixLine, nullptr, StructureEntry::InAppendix);
+		mAppendixLine = nullptr;
 	}
 
 	int linenr = indexOf(dlh);
@@ -350,7 +352,7 @@ void LatexDocument::patchStructureRemoval(QDocumentLineHandle *dlh)
 	LatexStructureMergerMerge(this, LatexParser::getInstance().structureDepth(), linenr, 1)(tmp);
 
 	// rehighlight current cursor position
-    StructureEntry *newSection = nullptr;
+	StructureEntry *newSection = nullptr;
 	if (edView) {
 		int i = edView->editor->cursor().lineNumber();
 		if (i >= 0) {
@@ -358,8 +360,8 @@ void LatexDocument::patchStructureRemoval(QDocumentLineHandle *dlh)
 		}
 	}
 
-    emit structureUpdated(this, newSection);
-    //emit setHighlightedEntry(newSection);
+	emit structureUpdated(this, newSection);
+	//emit setHighlightedEntry(newSection);
 
 	if (bibTeXFilesNeedsUpdate)
 		emit updateBibTeXFiles();
@@ -1449,22 +1451,22 @@ void LatexDocument::replaceItems(QMultiHash<QDocumentLineHandle *, ReferencePair
 		cur->beginEditBlock();
 	}
 	QMultiHash<QDocumentLineHandle *, ReferencePair>::const_iterator it;
-    int oldLineNr=-1;
-    int offset=0;
+	int oldLineNr=-1;
+	int offset=0;
 	for (it = items.constBegin(); it != items.constEnd(); ++it) {
 		QDocumentLineHandle *dlh = it.key();
 		ReferencePair rp = it.value();
 		int lineNo = indexOf(dlh);
-        if(oldLineNr!=lineNo){
-            offset=0;
-        }
+		if(oldLineNr!=lineNo){
+			offset=0;
+		}
 		if (lineNo >= 0) {
 			cur->setLineNumber(lineNo);
-            cur->setColumnNumber(rp.start+offset);
+			cur->setColumnNumber(rp.start+offset);
 			cur->movePosition(rp.name.length(), QDocumentCursor::NextCharacter, QDocumentCursor::KeepAnchor);
 			cur->replaceSelectedText(newName);
-            offset+=newName.length()-rp.name.length();
-            oldLineNr=lineNo;
+			offset+=newName.length()-rp.name.length();
+			oldLineNr=lineNo;
 		}
 	}
 	if (!cursor) {
@@ -1699,7 +1701,7 @@ void LatexDocuments::addDocument(LatexDocument *document, bool hidden)
 	connect(document, SIGNAL(updateBibTeXFiles()), SLOT(bibTeXFilesNeedUpdate()));
 	connect(document, SIGNAL(structureLost(LatexDocument *)), model, SLOT(structureLost(LatexDocument *)));
 	connect(document, SIGNAL(structureUpdated(LatexDocument *, StructureEntry *)), model, SLOT(structureUpdated(LatexDocument *, StructureEntry *)));
-    //connect(document, SIGNAL(setHighlightedEntry(StructureEntry *)), model, SLOT(setHighlightedEntry(StructureEntry *)));
+	//connect(document, SIGNAL(setHighlightedEntry(StructureEntry *)), model, SLOT(setHighlightedEntry(StructureEntry *)));
 	connect(document, SIGNAL(toBeChanged()), model, SIGNAL(layoutAboutToBeChanged()));
 	connect(document, SIGNAL(removeElement(StructureEntry *, int)), model, SLOT(removeElement(StructureEntry *, int)));
 	connect(document, SIGNAL(removeElementFinished()), model, SLOT(removeElementFinished()));
@@ -1715,7 +1717,7 @@ void LatexDocuments::addDocument(LatexDocument *document, bool hidden)
 		}
 	}
 	if (!hidden)
-        model->structureUpdated(document, nullptr);
+		model->structureUpdated(document, nullptr);
 }
 
 void LatexDocuments::deleteDocument(LatexDocument *document, bool hidden, bool purge)
@@ -1744,7 +1746,7 @@ void LatexDocuments::deleteDocument(LatexDocument *document, bool hidden, bool p
 					if (elem->isHidden())
 						deleteDocument(elem, true, true);
 					else
-                        elem->setMasterDocument(nullptr);
+						elem->setMasterDocument(nullptr);
 				}
 			}
 			delete document;
@@ -1824,7 +1826,7 @@ void LatexDocuments::deleteDocument(LatexDocument *document, bool hidden, bool p
 			hideDocInEditor(document->getEditorView());
 			return;
 		}
-        delete view;
+		delete view;
 		delete document;
 	} else {
 		if (hidden) {
@@ -1834,9 +1836,9 @@ void LatexDocuments::deleteDocument(LatexDocument *document, bool hidden, bool p
 		document->setFileName(document->getFileName());
 		model->resetAll();
 		document->clearAppendix();
-        delete view;
+		delete view;
 		if (document == currentDocument)
-            currentDocument = nullptr;
+			currentDocument = nullptr;
 	}
 }
 
@@ -1850,17 +1852,17 @@ void LatexDocuments::requestedClose()
 void LatexDocuments::setMasterDocument(LatexDocument *document)
 {
 	if (document == masterDocument) return;
-    if (masterDocument != nullptr && masterDocument->getEditorView() == nullptr) {
+	if (masterDocument != nullptr && masterDocument->getEditorView() == nullptr) {
 		QString fn = masterDocument->getFileName();
 		addDocToLoad(fn);
 		LatexDocument *doc = masterDocument;
-        masterDocument = nullptr;
+		masterDocument = nullptr;
 		deleteDocument(doc);
 		//documents.removeAll(masterDocument);
 		//delete masterDocument;
 	}
 	masterDocument = document;
-    if (masterDocument != nullptr) {
+	if (masterDocument != nullptr) {
 		documents.removeAll(masterDocument);
 		documents.prepend(masterDocument);
 		// repaint doc
@@ -2072,7 +2074,7 @@ void LatexDocuments::updateBibFiles(bool updateFiles)
 			bibTex.loadIfModified(fileName);
 
 			/*if (bibTex.loadIfModified(fileName))
-			  changed = true;*/
+				changed = true;*/
 			if (bibTex.ids.empty() && !bibTex.linksTo.isEmpty())
 				//handle obscure bib tex feature, a just line containing "link fileName"
 				mentionedBibTeXFiles.append(bibTex.linksTo);
@@ -2080,16 +2082,16 @@ void LatexDocuments::updateBibFiles(bool updateFiles)
 	}
 	/*
 	if (changed || (newBibItems!=bibItems)) {
-	  allBibTeXIds.clear();
-	  bibItems=newBibItems;
-	  for (QMap<QString, BibTeXFileInfo>::const_iterator it=bibTeXFiles.constBegin(); it!=bibTeXFiles.constEnd();++it)
-	    foreach (const QString& s, it.value().ids)
-	      allBibTeXIds << s;
-	  allBibTeXIds.unite(bibItems);
-	  for (int i=0;i<documents.size();i++)
-	    if (documents[i]->getEditorView())
-	      documents[i]->getEditorView()->setBibTeXIds(&allBibTeXIds);
-	  bibTeXFilesModified=true;
+		allBibTeXIds.clear();
+		bibItems=newBibItems;
+		for (QMap<QString, BibTeXFileInfo>::const_iterator it=bibTeXFiles.constBegin(); it!=bibTeXFiles.constEnd();++it)
+			foreach (const QString& s, it.value().ids)
+		allBibTeXIds << s;
+		allBibTeXIds.unite(bibItems);
+		for (int i=0;i<documents.size();i++)
+			if (documents[i]->getEditorView())
+				documents[i]->getEditorView()->setBibTeXIds(&allBibTeXIds);
+		bibTeXFilesModified=true;
 	}*/
 }
 
@@ -2106,7 +2108,7 @@ void LatexDocuments::removeDocs(QStringList removeIncludes)
 		}
 		if (dc && dc->isHidden()) {
 			QStringList toremove = dc->includedFiles();
-            dc->setMasterDocument(nullptr);
+			dc->setMasterDocument(nullptr);
 			hiddenDocuments.removeAll(dc);
 			//qDebug()<<fname;
 			delete dc->getEditorView();
@@ -2244,7 +2246,7 @@ void LatexDocument::removeElementWithSignal(StructureEntry *se)
 	REQUIRE(parentRow >= 0);
 	emit removeElement(se, parentRow);
 	se->parent->children.removeAt(parentRow);
-    se->parent = nullptr;
+	se->parent = nullptr;
 	emit removeElementFinished();
 }
 
@@ -2297,7 +2299,7 @@ public:
 void LatexStructureMerger::moveToAppropiatePositionWithSignal(StructureEntry *se)
 {
 	REQUIRE(se);
-    StructureEntry *newParent = parent_level.value(se->level, nullptr);
+	StructureEntry *newParent = parent_level.value(se->level, nullptr);
 	if (!newParent) {
 		qDebug("structure update failed!");
 		return;
@@ -2550,7 +2552,7 @@ void LatexDocuments::updateMasterSlaveRelations(LatexDocument *doc, bool recheck
 {
 	//update Master/Child relations
 	//remove old settings ...
-    doc->setMasterDocument(nullptr, false);
+	doc->setMasterDocument(nullptr, false);
 	QList<LatexDocument *> docs = getDocuments();
 	foreach (LatexDocument *elem, docs) {
 		if (elem->getMasterDocument() == doc) {
@@ -2673,8 +2675,8 @@ bool LatexDocument::updateCompletionFiles(bool forceUpdate, bool forceLabelUpdat
 	//recheck syntax of ALL documents ...
 	LatexPackage pck;
 	pck.commandDescriptions = latexParser.commandDefs;
-    pck.specialDefCommands = latexParser.specialDefCommands;
-    QStringList loadedFiles;
+	pck.specialDefCommands = latexParser.specialDefCommands;
+	QStringList loadedFiles;
 	for (int i = 0; i < files.count(); i++) {
 		if (!files.at(i).endsWith(".cwl"))
 			files[i] = files[i] + ".cwl";
@@ -2843,7 +2845,7 @@ StructureEntry *LatexDocument::getMagicCommentEntry(const QString &name) const
 	QString seName;
 	QString val;
 
-    if (!magicCommentList) return nullptr;
+	if (!magicCommentList) return nullptr;
 
 	StructureEntryIterator iter(magicCommentList);
 	while (iter.hasNext()) {
@@ -2851,7 +2853,7 @@ StructureEntry *LatexDocument::getMagicCommentEntry(const QString &name) const
 		splitMagicComment(se->title, seName, val);
 		if (seName == name) return se;
 	}
-    return nullptr;
+	return nullptr;
 }
 
 /*!

--- a/src/latexdocument.h
+++ b/src/latexdocument.h
@@ -228,6 +228,7 @@ private:
 
 	int findStructureParentPos(const QList<StructureEntry *> &children, QList<StructureEntry *> &removedElements, int linenr, int count);
 
+	bool IsInTree (StructureEntry *se);
 	void updateElementWithSignal(StructureEntry *se){ emit updateElement(se); }
 	void removeElementWithSignal(StructureEntry *se);
 	void addElementWithSignal(StructureEntry *parent, StructureEntry *se);

--- a/src/latexdocument.h
+++ b/src/latexdocument.h
@@ -226,7 +226,7 @@ private:
 	void updateContext(QDocumentLineHandle *oldLine, QDocumentLineHandle *newLine, StructureEntry::Context context);
 	void setContextForLines(StructureEntry *se, int startLine, int endLine, StructureEntry::Context context, bool state);
 
-	void findStructureEntryBefore(QMutableListIterator<StructureEntry *> &iter, QMultiHash<QDocumentLineHandle *, StructureEntry *> &MapOfElemnts, int linenr, int count);
+	int findStructureParentPos(const QList<StructureEntry *> &children, QList<StructureEntry *> &removedElements, int linenr, int count);
 
 	void updateElementWithSignal(StructureEntry *se){ emit updateElement(se); }
 	void removeElementWithSignal(StructureEntry *se);
@@ -234,7 +234,7 @@ private:
 	void insertElementWithSignal(StructureEntry *parent, int pos, StructureEntry *se);
 	void moveElementWithSignal(StructureEntry *se, StructureEntry *parent, int pos);
 
-	void addMagicComment(const QString &text, int lineNr, QMultiHash<QDocumentLineHandle *, StructureEntry *> &MapOfMagicComments, QMutableListIterator<StructureEntry *> &iter_magicComment);
+	void addMagicComment(const QString &text, int lineNr, int posMagicComment);
 	void parseMagicComment(const QString &name, const QString &val, StructureEntry *se);
 
 	void gatherCompletionFiles(QStringList &files, QStringList &loadedFiles, LatexPackage &pck, bool gatherForCompleter = false);

--- a/src/latexstructure.cpp
+++ b/src/latexstructure.cpp
@@ -320,7 +320,9 @@ QModelIndex LatexDocumentsModel::index ( int row, int column, const QModelIndex 
 			return QModelIndex(); //should never happen
 		}
 		if (row >= entry->children.size()) {
-			return QModelIndex(); //shouldn't happen in a correct view
+			// QAbstractItemView::rowsAboutToBeRemoved can call us with row == entry->children.size()
+			// if there are no visible and enabled rows after the last removed row
+			return QModelIndex();
 		}
 		return createIndex(row, column, entry->children.at(row));
 	} else {

--- a/src/latexstructure.cpp
+++ b/src/latexstructure.cpp
@@ -311,11 +311,17 @@ int LatexDocumentsModel::columnCount ( const QModelIndex &parent ) const
 QModelIndex LatexDocumentsModel::index ( int row, int column, const QModelIndex &parent ) const
 {
 	if (column != 0) return QModelIndex(); //one column
-	if (row < 0) return QModelIndex(); //shouldn't happen
+	if (row < 0) {
+		return QModelIndex(); //shouldn't happen
+	}
 	if (parent.isValid()) {
-        const StructureEntry *entry = static_cast<StructureEntry *>(parent.internalPointer());
-		if (!entry) return QModelIndex(); //should never happen
-		if (row >= entry->children.size()) return QModelIndex(); //shouldn't happen in a correct view
+		const StructureEntry *entry = static_cast<StructureEntry *>(parent.internalPointer());
+		if (!entry) {
+			return QModelIndex(); //should never happen
+		}
+		if (row >= entry->children.size()) {
+			return QModelIndex(); //shouldn't happen in a correct view
+		}
 		return createIndex(row, column, entry->children.at(row));
 	} else {
 		if (row >= documents.documents.size()) return QModelIndex();
@@ -332,19 +338,25 @@ QModelIndex LatexDocumentsModel::index ( int row, int column, const QModelIndex 
 
 QModelIndex LatexDocumentsModel::index ( StructureEntry *entry ) const
 {
-	if (!entry) return QModelIndex();
-    if (entry->parent == nullptr && entry->type == StructureEntry::SE_DOCUMENT_ROOT) {
+	if (!entry) {
+		return QModelIndex();
+	}
+	if (entry->parent == nullptr && entry->type == StructureEntry::SE_DOCUMENT_ROOT) {
 		int row = documents.documents.indexOf(entry->document);
 		if (m_singleMode) {
 			row = 0;
 		}
 		if (row < 0) return QModelIndex();
 		return createIndex(row, 0, entry);
-    } else if (entry->parent != nullptr && entry->type != StructureEntry::SE_DOCUMENT_ROOT) {
+	} else if (entry->parent != nullptr && entry->type != StructureEntry::SE_DOCUMENT_ROOT) {
 		int row = entry->getRealParentRow();
-		if (row < 0) return QModelIndex(); //shouldn't happen
+		if (row < 0) {
+			return QModelIndex(); //shouldn't happen
+		}
 		return createIndex(row, 0, entry);
-	} else return QModelIndex(); //shouldn't happen
+	} else {
+		return QModelIndex(); //shouldn't happen
+	}
 }
 
 QModelIndex LatexDocumentsModel::parent ( const QModelIndex &index ) const


### PR DESCRIPTION
There is an easily reproducible crash that occurs when a user uses multiple undo/redo on code that contains labels or other structure elements.

How to reproduce the crash:

1. Create a simple tex file with only two lines:
\label{abc}
\label{def}

2. In the structure view panel on the left open tree with the labels. Right click on the "def" label (the second label), select "Find usages", then in the "Replace by" box enter "def2" (any different name will do), then click the [Replace all] button.

3. In the structure view panel on the left right click on the "abc" label (the first label), select "Find usages", then in the "Replace by" box enter "abc2" (any different name will do), then click the [Replace all] button.

4. Then in the main text window click the undo (CTRL-Z) and redo (CTRL-SHIFT-Z) shortcuts in the following order.

CTRL-Z (undo)
CTRL-Z (undo)
CTRL-SHIFT-Z (redo)
CTRL-SHIFT-Z (redo)
CTRL-Z (undo)
CTRL-Z (undo)
CTRL-SHIFT-Z (redo)
CTRL-SHIFT-Z (redo)
CTRL-Z (undo)
CTRL-Z (undo)
CTRL-SHIFT-Z (redo)
CTRL-SHIFT-Z (redo)

It usually takes 2-3 undo-redo loops until TexStudio crashes.

The reason for the crash is that the structure view panel on the left uses a QTreeView control which implements QItemSelectionModel that keeps the current selection in persistent indexes (QPersistentModelIndex)
These persistent indexes should be updated when the code in LatexDocument::patchStructure adds and removes rows. However patchStructure does not send update notifications for most changes (it only notifies for category addition/removal).
So once the persistent indexes go out of sync with the actual entries in the tree view and sooner or later it tries to reference an already freed StructureEntry item (the data item for QPersistentModelIndex). Such attempt to work with an already freed StructureEntry data causes a crash.

The only reasonable solution is to keep any persistent indexes (QPersistentModelIndex) in sync with the QTreeView items which means that we must notify the control of any changes to the data items either explicitly through changePersistentIndex/changePersistentIndexList or implicitly by calling the member functions beginInsertRows/beginMoveRows/beginRemoveRows/endInsertRows/endMoveRows/endRemoveRows.

The proposed patch uses the second approach since the code already has most of the infrastructure for that it arguably it is the proper solution anyway because these member functions will call take care of the calculations that we would have to do if we were to use changePersistentIndex/changePersistentIndexList.

The updated code seems to work correctly for me and it does not crash. However it is a significant change so maybe it needs more thorough testing.
