### PR TITLE
Fix Qt4 build

### DIFF
--- a/src/qcodeedit/lib/document/qdocumentsearch.cpp
+++ b/src/qcodeedit/lib/document/qdocumentsearch.cpp
@@ -162,7 +162,7 @@ void QDocumentSearch::searchMatches(const QDocumentCursor& subHighlightScope, bo
         int length = m_match.capturedLength();
 #else
 		int column=m_regexp.indexIn(s, hc.columnNumber());
-        int length=m_regexp.capturedLength();
+        int length=m_regexp.matchedLength();
 #endif
 
 		/*


### PR DESCRIPTION
When refactoring for using QRegularExpression in Qt5, the wrong function
was called in Qt4.

The CI showed you broke the Qt4 build: https://travis-ci.org/texstudio-org/texstudio/jobs/597073296

NOTE: since I don't have Qt4 locally, I couldn't actually test and build this. Make sure to test that the CI passes before merging.