### PR TITLE
Fix gcc9 compile warnings

### DIFF
--- a/src/bidiextender.cpp
+++ b/src/bidiextender.cpp
@@ -33,7 +33,7 @@ HKL getCurrentLanguage()
 	try {
 		kb::XKeyboard xkb;
 		return xkb.get_group() + 1;
-	} catch (X11Exception) {
+	} catch (X11Exception &) {
 		return 0;
 	}
 
@@ -67,7 +67,7 @@ bool isProbablyLTRLanguageCode(HKL id)
 		id --;
         if (id >= 0 && id < static_cast<HKL>(installedLangSymbols.size()))
 			return isProbablyLTRLanguageRaw(installedLangSymbols[id]);
-	} catch (X11Exception) { }
+	} catch (X11Exception &) { }
 	return false;
 #else
 	return false;
@@ -120,7 +120,7 @@ void initializeLanguages()
 			} else if (!languageIdRTL) languageIdRTL = i + 1;
 		}
 		if (!languageIdLTR) languageIdLTR = bestLTR + 1;
-	} catch (X11Exception) {}
+	} catch (X11Exception &) {}
 #endif // WS_X11
 	languagesInitialized = true;
 }
@@ -136,7 +136,7 @@ void setInputLanguage(HKL code)
 	try{
 		kb::XKeyboard xkb;
 		xkb.set_group(code - 1);
-	} catch (X11Exception) {}
+	} catch (X11Exception &) {}
 #endif
 }
 

--- a/src/codesnippet.h
+++ b/src/codesnippet.h
@@ -29,8 +29,8 @@ struct CodeSnippetPlaceHolder {
 class CodeSnippet
 {
 public:
-    CodeSnippet(): cursorLine(-1), cursorOffset(-1), anchorOffset(-1), usageCount(0), index(0), snippetLength(0), score(0), type(none) {} ///< generate empty codesnippet
-    CodeSnippet(const CodeSnippet &cw): word(cw.word), sortWord(cw.sortWord), lines(cw.lines), cursorLine(cw.cursorLine), cursorOffset(cw.cursorOffset), anchorOffset(cw.anchorOffset), placeHolders(cw.placeHolders), usageCount(cw.usageCount), index(cw.index), snippetLength(cw.snippetLength), score(cw.score), type(cw.type), name(cw.name) {} ///< copy constructor
+	CodeSnippet(): cursorLine(-1), cursorOffset(-1), anchorOffset(-1), usageCount(0), index(0), snippetLength(0), score(0), type(none) {} ///< generate empty codesnippet
+	CodeSnippet(const CodeSnippet &cw): word(cw.word), sortWord(cw.sortWord), lines(cw.lines), cursorLine(cw.cursorLine), cursorOffset(cw.cursorOffset), anchorOffset(cw.anchorOffset), placeHolders(cw.placeHolders), usageCount(cw.usageCount), index(cw.index), snippetLength(cw.snippetLength), score(cw.score), type(cw.type), name(cw.name) {} ///< copy constructor
 	CodeSnippet(const QString &newWord, bool replacePercentNewline = true); ///< generate codesnippet from text string
 	bool operator< (const CodeSnippet &cw) const; ///< define sorting operator
 	bool operator== (const CodeSnippet &cw) const;
@@ -38,7 +38,7 @@ public:
 	enum PlaceholderMode { PlacehodersActive, PlaceholdersToPlainText, PlaceholdersRemoved }; ///< configuaration of placeholder handling
 
 	QString word; ///< displayed snippet name
-    QString sortWord; ///< for sorting used snippet name, allows change of sort-order by replacement special characters especially braces
+	QString sortWord; ///< for sorting used snippet name, allows change of sort-order by replacement special characters especially braces
 	QStringList lines; ///< to be inserted code
 	//TODO: Multirow selection
 	int cursorLine;  ///< placement of cursor after insert concerning line of codesnippet; -1 => not defined
@@ -48,8 +48,8 @@ public:
 	int usageCount; ///< usage count for favourite detection
 	uint index; ///< hash index for usage count identification
 	int snippetLength; ///< number of characters
-    int score;
-    enum Type {none, length,userConstruct};
+	int score;
+	enum Type {none, length,userConstruct};
 	Type type;
 
 	QString expandCode(const QString &code);

--- a/src/codesnippet.h
+++ b/src/codesnippet.h
@@ -32,6 +32,7 @@ public:
 	CodeSnippet(): cursorLine(-1), cursorOffset(-1), anchorOffset(-1), usageCount(0), index(0), snippetLength(0), score(0), type(none) {} ///< generate empty codesnippet
 	CodeSnippet(const CodeSnippet &cw): word(cw.word), sortWord(cw.sortWord), lines(cw.lines), cursorLine(cw.cursorLine), cursorOffset(cw.cursorOffset), anchorOffset(cw.anchorOffset), placeHolders(cw.placeHolders), usageCount(cw.usageCount), index(cw.index), snippetLength(cw.snippetLength), score(cw.score), type(cw.type), name(cw.name) {} ///< copy constructor
 	CodeSnippet(const QString &newWord, bool replacePercentNewline = true); ///< generate codesnippet from text string
+	CodeSnippet & operator= (const CodeSnippet&) = default;	// Avoid GCC9 -Wdeprecated-copy warning
 	bool operator< (const CodeSnippet &cw) const; ///< define sorting operator
 	bool operator== (const CodeSnippet &cw) const;
 

--- a/src/hunspell/dictmgr.cxx
+++ b/src/hunspell/dictmgr.cxx
@@ -100,7 +100,8 @@ int  DictMgr::parse_file(const char * dictpath, const char * etype)
                     case 3:
                        free(pdict->region);
                        pdict->region=NULL;
-                    case 2: //deliberate fallthrough
+		       // Intentional fallthrough
+                    case 2:
                        free(pdict->lang);
                        pdict->lang=NULL;
                     default:

--- a/src/hunspell/hunspell.cxx
+++ b/src/hunspell/hunspell.cxx
@@ -561,6 +561,7 @@ bool HunspellImpl::spell(const std::string& word, int* info, std::string* root) 
           break;
       }
     }
+    /* FALLTHROUGH */
     case INITCAP: {
 
       *info += SPELL_ORIGCAP;
@@ -898,6 +899,7 @@ std::vector<std::string> HunspellImpl::suggest(const std::string& word) {
     }
     case HUHINITCAP:
       capwords = 1;
+      // Intentional fallthrough
     case HUHCAP: {
       pSMgr->suggest(slst, scw.c_str(), &onlycmpdsug);
       // something.The -> something. The
@@ -1010,6 +1012,7 @@ std::vector<std::string> HunspellImpl::suggest(const std::string& word) {
       }
       case HUHINITCAP:
         capwords = 1;
+        // Intentional fallthrough
       case HUHCAP: {
         std::string wspace(scw);
         mkallsmall2(wspace, sunicw);

--- a/src/latexeditorview.h
+++ b/src/latexeditorview.h
@@ -55,6 +55,7 @@ struct LinkOverlay {
 	{
 		return type != Invalid;
 	}
+	LinkOverlay & operator= (const LinkOverlay &) = default;	// Avoid GCC9 -Wdeprecated-copy warning
 	bool operator ==(const LinkOverlay &o) const
 	{
 		return (docLine == o.docLine) && (formatRange == o.formatRange);

--- a/src/pdfviewer/PDFDocks.cpp
+++ b/src/pdfviewer/PDFDocks.cpp
@@ -948,7 +948,6 @@ void PDFClockDock::restart()
 
 void PDFClockDock::setInterval()
 {
-	bool ok;
 	int i = (start.secsTo(end) + 30) / 60;
 	QString s = start.time().toString();
 	UniversalInputDialog d;

--- a/src/pdfviewer/pdfrendermanager.cpp
+++ b/src/pdfviewer/pdfrendermanager.cpp
@@ -171,7 +171,7 @@ QSharedPointer<Poppler::Document> PDFRenderManager::loadDocument(const QString &
 				docPtr = Poppler::Document::load(fileName, ownerPassword, userPassword);
 			}
 		}
-	} catch (std::bad_alloc) {
+	} catch (std::bad_alloc &) {
 		error = PopplerErrorBadAlloc;
 		return QSharedPointer<Poppler::Document>();
 	} catch (...) {

--- a/src/pdfviewer/synctex/synctex_parser.c
+++ b/src/pdfviewer/synctex/synctex_parser.c
@@ -95,6 +95,7 @@
 #       endif
 #   endif
 
+#define _GNU_SOURCE
 #include <stdlib.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/src/pdfviewer/synctex/synctex_parser.c
+++ b/src/pdfviewer/synctex/synctex_parser.c
@@ -747,7 +747,6 @@ synctex_reader_p synctex_reader_init_with_output_file(synctex_reader_p reader, c
             (char *)_synctex_malloc(reader->size+1); /*  one more character for null termination */
         if (NULL == reader->start) {
             _synctex_error("!  malloc error in synctex_reader_init_with_output_file.");
-        bailey:
 #ifdef SYNCTEX_DEBUG
             return reader;
 #else
@@ -5452,7 +5451,6 @@ content_loop:
 #       pragma mark + SCAN KERN
 #   endif
             ns = _synctex_parse_new_kern(scanner);
-        continue_scan:
             if (ns.status == SYNCTEX_STATUS_OK) {
                 if (child) {
                     _synctex_node_set_sibling(child,ns.node);

--- a/src/qcodeedit/lib/document/qdocumentline.cpp
+++ b/src/qcodeedit/lib/document/qdocumentline.cpp
@@ -462,7 +462,7 @@ int QDocumentLine::leftCursorPosition(int oldPos) const{
 		QReadLocker locker(&m_handle->mLock); //no idea if this is needed
 		try {
 			return m_handle->m_layout->leftCursorPosition(oldPos);
-		} catch (std::bad_alloc){
+		} catch (std::bad_alloc &){
 
 		}
 	}
@@ -476,7 +476,7 @@ int QDocumentLine::rightCursorPosition(int oldPos) const{
 		QReadLocker locker(&m_handle->mLock); //no idea if this is needed
 		try {
 			return m_handle->m_layout->rightCursorPosition(oldPos);
-		} catch (std::bad_alloc){ //this is sometimes thrown on qt4.8.7 with 7*hex:(d8ba d8b1) 2478 5e32 2409
+		} catch (std::bad_alloc &){ //this is sometimes thrown on qt4.8.7 with 7*hex:(d8ba d8b1) 2478 5e32 2409
 
 		}
 	}

--- a/src/qcodeedit/lib/qnfa/qnfa.h
+++ b/src/qcodeedit/lib/qnfa/qnfa.h
@@ -194,8 +194,7 @@ class QNFAMatchNotifier
 		typedef QList<Command> CommandList;
 
 	public:
-		// Define the copy constructor explicitly to avoid -Wdeprecated-copy by gcc9
-		inline QNFAMatchNotifier(const QNFAMatchNotifier&) = default;
+		inline QNFAMatchNotifier(const QNFAMatchNotifier&) = default;	// Avoid GCC9 -Wdeprecated-copy warning
 
 		inline QNFAMatchNotifier(QNFAMatchHandler *h)
 		 : handler(h) {}

--- a/src/qcodeedit/lib/qnfa/qnfa.h
+++ b/src/qcodeedit/lib/qnfa/qnfa.h
@@ -194,6 +194,7 @@ class QNFAMatchNotifier
 		typedef QList<Command> CommandList;
 
 	public:
+		// Define the copy constructor explicitly to avoid -Wdeprecated-copy by gcc9
 		inline QNFAMatchNotifier(const QNFAMatchNotifier&) = default;
 
 		inline QNFAMatchNotifier(QNFAMatchHandler *h)

--- a/src/qcodeedit/lib/qnfa/qnfa.h
+++ b/src/qcodeedit/lib/qnfa/qnfa.h
@@ -3,7 +3,7 @@
 ** Copyright (C) 2006-2009 fullmetalcoder <fullmetalcoder@hotmail.fr>
 **
 ** This file is part of the Edyuk project <http://edyuk.org>
-** 
+**
 ** This file may be used under the terms of the GNU General Public License
 ** version 3 as published by the Free Software Foundation and appearing in the
 ** file GPL.txt included in the packaging of this file.
@@ -42,45 +42,45 @@ class QNFABranch : public light_vector<QNFA*>
 enum NFAType
 {
 	Char			= 0,
-	
+
 	Match			= 1,
-	
+
 	CxtBeg			= 2,
 	CxtEnd			= 4,
 	CxtEsc			= 8,
-	
+
 	ContextBegin	= Match | CxtBeg,
 	ContextEnd		= Match | CxtEnd,
 	EscapeSeq		= Match | CxtEsc,
-	
+
 	Escaped			= 16,
 	Exclusive		= 32,
 	StayOnLine		= 64,
-	
+
 	Reserved		= 128
 };
 
 enum NFAAssertion
 {
 	NoAssertion		= 0,
-	
+
 	One				= 0,		// default standard
 	ZeroOrOne		= 1,		// ?
 	ZeroOrMore		= 2,		// *
 	OneOrMore		= 4,		// +
-	
+
 	WordStart		= 8,
 	WordEnd			= 16,
-	
+
 	Word			= 32,
 	NonWord			= 64,
-	
+
 	Digit			= 128,
 	NonDigit		= 256,
-	
+
 	Space			= 512,
 	NonSpace		= 1024,
-	
+
 	CaseSensitive	= 2048,
 
 	LineStart = 4096
@@ -94,13 +94,13 @@ struct QCharTreeNode
 {
 	inline QCharTreeNode(quint16 v = 0) { value.unicode = v; }
 	inline QCharTreeNode(const QCharTreeNode& o) { value = o.value; next = o.next; }
-	
+
 	union
 	{
 		int action;
 		quint16 unicode;
 	} value;
-	
+
 	QCharTreeLevel next;
 };
 
@@ -112,28 +112,28 @@ struct QNFA
 {
 	QNFA();
 	~QNFA();
-	
+
 	QNFASet c;
 	QCharTree tree;
-	
+
 	union
 	{
 		QNFA *next;
 		QNFABranch *branch;
 	} out;
-	
+
 	quint8 type;
 	quint16 assertion;
-	
+
 	int actionid;
-	
+
 	static quint32 _count;
 };
 
 struct QNFAMatchContext
 {
 	inline QNFAMatchContext(QNFA *root = 0) : context(root) {}
-	
+
 	inline QNFAMatchContext& operator = (QNFAMatchContext *c)
 	{
 		if ( c )
@@ -144,27 +144,27 @@ struct QNFAMatchContext
 		} else {
 			reset();
 		}
-		
+
 		return *this;
 	}
-	
+
 	inline QNFAMatchContext& operator = (const QNFAMatchContext& c)
 	{
 		context = c.context;
 		parents = c.parents;
 		meaningless = c.meaningless;
-		
+
 		return *this;
 	}
-	
+
 	inline void reset()
 	{
 		context = 0;
-		
+
 		while ( parents.count() )
 			context = parents.pop();
 	}
-	
+
 	QNFA *context;
 	QNFASet meaningless;
 	QStack<QNFA*> parents;
@@ -174,7 +174,7 @@ class QNFAMatchHandler
 {
 	public:
 		virtual ~QNFAMatchHandler() {}
-		
+
 		virtual void matched(int pos, int len, int action) = 0;
 };
 
@@ -185,25 +185,25 @@ class QNFAMatchNotifier
 		{
 			inline Command(int p, int len, int act)
 			 : pos(p), length(len), action(act) {}
-			
+
 			int pos;
 			int length;
 			int action;
 		};
-		
+
 		typedef QList<Command> CommandList;
-		
+
 	public:
 		inline QNFAMatchNotifier(QNFAMatchHandler *h)
 		 : handler(h) {}
-		
+
 		inline QNFAMatchNotifier& operator = (const QNFAMatchNotifier& n)
 		{
 			handler = n.handler;
-			
+
 			return *this;
 		}
-		
+
 		inline void operator () (int pos, int len, int action)
 		{
 			if ( handler && (m_buffers.isEmpty() || m_pending.count()) )
@@ -211,39 +211,39 @@ class QNFAMatchNotifier
 			else
 				m_buffers.top() << Command(pos, len, action);
 		}
-		
+
 		inline int bufferLevel() const
 		{
 			return m_buffers.count();
 		}
-		
+
 		inline void startBuffering()
 		{
 			m_buffers.push(CommandList());
 		}
-		
+
 		inline void stopBuffering()
 		{
 			m_pending = m_buffers.pop();
 		}
-		
+
 		inline void flush()
 		{
 			foreach ( Command c, m_pending )
 				handler->matched(c.pos, c.length, c.action);
-			
+
 			m_pending.clear();
 		}
-		
+
 		inline void clear()
 		{
 			m_pending.clear();
 			m_buffers.clear();
 		}
-		
+
 	private:
 		QNFAMatchHandler *handler;
-		
+
 		CommandList m_pending;
 		QStack<CommandList> m_buffers;
 };

--- a/src/qcodeedit/lib/qnfa/qnfa.h
+++ b/src/qcodeedit/lib/qnfa/qnfa.h
@@ -194,6 +194,8 @@ class QNFAMatchNotifier
 		typedef QList<Command> CommandList;
 
 	public:
+		inline QNFAMatchNotifier(const QNFAMatchNotifier&) = default;
+
 		inline QNFAMatchNotifier(QNFAMatchHandler *h)
 		 : handler(h) {}
 

--- a/src/scriptengine.h
+++ b/src/scriptengine.h
@@ -2,11 +2,15 @@
 #define SCRIPTENGINE_H
 
 #include "mostQtHeaders.h"
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (__GNUC__ >= 8)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
 #include <QtScript>
 #include <QScriptEngine>
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (__GNUC__ >= 8)
 #pragma GCC diagnostic pop
+#endif
 
 #include "qeditor.h"
 class BuildManager;

--- a/src/scriptengine.h
+++ b/src/scriptengine.h
@@ -2,8 +2,11 @@
 #define SCRIPTENGINE_H
 
 #include "mostQtHeaders.h"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #include <QtScript>
 #include <QScriptEngine>
+#pragma GCC diagnostic pop
 
 #include "qeditor.h"
 class BuildManager;

--- a/src/session.h
+++ b/src/session.h
@@ -23,7 +23,7 @@ class Session
 public:
 	Session(): m_pdfEmbedded(false) {}
 	Session(const Session &s);
-	Session & operator=(const Session &) = default;
+	Session & operator=(const Session &) = default;	// Avoid GCC9 -Wdeprecated-copy warning
 
 	bool load(const QString &file);
 	bool save(const QString &file, bool relPaths=true) const;

--- a/src/session.h
+++ b/src/session.h
@@ -23,6 +23,7 @@ class Session
 public:
 	Session(): m_pdfEmbedded(false) {}
 	Session(const Session &s);
+	Session & operator=(const Session &) = default;
 
 	bool load(const QString &file);
 	bool save(const QString &file, bool relPaths=true) const;

--- a/texstudio.pro
+++ b/texstudio.pro
@@ -418,7 +418,7 @@ exists(./.git)  {
 
 !win32-msvc*: {
   QMAKE_CXXFLAGS_DEBUG -= -O -O1 -O2 -O3
-  QMAKE_CXXFLAGS_DEBUG += -Wall -Wextra -Winit-self -Wmissing-include-dirs -Wtrigraphs -Wunused -Wunknown-pragmas -Wundef -Wpointer-arith -Wwrite-strings -Wempty-body -Wsign-compare -Waddress -Winline -O0
+  QMAKE_CXXFLAGS_DEBUG += -Wall -Wextra -Wmissing-include-dirs -Wunknown-pragmas -Wundef -Wpointer-arith -Winline -O0
   QMAKE_CXXFLAGS += -std=c++0x
   !win32:!haiku: QMAKE_LFLAGS += -rdynamic # option not supported by mingw and haiku
   else {

--- a/texstudio.pro
+++ b/texstudio.pro
@@ -429,3 +429,7 @@ exists(./.git)  {
 } else {
   DEFINES += _CRT_SECURE_NO_WARNINGS
 }
+
+*-g++:equals(QT_MAJOR_VERSION, 5):lessThan(QT_MINOR_VERSION, 13) {
+  QMAKE_CXXFLAGS += -Wno-deprecated-copy
+}


### PR DESCRIPTION
This is the first set of cosmetic patches that fix the issues mentioned in https://github.com/texstudio-org/texstudio/issues/748
This set fixes the GCC compiler warnings. The patches fix the following groups of GCC warnings:

1. -Wcast-function-type warnings when including QtScript headers. These are the compiler warnings reported in https://github.com/texstudio-org/texstudio/issues/748
Even though I initially thought that the warnings are caused by TexStudio code it turned out that the warnings are caused entirely by code in QtScript/qscriptengine.h
I reported the issue in the Qt bugtracking system at https://bugreports.qt.io/browse/QTBUG-79242 but until they fix it I have added a bit of code to TXS src/scriptengine.h to silence the warnings. Given that it is a low-priority issue it may take a while until it is fixed in the QtScript headers.

2. -Wdeprecated-copy warnings in the TXS code reported by GCC9. These have been fixed by adding explicit default constructors and operator= to some classes in TXS.

3. -Wdeprecated-copy warnings in the Qt headers. I have added a bit of code to texstudio.pro to silence the warnings when building with GCC and Qt version is between 5.0.0 and 5.12.x
These warnings have been fixed in Qt 5.13.x so we don't silence them with newer versions of Qt.

4. Warnings about two unused labels in src/pdfviewer/synctex/synctex_parser.c. Fixed by removing the unused labels.

5. Warning about unused variable in rc/pdfviewer/PDFDocks.cpp. Fixed by removing the unused variable.

6. -Wcatch-value warnings in several files. gcc9 complains when we catch polymorphic objects by value instead of reference. Fixed by catching the exception objects by reference.

7. -Wimplicit-fallthrough warnings in several files. Fixed by adding the magic comment "// Intentional fallthrough" in the corresponding case statements. gcc recognizes the magic comment and silences the corresponding warnings.

8. Warning about about implicit declaration of vasprintf in one source file. Fixed by defining _GNU_SOURCE just before including stdio.h.

9. For the debug build removed some -W flags which are already enabled by -Wall and -Wextra.
