### PR TITLE
Fix linked libraries on Windows

### DIFF
--- a/texstudio.pro
+++ b/texstudio.pro
@@ -314,6 +314,9 @@ isEmpty(USE_SYSTEM_QUAZIP) {
 
 include(src/pdfviewer/pdfviewer.pri)
 LIBS += -lz # Internal PDF viewer and internal QuaZIP require zlib
+win32: {
+    LIBS += -lShlwapi # SyncTeX/Windows uses Shlwapi
+}
 
 # ###############################
 

--- a/texstudio.pro
+++ b/texstudio.pro
@@ -315,7 +315,7 @@ isEmpty(USE_SYSTEM_QUAZIP) {
 include(src/pdfviewer/pdfviewer.pri)
 LIBS += -lz # Internal PDF viewer and internal QuaZIP require zlib
 win32: {
-    LIBS += -lShlwapi # SyncTeX/Windows uses Shlwapi
+    LIBS += -lshlwapi # SyncTeX/Windows uses shlwapi
 }
 
 # ###############################

--- a/texstudio.pro
+++ b/texstudio.pro
@@ -313,6 +313,7 @@ isEmpty(USE_SYSTEM_QUAZIP) {
 }
 
 include(src/pdfviewer/pdfviewer.pri)
+LIBS += -lz # Internal PDF viewer and internal QuaZIP require zlib
 
 # ###############################
 
@@ -382,10 +383,6 @@ CONFIG(debug, debug|release) {
     macx:LIBS += -framework QtTest
 }
 macx:LIBS += -framework CoreFoundation
-
-unix {
-    LIBS += -lz
-}
 
 freebsd-* {
     LIBS += -lexecinfo


### PR DESCRIPTION
This PR fixes a build error on Windows 7, Qt 5.12.6 and MinGW 7.3.0 (bundled with Qt)

Currently when trying to build using the following configuration
`qmake.exe "CONFIG+=debug" "CONFIG-=debug_and_release" "CONFIG-=release"`
it fails to find the zlib and Shlwapi libraries.
zlib is used by the internal PDF viewer and QuaZIP
Shlwapi is used by SyncTeX (part of the internal PDF viewer) when it is built on Windows.