### PR TITLE
Add doxygen comments to QDocumentLineHandle cookie methods

### DIFF
--- a/src/findindirs.cpp
+++ b/src/findindirs.cpp
@@ -1,6 +1,19 @@
 #include "findindirs.h"
 #include "utilsSystem.h"
 
+/*!
+ * \brief     Creates a search object with search modifiers.
+ * \param[in] mostRecent From all matching files return the most recent one.
+ * \param[in] checkReadable A matching file must be readable.
+ * \param[in] resolveDir An absolute directory path that is used to turn
+ * loaded search directories into absolute ones. For each loaded
+ * directory a check is made if it is absolute. Absolute directories
+ * are used unchanged while relative directories have resolveDir
+ * prepended to them.
+ * \param[in] dirs Optional search directories to load into the search object.
+ * Multiple directories should be separated by the platform-specific
+ * directory separator.
+ */
 FindInDirs::FindInDirs(bool mostRecent, bool checkReadable, const QString &resolveDir, const QString &dirs) :
 	m_mostRecent(mostRecent),
 	m_checkReadable(checkReadable),
@@ -12,11 +25,23 @@ FindInDirs::FindInDirs(bool mostRecent, bool checkReadable, const QString &resol
 	}
 }
 
+/*!
+ * \brief     Load additional search directories into the search object.
+ * \param[in] dirs Search directories to load into the search object. Multiple
+ * directories should be separated by the platform-specific directory
+ * separator. Relative directory pathnames have resolveDir prepended
+ * to them.
+ */
 void FindInDirs::loadDirs(const QString &dirs)
 {
 	loadDirs(splitPaths(dirs));
 }
 
+/*!
+ * \brief Load additional search directories into the search object.
+ * \param[in] dirs Search directories to load into the search object. Relative
+ * directory pathnames have resolveDir prepended to them.
+ */
 void FindInDirs::loadDirs(const QStringList &dirs)
 {
 	foreach(const QString &oneDir, dirs) {
@@ -28,6 +53,19 @@ void FindInDirs::loadDirs(const QStringList &dirs)
 	}
 }
 
+/*!
+ * \brief Searches for a given filename.
+ * \details Searches for a given filename. First a direct check for the specified
+ * filename is made in the current directory. If the specified filename
+ * is absolute then the current directory is ignored. If the direct check
+ * did not find a matching file, then the loaded search directories are
+ * checked one by one for the specified filename (ignoring any directory
+ * component of the searched filename.
+ * \param[in] pathname Searched pathname. After the initial direct check, the
+ * search in the loaded directories ignores the directory component of pathname.
+ * \return Returns the absolute pathname of the found file. If no matching
+ * file is found then an empty string ("") is returned.
+ */
 QString FindInDirs::findAbsolute(const QString &pathname) const
 {
 	QFileInfo pathInfo(pathname);

--- a/src/findindirs.h
+++ b/src/findindirs.h
@@ -12,47 +12,9 @@
 class FindInDirs
 {
 public:
-	/*!
-	 * \brief     Creates a search object with search modifiers.
-	 * \param[in] mostRecent From all matching files return the most recent one.
-	 * \param[in] checkReadable A matching file must be readable.
-	 * \param[in] resolveDir An absolute directory path that is used to turn
-	 * loaded search directories into absolute ones. For each loaded
-	 * directory a check is made if it is absolute. Absolute directories
-	 * are used unchanged while relative directories have resolveDir
-	 * prepended to them.
-	 * \param[in] dirs Optional search directories to load into the search object.
-	 * Multiple directories should be separated by the platform-specific
-	 * directory separator.
-	 */
 	FindInDirs(bool mostRecent, bool checkReadable, const QString &resolveDir, const QString &dirs = "");
-	/*!
-	 * \brief     Load additional search directories into the search object.
-	 * \param[in] dirs Search directories to load into the search object. Multiple
-	 * directories should be separated by the platform-specific directory
-	 * separator. Relative directory pathnames have resolveDir prepended
-	 * to them.
-	 */
 	void loadDirs(const QString &dirs);
-	/*!
-	 * \brief Load additional search directories into the search object.
-	 * \param[in] dirs Search directories to load into the search object. Relative
-	 * directory pathnames have resolveDir prepended to them.
-	 */
 	void loadDirs(const QStringList &dirs);
-	/*!
-	 * \brief Searches for a given filename.
-	 * \details Searches for a given filename. First a direct check for the specified
-	 * filename is made in the current directory. If the specified filename
-	 * is absolute then the current directory is ignored. If the direct check
-	 * did not find a matching file, then the loaded search directories are
-	 * checked one by one for the specified filename (ignoring any directory
-	 * component of the searched filename.
-	 * \param[in] pathname Searched pathname. After the initial direct check, the
-	 * search in the loaded directories ignores the directory component of pathname.
-	 * \return Returns the absolute pathname of the found file. If no matching
-	 * file is found then an empty string ("") is returned.
-	 */
 	QString findAbsolute(const QString &pathname) const;
 
 private:

--- a/src/qcodeedit/lib/document/qdocument.cpp
+++ b/src/qcodeedit/lib/document/qdocument.cpp
@@ -3173,6 +3173,70 @@ QVector<int> QDocumentLineHandle::getCachedFormats() const
 	return m_cache;
 }
 
+/*!
+ * \brief Returns the specified cookie type associated with this line.
+ * \details Returns the specified cookie type associated with this line.
+ * Not thread safe. Caller must hold a read lock of the line.
+ * \param[in] type The type of the returned cookie.
+ * \return Returns the cookie of the specified type.
+ */
+QVariant QDocumentLineHandle::getCookie(int type) const
+{
+	return mCookies.value(type,QVariant());
+}
+
+/*!
+ * \brief Returns the specified cookie type associated with this line.
+ * \details Returns the specified cookie type associated with this line.
+ * Thread safe. Obtains a read lock for the duration of the call.
+ * \param[in] type The type of the returned cookie.
+ * \return Returns the cookie of the specified type.
+ */
+QVariant QDocumentLineHandle::getCookieLocked(int type) const
+{
+	QReadLocker locker(&mLock);
+	return mCookies.value(type,QVariant());
+}
+
+/*!
+ * \brief Sets the specified cookie type for this line to the specified value.
+ * \details Sets the specified cookie type for this line to the specified value.
+ * Not thread safe. Caller must hold a write lock of the line.
+ * \param[in] type The type of the cookie to be set.
+ * \param[in] data The value of the cookie to be set.
+ */
+void QDocumentLineHandle::setCookie(int type,QVariant data)
+{
+	mCookies.insert(type,data);
+}
+
+/*!
+ * \brief Checks if the line has a cookie of the specified type.
+ * \details Checks if the line has a cookie of the specified type.
+ * Not thread safe. Caller must hold a read lock of the line.
+ * \param[in] type The type of the checked cookie.
+ * \return Returns a boolean flag indicating if the line has a cookie of the
+ * specified type.
+ */
+bool QDocumentLineHandle::hasCookie(int type) const
+{
+	return mCookies.contains(type);
+}
+
+/*!
+ * \brief Removes the specified cookie type for this line.
+ * \details Removes the specified cookie type for this line.
+ * If this line does not have a cookie of the specified type then does nothing.
+ * Not thread safe. Caller must hold a write lock of the line.
+ * \param[in] type The type of the cookie to be removed.
+ * \return Returns a boolean flag indicating if the line had a cookie of the
+ * specified type.
+ */
+bool QDocumentLineHandle::removeCookie(int type)
+{
+	return mCookies.remove(type);
+}
+
 bool QDocumentLineHandle::isRTLByLayout() const{
 	if (!m_layout) return false;
 	else {

--- a/src/qcodeedit/lib/document/qdocumentline_p.h
+++ b/src/qcodeedit/lib/document/qdocumentline_p.h
@@ -158,19 +158,57 @@ public:
 		    return mTicket;
 		}
 
-		QVariant getCookie(int type) const{ //locking needs to be done externally !!!
+		/*!
+		 * \brief Returns the specified cookie type associated with this line.
+		 * \details Returns the specified cookie type associated with this line.
+		 * Not thread safe. Caller must hold a read lock of the line.
+		 * \param[in] type The type of the returned cookie.
+		 * \return Returns the cookie of the specified type.
+		 */
+		QVariant getCookie(int type) const{
 			return mCookies.value(type,QVariant());
 		}
+		/*!
+		 * \brief Returns the specified cookie type associated with this line.
+		 * \details Returns the specified cookie type associated with this line.
+		 * Thread safe. Obtains a read lock for the duration of the call.
+		 * \param[in] type The type of the returned cookie.
+		 * \return Returns the cookie of the specified type.
+		 */
 		QVariant getCookieLocked(int type) const{
 			QReadLocker locker(&mLock);
 			return mCookies.value(type,QVariant());
 		}
+		/*!
+		 * \brief Sets the specified cookie type for this line to the specified value.
+		 * \details Sets the specified cookie type for this line to the specified value.
+		 * Not thread safe. Caller must hold a write lock of the line.
+		 * \param[in] type The type of the cookie to be set.
+		 * \param[in] data The value of the cookie to be set.
+		 */
 		void setCookie(int type,QVariant data){ //locking needs to be done externally !!!
 			mCookies.insert(type,data);
 		}
+		/*!
+		 * \brief Checks if the line has a cookie of the specified type.
+		 * \details Checks if the line has a cookie of the specified type.
+		 * Not thread safe. Caller must hold a read lock of the line.
+		 * \param[in] type The type of the checked cookie.
+		 * \return Returns a boolean flag indicating if the line has a cookie of the
+		 * specified type.
+		 */
 		bool hasCookie(int type) const{
 			return mCookies.contains(type);
 		}
+		/*!
+		 * \brief Removes the specified cookie type for this line.
+		 * \details Removes the specified cookie type for this line.
+		 * If this line does not have a cookie of the specified type then does nothing.
+		 * Not thread safe. Caller must hold a write lock of the line.
+		 * \param[in] type The type of the cookie to be removed.
+		 * \return Returns a boolean flag indicating if the line had a cookie of the
+		 * specified type.
+		 */
 		bool removeCookie(int type){
 			return mCookies.remove(type);
 		}

--- a/src/qcodeedit/lib/document/qdocumentline_p.h
+++ b/src/qcodeedit/lib/document/qdocumentline_p.h
@@ -3,7 +3,7 @@
 ** Copyright (C) 2006-2009 fullmetalcoder <fullmetalcoder@hotmail.fr>
 **
 ** This file is part of the Edyuk project <http://edyuk.org>
-** 
+**
 ** This file may be used under the terms of the GNU General Public License
 ** version 3 as published by the Free Software Foundation and appearing in the
 ** file GPL.txt included in the packaging of this file.
@@ -54,16 +54,16 @@ class QCE_EXPORT QDocumentLineHandle
 	friend class QDocumentLine;
 	friend class QDocumentBuffer;
 	friend class QDocumentPrivate;
-	
+
 	public:
 		QDocumentLineHandle(QDocument *d);
 		QDocumentLineHandle(const QString& s, QDocument *d);
-		
+
 		int count() const;
 		int length() const;
-		
+
 		int position() const;
-		
+
 		QString text() const;
 //private:
 //		int line() const;
@@ -71,35 +71,35 @@ public:
 		int xToCursor(int x) const;
 		int cursorToX(int i) const;
 		int cursorToXNoLock(int i) const;
-		
+
 		int wrappedLineForCursor(int cpos) const;
 		int wrappedLineForCursorNoLock(int cpos) const;
-		
+
 		int documentOffsetToCursor(int x, int y) const;
 		void cursorToDocumentOffset(int cpos, int& x, int& y) const;
-		
+
 		QPoint cursorToDocumentOffset(int cpos) const;
-		
+
 		int indent() const;
-		
+
 		int nextNonSpaceChar(uint pos) const;
 		int previousNonSpaceChar(int pos) const;
 		int nextNonSpaceCharNoLock(uint pos) const;
 		int previousNonSpaceCharNoLock(int pos) const;
-		
+
 		bool hasFlag(int flag) const;
 		void setFlag(int flag, bool y = true) const;
-		
+
 		QDocument* document() const;
 
 		void updateWrap(int lineNr) const;
 		void updateWrapAndNotifyDocument(int ownLineNumber) const;
-		
+
 		void setFormats(const QVector<int>& formats);
-		
+
 		void clearOverlays();
 		void clearOverlays(int format);
-        void clearOverlays(QList<int> formats);
+		void clearOverlays(QList<int> formats);
 		void addOverlay(const QFormatRange& over);
 		void addOverlayNoLock(const QFormatRange& over);
 		void removeOverlay(const QFormatRange& over);
@@ -108,9 +108,9 @@ public:
 		QFormatRange getOverlayAt(int index, int preferredFormat) const;
 		QFormatRange getFirstOverlay(int start = 0, int end = -1, int preferredFormat = -1) const;
 		QFormatRange getLastOverlay(int start = 0, int end = -1, int preferredFormat = -1) const;
-		
+
 		void shiftOverlays(int position, int offset);
-		
+
 		void draw(int lineNr,
 					QPainter *p,
 					int xOffset,
@@ -120,25 +120,25 @@ public:
 					bool fullSel,
 					int yStart=0,
 					int yEnd=-1) const;
-		
+
 		QString exportAsHtml(int fromOffset=0, int toOffset = -1, int maxLineWidth = -1, int maxWrap = 0) const;
 
 		inline QString& textBuffer() { setFlag(QDocumentLine::LayoutDirty, true); return m_text; }
-		
+
 		inline void ref() { m_ref.ref(); }
-        inline void deref() { if ( !m_ref.deref() ) delete this; }
-        int getRef(){ return m_ref.fetchAndAddRelaxed(0); }
+		inline void deref() { if ( !m_ref.deref() ) delete this; }
+		int getRef(){ return m_ref.fetchAndAddRelaxed(0); }
 
 		QList<int> getBreaks();
 		void clearFrontiers(){
 		    m_frontiers.clear();
 		}
-		
+
 		~QDocumentLineHandle();
 
-        QVector<int> compose() const;
+		QVector<int> compose() const;
 		QVector<int> getFormats() const;
-        QVector<int> getCachedFormats() const;
+		QVector<int> getCachedFormats() const;
 
 		void lockForRead() const {
 		    mLock.lockForRead();
@@ -161,10 +161,10 @@ public:
 		QVariant getCookie(int type) const{ //locking needs to be done externally !!!
 			return mCookies.value(type,QVariant());
 		}
-        QVariant getCookieLocked(int type) const{ //locking needs to be done externally !!!
-            QReadLocker locker(&mLock);
-            return mCookies.value(type,QVariant());
-        }
+		QVariant getCookieLocked(int type) const{ //locking needs to be done externally !!!
+			QReadLocker locker(&mLock);
+			return mCookies.value(type,QVariant());
+		}
 		void setCookie(int type,QVariant data){ //locking needs to be done externally !!!
 			mCookies.insert(type,data);
 		}
@@ -182,25 +182,25 @@ public:
 		void drawBorders(QPainter *p, int yStart, int yEnd) const;
 
 		void applyOverlays() const;
-        void splitAtFormatChanges(QList<RenderRange>* ranges, const QVector<int>* sel = nullptr, int from = 0, int until = -1) const;
-		
+		void splitAtFormatChanges(QList<RenderRange>* ranges, const QVector<int>* sel = nullptr, int from = 0, int until = -1) const;
+
 		int getPictureCookieHeight() const;
 
 		QList<QTextLayout::FormatRange> decorations() const;
-		
+
 		QString m_text;
 		QDocument *m_doc;
 
 		QAtomicInt m_ref;
 
-        mutable int m_indent;
+		mutable int m_indent;
 		mutable quint16 m_state;
 		mutable QTextLayout *m_layout;
 		mutable QVector<int> m_cache;
 		mutable QVector< QPair<int, int> > m_frontiers; //list of line wraps, <character, x in pixel (if it were unwrapped) >
-		
+
 		QNFAMatchContext m_context;
-		
+
 		QVector<int> m_formats;
 		QVector<QParenthesis> m_parens;
 		QList<QFormatRange> m_overlays;

--- a/src/qcodeedit/lib/document/qdocumentline_p.h
+++ b/src/qcodeedit/lib/document/qdocumentline_p.h
@@ -161,7 +161,7 @@ public:
 		QVariant getCookie(int type) const{ //locking needs to be done externally !!!
 			return mCookies.value(type,QVariant());
 		}
-		QVariant getCookieLocked(int type) const{ //locking needs to be done externally !!!
+		QVariant getCookieLocked(int type) const{
 			QReadLocker locker(&mLock);
 			return mCookies.value(type,QVariant());
 		}

--- a/src/qcodeedit/lib/document/qdocumentline_p.h
+++ b/src/qcodeedit/lib/document/qdocumentline_p.h
@@ -158,60 +158,11 @@ public:
 		    return mTicket;
 		}
 
-		/*!
-		 * \brief Returns the specified cookie type associated with this line.
-		 * \details Returns the specified cookie type associated with this line.
-		 * Not thread safe. Caller must hold a read lock of the line.
-		 * \param[in] type The type of the returned cookie.
-		 * \return Returns the cookie of the specified type.
-		 */
-		QVariant getCookie(int type) const{
-			return mCookies.value(type,QVariant());
-		}
-		/*!
-		 * \brief Returns the specified cookie type associated with this line.
-		 * \details Returns the specified cookie type associated with this line.
-		 * Thread safe. Obtains a read lock for the duration of the call.
-		 * \param[in] type The type of the returned cookie.
-		 * \return Returns the cookie of the specified type.
-		 */
-		QVariant getCookieLocked(int type) const{
-			QReadLocker locker(&mLock);
-			return mCookies.value(type,QVariant());
-		}
-		/*!
-		 * \brief Sets the specified cookie type for this line to the specified value.
-		 * \details Sets the specified cookie type for this line to the specified value.
-		 * Not thread safe. Caller must hold a write lock of the line.
-		 * \param[in] type The type of the cookie to be set.
-		 * \param[in] data The value of the cookie to be set.
-		 */
-		void setCookie(int type,QVariant data){ //locking needs to be done externally !!!
-			mCookies.insert(type,data);
-		}
-		/*!
-		 * \brief Checks if the line has a cookie of the specified type.
-		 * \details Checks if the line has a cookie of the specified type.
-		 * Not thread safe. Caller must hold a read lock of the line.
-		 * \param[in] type The type of the checked cookie.
-		 * \return Returns a boolean flag indicating if the line has a cookie of the
-		 * specified type.
-		 */
-		bool hasCookie(int type) const{
-			return mCookies.contains(type);
-		}
-		/*!
-		 * \brief Removes the specified cookie type for this line.
-		 * \details Removes the specified cookie type for this line.
-		 * If this line does not have a cookie of the specified type then does nothing.
-		 * Not thread safe. Caller must hold a write lock of the line.
-		 * \param[in] type The type of the cookie to be removed.
-		 * \return Returns a boolean flag indicating if the line had a cookie of the
-		 * specified type.
-		 */
-		bool removeCookie(int type){
-			return mCookies.remove(type);
-		}
+		QVariant getCookie(int type) const;
+		QVariant getCookieLocked(int type) const;
+		void setCookie(int type,QVariant data);
+		bool hasCookie(int type) const;
+		bool removeCookie(int type);
 
 		bool isRTLByLayout() const;
 		bool isRTLByText() const;


### PR DESCRIPTION
While working on changes to the tokenizer code I came across an incorrect comment about QDocumentLineHandle::getCookieLocked which said that the method needs external logging. Most likely the incorrect comment was just a copy&paste error, but I decided to add doxygen code for the QDocumentLineHandle cookie methods, documenting the parameters, return values and thread safety of these methods.

I am using the doxygen comments for my own reference, but they may be useful to someone else too so I am providing a PR for them