### PR TITLE
Cleanup execution of external programs. Fix #768

### DIFF
--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -3,6 +3,7 @@
 #include "smallUsefulFunctions.h"
 #include "configmanagerinterface.h"
 #include "utilsSystem.h"
+#include "execprogram.h"
 
 #include "userquickdialog.h"
 
@@ -2380,18 +2381,10 @@ void ProcessX::startCommand()
 	if (stderrEnabled)
 		connect(this, SIGNAL(readyReadStandardError()), this, SLOT(readFromStandardError()));
 
-	//qDebug() << workingDirectory();
-	//qDebug() << cmd;
-	QByteArray path = qgetenv("PATH");
-#ifdef Q_OS_OSX
-	QString basePath = getEnvironmentPath();
-	qputenv("PATH", path + getPathListSeparator().toLatin1() + BuildManager::resolvePaths(BuildManager::additionalSearchPaths).toUtf8() + getPathListSeparator().toLatin1() + basePath.toUtf8());
-	// needed for searching the executable in the additional paths see https://bugreports.qt-project.org/browse/QTBUG-18387
-#else
-	qputenv("PATH", path + getPathListSeparator().toLatin1() + BuildManager::resolvePaths(BuildManager::additionalSearchPaths).toUtf8()); // needed for searching the executable in the additional paths see https://bugreports.qt-project.org/browse/QTBUG-18387
-#endif
-	QProcess::start(cmd);
-	qputenv("PATH", path); // restore
+	ExecProgram execProgram;
+	execProgram.program = cmd;
+	execProgram.additionalSearchPaths = BuildManager::resolvePaths(BuildManager::additionalSearchPaths);
+	execProgram.execAndNoWait(*this);
 
 	if (error() == FailedToStart || error() == Crashed)
 		isStarted = ended = true; //prevent call of waitForStarted, if it failed to start (see QTBUG-33021)

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -2381,9 +2381,7 @@ void ProcessX::startCommand()
 	if (stderrEnabled)
 		connect(this, SIGNAL(readyReadStandardError()), this, SLOT(readFromStandardError()));
 
-	ExecProgram execProgram;
-	execProgram.program = cmd;
-	execProgram.additionalSearchPaths = BuildManager::resolvePaths(BuildManager::additionalSearchPaths);
+	ExecProgram execProgram(cmd, BuildManager::resolvePaths(BuildManager::additionalSearchPaths));
 	execProgram.execAndNoWait(*this);
 
 	if (error() == FailedToStart || error() == Crashed)

--- a/src/execprogram.cpp
+++ b/src/execprogram.cpp
@@ -1,0 +1,39 @@
+#include "execprogram.h"
+#include "utilsSystem.h"
+
+void ExecProgram::execAndWait (void)
+{
+	QProcess proc;
+
+	execAndNoWait(proc);
+	proc.waitForFinished();
+	normalRun =
+		(proc.error() == QProcess::UnknownError) &&
+		(proc.exitStatus() == QProcess::NormalExit);
+	exitCode = proc.exitCode();
+	standardOutput = proc.readAllStandardOutput();
+	standardError = proc.readAllStandardError();
+}
+
+void ExecProgram::execAndNoWait (QProcess &proc) const
+{
+	if (!workingDirectory.isEmpty()) {
+		proc.setWorkingDirectory(workingDirectory);
+	}
+	QChar pathSep = getPathListSeparator();
+	QString pathOrig = QString::fromLocal8Bit(qgetenv("PATH"));
+	// We add the path from getEnvironmentPath() because it can be extended by shell startup scripts
+	QString pathExtended = pathOrig + pathSep + getEnvironmentPath();
+	if (!additionalSearchPaths.isEmpty()) {
+		pathExtended += pathSep + additionalSearchPaths;
+	}
+	qputenv("PATH", pathExtended.toLocal8Bit());
+	// If there are no arguments specified separately assume that the program name
+	// also contains all the arguments (if any)
+	if (arguments.isEmpty()) {
+		proc.start(program);
+	} else {
+		proc.start(program, arguments);
+	}
+	qputenv("PATH", pathOrig.toLocal8Bit());
+}

--- a/src/execprogram.cpp
+++ b/src/execprogram.cpp
@@ -1,40 +1,63 @@
 #include "execprogram.h"
 #include "utilsSystem.h"
 
+ExecProgram::ExecProgram(void)
+{
+	m_exitCode = 0;
+}
+
+ExecProgram::ExecProgram(const QString &progNameAndArguments, const QString &additionalSearchPaths, const QString &workingDirectory)
+{
+	m_program = progNameAndArguments;
+	m_additionalSearchPaths = additionalSearchPaths;
+	m_workingDirectory = workingDirectory;
+	m_exitCode = 0;
+}
+
+ExecProgram::ExecProgram(const QString &progName, const QStringList &arguments, const QString &additionalSearchPaths, const QString &workingDirectory)
+{
+	m_program = progName;
+	m_arguments = arguments;
+	m_additionalSearchPaths = additionalSearchPaths;
+	m_workingDirectory = workingDirectory;
+	m_exitCode = 0;
+}
+
+
 bool ExecProgram::execAndWait(void)
 {
 	QProcess proc;
 
 	execAndNoWait(proc);
 	proc.waitForFinished();
-	normalRun =
+	m_normalRun =
 		(proc.error() == QProcess::UnknownError) &&
 		(proc.exitStatus() == QProcess::NormalExit);
-	exitCode = proc.exitCode();
-	standardOutput = proc.readAllStandardOutput();
-	standardError = proc.readAllStandardError();
-	return normalRun && (exitCode == 0);
+	m_exitCode = proc.exitCode();
+	m_standardOutput = proc.readAllStandardOutput();
+	m_standardError = proc.readAllStandardError();
+	return m_normalRun && (m_exitCode == 0);
 }
 
 void ExecProgram::execAndNoWait(QProcess &proc) const
 {
-	if (!workingDirectory.isEmpty()) {
-		proc.setWorkingDirectory(workingDirectory);
+	if (!m_workingDirectory.isEmpty()) {
+		proc.setWorkingDirectory(m_workingDirectory);
 	}
 	QChar pathSep = getPathListSeparator();
 	QString pathOrig = QString::fromLocal8Bit(qgetenv("PATH"));
 	// We add the path from getEnvironmentPath() because it can be extended by shell startup scripts
 	QString pathExtended = pathOrig + pathSep + getEnvironmentPath();
-	if (!additionalSearchPaths.isEmpty()) {
-		pathExtended += pathSep + additionalSearchPaths;
+	if (!m_additionalSearchPaths.isEmpty()) {
+		pathExtended += pathSep + m_additionalSearchPaths;
 	}
 	qputenv("PATH", pathExtended.toLocal8Bit());
 	// If there are no arguments specified separately assume that the program name
 	// also contains all the arguments (if any)
-	if (arguments.isEmpty()) {
-		proc.start(program);
+	if (m_arguments.isEmpty()) {
+		proc.start(m_program);
 	} else {
-		proc.start(program, arguments);
+		proc.start(m_program, m_arguments);
 	}
 	qputenv("PATH", pathOrig.toLocal8Bit());
 }

--- a/src/execprogram.cpp
+++ b/src/execprogram.cpp
@@ -1,7 +1,7 @@
 #include "execprogram.h"
 #include "utilsSystem.h"
 
-bool ExecProgram::execAndWait (void)
+bool ExecProgram::execAndWait(void)
 {
 	QProcess proc;
 
@@ -16,7 +16,7 @@ bool ExecProgram::execAndWait (void)
 	return normalRun && (exitCode == 0);
 }
 
-void ExecProgram::execAndNoWait (QProcess &proc) const
+void ExecProgram::execAndNoWait(QProcess &proc) const
 {
 	if (!workingDirectory.isEmpty()) {
 		proc.setWorkingDirectory(workingDirectory);

--- a/src/execprogram.cpp
+++ b/src/execprogram.cpp
@@ -1,7 +1,7 @@
 #include "execprogram.h"
 #include "utilsSystem.h"
 
-void ExecProgram::execAndWait (void)
+bool ExecProgram::execAndWait (void)
 {
 	QProcess proc;
 
@@ -13,6 +13,7 @@ void ExecProgram::execAndWait (void)
 	exitCode = proc.exitCode();
 	standardOutput = proc.readAllStandardOutput();
 	standardError = proc.readAllStandardError();
+	return normalRun && (exitCode == 0);
 }
 
 void ExecProgram::execAndNoWait (QProcess &proc) const

--- a/src/execprogram.cpp
+++ b/src/execprogram.cpp
@@ -1,28 +1,30 @@
 #include "execprogram.h"
 #include "utilsSystem.h"
 
-ExecProgram::ExecProgram(void)
+ExecProgram::ExecProgram(void) :
+	m_normalRun(false),
+	m_exitCode(-1)
 {
-	m_exitCode = 0;
 }
 
-ExecProgram::ExecProgram(const QString &progNameAndArguments, const QString &additionalSearchPaths, const QString &workingDirectory)
+ExecProgram::ExecProgram(const QString &progNameAndArguments, const QString &additionalSearchPaths, const QString &workingDirectory) :
+	m_program(progNameAndArguments),
+	m_additionalSearchPaths(additionalSearchPaths),
+	m_workingDirectory(workingDirectory),
+	m_normalRun(false),
+	m_exitCode(-1)
 {
-	m_program = progNameAndArguments;
-	m_additionalSearchPaths = additionalSearchPaths;
-	m_workingDirectory = workingDirectory;
-	m_exitCode = 0;
 }
 
-ExecProgram::ExecProgram(const QString &progName, const QStringList &arguments, const QString &additionalSearchPaths, const QString &workingDirectory)
+ExecProgram::ExecProgram(const QString &progName, const QStringList &arguments, const QString &additionalSearchPaths, const QString &workingDirectory) :
+	m_program(progName),
+	m_arguments(arguments),
+	m_additionalSearchPaths(additionalSearchPaths),
+	m_workingDirectory(workingDirectory),
+	m_normalRun(false),
+	m_exitCode(-1)
 {
-	m_program = progName;
-	m_arguments = arguments;
-	m_additionalSearchPaths = additionalSearchPaths;
-	m_workingDirectory = workingDirectory;
-	m_exitCode = 0;
 }
-
 
 bool ExecProgram::execAndWait(void)
 {

--- a/src/execprogram.h
+++ b/src/execprogram.h
@@ -1,0 +1,25 @@
+#ifndef EXECPROGRAM_H
+#define EXECPROGRAM_H
+
+#include "mostQtHeaders.h"
+
+class ExecProgram
+{
+public:
+	// Input parameters
+	QString program;
+	QStringList arguments;
+	QString additionalSearchPaths;
+	QString workingDirectory;
+
+	// Output parameters. Only assigned by synchronous execAndWait
+	bool normalRun; // If false then program either did not run or crashed
+	int exitCode;
+	QString standardOutput;
+	QString standardError;
+
+	void execAndWait (void);
+	void execAndNoWait (QProcess &proc) const;
+};
+
+#endif // EXECPROGRAM_H

--- a/src/execprogram.h
+++ b/src/execprogram.h
@@ -6,20 +6,24 @@
 class ExecProgram
 {
 public:
-	// Input parameters
-	QString program;
-	QStringList arguments;
-	QString additionalSearchPaths;
-	QString workingDirectory;
-
-	// Output parameters. Only assigned by synchronous execAndWait
-	bool normalRun; // If false then program either did not run or crashed
-	int exitCode;
-	QString standardOutput;
-	QString standardError;
+	ExecProgram(void);
+	ExecProgram(const QString &progNameAndArguments, const QString &additionalSearchPaths, const QString &workingDirectory = QString());
+	ExecProgram(const QString &progName, const QStringList &arguments, const QString &additionalSearchPaths = QString(), const QString &workingDirectory = QString());
 
 	bool execAndWait(void);
 	void execAndNoWait(QProcess &proc) const;
+
+	// Input parameters
+	QString m_program;
+	QStringList m_arguments;
+	QString m_additionalSearchPaths;
+	QString m_workingDirectory;
+
+	// Output parameters. Only assigned by synchronous execAndWait
+	bool m_normalRun; // If false then program either did not run or crashed
+	int m_exitCode;
+	QString m_standardOutput;
+	QString m_standardError;
 };
 
 #endif // EXECPROGRAM_H

--- a/src/execprogram.h
+++ b/src/execprogram.h
@@ -18,7 +18,7 @@ public:
 	QString standardOutput;
 	QString standardError;
 
-	void execAndWait (void);
+	bool execAndWait (void);
 	void execAndNoWait (QProcess &proc) const;
 };
 

--- a/src/execprogram.h
+++ b/src/execprogram.h
@@ -18,8 +18,8 @@ public:
 	QString standardOutput;
 	QString standardError;
 
-	bool execAndWait (void);
-	void execAndNoWait (QProcess &proc) const;
+	bool execAndWait(void);
+	void execAndNoWait(QProcess &proc) const;
 };
 
 #endif // EXECPROGRAM_H

--- a/src/kpathseaParser.cpp
+++ b/src/kpathseaParser.cpp
@@ -1,5 +1,5 @@
 #include "kpathseaParser.h"
-#include "utilsSystem.h"
+#include "execprogram.h"
 
 PackageScanner::PackageScanner(QObject *parent) :
 	SafeThread(parent)
@@ -74,7 +74,12 @@ void KpathSeaParser::run()
 
 QString KpathSeaParser::kpsewhich(const QString &arg)
 {
-    return execCommand(kpseWhichCmd + " " + arg,m_additionalPaths);
+	ExecProgram execProgram;
+
+	execProgram.program = kpseWhichCmd + " " + arg;
+	execProgram.additionalSearchPaths = m_additionalPaths;
+	execProgram.execAndWait();
+	return execProgram.standardOutput;
 }
 
 
@@ -87,7 +92,11 @@ MiktexPackageScanner::MiktexPackageScanner(QString mpmcmd, QString settingsDir, 
 
 QString MiktexPackageScanner::mpm(const QString &arg)
 {
-	return execCommand(mpmCmd + " " + arg);
+	ExecProgram execProgram;
+
+	execProgram.program = mpmCmd + " " + arg;
+	execProgram.execAndWait();
+	return execProgram.standardOutput;
 }
 
 void MiktexPackageScanner::savePackageMap(const QHash<QString, QStringList> &map)

--- a/src/kpathseaParser.cpp
+++ b/src/kpathseaParser.cpp
@@ -74,12 +74,9 @@ void KpathSeaParser::run()
 
 QString KpathSeaParser::kpsewhich(const QString &arg)
 {
-	ExecProgram execProgram;
-
-	execProgram.program = kpseWhichCmd + " " + arg;
-	execProgram.additionalSearchPaths = m_additionalPaths;
+	ExecProgram execProgram(kpseWhichCmd + " " + arg, m_additionalPaths);
 	execProgram.execAndWait();
-	return execProgram.standardOutput;
+	return execProgram.m_standardOutput;
 }
 
 
@@ -92,11 +89,9 @@ MiktexPackageScanner::MiktexPackageScanner(QString mpmcmd, QString settingsDir, 
 
 QString MiktexPackageScanner::mpm(const QString &arg)
 {
-	ExecProgram execProgram;
-
-	execProgram.program = mpmCmd + " " + arg;
+	ExecProgram execProgram(mpmCmd + " " + arg, "");
 	execProgram.execAndWait();
-	return execProgram.standardOutput;
+	return execProgram.m_standardOutput;
 }
 
 void MiktexPackageScanner::savePackageMap(const QHash<QString, QStringList> &map)

--- a/src/latexstyleparser.cpp
+++ b/src/latexstyleparser.cpp
@@ -15,8 +15,7 @@ LatexStyleParser::LatexStyleParser(QObject *parent, QString baseDirName, QString
 	ExecProgram execProgram;
 	execProgram.program = texdefDir + "pdflatex";
 	execProgram.arguments << "--version";
-	execProgram.execAndWait();
-	texdefMode = execProgram.normalRun && (execProgram.exitCode == 0);
+	texdefMode = execProgram.execAndWait();
 	if (texdefMode) {
 		QString output = execProgram.standardOutput.split("\n").first().trimmed();
 		if (output.contains("MiKTeX")) {
@@ -719,8 +718,7 @@ QString LatexStyleParser::kpsewhich(QString name, QString dirName) const
 			execProgram.arguments << "-path=" + dirName;
 		}
 		execProgram.arguments << fn;
-		execProgram.execAndWait();
-		if (execProgram.normalRun && (execProgram.exitCode == 0)) {
+		if (execProgram.execAndWait()) {
 			fn = execProgram.standardOutput.split('\n').first().trimmed(); // in case more than one results are present
 		} else
 			fn.clear();
@@ -740,8 +738,7 @@ QStringList LatexStyleParser::readPackageTexDef(QString fn) const
 	if (!texdefDir.isEmpty()) {
 		execProgram.additionalSearchPaths = texdefDir;
 	}
-	execProgram.execAndWait ();
-	if (!execProgram.normalRun || (execProgram.exitCode != 0)) {
+	if (!execProgram.execAndWait()) {
 		return QStringList();
 	}
 	QStringList lines = execProgram.standardOutput.split('\n');
@@ -818,8 +815,7 @@ QStringList LatexStyleParser::readPackageTracing(QString fn) const
 	}
 	execProgram.arguments << "-draftmode" << "-interaction=nonstopmode" << "--disable-installer" << tf->fileName();
 	execProgram.workingDirectory = QFileInfo(tf->fileName()).absoluteDir().absolutePath();
-	execProgram.execAndWait();
-	if (!execProgram.normalRun || (execProgram.exitCode != 0)) {
+	if (!execProgram.execAndWait()) {
 		return QStringList();
 	}
 	QStringList lines = execProgram.standardOutput.split('\n');

--- a/src/sources.pri
+++ b/src/sources.pri
@@ -25,6 +25,7 @@ HEADERS += \
     $$PWD/editors.h \
     $$PWD/encoding.h \
     $$PWD/encodingdialog.h \
+    $$PWD/execprogram.h \
     $$PWD/filechooser.h \
     $$PWD/fileselector.h \
     $$PWD/flowlayout.h \
@@ -131,6 +132,7 @@ SOURCES += \
     $$PWD/editors.cpp \
     $$PWD/encoding.cpp \
     $$PWD/encodingdialog.cpp \
+    $$PWD/execprogram.cpp \
     $$PWD/filechooser.cpp \
     $$PWD/fileselector.cpp \
     $$PWD/flowlayout.cpp \

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -9345,12 +9345,9 @@ void Texstudio::readinAllPackageNames()
 			if (baseDir.contains("miktex", Qt::CaseInsensitive)) {
 				isMiktex = true;
 			} else if (!baseDir.contains("texlive", Qt::CaseInsensitive)) {
-				ExecProgram execProgram;
-
-				execProgram.program = baseDir + "latex.exe";
-				execProgram.arguments << "--version";
+				ExecProgram execProgram(baseDir + "latex.exe --version", "");
 				execProgram.execAndWait();
-				if (execProgram.normalRun && execProgram.standardOutput.contains("miktex", Qt::CaseInsensitive)) {
+				if (execProgram.m_normalRun && execProgram.m_standardOutput.contains("miktex", Qt::CaseInsensitive)) {
 					isMiktex = true;
 				}
 			}

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -68,6 +68,7 @@
 #include "structuretreeview.h"
 #include "symbollistmodel.h"
 #include "symbolwidget.h"
+#include "execprogram.h"
 
 #include <QScreen>
 
@@ -9340,8 +9341,19 @@ void Texstudio::readinAllPackageNames()
 			if (!QFileInfo(cmd_latex).isRelative())
 				baseDir = QFileInfo(cmd_latex).absolutePath() + "/";
 #ifdef Q_OS_WIN
-			bool isMiktex = baseDir.contains("miktex", Qt::CaseInsensitive)
-			                || (!baseDir.contains("texlive", Qt::CaseInsensitive) && execCommand(baseDir + "latex.exe --version").contains("miktex", Qt::CaseInsensitive));
+			bool isMiktex = false;
+			if (baseDir.contains("miktex", Qt::CaseInsensitive)) {
+				isMiktex = true;
+			} else if (!baseDir.contains("texlive", Qt::CaseInsensitive)) {
+				ExecProgram execProgram;
+
+				execProgram.program = baseDir + "latex.exe";
+				execProgram.arguments << "--version";
+				execProgram.execAndWait();
+				if (execProgram.normalRun && execProgram.standardOutput.contains("miktex", Qt::CaseInsensitive)) {
+					isMiktex = true;
+				}
+			}
 			if (isMiktex)
 				packageListReader = new MiktexPackageScanner(quotePath(baseDir + "mpm.exe"), configManager.configBaseDir, this);
 			else

--- a/src/utilsSystem.cpp
+++ b/src/utilsSystem.cpp
@@ -676,24 +676,6 @@ QStringList envKeys(const QProcessEnvironment &env)
 #endif
 }
 
-// run the command in a separate process, wait and return the result
-// use for internal queries that should be silent. Not to be mixed up with BuildManager::runCommand
-QString execCommand(const QString &cmd, QString additionalPaths)
-{
-	if (cmd.isEmpty()) return QString();
-    QProcess myProc(nullptr);
-    if(!additionalPaths.isEmpty()){
-        updatePathSettings(&myProc,additionalPaths);
-    }
-	myProc.start(cmd);
-	myProc.waitForFinished();
-	QString result;
-	if (myProc.exitCode() == 0) {
-		result = myProc.readAllStandardOutput();
-	}
-	return result.trimmed();
-}
-
 void ThreadBreaker::sleep(unsigned long s)
 {
 	QThread::sleep(s);

--- a/src/utilsSystem.h
+++ b/src/utilsSystem.h
@@ -76,8 +76,6 @@ bool connectUnique(const QObject *sender, const char *signal, const QObject *rec
 
 QStringList envKeys(const QProcessEnvironment &env);
 
-QString execCommand(const QString &cmd,QString additionalPaths="");
-
 
 class ThreadBreaker : public QThread
 {

--- a/src/utilssystem_unix.cpp
+++ b/src/utilssystem_unix.cpp
@@ -10,25 +10,21 @@ QString getTerminalCommand()
 	return command;
 #else // Linux
 	// Linux does not have a uniform way to determine the default terminal application
-	ExecProgram execProgram;
 
 	// gnome
-	execProgram.program = "gsettings";
-	execProgram.arguments << "get" << "org.gnome.desktop.default-applications.terminal" << "exec";
-	if (execProgram.execAndWait()) {
+	ExecProgram execGsettings("gsettings get org.gnome.desktop.default-applications.terminal exec", "");
+	if (execGsettings.execAndWait()) {
 		// "gsettings" terminates with exit code 0 if settings were fetched successfully
-		return execProgram.standardOutput.replace('\'', "");
+		return execGsettings.m_standardOutput.replace('\'', "");
 	}
 
 	// fallback
 	QStringList fallbacks = QStringList() << "konsole" << "xterm";
-	execProgram.program = "which";
 	foreach (const QString &fallback, fallbacks) {
-		execProgram.arguments.clear ();
-		execProgram.arguments << fallback;
-		if (execProgram.execAndWait()) {
+		ExecProgram execWhich("which " + fallback, "");
+		if (execWhich.execAndWait()) {
 			// "which" terminates with exit code 0 if settings were fetched successfully
-			return execProgram.standardOutput;
+			return execWhich.m_standardOutput;
 		}
 	}
 	return QString();

--- a/src/utilssystem_unix.cpp
+++ b/src/utilssystem_unix.cpp
@@ -15,8 +15,8 @@ QString getTerminalCommand()
 	// gnome
 	execProgram.program = "gsettings";
 	execProgram.arguments << "get" << "org.gnome.desktop.default-applications.terminal" << "exec";
-	execProgram.execAndWait();
-	if (execProgram.normalRun) {
+	if (execProgram.execAndWait()) {
+		// "gsettings" terminates with exit code 0 if settings were fetched successfully
 		return execProgram.standardOutput.replace('\'', "");
 	}
 
@@ -26,8 +26,8 @@ QString getTerminalCommand()
 	foreach (const QString &fallback, fallbacks) {
 		execProgram.arguments.clear ();
 		execProgram.arguments << fallback;
-		execProgram.execAndWait();
-		if (execProgram.normalRun) {
+		if (execProgram.execAndWait()) {
+			// "which" terminates with exit code 0 if settings were fetched successfully
 			return execProgram.standardOutput;
 		}
 	}

--- a/src/utilssystem_unix.cpp
+++ b/src/utilssystem_unix.cpp
@@ -1,5 +1,6 @@
 #include "utilsSystem.h"
 #include "utilsUI.h"
+#include "execprogram.h"
 
 
 QString getTerminalCommand()
@@ -9,18 +10,25 @@ QString getTerminalCommand()
 	return command;
 #else // Linux
 	// Linux does not have a uniform way to determine the default terminal application
+	ExecProgram execProgram;
+
 	// gnome
-	QString command = execCommand("gsettings get org.gnome.desktop.default-applications.terminal exec");
-	command = command.replace('\'', "");
-	if (!command.isEmpty()) {
-		return command;
+	execProgram.program = "gsettings";
+	execProgram.arguments << "get" << "org.gnome.desktop.default-applications.terminal" << "exec";
+	execProgram.execAndWait();
+	if (execProgram.normalRun) {
+		return execProgram.standardOutput.replace('\'', "");
 	}
+
 	// fallback
 	QStringList fallbacks = QStringList() << "konsole" << "xterm";
+	execProgram.program = "which";
 	foreach (const QString &fallback, fallbacks) {
-		QString command = execCommand("which " + fallback);
-		if (!command.isEmpty()) {
-			return command;
+		execProgram.arguments.clear ();
+		execProgram.arguments << fallback;
+		execProgram.execAndWait();
+		if (execProgram.normalRun) {
+			return execProgram.standardOutput;
 		}
 	}
 	return QString();


### PR DESCRIPTION
This is the PR following the discussion in #768 and after implementing what I suggested in #802 

Basically TXS has many places where it invokes different external programs. Two of the most often used ones are in ProcessX (where it executes txs:/// commands) and LatexStyleParser (where it invokes kpathsea/miktex external programs in order to parse tex files and generate .cwl definitions).

In all these places the code uses different ad-hoc implementations to 
1. Adjust the system PATH so that QProcess would be able to find executables without absolute path.
2. Wait for program to complete.
3. Check whether it completed successfully.
4. Read its output.

All these adhoc solutions use different approaches, #ifdefs for the different platforms and generally some of them may work for one platform but others will fail, just like with #768 where running of the build chain from ProcessX worked but running pdflatex from Latexstyleparser failed. Additional problem was that different solutions use different mixes of latin1, utf8 and local text encoding which is another source of possible issues (the correct approach as implied by qgetenv/qputenv is to use only local 8-bit encoding).

So what this patch does is to 

1. Implement a simple class ExecProgram which has two wrapper methods around QProcess.start().

ExecProgram.execAndWait (synchronous)
ExecProgram.execAndNoWait (asynchronous)

Both wrappers adjust the path to include the paths visible from the command shell and optionally to include caller-provided additional search directories.

2. Change LatexStyleParser, ProcessX, KpathseaParser and a couple of other places to use ExecProgram instead of ExecCommand().

3. Remove the no-longer used ExecCommand
