### PR TITLE
Remove redundant calls to std::move

### DIFF
--- a/src/latexdocument.cpp
+++ b/src/latexdocument.cpp
@@ -1394,7 +1394,7 @@ QMultiHash<QDocumentLineHandle *, int> LatexDocument::getBibItems(const QString 
 			}
 		}
 	}
-	return std::move(result);
+	return result;
 }
 
 QMultiHash<QDocumentLineHandle *, int> LatexDocument::getLabels(const QString &name)
@@ -1409,7 +1409,7 @@ QMultiHash<QDocumentLineHandle *, int> LatexDocument::getLabels(const QString &n
 			}
 		}
 	}
-	return std::move(result);
+	return result;
 }
 
 QMultiHash<QDocumentLineHandle *, int> LatexDocument::getRefs(const QString &name)
@@ -1424,7 +1424,7 @@ QMultiHash<QDocumentLineHandle *, int> LatexDocument::getRefs(const QString &nam
 			}
 		}
 	}
-	return std::move(result);
+	return result;
 }
 
 /*!


### PR DESCRIPTION
In src/latexdocument.cpp there are three functions which end with
`return std::move(result);`

Modern C++ compilers starting with C++11 (which includes GCC9) are allowed to do "copy elision" and construct the result directly in the destination address without performing an extra object construction/copy even if the object copy/move constructor has side effects. So the call to std::move is redundant and GCC9 warns about it.

More information about copy elision can be found here:
https://developers.redhat.com/blog/2019/04/12/understanding-when-not-to-stdmove-in-c/
https://en.cppreference.com/w/cpp/language/copy_elision

The proposed patch removes the redundant calls to std::move()