### PR TITLE
Workaround for a qmake bug when building with phonon support

### DIFF
--- a/texstudio.pro
+++ b/texstudio.pro
@@ -29,6 +29,7 @@ QT += \
 !isEmpty(PHONON){
     greaterThan(QT_MAJOR_VERSION, 4) { #Qt5
         QT += phonon4qt5
+        LIBS += -lphonon4qt5
     } else { #Qt4
         QT += phonon
     }


### PR DESCRIPTION
This PR fixes https://github.com/texstudio-org/texstudio/issues/828
There is a bug in Qt 5.12.x where `QT += phonon4qt5` does not add `-lphonon4qt5` to the linker command line. The proposed PR adds a  workaround for this issue which shows up in Ubuntu 19, Fedora 30 (and probably in any distribution that uses Qt 5.12.x)