### PR TITLE
Fix the "Open Terminal" command under Linux

### DIFF
--- a/src/utilssystem_unix.cpp
+++ b/src/utilssystem_unix.cpp
@@ -14,8 +14,12 @@ QString getTerminalCommand()
 	// gnome
 	ExecProgram execGsettings("gsettings get org.gnome.desktop.default-applications.terminal exec", "");
 	if (execGsettings.execAndWait()) {
-		// "gsettings" terminates with exit code 0 if settings were fetched successfully
-		return execGsettings.m_standardOutput.replace('\'', "");
+		/*
+			1. "gsettings" terminates with exit code 0 if settings were fetched successfully.
+			2. The returned value has a trailing LF so we trim it.
+			3. The command is wrapped in single quotes, e.g. 'gnome-terminal' so we remove the single quotes.
+		 */
+		return execGsettings.m_standardOutput.trimmed().replace('\'', "");
 	}
 
 	// fallback


### PR DESCRIPTION
This PR fixes the bugreport for non-working terminal command ( https://github.com/texstudio-org/texstudio/issues/888#issuecomment-576333120 )

The problem was that `gsettings get org.gnome.desktop.default-applications.terminal exec` returns the command with a trailing line feed that we did not remove. This was fixed by calling .trimmed() on the returned command.