### PR TITLE
Fix debug builds on MinGW platform 

### DIFF
--- a/src/modifiedQObject.h
+++ b/src/modifiedQObject.h
@@ -4,8 +4,8 @@
 
 #include <qglobal.h>
 
-
-#ifndef NO_CRASH_HANDLER
+// Crash handler and its helper functions are available only when using GNU libc
+#if !defined(NO_CRASH_HANDLER) && defined(__GLIBC__)
 
 #define ASSERT_THROW Q_DECL_NOTHROW
 


### PR DESCRIPTION
This PR fixes the debug builds on the MinGW platform.

Currently the debug builds use `txs_assert()` and `txs_assert_x()`. However these two functions are only defined on platforms that support GNU libc. MinGW on the other hand does not use/support glibc. So currently the debug builds fail on MinGW.

The proposed PR changes the debug code so that it only uses `txs_assert()` and `txs_assert_x()` when the crash handler and its helper functions ( `txs_assert()` and `txs_assert_x()` ) are actually defined.
