### PR TITLE
minor changes to declare-catch regex

### DIFF
--- a/src/latexstyleparser.cpp
+++ b/src/latexstyleparser.cpp
@@ -203,11 +203,11 @@ QString LatexStyleParser::makeArgString(int count, bool withOptional) const
  */
 QStringList LatexStyleParser::parseLine(const QString &line, bool &inRequirePackage, QStringList &parsedPackages, const QString &fileName) const
 {
-	static const QRegExp rxDef("\\\\def\\s*(\\\\[\\w@]+)(\\s*#1)?(\\s*#2)?(\\s*#3)?(\\s*#4)?(\\s*#5)?");
+	static const QRegExp rxDef("\\\\[egx]?def\\s*(\\\\[\\w@]+)(\\s*#1)?(\\s*#2)?(\\s*#3)?(\\s*#4)?(\\s*#5)?");
 	static const QRegExp rxLet("\\\\let\\s*(\\\\[\\w@]+)");
-	static const QRegExp rxCom("\\\\(newcommand|providecommand|DeclareRobustCommand)\\*?\\s*\\{(\\\\\\w+)\\}\\s*\\[?(\\d+)?\\]?(?:\\s*\\[([^\\]]+)\\])?");
-	static const QRegExp rxComNoBrace("\\\\(newcommand|providecommand|DeclareRobustCommand)\\*?\\s*(\\\\\\w+)\\s*\\[?(\\d+)?\\]?(?:\\s*\\[([^\\]]+)\\])?");
-	static const QRegExp rxEnv("\\\\newenvironment\\s*\\{(\\w+)\\}\\s*\\[?(\\d+)?\\]?");
+	static const QRegExp rxCom("\\\\(newcommand|providecommand|DeclareRobustCommand)\\*?\\s*\\{(\\\\\\w+)\\}\\s*\\[?(\\d+)?\\]?(?:\\s*\\[([^\\]]*)\\])?");
+	static const QRegExp rxComNoBrace("\\\\(newcommand|providecommand|DeclareRobustCommand)\\*?\\s*(\\\\\\w+)\\s*\\[?(\\d+)?\\]?(?:\\s*\\[([^\\]]*)\\])?");
+	static const QRegExp rxEnv("\\\\newenvironment\\*?\\s*\\{(\\w+)\\}\\s*\\[?(\\d+)?\\]?");
 	static const QRegExp rxInput("\\\\input\\s*\\{?([\\w._]+)");
     static QRegExp rxRequire("\\\\(RequirePackage|RequirePackageWithOptions)\\s*\\{(\\S+)\\}");
 	rxRequire.setMinimal(true);


### PR DESCRIPTION
Main changes:
 - add support for `\edef`, `\gdef`, and `\xdef`, whose syntax is identical to `\def`'s
 - allow empty default value for optional argument, e.g., `\newcommand\abc[1][]{code}`
 - allow optional star right after `\newenvironment`, see [related doc](https://latexref.xyz/_005cnewenvironment-_0026-_005crenewenvironment.html#g_t_005cnewenvironment-_0026-_005crenewenvironment)