### PR TITLE
Fix linker warnings on 64-bit Linux

### DIFF
--- a/texstudio.pro
+++ b/texstudio.pro
@@ -380,8 +380,7 @@ CONFIG(debug, debug|release) {
 macx:LIBS += -framework CoreFoundation
 
 unix {
-    LIBS += -L/usr/lib \
-    -lz
+    LIBS += -lz
 }
 
 freebsd-* {


### PR DESCRIPTION
This PR fixes the linker warnings mentioned in https://github.com/texstudio-org/texstudio/issues/748
The warnings show up on 64-bit machines when gcc/ld tries to link TXS if the linked libraries are present both in 64-bit form (usually in /usr/lib64) and in 32-bit form in /usr/lib.

The issue is caused by the fact that texstudio.pro explicitly adds "-L /usr/lib" for unix builds that giving highest priority to /usr/lib in the list of the searched directories.

The fix is done by removing "-L /usr/lib" and letting the linker use its default search path.
There is no need to list explicitly /usr/lib because:

1. TXS build file tries to guess the correct linker search path which it cannot do better than the corresponding Linux (or Unix) distribution. The binutils and/or the configuration of the specific distribution know the correct location of the libraries much better and we cannot outperform them in this task.
2. qmake also adjusts the linker search path in the generated Makefile if that is necessary.
3. Quite often on 64-bit machines adding /usr/lib/ to the linker search path points the linker to the wrong location and causes warnings because it finds the wrong libraries first.
4. In the rare cases where the user builds and installs the necessary libraries manually, the location of the installed libraries would be /usr/local/lib or /usr/local/lib64, so adding /usr/lib does not help.

So the bottom line is that we can safely get rid of /usr/lib and thus remove the linker warnings.