### PR TITLE
Improvement to configure MiKTeX portable under Windows.

### DIFF
--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1495,6 +1495,7 @@ void BuildManager::checkLatexConfiguration(bool &noWarnAgain)
 	}
 }
 
+#ifdef Q_OS_WIN32
 void BuildManager::swapWinSearchPath(QString &miktex, QString &texlive)
 {
 	QString oldMiktexBinPath = miktexBinPath;
@@ -1504,6 +1505,7 @@ void BuildManager::swapWinSearchPath(QString &miktex, QString &texlive)
 	miktex = oldMiktexBinPath;
 	texlive = oldTexliveWinBinPath;
 }
+#endif
 
 bool BuildManager::runCommand(const QString &unparsedCommandLine, const QFileInfo &mainFile, const QFileInfo &currentFile, int currentLine, QString *buffer, QTextCodec *codecForBuffer )
 {

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1495,6 +1495,16 @@ void BuildManager::checkLatexConfiguration(bool &noWarnAgain)
 	}
 }
 
+void BuildManager::swapWinSearchPath(QString &miktex, QString &texlive)
+{
+	QString oldMiktexBinPath = miktexBinPath;
+	QString oldTexliveWinBinPath = texliveWinBinPath;
+	miktexBinPath = miktex;
+	texliveWinBinPath = texlive;
+	miktex = oldMiktexBinPath;
+	texlive = oldTexliveWinBinPath;
+}
+
 bool BuildManager::runCommand(const QString &unparsedCommandLine, const QFileInfo &mainFile, const QFileInfo &currentFile, int currentLine, QString *buffer, QTextCodec *codecForBuffer )
 {
 	if (waitingForProcess()) return false;

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -139,7 +139,7 @@ public:
 	void saveSettings(QSettings &settings);
 
 	void checkLatexConfiguration(bool &noWarnAgain);
-
+	void swapWinSearchPath(QString &miktex, QString &texlive);
 
 public slots:
     bool runCommand(const QString &unparsedCommandLine, const QFileInfo &mainFile, const QFileInfo &currentFile = QFileInfo(), int currentLine = 0, QString *buffer = nullptr, QTextCodec *codecForBuffer = nullptr);

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -139,7 +139,9 @@ public:
 	void saveSettings(QSettings &settings);
 
 	void checkLatexConfiguration(bool &noWarnAgain);
+#ifdef Q_OS_WIN32
 	void swapWinSearchPath(QString &miktex, QString &texlive);
+#endif
 
 public slots:
     bool runCommand(const QString &unparsedCommandLine, const QFileInfo &mainFile, const QFileInfo &currentFile = QFileInfo(), int currentLine = 0, QString *buffer = nullptr, QTextCodec *codecForBuffer = nullptr);

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -3555,13 +3555,10 @@ void ConfigManager::updateManagedOptionObjects(ManagedProperty *property)
 		property->writeToObject(o);
 }
 
+#ifdef Q_OS_WIN
 void ConfigManager::searchLaTeX()
 {
-#ifdef Q_OS_WIN
 	QString fileName = QFileDialog::getOpenFileName(nullptr, tr("Browse program"), "", tr("pdflatex.exe"));
-#else
-	QString fileName = QFileDialog::getOpenFileName(nullptr, tr("Browse program"), "", tr("pdflatex"));
-#endif
 	if (fileName.isEmpty()) return;
 	QFileInfo fi(fileName);
 	if (!fi.exists()) return;
@@ -3589,3 +3586,4 @@ void ConfigManager::searchLaTeX()
 	}
 	buildManager->swapWinSearchPath(tmpMiktex, tmpTexlive);
 }
+#endif

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -345,7 +345,9 @@ private slots:
 	void managedOptionBoolToggled();
 private:
 	void updateManagedOptionObjects(ManagedProperty *property);
+#ifdef Q_OS_WIN32
 private slots:
 	void searchLaTeX();
+#endif
 };
 #endif

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -345,5 +345,7 @@ private slots:
 	void managedOptionBoolToggled();
 private:
 	void updateManagedOptionObjects(ManagedProperty *property);
+private slots:
+	void searchLaTeX();
 };
 #endif


### PR DESCRIPTION
If you use MiKTeX portable under Windows, no environment variables are created and MiKTeX is not necessarily installed in C:\MikTeX, i.e. TeXstudio cannot find it. The same applies if you have installed different versions of MiKTeX, because for some special cases only an old version works.

The patch adds a button to the configuration page under Windows. With this button you can then select pdflatex.exe in the MiKTeX directory and the other commands are automatically searched in the same directory.

Not interesting for Linux and macOS, but it makes work easier under Windows if you don't have to reset all commands manually.
