### PR TITLE
Fix for issue #856

### DIFF
--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -2146,12 +2146,13 @@ QString BuildManager::findFile(const QString &defaultName, const QStringList &se
 {
 	//TODO: merge with findResourceFile
 	QFileInfo base(defaultName);
-	QFileInfo* mr = nullptr;
+	QFileInfo mrFileInfo;
 	if (base.exists()) {
-		if (mostRecent)
-			mr = new QFileInfo(base);
-		else
+		if (mostRecent) {
+			mrFileInfo = base;
+		} else {
 			return defaultName;
+		}
 	}
 	foreach (QString p, searchPaths) {
 		QFileInfo fi;
@@ -2169,19 +2170,19 @@ QString BuildManager::findFile(const QString &defaultName, const QStringList &se
 		}
 		if (fi.exists()) {
 			if (mostRecent) {
-				if (mr == nullptr || mr->lastModified() < fi.lastModified()) {
-					if (mr != nullptr)
-						delete mr;
-					mr = new QFileInfo(fi);
+				if (
+					mrFileInfo.filePath().isEmpty() ||
+					mrFileInfo.lastModified() < fi.lastModified()
+				) {
+					mrFileInfo = fi;
 				}
-			} else
+			} else {
 				return fi.absoluteFilePath();
+			}
 		}
 	}
-	if (mostRecent && mr != nullptr) {
-		QString result = mr->absoluteFilePath();
-		delete mr;
-		return result;
+	if (mostRecent && (mrFileInfo.filePath().isEmpty() == false)) {
+		return mrFileInfo.absoluteFilePath();
 	} else {
 		return "";
 	}

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -2151,7 +2151,7 @@ QString BuildManager::findFile(const QString &defaultName, const QStringList &se
 		if (mostRecent) {
 			mrFileInfo = defaultFileInfo;
 		} else {
-			return defaultName;
+			return defaultFileInfo.absoluteFilePath();
 		}
 	}
 	foreach (QString p, searchPaths) {

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -2153,9 +2153,8 @@ QString BuildManager::findFile(const QString &defaultName, const QStringList &se
 		else
 			return defaultName;
 	}
-
 	foreach (QString p, searchPaths) {
-        QFileInfo fi;
+		QFileInfo fi;
 		if (p.startsWith('/') || p.startsWith("\\\\") || (p.length() > 2 && p[1] == ':' && (p[2] == '\\' || p[2] == '/'))) {
 			fi = QFileInfo(QDir(p), base.fileName());
 		} else {
@@ -2195,7 +2194,7 @@ QString BuildManager::findCompiledFile(const QString &compiledFilename, const QF
 
 	searchPaths << mainFile.absolutePath();
 	searchPaths << splitPaths(resolvePaths(additionalPdfPaths));
-    foundPathname = findFile(mainFile.absolutePath()+QDir::separator()+compiledFilename, searchPaths, true);
+	foundPathname = findFile(mainFile.absolutePath()+QDir::separator()+compiledFilename, searchPaths, true);
 	if (foundPathname == "") {
 		// If searched filename is relative prepend the mainFile directory
 		// so PDF viewer shows a reasonable error message

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -2145,11 +2145,11 @@ bool BuildManager::testAndRunInternalCommand(const QString &cmd, const QFileInfo
 QString BuildManager::findFile(const QString &defaultName, const QStringList &searchPaths, bool mostRecent)
 {
 	//TODO: merge with findResourceFile
-	QFileInfo base(defaultName);
+	QFileInfo defaultFileInfo(defaultName);
 	QFileInfo mrFileInfo;
-	if (base.exists()) {
+	if (defaultFileInfo.exists()) {
 		if (mostRecent) {
-			mrFileInfo = base;
+			mrFileInfo = defaultFileInfo;
 		} else {
 			return defaultName;
 		}
@@ -2157,15 +2157,15 @@ QString BuildManager::findFile(const QString &defaultName, const QStringList &se
 	foreach (QString p, searchPaths) {
 		QFileInfo fi;
 		if (p.startsWith('/') || p.startsWith("\\\\") || (p.length() > 2 && p[1] == ':' && (p[2] == '\\' || p[2] == '/'))) {
-			fi = QFileInfo(QDir(p), base.fileName());
+			fi = QFileInfo(QDir(p), defaultFileInfo.fileName());
 		} else {
 			// ?? seems a bit weird: if p is not an absolute path, then interpret p as directory
 			// e.g. default = /my/filename.tex
 			//	  p = foo
 			// -->  /my/foo/filename.tex
 			// TODO: do we want/use this anywere or can it be removed?
-			QString absPath = base.absolutePath() + "/";
-			QString baseName = "/" + base.fileName();
+			QString absPath = defaultFileInfo.absolutePath() + "/";
+			QString baseName = "/" + defaultFileInfo.fileName();
 			fi = QFileInfo(absPath + p + baseName);
 		}
 		if (fi.exists()) {

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -2146,7 +2146,7 @@ bool BuildManager::testAndRunInternalCommand(const QString &cmd, const QFileInfo
 QString BuildManager::findCompiledFile(const QString &compiledFilename, const QFileInfo &mainFile)
 {
 	QString mainDir(mainFile.absolutePath());
-	FindInDirs findInDirs(true, mainDir);
+	FindInDirs findInDirs(true, false, mainDir);
 	findInDirs.loadOneDir(mainDir);
 	findInDirs.loadDirs(resolvePaths(additionalPdfPaths));
 	QString foundPathname = findInDirs.findAbsolute(compiledFilename);

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -2147,7 +2147,7 @@ QString BuildManager::findCompiledFile(const QString &compiledFilename, const QF
 {
 	QString mainDir(mainFile.absolutePath());
 	FindInDirs findInDirs(true, false, mainDir);
-	findInDirs.loadOneDir(mainDir);
+	findInDirs.loadDirs(mainDir);
 	findInDirs.loadDirs(resolvePaths(additionalPdfPaths));
 	QString foundPathname = findInDirs.findAbsolute(compiledFilename);
 	if (foundPathname == "") {

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -236,7 +236,6 @@ public:
 	static QString autoRerunCommands;
 	static QString additionalSearchPaths, additionalLogPaths, additionalPdfPaths;
 
-	static QString findFile(const QString &baseName, const QStringList &searchPaths, bool mostRecent = false);
 	static QString findCompiledFile(const QString &compiledFilename, const QFileInfo &mainFile);
 	void addPreviewFileName(QString fn)
 	{

--- a/src/findindirs.cpp
+++ b/src/findindirs.cpp
@@ -20,17 +20,12 @@ void FindInDirs::loadDirs(const QString &dirs)
 void FindInDirs::loadDirs(const QStringList &dirs)
 {
 	foreach(const QString &oneDir, dirs) {
-		loadOneDir(oneDir);
+		m_absDirs.push_back(
+			QDir::isAbsolutePath(oneDir) ?
+			oneDir :
+			m_resolveDir + QDir::separator() + oneDir
+		);
 	}
-}
-
-void FindInDirs::loadOneDir(const QString &dir)
-{
-	QString resolved =
-		QDir::isAbsolutePath(dir) ?
-		dir :
-		m_resolveDir + QDir::separator() + dir;
-	m_absDirs.push_back(resolved);
 }
 
 QString FindInDirs::findAbsolute(const QString &pathname)

--- a/src/findindirs.cpp
+++ b/src/findindirs.cpp
@@ -28,7 +28,7 @@ void FindInDirs::loadDirs(const QStringList &dirs)
 	}
 }
 
-QString FindInDirs::findAbsolute(const QString &pathname)
+QString FindInDirs::findAbsolute(const QString &pathname) const
 {
 	QFileInfo pathInfo(pathname);
 	QFileInfo mrInfo;

--- a/src/findindirs.cpp
+++ b/src/findindirs.cpp
@@ -1,8 +1,9 @@
 #include "findindirs.h"
 #include "utilsSystem.h"
 
-FindInDirs::FindInDirs(bool mostRecent, const QString &resolveDir, const QString &dirs) :
+FindInDirs::FindInDirs(bool mostRecent, bool checkReadable, const QString &resolveDir, const QString &dirs) :
 	m_mostRecent(mostRecent),
+	m_checkReadable(checkReadable),
 	m_resolveDir(resolveDir)
 {
 	Q_ASSERT(QDir::isAbsolutePath(resolveDir));
@@ -36,7 +37,7 @@ QString FindInDirs::findAbsolute(const QString &pathname)
 {
 	QFileInfo pathInfo(pathname);
 	QFileInfo mrInfo;
-	if (pathInfo.exists()) {
+	if (findCheckFile(pathInfo)) {
 		if (m_mostRecent) {
 			mrInfo = pathInfo;
 		} else {
@@ -45,7 +46,7 @@ QString FindInDirs::findAbsolute(const QString &pathname)
 	}
 	foreach (const QString &oneSearchDir, m_absDirs) {
 		QFileInfo fi (QDir(oneSearchDir), pathInfo.fileName());
-		if (fi.exists()) {
+		if (findCheckFile(fi)) {
 			if (m_mostRecent) {
 				if (
 					mrInfo.filePath().isEmpty() ||
@@ -63,4 +64,9 @@ QString FindInDirs::findAbsolute(const QString &pathname)
 	} else {
 		return "";
 	}
+}
+
+bool FindInDirs::findCheckFile(const QFileInfo &fileInfo) const
+{
+	return(m_checkReadable ? fileInfo.isReadable() : fileInfo.exists());
 }

--- a/src/findindirs.h
+++ b/src/findindirs.h
@@ -1,0 +1,22 @@
+#ifndef FINDINDIRS_H
+#define FINDINDIRS_H
+
+#include "mostQtHeaders.h"
+
+//TODO: merge findResourceFile into this class
+class FindInDirs
+{
+public:
+	FindInDirs(bool mostRecent, const QString &resolveDir, const QString &dirs = "");
+	void loadDirs(const QString &dirs);
+	void loadDirs(const QStringList &dirs);
+	void loadOneDir(const QString &dir);
+	QString findAbsolute(const QString &pathname);
+
+private:
+	bool m_mostRecent;
+	QString m_resolveDir;
+	QStringList m_absDirs;
+};
+
+#endif // FINDINDIRS_H

--- a/src/findindirs.h
+++ b/src/findindirs.h
@@ -10,7 +10,6 @@ public:
 	FindInDirs(bool mostRecent, bool checkReadable, const QString &resolveDir, const QString &dirs = "");
 	void loadDirs(const QString &dirs);
 	void loadDirs(const QStringList &dirs);
-	void loadOneDir(const QString &dir);
 	QString findAbsolute(const QString &pathname);
 
 private:

--- a/src/findindirs.h
+++ b/src/findindirs.h
@@ -53,7 +53,7 @@ public:
 	 * \return Returns the absolute pathname of the found file. If no matching
 	 * file is found then an empty string ("") is returned.
 	 */
-	QString findAbsolute(const QString &pathname);
+	QString findAbsolute(const QString &pathname) const;
 
 private:
 	bool findCheckFile(const QFileInfo &fileInfo) const;

--- a/src/findindirs.h
+++ b/src/findindirs.h
@@ -7,14 +7,17 @@
 class FindInDirs
 {
 public:
-	FindInDirs(bool mostRecent, const QString &resolveDir, const QString &dirs = "");
+	FindInDirs(bool mostRecent, bool checkReadable, const QString &resolveDir, const QString &dirs = "");
 	void loadDirs(const QString &dirs);
 	void loadDirs(const QStringList &dirs);
 	void loadOneDir(const QString &dir);
 	QString findAbsolute(const QString &pathname);
 
 private:
+	bool findCheckFile(const QFileInfo &fileInfo) const;
+
 	bool m_mostRecent;
+	bool m_checkReadable;
 	QString m_resolveDir;
 	QStringList m_absDirs;
 };

--- a/src/findindirs.h
+++ b/src/findindirs.h
@@ -3,13 +3,56 @@
 
 #include "mostQtHeaders.h"
 
-//TODO: merge findResourceFile into this class
+/*!
+ * \brief   Search for a given filename in a specified list of directories
+ * \details This class implements search for a given filename in a list of directories.
+ * It also supports optional search modifiers for the search criteria.
+ * TODO: Merge other file search functions (e.g. findResourceFile) into this class.
+*/
 class FindInDirs
 {
 public:
+	/*!
+	 * \brief     Creates a search object with search modifiers.
+	 * \param[in] mostRecent From all matching files return the most recent one.
+	 * \param[in] checkReadable A matching file must be readable.
+	 * \param[in] resolveDir An absolute directory path that is used to turn
+	 * loaded search directories into absolute ones. For each loaded
+	 * directory a check is made if it is absolute. Absolute directories
+	 * are used unchanged while relative directories have resolveDir
+	 * prepended to them.
+	 * \param[in] dirs Optional search directories to load into the search object.
+	 * Multiple directories should be separated by the platform-specific
+	 * directory separator.
+	 */
 	FindInDirs(bool mostRecent, bool checkReadable, const QString &resolveDir, const QString &dirs = "");
+	/*!
+	 * \brief     Load additional search directories into the search object.
+	 * \param[in] dirs Search directories to load into the search object. Multiple
+	 * directories should be separated by the platform-specific directory
+	 * separator. Relative directory pathnames have resolveDir prepended
+	 * to them.
+	 */
 	void loadDirs(const QString &dirs);
+	/*!
+	 * \brief Load additional search directories into the search object.
+	 * \param[in] dirs Search directories to load into the search object. Relative
+	 * directory pathnames have resolveDir prepended to them.
+	 */
 	void loadDirs(const QStringList &dirs);
+	/*!
+	 * \brief Searches for a given filename.
+	 * \details Searches for a given filename. First a direct check for the specified
+	 * filename is made in the current directory. If the specified filename
+	 * is absolute then the current directory is ignored. If the direct check
+	 * did not find a matching file, then the loaded search directories are
+	 * checked one by one for the specified filename (ignoring any directory
+	 * component of the searched filename.
+	 * \param[in] pathname Searched pathname. After the initial direct check, the
+	 * search in the loaded directories ignores the directory component of pathname.
+	 * \return Returns the absolute pathname of the found file. If no matching
+	 * file is found then an empty string ("") is returned.
+	 */
 	QString findAbsolute(const QString &pathname);
 
 private:

--- a/src/sources.pri
+++ b/src/sources.pri
@@ -27,6 +27,7 @@ HEADERS += \
     $$PWD/execprogram.h \
     $$PWD/filechooser.h \
     $$PWD/fileselector.h \
+    $$PWD/findindirs.h \
     $$PWD/flowlayout.h \
     $$PWD/grammarcheck.h \
     $$PWD/grammarcheck_config.h \
@@ -133,6 +134,7 @@ SOURCES += \
     $$PWD/execprogram.cpp \
     $$PWD/filechooser.cpp \
     $$PWD/fileselector.cpp \
+    $$PWD/findindirs.cpp \
     $$PWD/flowlayout.cpp \
     $$PWD/grammarcheck.cpp \
     $$PWD/help.cpp \

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -5866,7 +5866,7 @@ QDateTime Texstudio::GetBblLastModified(void)
 	QFileInfo compileFile (documents.getTemporaryCompileFileName());
 	QString compileDir(compileFile.absolutePath());
 	FindInDirs findInDirs(true, false, compileDir);
-	findInDirs.loadOneDir(compileDir);
+	findInDirs.loadDirs(compileDir);
 	findInDirs.loadDirs(BuildManager::resolvePaths(buildManager.additionalLogPaths));
 	QString bblPathname = findInDirs.findAbsolute(compileFile.completeBaseName() + ".bbl");
 	if (bblPathname == "") {

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -5865,7 +5865,7 @@ QDateTime Texstudio::GetBblLastModified(void)
 {
 	QFileInfo compileFile (documents.getTemporaryCompileFileName());
 	QString compileDir(compileFile.absolutePath());
-	FindInDirs findInDirs(true, compileDir);
+	FindInDirs findInDirs(true, false, compileDir);
 	findInDirs.loadOneDir(compileDir);
 	findInDirs.loadDirs(BuildManager::resolvePaths(buildManager.additionalLogPaths));
 	QString bblPathname = findInDirs.findAbsolute(compileFile.completeBaseName() + ".bbl");
@@ -6128,17 +6128,11 @@ bool Texstudio::logExists()
 	QString logPathname(getAbsoluteFilePath(documents.getLogFileName()));
 	FindInDirs findInDirs(
 		true,
+		true,
 		QFileInfo(logPathname).absolutePath(),
 		BuildManager::resolvePaths(buildManager.additionalLogPaths)
 	);
-	QString foundPathname = findInDirs.findAbsolute(logPathname);
-	if (foundPathname == "") {
-		return false;
-	}
-	if (QFileInfo(foundPathname).isReadable() == false) {
-		return false;
-	}
-	return true;
+	return findInDirs.findAbsolute(logPathname) != "";
 }
 
 bool Texstudio::loadLog()
@@ -6152,6 +6146,7 @@ bool Texstudio::loadLog()
 	}
 	QString logPathname(getAbsoluteFilePath(documents.getLogFileName()));
 	FindInDirs findInDirs(
+		true,
 		true,
 		QFileInfo(logPathname).absolutePath(),
 		BuildManager::resolvePaths(buildManager.additionalLogPaths)

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -25,6 +25,7 @@
 #include "dblclickmenubar.h"
 #include "filechooser.h"
 #include "filedialog.h"
+#include "findindirs.h"
 #include "tabdialog.h"
 #include "arraydialog.h"
 #include "bibtexdialog.h"
@@ -5863,10 +5864,11 @@ void Texstudio::runBibliographyIfNecessary(const QFileInfo &mainFile)
 QDateTime Texstudio::GetBblLastModified(void)
 {
 	QFileInfo compileFile (documents.getTemporaryCompileFileName());
-	QStringList searchPaths;
-	searchPaths << compileFile.absolutePath();
-	searchPaths << splitPaths(BuildManager::resolvePaths(buildManager.additionalLogPaths));
-	QString bblPathname = buildManager.findFile(compileFile.completeBaseName() + ".bbl", searchPaths, true);
+	QString compileDir(compileFile.absolutePath());
+	FindInDirs findInDirs(true, compileDir);
+	findInDirs.loadOneDir(compileDir);
+	findInDirs.loadDirs(BuildManager::resolvePaths(buildManager.additionalLogPaths));
+	QString bblPathname = findInDirs.findAbsolute(compileFile.completeBaseName() + ".bbl");
 	if (bblPathname == "") {
 		return QDateTime();
 	}
@@ -6123,10 +6125,20 @@ bool Texstudio::logExists()
 	QString finame = documents.getTemporaryCompileFileName();
 	if (finame == "")
 		return false;
-	QString logFileName = buildManager.findFile(getAbsoluteFilePath(documents.getLogFileName()), splitPaths(BuildManager::resolvePaths(buildManager.additionalLogPaths)), true);
-	QFileInfo fic(logFileName);
-	if (fic.exists() && fic.isReadable()) return true;
-	else return false;
+	QString logPathname(getAbsoluteFilePath(documents.getLogFileName()));
+	FindInDirs findInDirs(
+		true,
+		QFileInfo(logPathname).absolutePath(),
+		BuildManager::resolvePaths(buildManager.additionalLogPaths)
+	);
+	QString foundPathname = findInDirs.findAbsolute(logPathname);
+	if (foundPathname == "") {
+		return false;
+	}
+	if (QFileInfo(foundPathname).isReadable() == false) {
+		return false;
+	}
+	return true;
 }
 
 bool Texstudio::loadLog()
@@ -6138,9 +6150,22 @@ bool Texstudio::loadLog()
 		QMessageBox::warning(this, tr("Error"), tr("File must be saved and compiling before you can view the log"));
 		return false;
 	}
-	QString logFileName = buildManager.findFile(getAbsoluteFilePath(documents.getLogFileName()), splitPaths(BuildManager::resolvePaths(buildManager.additionalLogPaths)), true);
+	QString logPathname(getAbsoluteFilePath(documents.getLogFileName()));
+	FindInDirs findInDirs(
+		true,
+		QFileInfo(logPathname).absolutePath(),
+		BuildManager::resolvePaths(buildManager.additionalLogPaths)
+	);
+	QString foundPathname = findInDirs.findAbsolute(logPathname);
+	if (foundPathname == "") {
+		return false;
+	}
 	QTextCodec * codec = QTextCodec::codecForName(configManager.logFileEncoding.toLatin1());
-	return outputView->getLogWidget()->loadLogFile(logFileName, compileFileName, codec ? codec : documents.getCurrentDocument()->codec() );
+	return outputView->getLogWidget()->loadLogFile(
+		foundPathname,
+		compileFileName,
+		codec ? codec : documents.getCurrentDocument()->codec()
+	);
 }
 
 void Texstudio::showLog()


### PR DESCRIPTION
This PR fixes issue #856
The problem was caused by the fact that when searching for an existing .bbl file we were passing a relative pathname (actually just a .bbl filename) for that existing .bbl file. Since the user also specified relative pathname for the additional log files, the generic search function `BuildManager::findfile()` failed to find the .bbl file.

The proposed fix replaces `BuildManager::findfile()` with a separate class `FindInDirs`. That class has the following features:

1. It does everything that `BuildManager::findfile()` could do
2. It enforces search in absolute directory pathnames. This enforcing is implemented by specifying an absolute directory in the constructor ( `resolveDir`). Any search directory that is loaded afterwards is checked and if it is not absolute, then it is resolved to an absolute directory by prepending `resolveDir` to it. This enforcing of absolute pathnames takes care of the problem with the lookup of .bbl filenames.
3. The return value from `FindInDirs::findAbsolute()` is always absolute. On the other hand `BuildManager::findfile()` could return a relative pathname if it was passed a relative pathname and that relative pathname was found relative to current directory.

Ideally `FindInDirs` will be used to replace all the other search functions like `findResourceFile()`, etc. but it probably needs to be extended with extra properties/methods to achieve that. 