### PR TITLE
Add support for %short title and %envname Resolves #748

### DIFF
--- a/src/latexpackage.cpp
+++ b/src/latexpackage.cpp
@@ -64,7 +64,7 @@ void LatexPackage::unite(LatexPackage &add, bool forCompletion)
 	environmentAliases.unite(add.environmentAliases);
 	specialTreatmentCommands.unite(add.specialTreatmentCommands);
 	specialDefCommands.unite(add.specialDefCommands);
-    commandDescriptions.unite(add.commandDescriptions); // overloaded unit, which does not overwrite well defined CDs with poorly defined ones
+	commandDescriptions.unite(add.commandDescriptions); // overloaded unit, which does not overwrite well defined CDs with poorly defined ones
 
 	//possibleCommands.unite(add.possibleCommands);
 	foreach (const QString &elem, add.possibleCommands.keys()) { //expensive
@@ -136,17 +136,17 @@ LatexPackage loadCwlFile(const QString fileName, LatexCompleterConfig *config, Q
 
 			if (!keyvals.isEmpty()) {
 				// read keyval (name stored in "keyvals")
-                QStringList l_cmds=keyvals.split(',');
-                QString key;
-                CommandDescription cd = extractCommandDefKeyVal(line, key);
-                for(const QString &elem:l_cmds){
-                    package.possibleCommands["key%" + elem] << line;
-                    if (cd.args > 0) {
-                        if (key.endsWith("="))
-                            key.chop(1);
-                        package.commandDescriptions.insert(elem + "/" + key, cd);
-                    }
-                }
+				QStringList l_cmds=keyvals.split(',');
+				QString key;
+				CommandDescription cd = extractCommandDefKeyVal(line, key);
+				for(const QString &elem:l_cmds){
+					package.possibleCommands["key%" + elem] << line;
+					if (cd.args > 0) {
+						if (key.endsWith("="))
+							key.chop(1);
+						package.commandDescriptions.insert(elem + "/" + key, cd);
+					}
+				}
 				continue;
 			}
 			if (line.startsWith("#repl:")) {
@@ -208,11 +208,11 @@ LatexPackage loadCwlFile(const QString fileName, LatexCompleterConfig *config, Q
 
 				// get commandDefinition
 				CommandDescription cd = extractCommandDef(line, valid);
-                if(valid.contains('K')){
-                    // bracket command like \left etc
-                    cd.bracketCommand=true;
-                    valid.remove("K");
-                }
+				if(valid.contains('K')){
+					// bracket command like \left etc
+					cd.bracketCommand=true;
+					valid.remove("K");
+				}
 				QString cmd = rxCom3.cap(1);
 				if (cmd == "\\begin") {
 					if (!package.commandDescriptions.contains(cmd)) {
@@ -228,10 +228,10 @@ LatexPackage loadCwlFile(const QString fileName, LatexCompleterConfig *config, Q
 					CommandDescription cd_old = package.commandDescriptions.value(cmd);
 					if (cd_old.args == cd.args && cd_old.optionalArgs > cd.optionalArgs ) {
 						cd = cd_old;
-                    }
-                    if (cd_old.args == cd.args && cd_old.optionalArgs == cd.optionalArgs && cd_old.overlayArgs > cd.overlayArgs ) {
-                        cd = cd_old;
-                    }
+					}
+					if (cd_old.args == cd.args && cd_old.optionalArgs == cd.optionalArgs && cd_old.overlayArgs > cd.overlayArgs ) {
+						cd = cd_old;
+					}
 					if (cd_old.args < cd.args && cd_old.args > 0) {
 						cd = cd_old;
 #ifndef QT_NO_DEBUG
@@ -255,12 +255,12 @@ LatexPackage loadCwlFile(const QString fileName, LatexCompleterConfig *config, Q
 					}
 
 				}
-                if(!valid.contains('M')){
-                    package.commandDescriptions.insert(cmd, cd);
-                }else{
-                    // don't use line for command description
-                    valid.remove('M');
-                }
+				if(!valid.contains('M')){
+					package.commandDescriptions.insert(cmd, cd);
+				}else{
+					// don't use line for command description
+					valid.remove('M');
+				}
 
 
 				valid.remove('N'); // remove newtheorem declaration
@@ -649,8 +649,8 @@ Token::TokenType tokenTypeFromCwlArg(QString arg, QString definition)
 	}
 	// type from name
 	if (arg == "text") return Token::text;
-    if (arg == "title") return Token::title;
-    if (arg == "short title" ) return Token::shorttitle;
+	if (arg == "title") return Token::title;
+	if (arg == "short title" ) return Token::shorttitle;
 	if (arg == "package") return Token::package;
 	if (arg == "cols" || arg == "preamble") return Token::colDef;
 	if (arg == "color") return Token::color;
@@ -668,7 +668,7 @@ Token::TokenType tokenTypeFromCwlArg(QString arg, QString definition)
 	if (arg.contains("keys") || arg == "keyvals" || arg == "%<options%>") return Token::keyValArg;
 	if (arg == "options") return Token::packageoption;
 	if (arg == "class") return Token::documentclass;
-    if (arg == "formula") return Token::formula;
+	if (arg == "formula") return Token::formula;
 	if (arg == "beamertheme") return Token::beamertheme;
 	if (arg == "keylist" || arg == "bibid") return Token::bibItem;
 	if (arg == "placement" || arg == "position") return Token::placement;
@@ -678,7 +678,7 @@ Token::TokenType tokenTypeFromCwlArg(QString arg, QString definition)
 	if ((arg == "label" || arg == "%<label%>") && definition.contains('r')) return Token::labelRef;  // reference with keyword label
 	if ((arg == "label" || arg == "%<label%>") && definition.contains('l')) return Token::label;
 	if (arg == "labellist") return Token::labelRefList;
-    if (arg.contains("overlay specification")) return Token::overlay;
+	if (arg.contains("overlay specification")) return Token::overlay;
 	return Token::generalArg;
 }
 
@@ -729,8 +729,8 @@ CommandDescription extractCommandDef(QString line, QString definition)
 	int i = rxCom.indexIn(line);
 	QString command = rxCom.cap();
 	line = line.mid(command.length());
-    const QString specialChars = "{[(<";
-    const QString specialChars2 = "}])>";
+	const QString specialChars = "{[(<";
+	const QString specialChars2 = "}])>";
 	CommandDescription cd;
 	if (line.isEmpty())
 		return cd;
@@ -763,10 +763,10 @@ CommandDescription extractCommandDef(QString line, QString definition)
 				cd.bracketArgs = cd.bracketArgs + 1;
 				cd.bracketTypes.append(type);
 				break;
-            case 3:
-                cd.overlayArgs = cd.overlayArgs + 1;
-                cd.overlayTypes.append(type);
-                break;
+			case 3:
+				cd.overlayArgs = cd.overlayArgs + 1;
+				cd.overlayTypes.append(type);
+				break;
 			default:
 				break;
 			}
@@ -794,9 +794,9 @@ CommandDescription extractCommandDefKeyVal(QString line, QString &key)
 		cd.args = 1;
 		cd.argTypes << Token::width;
 	}
-    if (vals == "#l") {
-        cd.args = 1;
-        cd.argTypes << Token::label;
-    }
+	if (vals == "#l") {
+		cd.args = 1;
+		cd.argTypes << Token::label;
+	}
 	return cd;
 }

--- a/src/latexpackage.cpp
+++ b/src/latexpackage.cpp
@@ -627,10 +627,12 @@ Token::TokenType tokenTypeFromCwlArg(QString arg, QString definition)
 		if (suffix == "%plain") return Token::generalArg;
 		if (suffix == "%text") return Token::text;
 		if (suffix == "%title") return Token::title;
+		if (suffix == "%short title") return Token::shorttitle;
 		if (suffix == "%todo") return Token::todo;
 		if (suffix == "%l") return Token::width;
 		if (suffix == "%cmd") return Token::def;
 		if (suffix == "%keyvals") return Token::keyValArg;
+		if ((suffix == "%envname") && definition.contains('N')) return Token::newTheorem;
 		if (suffix == "%ref") return Token::labelRef;
 		if (suffix == "%labeldef") return Token::label;
 		if (suffix == "%special") {

--- a/utilities/manual/usermanual_en.html
+++ b/utilities/manual/usermanual_en.html
@@ -1526,7 +1526,7 @@ Each line of a cwl file defines a command. Comment lines are possible and start 
 <p>There are a few argument names that have special meaning:</p>
 <ul>
   <li><code>text</code> or ends with <code>%text</code>: The spellchecker will operate inside this argument (by default arguments are not spellchecked).</li>
-  <li><code>title</code>, <code>short title</code> or ends with <code>%title</code>: The spellchecker will operate inside this argument (by default arguments are not spellchecked). Furthermore the argument will be set in bold text (like in section)</li>
+  <li><code>title</code>, ends with <code>%title</code>, <code>short title</code> or ends with <code>%short title</code>: The spellchecker will operate inside this argument (by default arguments are not spellchecked). Furthermore the argument will be set in bold text (like in section).</li>
   <li><code>bibid</code> and <code>keylists</code>: If used in a command classified as "C". See the classifier description below.</li>
   <li><code>cmd</code> and <code>command</code> or ends with <code>%cmd</code>: definition for command, e.g. \newcommand{cmd}. This "cmd" will considered to have no arguments and convey no functionality.</li>
   <li><code>def</code> and <code>definition</code>: actual definition for command, e.g. \newcommand{cmd}{definition}. This "definition" will ignored for syntax check.</li>
@@ -1553,7 +1553,7 @@ Each line of a cwl file defines a command. Comment lines are possible and start 
   <li><code>%plain</code>: options ending with <code>%plain</code> are interpreted to have no special meaning. This way, you can e.g. define <code>label%plain</code> to have a placeholder named <code>label</code> without the semantics that it defines a label.</li>
   <li><code>beamertheme</code>: beamer theme, e.g. \usebeamertheme{beamertheme}</li>
   <li><code>keys</code>, <code>keyvals</code>, <code>%&lt;options%&gt;</code> or ends with <code>%keyvals</code>: key/value list</li>
-  <li><code>envname</code> and <code>environment name</code>: environment name for \newtheorem, e.g. \newtheorem{envname}#N (classification N needs to be present !)</li>
+  <li><code>envname</code>, <code>environment name</code> or ends with <code>%envname</code>: environment name for \newtheorem, e.g. \newtheorem{envname}#N (classification N needs to be present !)</li>
 </ul>
 <p>A %-suffix takes precedence over detection by name, i.e. an argument <code>file%text</code> will be treated as text not as file.</p>
 <h3>4.14.3 Classification format</h3>


### PR DESCRIPTION
This PR fixes the last test error reported in #748.
There was a report of a failing test
`FAIL! : LatexParsingTest::test_latexLexing(section command, multi-line optional)`
`'Token::generalArg == Token::UnknownTokenType' returned FALSE. (incorrect subtype at index 1)`

After some investigation it turned out that the error could be reproduced by enabling the checkbox for  yathesis.cwl in `Options / Configure TeXstudio / Completion / yathesis.cwl`

Initially I thought that it was a defective test but it turned out that the test is actually catching a real bug in the CWL code in yathesis.cwl
This file contains a number of cwl definitions like :
`\section[titre alt. pour TdM et entête%short title]{titre%title}#L2`
`\paragraph*{titre%title}#L5`
The problem with these definitions is that `%short title` and `%title` are not valid modifiers for the argument type so using them is ignored and the corresponding arguments get the type "general argument" instead of "short title" or "title". The proper way to define an argument of type "short title" or "title" is to use "short title" or "title" as the whole argument name.
The proposed PR does this and fixes the test error in `LatexParsingTest::test_latexLexing(section command, multi-line optional)`
