### PR TITLE
When looking for .bbl files also check in the additional PDF search paths

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -5916,12 +5916,14 @@ void Texstudio::runBibliographyIfNecessary(const QFileInfo &mainFile)
 
 	QList<LatexDocument *> docs = rootDoc->getListOfDocs();
 	QSet<QString> bibFiles;
-	foreach (const LatexDocument *doc, docs)
-		foreach (const FileNamePair &bf, doc->mentionedBibTeXFiles())
+	foreach (const LatexDocument *doc, docs) {
+		foreach (const FileNamePair &bf, doc->mentionedBibTeXFiles()) {
 			bibFiles.insert(bf.absolute);
-    if(bibFiles.isEmpty()){
-        return; // don't try to compile bibtex files if there none
-    }
+		}
+	}
+	if(bibFiles.isEmpty()) {
+		return; // don't try to compile bibtex files if there none
+	}
 	if (bibFiles == rootDoc->lastCompiledBibTeXFiles) {
 		QFileInfo bbl(BuildManager::parseExtendedCommandLine("?am.bbl", documents.getTemporaryCompileFileName()).first());
 		if (bbl.exists()) {
@@ -5936,7 +5938,7 @@ void Texstudio::runBibliographyIfNecessary(const QFileInfo &mainFile)
 				}
 			}
 			if (!bibFilesChanged) return;
-        }
+		}
 	} else rootDoc->lastCompiledBibTeXFiles = bibFiles;
 
 	runBibliographyIfNecessaryEntered = true;

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -5947,22 +5947,14 @@ void Texstudio::runBibliographyIfNecessary(const QFileInfo &mainFile)
 QDateTime Texstudio::GetBblLastModified(void)
 {
 	QFileInfo compileFile (documents.getTemporaryCompileFileName());
-	QString bblPathname = findInLogPaths(
-		compileFile.absolutePath(),
-		compileFile.completeBaseName() + ".bbl"
-	);
+	QStringList searchPaths;
+	searchPaths << compileFile.absolutePath();
+	searchPaths << splitPaths(BuildManager::resolvePaths(buildManager.additionalLogPaths));
+	QString bblPathname = buildManager.findFile(compileFile.completeBaseName() + ".bbl", searchPaths, true);
 	if (bblPathname == "") {
 		return QDateTime();
 	}
 	return QFileInfo(bblPathname).lastModified();
-}
-
-QString Texstudio::findInLogPaths(const QString &primaryPath, const QString &fileName)
-{
-	QStringList searchPaths;
-	searchPaths << primaryPath;
-	searchPaths << splitPaths(BuildManager::resolvePaths(buildManager.additionalLogPaths));
-	return buildManager.findFile(fileName, searchPaths, true);
 }
 
 void Texstudio::runInternalCommand(const QString &cmd, const QFileInfo &mainfile, const QString &options)

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -5833,7 +5833,9 @@ void Texstudio::runInternalPdfViewer(const QFileInfo &master, const QString &opt
 
 	if (pdfFile.isNull()) pdfFile = "?am.pdf";  // no file was explicitly specified in the command
 	QString pdfDefFile = BuildManager::parseExtendedCommandLine(pdfFile, master).first();
-	pdfFile = findInPdfPaths(master.absolutePath(), pdfDefFile);
+	QStringList searchPaths = splitPaths(BuildManager::resolvePaths(buildManager.additionalPdfPaths));
+	searchPaths.insert(0, master.absolutePath());
+	pdfFile = buildManager.findFile(pdfDefFile, searchPaths, true);
 	if (pdfFile == "") pdfFile = pdfDefFile; //use old file name, so pdf viewer shows reasonable error message
 	int ln = 0;
 	int col = 0;
@@ -5945,7 +5947,7 @@ void Texstudio::runBibliographyIfNecessary(const QFileInfo &mainFile)
 QDateTime Texstudio::GetBblLastModified(void)
 {
 	QFileInfo compileFile (documents.getTemporaryCompileFileName());
-	QString bblPathname = findInPdfPaths(
+	QString bblPathname = findInLogPaths(
 		compileFile.absolutePath(),
 		compileFile.completeBaseName() + ".bbl"
 	);
@@ -5955,11 +5957,11 @@ QDateTime Texstudio::GetBblLastModified(void)
 	return QFileInfo(bblPathname).lastModified();
 }
 
-QString Texstudio::findInPdfPaths(const QString &primaryPath, const QString &fileName)
+QString Texstudio::findInLogPaths(const QString &primaryPath, const QString &fileName)
 {
 	QStringList searchPaths;
 	searchPaths << primaryPath;
-	searchPaths << splitPaths(BuildManager::resolvePaths(buildManager.additionalPdfPaths));
+	searchPaths << splitPaths(BuildManager::resolvePaths(buildManager.additionalLogPaths));
 	return buildManager.findFile(fileName, searchPaths, true);
 }
 

--- a/src/texstudio.h
+++ b/src/texstudio.h
@@ -414,7 +414,7 @@ protected slots:
 	void runInternalPdfViewer(const QFileInfo &master, const QString &options);
 	void runBibliographyIfNecessary(const QFileInfo &cmd);
 	QDateTime GetBblLastModified(void);
-	QString findInPdfPaths(const QString &primaryPath, const QString &fileName);
+	QString findInLogPaths(const QString &primaryPath, const QString &fileName);
 
 	void showExtendedSearch();
 

--- a/src/texstudio.h
+++ b/src/texstudio.h
@@ -414,7 +414,6 @@ protected slots:
 	void runInternalPdfViewer(const QFileInfo &master, const QString &options);
 	void runBibliographyIfNecessary(const QFileInfo &cmd);
 	QDateTime GetBblLastModified(void);
-	QString findInLogPaths(const QString &primaryPath, const QString &fileName);
 
 	void showExtendedSearch();
 

--- a/src/texstudio.h
+++ b/src/texstudio.h
@@ -413,6 +413,8 @@ protected slots:
 	bool checkProgramPermission(const QString &program, const QString &cmdId, LatexDocument *master);
 	void runInternalPdfViewer(const QFileInfo &master, const QString &options);
 	void runBibliographyIfNecessary(const QFileInfo &cmd);
+	QDateTime GetBblLastModified(void);
+	QString findInPdfPaths(const QString &primaryPath, const QString &fileName);
 
 	void showExtendedSearch();
 


### PR DESCRIPTION
Right now TXS decides whether to recompile the .bib files by comparing the timestamps of the .bib files with the timestamp of the output .bbl file. If the .bbl file is created in a directory other than the input .tex file, TXS is unable to find the output .bib file and runs the .bib compiler each time when the .tex document is compiled.

This slows down recompilation of the .tex file as reported in https://github.com/texstudio-org/texstudio/issues/728
The proposed patch works around this issue by also looking in the additional PDF search directories when searching for the compiled .bbl file.

On a side note:

1. We probably need support for a directory containing all kinds of temporary output files (bibliography, synctex, etc.). By default it should be the directory where the .tex and/or .pdf files are located but it could be a separate directory. I don't have a clear idea how this should be organized so I am mentioning it in case someone wants to discuss this feature.

2. The different findFile, findFileInPath, findAbsoluteFilePath seem to need overhaul and/or unification. The different logfile methods could move some of their code into the overhauled search functions too.