### PR TITLE
Add the ?p command-line expansion that searches for compiled PDF file

### DIFF
--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -577,6 +577,29 @@ QStringList BuildManager::parseExtendedCommandLine(QString str, const QFileInfo 
 	return result;
 }
 
+/*
+ * Select a file which provides the pathname parts used by the "ame" expansions. Currently we can select
+ * one of the following files:
+ *
+ * - Master (root) .tex file (default).
+ * - Current .tex file. Selected by the c: prefix.
+ * - A file with the same complete basename as the master file and a chosen extension. The search for this
+ *   file is done in the master file directory and then the extra PDF directories. Selected by the p{ext}:
+ *   prefix.
+ *
+ * TODO: If selector ?p{ext}: is not flexible enough then maybe we should implement another selector:
+ * ?f{regexp_with_basename}:
+ *
+ * It will be processed like this:
+ *
+ * 1. regexp_with_basename undergoes %-token replacement
+ *    %m is replaced by the complete basename of the master file.
+ *    %% is replaced by %
+ * 2. The expression from 1 is used to search the master file directory, the current file
+ *    directory and the extra PDF directories.
+ * 3. If step 2 finds a matching file it is used as a selected file. If step 2 does not
+ *    find a file, then some reasonable default is used.
+ */
 QFileInfo BuildManager::parseExtendedSelectFile(QString &command, const QFileInfo &mainFile, const QFileInfo &currentFile)
 {
 	QFileInfo selectedFile;

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -535,6 +535,7 @@ QStringList BuildManager::parseExtendedCommandLine(QString str, const QFileInfo 
 				else if (command == "m") command = selectedFile.completeBaseName();
 				else if (command == "e") command = selectedFile.suffix();
 				else if (command.isEmpty() && !commandRem.isEmpty()); //empty search
+				else if (command == "p") command = findPdfFile(QString(), mainFile);
 				else continue; //invalid command
 
 				command.append(commandRem);
@@ -2148,6 +2149,22 @@ QString BuildManager::findFile(const QString &defaultName, const QStringList &se
 	} else {
 		return "";
 	}
+}
+
+QString BuildManager::findPdfFile(const QString &pdfFile, const QFileInfo &mainFile)
+{
+	QStringList searchPaths;
+	QString searchFilename, foundPathname;
+
+	searchPaths << mainFile.absolutePath();
+	searchPaths << splitPaths(resolvePaths(additionalPdfPaths));
+	searchFilename = pdfFile.isNull() ? mainFile.completeBaseName() + ".pdf" : pdfFile;
+	foundPathname = findFile(searchFilename, searchPaths, true);
+	if (foundPathname == "") {
+		// Fallback to searched filename, so PDF viewer shows a reasonable error message
+		foundPathname = searchFilename;
+	}
+	return (foundPathname);
 }
 
 void BuildManager::removePreviewFiles(QString elem)

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -127,7 +127,7 @@ QString CommandInfo::getProgramName() const
 
 QString CommandInfo::getProgramNameUnquoted() const
 {
-    return getProgramNameUnquoted(commandLine);
+	return getProgramNameUnquoted(commandLine);
 }
 
 ExpandingOptions::ExpandingOptions(const QFileInfo &mainFile, const QFileInfo &currentFile, const int currentLine): mainFile(mainFile), currentFile(currentFile), currentLine(currentLine), nestingDeep(0), canceled(false)
@@ -269,7 +269,7 @@ BuildManager::BuildManager(): processWaitedFor(nullptr)
 #endif
 {
 	initDefaultCommandNames();
-    connect(this, SIGNAL(commandLineRequested(QString, QString *, bool *)), SLOT(commandLineRequestedDefault(QString, QString *, bool *)));
+	connect(this, SIGNAL(commandLineRequested(QString, QString *, bool *)), SLOT(commandLineRequestedDefault(QString, QString *, bool *)));
 }
 
 BuildManager::~BuildManager()
@@ -418,8 +418,8 @@ void BuildManager::checkOSXElCapitanDeprecatedPaths(QSettings &settings, const Q
 		}
 	}
 #else
-    Q_UNUSED(settings)
-    Q_UNUSED(commands)
+	Q_UNUSED(settings)
+	Q_UNUSED(commands)
 #endif
 }
 
@@ -598,7 +598,7 @@ QString BuildManager::extractOutputRedirection(const QString &commandLine, QStri
 
 QString addPathDelimeter(const QString &a)
 {
-    return ((a.endsWith("/") || a.endsWith("\\")) ? a : (a + QDir::separator()));
+	return ((a.endsWith("/") || a.endsWith("\\")) ? a : (a + QDir::separator()));
 }
 
 QString BuildManager::findFileInPath(QString fileName)
@@ -710,7 +710,7 @@ QString getMiKTeXBinPathInternal()
 	}
 
 	// search all program file paths
-    if (mikPath.isEmpty()) {
+	if (mikPath.isEmpty()) {
 		mikPath = QDir::toNativeSeparators(findSubDir(getProgramFilesPaths(), "*miktex*", "miktex\\bin\\"));
 	}
 
@@ -928,10 +928,10 @@ ExpandedCommands BuildManager::expandCommandLine(const QString &str, ExpandingOp
 				UtilsUi::txsInformation(tr("You have used txs:///command[... or txs:///command{... modifiers, but we only support modifiers of the form txs:///command/[... or txs:///command/{... with an slash suffix to keep the syntax purer."));
 				modifiers.clear();
 			}
-            if (options.override.removeAll) {
-                parameters.clear();
-                modifiers.clear();
-            }
+			if (options.override.removeAll) {
+				parameters.clear();
+				modifiers.clear();
+			}
 
 			bool user;
 			QString cmd = getCommandLine(cmdName, &user);
@@ -948,8 +948,8 @@ ExpandedCommands BuildManager::expandCommandLine(const QString &str, ExpandingOp
 			int space = cmd.indexOf(' ');
 			if (space == -1) space = cmd.size();
 			if (cmd.startsWith(TXS_CMD_PREFIX) && internalCommands.contains(cmd.left(space))) {
-                QStringList exp=parseExtendedCommandLine(cmd, options.mainFile, options.currentFile, options.currentLine);
-                res.commands << CommandToRun(exp.first()+" "+parameters);
+				QStringList exp=parseExtendedCommandLine(cmd, options.mainFile, options.currentFile, options.currentLine);
+				res.commands << CommandToRun(exp.first()+" "+parameters);
 				res.commands.last().parentCommand = res.commands.last().command;
 				if (user) res.commands.last().flags |= RCF_CHANGE_PDF;
 				continue;
@@ -1065,7 +1065,7 @@ RunCommandFlags BuildManager::getSingleCommandFlags(const QString &subcmd) const
 #endif
 
 	if (viewerCommands.contains(subcmd) && !isAcrobat && singleViewerInstance) result |= RCF_SINGLE_INSTANCE;
-    return static_cast<RunCommandFlags>(result);
+	return static_cast<RunCommandFlags>(result);
 }
 
 bool BuildManager::hasCommandLine(const QString &program)
@@ -1375,7 +1375,7 @@ void BuildManager::readSettings(QSettings &settings)
 		if (!deprecatedUserToolNames[i].endsWith("!!!CONVERTED!!!")) {
 			QString cmd = deprecatedUserToolCommands[i];
 			cmd.replace(DEPRECACTED_TMX_INTERNAL_PDF_VIEWER, CMD_VIEW_PDF_INTERNAL);
-            CommandInfo &ci = registerCommand(QString("user%1").arg(i), "", deprecatedUserToolNames[i], "", "", nullptr, true);
+			CommandInfo &ci = registerCommand(QString("user%1").arg(i), "", deprecatedUserToolNames[i], "", "", nullptr, true);
 			ci.commandLine = cmd;
 			userToolOrder << ci.id;
 			userToolDisplayNames << ci.displayName;
@@ -1386,7 +1386,7 @@ void BuildManager::readSettings(QSettings &settings)
 		QString temp = settings.value(QString("User/Tool%1").arg(i), "").toString();
 		if (!temp.isEmpty()) {
 			temp.replace(DEPRECACTED_TMX_INTERNAL_PDF_VIEWER, CMD_VIEW_PDF_INTERNAL);
-            CommandInfo &ci = registerCommand(QString("userold%1").arg(i), "", settings.value(QString("User/ToolName%1").arg(i)).toString(), "", "", nullptr, true);
+			CommandInfo &ci = registerCommand(QString("userold%1").arg(i), "", settings.value(QString("User/ToolName%1").arg(i)).toString(), "", "", nullptr, true);
 			ci.commandLine  = temp;
 			userToolOrder << ci.id;
 			userToolDisplayNames << ci.displayName;
@@ -1394,7 +1394,7 @@ void BuildManager::readSettings(QSettings &settings)
 			settings.remove(QString("User/ToolName%1").arg(i));
 		}
 	}
-    int md = dvi2pngMode;
+	int md = dvi2pngMode;
 #ifdef NO_POPPLER_PREVIEW
 	if (md == DPM_EMBEDDED_PDF)
 		md = -1;
@@ -1597,20 +1597,19 @@ void BuildManager::emitEndRunningSubCommandFromProcessX(int)
 ProcessX *BuildManager::firstProcessOfDirectExpansion(const QString &command, const QFileInfo &mainFile, const QFileInfo &currentFile, int currentLine,bool nonstop)
 {
 	ExpandingOptions options(mainFile, currentFile, currentLine);
-    if(nonstop){
-        options.nestingDeep=1; // tweak to avoid pop-up error messages
-    }
+	if(nonstop){
+		options.nestingDeep=1; // tweak to avoid pop-up error messages
+	}
 	ExpandedCommands expansion = expandCommandLine(command, options);
-    if (options.canceled) return nullptr;
+	if (options.canceled) return nullptr;
 
-    if (expansion.commands.isEmpty()) { return nullptr; }
+	if (expansion.commands.isEmpty()) { return nullptr; }
 
-    foreach(CommandToRun elem,expansion.commands){
-        if(elem.command.isEmpty()){
-            return nullptr; // error in command expansion
-        }
-
-    }
+	foreach(CommandToRun elem,expansion.commands) {
+		if(elem.command.isEmpty()) {
+			return nullptr; // error in command expansion
+		}
+	}
 
 	return newProcessInternal(expansion.commands.first().command, mainFile);
 }
@@ -1755,7 +1754,7 @@ void BuildManager::preview(const QString &preamble, const PreviewSource &source,
 				QFileInfo fi(*tf);
 				preambleFormatFile = fi.completeBaseName();
 				previewFileNames.append(fi.absoluteFilePath());
-                ProcessX *p = nullptr;
+				ProcessX *p = nullptr;
 				if (dvi2pngMode == DPM_EMBEDDED_PDF) {
 					p = newProcessInternal(QString("%1 -interaction=nonstopmode -ini \"&pdflatex %3 \\dump\"").arg(getCommandInfo(CMD_PDFLATEX).getProgramName()).arg(preambleFormatFile), tf->fileName()); //no delete! goes automatically
 				} else {
@@ -1954,7 +1953,8 @@ QString BuildManager::guessCompilerFromProgramMagicComment(const QString &progra
  */
 QString BuildManager::guessViewerFromProgramMagicComment(const QString &program)
 {
-	if (program == "latex") return BuildManager::CMD_VIEW_DVI;
+	if (program == "latex")
+		return BuildManager::CMD_VIEW_DVI;
 	else if (program == "pdflatex" || program == "xelatex" || program == "luatex" || program == "lualatex") {
 		return CMD_VIEW_PDF;
 	}
@@ -1967,7 +1967,8 @@ void BuildManager::singleInstanceCompleted(int status)
 	QObject *s = sender();
 	REQUIRE(s);
 	for (QMap<QString, ProcessX *>::iterator it = runningCommands.begin(), end = runningCommands.end(); it != end;)
-		if (it.value() == s) it = runningCommands.erase(it);
+		if (it.value() == s)
+			it = runningCommands.erase(it);
 		else ++it;
 }
 
@@ -1991,7 +1992,7 @@ void BuildManager::latexPreviewCompleted(int status)
 		ProcessX *p1 = qobject_cast<ProcessX *> (sender());
 		if (!p1) return;
 		// dvi -> png
-        ProcessX *p2 = firstProcessOfDirectExpansion(CMD_DVIPNG, p1->getFile(),QFileInfo(),0,true);
+		ProcessX *p2 = firstProcessOfDirectExpansion(CMD_DVIPNG, p1->getFile(),QFileInfo(),0,true);
 		if (!p2) return; //dvipng does not work
 		//REQUIRE(p2);
 		if (!p1->overrideEnvironment().isEmpty()) p2->setOverrideEnvironment(p1->overrideEnvironment());
@@ -2002,7 +2003,7 @@ void BuildManager::latexPreviewCompleted(int status)
 		ProcessX *p1 = qobject_cast<ProcessX *> (sender());
 		if (!p1) return;
 		// dvi -> ps
-        ProcessX *p2 = firstProcessOfDirectExpansion("txs:///dvips/[-E]", p1->getFile(),QFileInfo(),0,true);
+		ProcessX *p2 = firstProcessOfDirectExpansion("txs:///dvips/[-E]", p1->getFile(),QFileInfo(),0,true);
 		if (!p2) return; //dvips does not work
 		//REQUIRE(p2);
 		if (!p1->overrideEnvironment().isEmpty()) p2->setOverrideEnvironment(p1->overrideEnvironment());
@@ -2033,19 +2034,19 @@ void BuildManager::dvi2psPreviewCompleted(int status)
 	if (!p2) return;
 	// ps -> png, ghostscript is quite, safe, will create 24-bit png
 	QString filePs = parseExtendedCommandLine("?am.ps", p2->getFile()).first();
-    ProcessX *p3 = firstProcessOfDirectExpansion("txs:///gs/[-q][-dSAFER][-dBATCH][-dNOPAUSE][-sDEVICE=png16m][-dEPSCrop][-sOutputFile=\"?am)1.png\"]", filePs,QFileInfo(),0,true);
-    if (!p3) return; //gs does not work
+	ProcessX *p3 = firstProcessOfDirectExpansion("txs:///gs/[-q][-dSAFER][-dBATCH][-dNOPAUSE][-sDEVICE=png16m][-dEPSCrop][-sOutputFile=\"?am)1.png\"]", filePs,QFileInfo(),0,true);
+	if (!p3) return; //gs does not work
 	if (!p2->overrideEnvironment().isEmpty()) p3->setOverrideEnvironment(p2->overrideEnvironment());
 	connect(p3, SIGNAL(finished(int)), this, SLOT(conversionPreviewCompleted(int)));
 	p3->startCommand();
 }
 void BuildManager::PreviewLatexCompleted(int status){
-    if(status!=0){
-        // latex compile failed, kill dvipng
-        ProcessX *p1 = qobject_cast<ProcessX *> (sender());
-        ProcessX *p2=p1->property("proc").value<ProcessX *>();
-        p2->terminate();
-    }
+	if(status!=0){
+		// latex compile failed, kill dvipng
+		ProcessX *p1 = qobject_cast<ProcessX *> (sender());
+		ProcessX *p2=p1->property("proc").value<ProcessX *>();
+		p2->terminate();
+	}
 }
 
 void BuildManager::conversionPreviewCompleted(int status)
@@ -2092,10 +2093,10 @@ bool BuildManager::testAndRunInternalCommand(const QString &cmd, const QFileInfo
 	int space = cmd.indexOf(' ');
 	QString cmdId, options;
 	if (space == -1 ) cmdId = cmd;
-    else {
-        cmdId = cmd.left(space);
-        options = cmd.mid(space + 1);
-    }
+	else {
+		cmdId = cmd.left(space);
+		options = cmd.mid(space + 1);
+	}
 	if (internalCommands.contains(cmdId)) {
 		emit runInternalCommand(cmdId, mainFile, options);
 		return true;
@@ -2128,17 +2129,17 @@ QString BuildManager::findFile(const QString &defaultName, const QStringList &se
 			QString absPath = base.absolutePath() + "/";
 			QString baseName = "/" + base.fileName();
 			fi = QFileInfo(absPath + p + baseName);
-        }
-        if (fi.exists()) {
-            if (mostRecent) {
-                if (mr == nullptr || mr->lastModified() < fi.lastModified()) {
-                    if (mr != nullptr)
-                        delete mr;
-                    mr = new QFileInfo(fi);
-                }
-            } else
-                return fi.absoluteFilePath();
-        }
+		}
+		if (fi.exists()) {
+			if (mostRecent) {
+				if (mr == nullptr || mr->lastModified() < fi.lastModified()) {
+					if (mr != nullptr)
+						delete mr;
+					mr = new QFileInfo(fi);
+				}
+			} else
+				return fi.absoluteFilePath();
+		}
 	}
 	if (mostRecent && mr != nullptr) {
 		QString result = mr->absoluteFilePath();
@@ -2328,7 +2329,7 @@ void ProcessX::startCommand()
 	QByteArray path = qgetenv("PATH");
 #ifdef Q_OS_OSX
 	QString basePath = getEnvironmentPath();
-    qputenv("PATH", path + getPathListSeparator().toLatin1() + BuildManager::resolvePaths(BuildManager::additionalSearchPaths).toUtf8() + getPathListSeparator().toLatin1() + basePath.toUtf8());
+	qputenv("PATH", path + getPathListSeparator().toLatin1() + BuildManager::resolvePaths(BuildManager::additionalSearchPaths).toUtf8() + getPathListSeparator().toLatin1() + basePath.toUtf8());
 	// needed for searching the executable in the additional paths see https://bugreports.qt-project.org/browse/QTBUG-18387
 #else
 	qputenv("PATH", path + getPathListSeparator().toLatin1() + BuildManager::resolvePaths(BuildManager::additionalSearchPaths).toUtf8()); // needed for searching the executable in the additional paths see https://bugreports.qt-project.org/browse/QTBUG-18387
@@ -2472,7 +2473,7 @@ void ProcessX::onFinished(int error)
 		readFromStandardError();
 	}
 	ended = true;
-    emit processFinished();
+	emit processFinished();
 }
 
 #ifdef PROFILE_PROCESSES

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -2176,8 +2176,9 @@ QString BuildManager::findCompiledFile(const QString &compiledFilename, const QF
 	searchPaths << splitPaths(resolvePaths(additionalPdfPaths));
 	foundPathname = findFile(compiledFilename, searchPaths, true);
 	if (foundPathname == "") {
-		// Fallback to searched filename, so PDF viewer shows a reasonable error message
-		foundPathname = compiledFilename;
+		// If searched filename is relative prepend the mainFile directory
+		// so PDF viewer shows a reasonable error message
+		foundPathname = QFileInfo(mainFile.absoluteDir(), compiledFilename).absoluteFilePath();
 	}
 	return (foundPathname);
 }

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -128,6 +128,7 @@ public:
 	static QString replaceEnvironmentVariables(const QString &s, const QHash<QString, QString> &variables, bool compareNamesToUpper);
 	static QString resolvePaths(QString paths);
 	static QStringList parseExtendedCommandLine(QString str, const QFileInfo &mainFile, const QFileInfo &currentFile = QFileInfo(), int currentLine = 0);
+	static QFileInfo parseExtendedSelectFile(QString &command, const QFileInfo &mainFile, const QFileInfo &currentFile);
 	static QString extractOutputRedirection(const QString &commandLine, QString &stdOut, QString &stdErr);
 	ExpandedCommands expandCommandLine(const QString &str, ExpandingOptions &expandingOptions);
 	RunCommandFlags getSingleCommandFlags(const QString &command) const;
@@ -236,7 +237,7 @@ public:
 	static QString additionalSearchPaths, additionalLogPaths, additionalPdfPaths;
 
 	static QString findFile(const QString &baseName, const QStringList &searchPaths, bool mostRecent = false);
-	static QString findPdfFile(const QString &pdfFile, const QFileInfo &mainFile);
+	static QString findCompiledFile(const QString &compiledFilename, const QFileInfo &mainFile);
 	void addPreviewFileName(QString fn)
 	{
 		if (!previewFileNames.contains(fn))

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -235,7 +235,8 @@ public:
 	static QString autoRerunCommands;
 	static QString additionalSearchPaths, additionalLogPaths, additionalPdfPaths;
 
-	QString findFile(const QString &baseName, const QStringList &searchPaths, bool mostRecent = false);
+	static QString findFile(const QString &baseName, const QStringList &searchPaths, bool mostRecent = false);
+	static QString findPdfFile(const QString &pdfFile, const QFileInfo &mainFile);
 	void addPreviewFileName(QString fn)
 	{
 		if (!previewFileNames.contains(fn))

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -153,7 +153,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>11</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="pageGeneral">
       <layout class="QVBoxLayout">
@@ -185,8 +185,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>632</width>
-            <height>678</height>
+            <width>708</width>
+            <height>756</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout">
@@ -666,8 +666,7 @@
        <item>
         <widget class="QLabel" name="label_4">
          <property name="text">
-          <string>&lt;b&gt;%&lt;/b&gt;: filename without extension; &lt;b&gt;@&lt;/b&gt;: line number; &lt;b&gt;?[selector][terminating char]&lt;/b&gt;: formated filename
-</string>
+          <string>&lt;b&gt;%&lt;/b&gt;: filename without extension; &lt;b&gt;@&lt;/b&gt;: line number; &lt;b&gt;?[selector][pathname parts][terminating char]&lt;/b&gt;: formated filename</string>
          </property>
          <property name="indent">
           <number>15</number>
@@ -677,12 +676,7 @@
        <item>
         <widget class="QLabel" name="label_17">
          <property name="text">
-          <string>&lt;i&gt;Selectors:&lt;/i&gt; a combination of &lt;b&gt;a&lt;/b&gt;: absolute path, &lt;!--&lt;i&gt;r&lt;/i&gt;: relative path, --&gt;&lt;b&gt;m&lt;/b&gt;: basefile name without extension,&lt;b&gt;e&lt;/b&gt;: extension, &lt;b&gt;r&lt;/b&gt;: path relative to master, &lt;b&gt;*&lt;/b&gt;: all files matching the following pattern&lt;br /&gt;
-prepend &lt;b&gt;c:&lt;/b&gt; for current file instead of master file (include the colon)&lt;br /&gt;
-&lt;i&gt;Terminating chars:&lt;/i&gt; &lt;b&gt;)&lt;/b&gt;: ends selector. The following chars end the selector and have additional meaning&lt;br /&gt;
-&lt;b&gt;&quot;&lt;/b&gt;: enclose in double-quotes, &lt;b&gt;.&lt;/b&gt; (dot) add a point at the end, (space): add a space at the end&lt;br /&gt;
-&lt;i&gt;Examples:&lt;/i&gt; &lt;b&gt;?ame&quot;&lt;/b&gt;: complete absolute filename enclosed in double-quotes, &lt;b&gt;?e)&lt;/b&gt; just the extension without leading dot (e.g. tex), &lt;br /&gt;
-&lt;b&gt;?m&quot;&lt;/b&gt; double-quoted filename without extension (identical to &lt;b&gt;%&lt;/b&gt;), &lt;b&gt;?me&lt;/b&gt; filename with extension (e.g. example.tex), &lt;b&gt;?*.aux&lt;/b&gt;: all .aux files in the current directory</string>
+          <string>&lt;i&gt;File selector (Optional. If present include the terminating colon):&lt;/i&gt; If no selector then select master file. &lt;b&gt;c:&lt;/b&gt; select current file, &lt;b&gt;p{ext}:&lt;/b&gt; Find a file with same basename as master file and extension &lt;b&gt;ext&lt;/b&gt;. Search is done in master file directory and additional PDF directories.&lt;br /&gt;&lt;i&gt;Pathname parts:&lt;/i&gt; a combination of &lt;b&gt;a&lt;/b&gt;: absolute path, &lt;b&gt;m&lt;/b&gt;: basefile name without extension,&lt;b&gt;e&lt;/b&gt;: extension, &lt;b&gt;r&lt;/b&gt;: path relative to master, &lt;b&gt;*&lt;/b&gt;: all files matching the following pattern&lt;br/&gt;&lt;i&gt;Terminating chars:&lt;/i&gt;&lt;b&gt;)&lt;/b&gt;: ends selector. The following chars end the selector and have additional meaning&lt;br/&gt;&lt;b&gt;&amp;quot;&lt;/b&gt;: enclose in double-quotes, &lt;b&gt;.&lt;/b&gt; (dot) add a point at the end, (space): add a space at the end&lt;br/&gt;&lt;i&gt;Examples:&lt;/i&gt;&lt;b&gt;?ame&amp;quot;&lt;/b&gt;: complete absolute filename enclosed in double-quotes, &lt;b&gt;?e)&lt;/b&gt; just the extension without leading dot (e.g. tex), &lt;br/&gt;&lt;b&gt;?m&amp;quot;&lt;/b&gt; double-quoted filename without extension (identical to &lt;b&gt;%&lt;/b&gt;), &lt;b&gt;?me&lt;/b&gt; filename with extension (e.g. example.tex), &lt;b&gt;?*.aux&lt;/b&gt;: all .aux files in the current directory</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -741,8 +735,8 @@ prepend &lt;b&gt;c:&lt;/b&gt; for current file instead of master file (include t
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>880</width>
-            <height>617</height>
+            <width>933</width>
+            <height>612</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_17">
@@ -899,8 +893,8 @@ prepend &lt;b&gt;c:&lt;/b&gt; for current file instead of master file (include t
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>850</width>
-                   <height>76</height>
+                   <width>240</width>
+                   <height>103</height>
                   </rect>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_1">
@@ -1935,8 +1929,8 @@ Then you can select a new shortcut by one of the following ways:
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>868</width>
-            <height>1675</height>
+            <width>889</width>
+            <height>1816</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -3275,8 +3269,8 @@ them here.</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>590</width>
-            <height>730</height>
+            <width>645</width>
+            <height>884</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -3801,8 +3795,8 @@ them here.</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>414</width>
-            <height>273</height>
+            <width>456</width>
+            <height>313</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -4063,8 +4057,8 @@ them here.</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>593</width>
-            <height>486</height>
+            <width>654</width>
+            <height>589</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_16">

--- a/src/tests/buildmanager_t.h
+++ b/src/tests/buildmanager_t.h
@@ -47,36 +47,36 @@ private slots:
 		QEQUAL(BuildManager::replaceEnvironmentVariables(command, variables, false), result);
 #endif
 	}
-	
-	void parseExtendedCommandLine_data(){ 
+
+	void parseExtendedCommandLine_data(){
 		QTest::addColumn<QString >("str");
 		QTest::addColumn<QString >("fileName");
 		QTest::addColumn<QString >("fileName2");
 		QTest::addColumn<int >("line");
 		QTest::addColumn<QString >("expected");
-		
+
 		QTest::newRow("basic meta") << "@-@@ %% ?? @" << "" << "!none" << 17 << "17-@ % ? 17";
-		QTest::newRow("relative file") << "%#?m)#?me)#?m.pdf:42!" << "pseudo.tex" << "!none" << 42  
+		QTest::newRow("relative file") << "%#?m)#?me)#?m.pdf:42!" << "pseudo.tex" << "!none" << 42
 				<< "\"pseudo\"#pseudo#pseudo.tex#pseudo.pdf:42!";
-		//use resource path so no drive letter will be inserted on windows 
-		QTest::newRow("absolute file") << "?a)~?am)~?ame)~" << ":/somewhere/something/test.tex" << "!none" << 0 
+		//use resource path so no drive letter will be inserted on windows
+		QTest::newRow("absolute file") << "?a)~?am)~?ame)~" << ":/somewhere/something/test.tex" << "!none" << 0
 				<< QString(":/somewhere/something/~:/somewhere/something/test~:/somewhere/something/test.tex~").replace("/",QDir::separator());;
-		QTest::newRow("placeholder end") << "?m.newExt##?m)##?m\"##?m ##?e)" << "rel.tex" << "!none" << 0 
+		QTest::newRow("placeholder end") << "?m.newExt##?m)##?m\"##?m ##?e)" << "rel.tex" << "!none" << 0
 				<< "rel.newExt##rel##\"rel\"##rel ##tex";
 		QTest::newRow("truncated placeholder") << "?m" << "inserted.here" << "!none" << 0 << "inserted";
-		
-		QTest::newRow("relative current file") << "?me)-?c:me)-?c:e)-?e)+?m.tex+?c:m.tex" << "main.mfile" << "current.cfile" << 0 
+
+		QTest::newRow("relative current file") << "?me)-?c:me)-?c:e)-?e)+?m.tex+?c:m.tex" << "main.mfile" << "current.cfile" << 0
 				<< "main.mfile-current.cfile-cfile-mfile+main.tex+current.tex";
 		QTest::newRow("absolute current file") << "?ame)?c:ame)?c:a)?c:am.tex?c:a" << ":/somewhere/mainfile.m" << ":/elsewhere/include/current.c" << 0
-				<< QString(":/somewhere/mainfile.m:/elsewhere/include/current.c:/elsewhere/include/:/elsewhere/include/current.tex:/elsewhere/include/").replace("/",QDir::separator());;		
+				<< QString(":/somewhere/mainfile.m:/elsewhere/include/current.c:/elsewhere/include/:/elsewhere/include/current.tex:/elsewhere/include/").replace("/",QDir::separator());;
 	}
-	void parseExtendedCommandLine(){ 
+	void parseExtendedCommandLine(){
 		QFETCH(QString, str);
 		QFETCH(QString, fileName);
 		QFileInfo file(fileName);
-		QFETCH(QString, fileName2);		
+		QFETCH(QString, fileName2);
 		QFileInfo file2;
-		if (fileName2!="!none") 
+		if (fileName2!="!none")
 			file2=QFileInfo(fileName2);
 		QFETCH(int, line);
 		QFETCH(QString, expected);

--- a/src/tests/buildmanager_t.h
+++ b/src/tests/buildmanager_t.h
@@ -69,6 +69,10 @@ private slots:
 				<< "main.mfile-current.cfile-cfile-mfile+main.tex+current.tex";
 		QTest::newRow("absolute current file") << "?ame)?c:ame)?c:a)?c:am.tex?c:a" << ":/somewhere/mainfile.m" << ":/elsewhere/include/current.c" << 0
 				<< QString(":/somewhere/mainfile.m:/elsewhere/include/current.c:/elsewhere/include/:/elsewhere/include/current.tex:/elsewhere/include/").replace("/",QDir::separator());;
+
+		QTest::newRow("search for non-existent output files") << "?p{dvi}:ame ?p{abc}:me ?p{def}:a" << "/somewhere/mainfile.m" << "/elsewhere/include/current.c" << 0
+				<< QString("/somewhere/mainfile.dvi mainfile.abc /somewhere/").replace("/",QDir::separator());
+		// TODO: Add search for existing output files
 	}
 	void parseExtendedCommandLine(){
 		QFETCH(QString, str);

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -5879,12 +5879,7 @@ void Texstudio::runInternalPdfViewer(const QFileInfo &master, const QString &opt
 		oldPDFs << doc;
 	}
 
-	if (pdfFile.isNull()) pdfFile = "?am.pdf";  // no file was explicitly specified in the command
-	QString pdfDefFile = BuildManager::parseExtendedCommandLine(pdfFile, master).first();
-	QStringList searchPaths = splitPaths(BuildManager::resolvePaths(buildManager.additionalPdfPaths));
-	searchPaths.insert(0, master.absolutePath());
-	pdfFile = buildManager.findFile(pdfDefFile, searchPaths, true);
-	if (pdfFile == "") pdfFile = pdfDefFile; //use old file name, so pdf viewer shows reasonable error message
+	pdfFile = buildManager.findPdfFile(pdfFile, master);
 	int ln = 0;
 	int col = 0;
 	if (currentEditorView()) {

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -5879,7 +5879,10 @@ void Texstudio::runInternalPdfViewer(const QFileInfo &master, const QString &opt
 		oldPDFs << doc;
 	}
 
-	pdfFile = buildManager.findPdfFile(pdfFile, master);
+	if (pdfFile.isNull()) {
+		pdfFile = master.completeBaseName() + ".pdf";
+	}
+	pdfFile = buildManager.findCompiledFile(pdfFile, master);
 	int ln = 0;
 	int col = 0;
 	if (currentEditorView()) {


### PR DESCRIPTION
This pull request implements the feature request from https://github.com/texstudio-org/texstudio/issues/754

Basically it adds the ?p command-line expansion which expands to absolute pathname of the PDF file. The file name of the PDF file is taken from the basename of the main .tex file with .pdf appended to it.
The searched directories are the directory that contains the main .tex file plus the additional PDF search directories.

I tested the patch and it seems to be working OK.

That being said, I am not sure that the selected design decision is correct. 

A) This pull request implements the ?p expansion for .pdf files, but TexStudio can also generate .ps or .dvi files (or any other image type for that matter). So while ?p solves the problem with .pdf files, it does not solve the problem with the other image types.
B) We can only search for files with the same basename as the main .tex file. What if someone compiles PDF files with some other name?

I can think of several possible workarounds that can be implemented in code:

1. Add the file extension in braces, e.g. ?p{pdf} or ?p{dvi} or ?p{ps} , etc. This solves the problem A (file extensions other than .pdf) but does not solve the problem with other filenames.

2. Use a new, third expansion syntax (besides % and ?). For example we could use expansions enclosed in { and } and inside them allow the following expansions:
%% is the % character
%b is the main file basename
%e is the main file extension
For example, let's say that we compile our tex files by adding the -compiled suffix to them and setting the extension .pdf. Then main.tex would be compiled to main-compiled.pdf

Then our command would look like this:

xdg-open {%b-compiled.pdf} > /dev/null

3. Maybe there is some other way to design the expansions so that they would allow solving problems A and B.

I am still unsure of the correct approach, so any comments, thoughts or suggestions are welcome.