### PR TITLE
Fix tests that failed in non-EN locales by translating UI strings.

### DIFF
--- a/src/tests/latexcompleter_t.cpp
+++ b/src/tests/latexcompleter_t.cpp
@@ -295,7 +295,7 @@ void LatexCompleterTest::simple(){
 	config->eowCompletes = eowCompletes;
 
 	edView->editor->cutBuffer = "";
-	
+
 	edView->editor->setFlag(QEditor::AutoCloseChars, autoParenComplete);
 	edView->editor->setText(text, false);
 	edView->editor->setCursor(edView->editor->document()->cursor(line,offset));
@@ -312,12 +312,15 @@ void LatexCompleterTest::simple(){
 		QString ist=edView->editor->text();
 		QEQUAL(ist, text);
 	}
- 
+
 	edView->editor->clearPlaceHolders();
 	edView->editor->clearCursorMirrors();
 }
 
 void LatexCompleterTest::keyval_data(){
+    const QString trEnvironmentName = QObject::tr("*environment-name*");
+    const QString trContent = QObject::tr("content...");
+
     QTest::addColumn<QString>("text");
     QTest::addColumn<QString>("workingDir");
     QTest::addColumn<int>("line");
@@ -334,7 +337,7 @@ void LatexCompleterTest::keyval_data(){
                                 << "b:>>\\b<<"
                                 << "e:>>\\be<<"
                                 << "g:>>\\beg<<"
-                                << "\n:>>\\begin{*environment-name*}\n\tcontent...\n\\end{*environment-name*}<<");
+                                << "\n:>>\\begin{" + trEnvironmentName + "}\n\t" + trContent + "\n\\end{" + trEnvironmentName + "}<<");
 
     QTest::newRow("ref") << ">>{}<<" << "" <<  0 << 3 << 5
                             << "" << ""

--- a/src/tests/structureview_t.cpp
+++ b/src/tests/structureview_t.cpp
@@ -12,6 +12,7 @@
 StructureViewTest::StructureViewTest(LatexEditorView* editor,LatexDocument *doc, bool all): edView(editor),document(doc), all(all){}
 
 void StructureViewTest::script_data(){
+	const QString trLabels = LatexDocument::tr("LABELS");
 	QTest::addColumn<QString>("script");
 	QTest::addColumn<QString>("expectedStructure");
 
@@ -20,67 +21,67 @@ void StructureViewTest::script_data(){
 		<< "editor.setText(\"Hallo\")"
 		<<"Root: LVL:0 IND:0" ;
 
-	
+
 	QTest::newRow("add Label")
 		<< "cursor.movePosition(1,cursorEnums.End);cursor.insertText(\"\\n \\\\label{test}\\n\")"
-		<< "Root: LVL:0 IND:0##Overview:LABELS LVL:0 IND:1##Label:test LVL:0 IND:2"
+		<< "Root: LVL:0 IND:0##Overview:" + trLabels + " LVL:0 IND:1##Label:test LVL:0 IND:2"
 		;
 
 	QTest::newRow("add Label2")
 		<< "cursor.insertText(\" \\\\label{test2}\\n\")"
-		<< "Root: LVL:0 IND:0##Overview:LABELS LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test2 LVL:0 IND:2" ;
+		<< "Root: LVL:0 IND:0##Overview:" + trLabels + " LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test2 LVL:0 IND:2" ;
 
 	QTest::newRow("add Label3")
 		<< "cursor.insertText(\" \\\\label{test3}\\n\");cursor.insertText(\" \\\\label{test4}\\n\");cursor.insertText(\" \\\\label{test5}\\n\");cursor.insertText(\" \\\\label{test6}\\n\")"
-		<< "Root: LVL:0 IND:0##Overview:LABELS LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test2 LVL:0 IND:2##Label:test3 LVL:0 IND:2##Label:test4 LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:test6 LVL:0 IND:2" ;
+		<< "Root: LVL:0 IND:0##Overview:" + trLabels + " LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test2 LVL:0 IND:2##Label:test3 LVL:0 IND:2##Label:test4 LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:test6 LVL:0 IND:2" ;
 
 	QTest::newRow("change Label")
 		<< "cursor.movePosition(1,cursorEnums.Up);cursor.movePosition(9,cursorEnums.Right);cursor.insertText(\"a\");cursor.insertText(\"b\");cursor.insertText(\"c\")"
-		<< "Root: LVL:0 IND:0##Overview:LABELS LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test2 LVL:0 IND:2##Label:test3 LVL:0 IND:2##Label:test4 LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2" ;
+		<< "Root: LVL:0 IND:0##Overview:" + trLabels + " LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test2 LVL:0 IND:2##Label:test3 LVL:0 IND:2##Label:test4 LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2" ;
 
 	QTest::newRow("change Label2")
 		<< "cursor.movePosition(1,cursorEnums.StartOfLine);cursor.movePosition(3,cursorEnums.Up);cursor.movePosition(9,cursorEnums.Right);cursor.insertText(\"a\");cursor.insertText(\"b\");cursor.insertText(\"c\")"
-		<< "Root: LVL:0 IND:0##Overview:LABELS LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test2 LVL:0 IND:2##Label:tabcest3 LVL:0 IND:2##Label:test4 LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2";
+		<< "Root: LVL:0 IND:0##Overview:" + trLabels + " LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test2 LVL:0 IND:2##Label:tabcest3 LVL:0 IND:2##Label:test4 LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2";
 
 
 	QTest::newRow("change Label3")
 		<< "cursor.deleteChar()"
-		<< "Root: LVL:0 IND:0##Overview:LABELS LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test2 LVL:0 IND:2##Label:tabcst3 LVL:0 IND:2##Label:test4 LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2" ;
+		<< "Root: LVL:0 IND:0##Overview:" + trLabels + " LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test2 LVL:0 IND:2##Label:tabcst3 LVL:0 IND:2##Label:test4 LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2" ;
 
 	QTest::newRow("remove line")
 		<< "cursor.eraseLine()"
-		<< "Root: LVL:0 IND:0##Overview:LABELS LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test2 LVL:0 IND:2##Label:test4 LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2" ;
+		<< "Root: LVL:0 IND:0##Overview:" + trLabels + " LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test2 LVL:0 IND:2##Label:test4 LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2" ;
 
 	QTest::newRow("remove lines2")
 		<< "cursor.movePosition(1,cursorEnums.EndOfLine);cursor.movePosition(1,cursorEnums.StartOfLine,cursorEnums.KeepAnchor);cursor.movePosition(1,cursorEnums.Up,cursorEnums.KeepAnchor);cursor.removeSelectedText()"
-		<< "Root: LVL:0 IND:0##Overview:LABELS LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2" ;
+		<< "Root: LVL:0 IND:0##Overview:" + trLabels + " LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2" ;
 
 	QTest::newRow("add section")
 		<< "cursor.movePosition(1,cursorEnums.End);cursor.insertText(\" \\\\section{sec:test}\\n\")"
-		<< "Root: LVL:0 IND:0##Overview:LABELS LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2##Section:sec:test LVL:2 IND:1" ;
+		<< "Root: LVL:0 IND:0##Overview:" + trLabels + " LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2##Section:sec:test LVL:2 IND:1" ;
 
 	QTest::newRow("add section2")
 		<< "cursor.movePosition(1,cursorEnums.End);cursor.insertText(\" \\\\section{sec:test}\\n\")"
-		<< "Root: LVL:0 IND:0##Overview:LABELS LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2##Section:sec:test LVL:2 IND:1##Section:sec:test LVL:2 IND:1" ;
+		<< "Root: LVL:0 IND:0##Overview:" + trLabels + " LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2##Section:sec:test LVL:2 IND:1##Section:sec:test LVL:2 IND:1" ;
 
 	QTest::newRow("change section")
 		<< "cursor.movePosition(1,cursorEnums.Up);cursor.movePosition(11,cursorEnums.Right);cursor.insertText(\"a\");cursor.insertText(\"b\");cursor.insertText(\"c\")"
-		<< "Root: LVL:0 IND:0##Overview:LABELS LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2##Section:sec:test LVL:2 IND:1##Section:sabcec:test LVL:2 IND:1" ;
+		<< "Root: LVL:0 IND:0##Overview:" + trLabels + " LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2##Section:sec:test LVL:2 IND:1##Section:sabcec:test LVL:2 IND:1" ;
 
 	QTest::newRow("change section2")
 		<< "cursor.movePosition(1,cursorEnums.StartOfLine);cursor.movePosition(2,cursorEnums.Right);cursor.insertText(\"sub\")"
-		<< "Root: LVL:0 IND:0##Overview:LABELS LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2##Section:sec:test LVL:2 IND:1##Section:sabcec:test LVL:3 IND:2" ;
+		<< "Root: LVL:0 IND:0##Overview:" + trLabels + " LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2##Section:sec:test LVL:2 IND:1##Section:sabcec:test LVL:3 IND:2" ;
 
 	QTest::newRow("change section3")
 		<< "cursor.movePosition(1,cursorEnums.StartOfLine);cursor.movePosition(2,cursorEnums.Right);cursor.insertText(\"sub\")"
-		<< "Root: LVL:0 IND:0##Overview:LABELS LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2##Section:sec:test LVL:2 IND:1##Section:sabcec:test LVL:4 IND:2" ;
+		<< "Root: LVL:0 IND:0##Overview:" + trLabels + " LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2##Section:sec:test LVL:2 IND:1##Section:sabcec:test LVL:4 IND:2" ;
 
 	if (!globalExecuteAllTests)
 		qDebug("skipped some tests");
 	else {
 		QTest::newRow("change section4")
 			<< "cursor.movePosition(1,cursorEnums.StartOfLine);cursor.movePosition(2,cursorEnums.Right);cursor.movePosition(6,cursorEnums.Right,cursorEnums.KeepAnchor);cursor.removeSelectedText()"
-			<< "Root: LVL:0 IND:0##Overview:LABELS LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2##Section:sec:test LVL:2 IND:1##Section:sabcec:test LVL:2 IND:1" ;
+			<< "Root: LVL:0 IND:0##Overview:" + trLabels + " LVL:0 IND:1##Label:test LVL:0 IND:2##Label:test5 LVL:0 IND:2##Label:tabcest6 LVL:0 IND:2##Section:sec:test LVL:2 IND:1##Section:sabcec:test LVL:2 IND:1" ;
 
 		QTest::newRow("set sequence of headings")
 				<< "editor.setText(\"\\\\section{a}\\n\\\\section{b}\\n\\\\section{c}\\n\")"
@@ -257,7 +258,7 @@ QStringList StructureViewTest::unrollStructure(StructureEntry *baseStructure){
 }
 
 void StructureViewTest::benchmark_data(){
-#if QT_VERSION >= 0x040500	
+#if QT_VERSION >= 0x040500
 	QTest::addColumn<QString>("text");
 	QTest::addColumn<int>("start");
 	QTest::addColumn<int>("count");
@@ -295,7 +296,7 @@ void StructureViewTest::benchmark_data(){
 }
 
 void StructureViewTest::benchmark(){
-#if QT_VERSION >= 0x040500	
+#if QT_VERSION >= 0x040500
 	QFETCH(QString, text);
 	QFETCH(int, start);
 	QFETCH(int, count);
@@ -304,7 +305,7 @@ void StructureViewTest::benchmark(){
 		qDebug() << "skipped benchmark";
 		return;
 	}
-	
+
 	edView->editor->setText(text, false);
 	QBENCHMARK {
 		document->patchStructure(start,count);


### PR DESCRIPTION
This PR fixes tests in two files (latexcompleter_t.cpp and structureview_t.cpp) that failed when run in non-English locales. There are a few strings that get translated in different locales and the tests did not expect the translated strings. The fixes are implemented by applying tr() for the corresponding context class.

This fixes all the test errors reported in https://github.com/texstudio-org/texstudio/issues/748