### PR TITLE
Fix the FAIL messages in HelpTest::packageDocFile

### DIFF
--- a/src/tests/help_t.h
+++ b/src/tests/help_t.h
@@ -31,6 +31,9 @@ private slots:
 		}
 		QStringList checkList=fileWithoutPath.split(";");
 		QString texdocPathname = Help::packageDocFile(package, true);
+		if (texdocPathname == "") {
+			QVERIFY2(false, QString("texdoc command was not found in the search path or package \"%1\" is not installed").arg(package).toLatin1().constData());
+		}
 		QString texdocFilename = QFileInfo(texdocPathname).fileName();
 		bool found=false;
 		for(int i=(checkList.count()-1);i>0;i--) {
@@ -40,9 +43,7 @@ private slots:
 				break;
 			}
 		}
-		if(!found) {
-			QEQUAL(texdocFilename, checkList.value(0,""));
-		}
+		QVERIFY2(found, QString("Could not find documentation file for package \"%1\"").arg(package).toLatin1().constData());
 	}
 
 private:

--- a/src/tests/help_t.h
+++ b/src/tests/help_t.h
@@ -25,20 +25,24 @@ private slots:
 	void packageDocFile() {
 		QFETCH(QString, package);
 		QFETCH(QString, fileWithoutPath);
-		if (!globalExecuteAllTests) { qDebug("skip"); return; }
-        QStringList lst=fileWithoutPath.split(";");
+		if (!globalExecuteAllTests) {
+			qDebug("skip");
+			return;
+		}
+		QStringList lst=fileWithoutPath.split(";");
 		QString file = Help::packageDocFile(package, true);
-        bool found=false;
-        for(int i=(lst.count()-1);i>0;i--){
-            QString fileName=lst.at(i);
-            if(fileName==QFileInfo(file).fileName()){
-                QEQUAL(QFileInfo(file).fileName(), fileName);
-                found=true;
-                break;
-            }
-        }
-        if(!found)
-            QEQUAL(QFileInfo(file).fileName(), lst.value(0,""));
+		bool found=false;
+		for(int i=(lst.count()-1);i>0;i--) {
+			QString fileName=lst.at(i);
+			if(fileName==QFileInfo(file).fileName()) {
+				QEQUAL(QFileInfo(file).fileName(), fileName);
+				found=true;
+				break;
+			}
+		}
+		if(!found) {
+			QEQUAL(QFileInfo(file).fileName(), lst.value(0,""));
+		}
 	}
 
 private:

--- a/src/tests/help_t.h
+++ b/src/tests/help_t.h
@@ -29,19 +29,20 @@ private slots:
 			qDebug("skip");
 			return;
 		}
-		QStringList lst=fileWithoutPath.split(";");
-		QString file = Help::packageDocFile(package, true);
+		QStringList checkList=fileWithoutPath.split(";");
+		QString texdocPathname = Help::packageDocFile(package, true);
+		QString texdocFilename = QFileInfo(texdocPathname).fileName();
 		bool found=false;
-		for(int i=(lst.count()-1);i>0;i--) {
-			QString fileName=lst.at(i);
-			if(fileName==QFileInfo(file).fileName()) {
-				QEQUAL(QFileInfo(file).fileName(), fileName);
+		for(int i=(checkList.count()-1);i>0;i--) {
+			QString checkFilename=checkList.at(i);
+			if(checkFilename==texdocFilename) {
+				QEQUAL(texdocFilename, checkFilename);
 				found=true;
 				break;
 			}
 		}
 		if(!found) {
-			QEQUAL(QFileInfo(file).fileName(), lst.value(0,""));
+			QEQUAL(texdocFilename, checkList.value(0,""));
 		}
 	}
 

--- a/src/tests/help_t.h
+++ b/src/tests/help_t.h
@@ -36,7 +36,7 @@ private slots:
 		}
 		QString texdocFilename = QFileInfo(texdocPathname).fileName();
 		bool found=false;
-		for(int i=(checkList.count()-1);i>0;i--) {
+		for(int i=0, n=checkList.count(); i<n; ++i) {
 			QString checkFilename=checkList.at(i);
 			if(checkFilename==texdocFilename) {
 				found=true;

--- a/src/tests/help_t.h
+++ b/src/tests/help_t.h
@@ -36,7 +36,6 @@ private slots:
 		for(int i=(checkList.count()-1);i>0;i--) {
 			QString checkFilename=checkList.at(i);
 			if(checkFilename==texdocFilename) {
-				QEQUAL(texdocFilename, checkFilename);
 				found=true;
 				break;
 			}


### PR DESCRIPTION
While running tests I noticed that HelpTest::packageDocFile was failing and the error messages did not tell clearly what was wrong with the help system. It turned out that the problem was that texdoc was not in the search path of TeXstudio.

This PR changes the error messages to make them clearer and it adds a separate error message for the case when TeXstudio is unable to find texdoc.