### PR TITLE
Fix tests that use SyntaxCheck

### DIFF
--- a/src/syntaxcheck.h
+++ b/src/syntaxcheck.h
@@ -101,12 +101,11 @@ public:
 	void stop();
 	void setErrFormat(int errFormat);
     QString getErrorAt(QDocumentLineHandle *dlh, int pos, StackEnvironment previous, TokenStack stack);
-	void waitForQueueProcess();
+	void waitForQueueProcess(void);
 	static int containsEnv(const LatexParser &parser, const QString &name, const StackEnvironment &envs, const int id = -1);
 	int topEnv(const QString &name, const StackEnvironment &envs, const int id = -1);
 	bool checkCommand(const QString &cmd, const StackEnvironment &envs);
 	static bool equalEnvStack(StackEnvironment env1, StackEnvironment env2);
-	bool queuedLines();
 
 	void setLtxCommands(const LatexParser &cmds);
     void setSpeller(SpellerUtility *su);
@@ -126,6 +125,7 @@ private:
 	QQueue<SyntaxLine> mLines;
 	QSemaphore mLinesAvailable;
 	QMutex mLinesLock;
+	QAtomicInt mLinesEnqueuedCounter; //!< Total number of lines enqueued from beginning. Never decremented.
 	bool stopped;
     int syntaxErrorFormat;
 	LatexParser *ltxCommands;

--- a/src/tests/latexeditorview_t.cpp
+++ b/src/tests/latexeditorview_t.cpp
@@ -17,34 +17,34 @@ void LatexEditorViewTest::insertHardLineBreaks_data(){
 	QTest::addColumn<int>("end");
 	QTest::addColumn<int>("length");
 	QTest::addColumn<QString>("newText");
-	
+
 	//-------------cursor without selection--------------
-	QTest::newRow("one break in single line") 
+	QTest::newRow("one break in single line")
 		<< "a\nhallo welt\nb"
 		<< 1 << 1
 		<< 5
 		<< "a\nhallo\nwelt\nb";
-	QTest::newRow("multiple breaks in single line") 
+	QTest::newRow("multiple breaks in single line")
 		<< "a\nhallo welt miau x y z ping pong thing\nb"
 		<< 1 << 1
 		<< 5
 		<< "a\nhallo\nwelt\nmiau\nx y z\nping\npong\nthing\nb";
-	QTest::newRow("one break in multi lines") 
+	QTest::newRow("one break in multi lines")
 		<< "a\nhallo welt\nb\nxyz\nc"
 		<< 0 << 3
 		<< 5
 		<< "a\nhallo\nwelt\nb\nxyz\nc";
-	QTest::newRow("multiple breaks in multiple lines") 
+	QTest::newRow("multiple breaks in multiple lines")
 		<< "hallo welt ilias ting ping 12 34\ntest test test 7 test test\nend"
 		<< 0 << 1
 		<< 5
 		<< "hallo\nwelt\nilias\nting\nping\n12 34\ntest\ntest\ntest\n7\ntest\ntest\nend";
-	QTest::newRow("long words") 
+	QTest::newRow("long words")
 		<< "hello world yipyip yeah\nabc def ghi ijk\nend"
 		<< 0 << 1
 		<< 5
 		<< "hello\nworld\nyipyip\nyeah\nabc\ndef\nghi\nijk\nend";
-	QTest::newRow("comments") 
+	QTest::newRow("comments")
 		<< "hello %world yipyip yeah\n%abc def ghi ijk\nend"
 		<< 0 << 1
 		<< 5
@@ -54,12 +54,12 @@ void LatexEditorViewTest::insertHardLineBreaks_data(){
 		<< 0 << 1
 		<< 5
 		<< "hello\nx y z\n%x y\n%z\n%world\n%a b\n%c\n%yipyip\n%yeah\n%abc\n%def\n%ghi\n%ijk\nend";
-	QTest::newRow("comments and percent") 
+	QTest::newRow("comments and percent")
 		<< "mui muo\\% mua muip abc %def ghi ijk\nend"
 		<< 0 << 0
 		<< 5
 		<< "mui\nmuo\\%\nmua\nmuip\nabc\n%def\n%ghi\n%ijk\nend";
-	
+
 }
 void LatexEditorViewTest::insertHardLineBreaks(){
 	QFETCH(QString, text);
@@ -67,16 +67,16 @@ void LatexEditorViewTest::insertHardLineBreaks(){
 	QFETCH(int, end);
 	QFETCH(int, length);
 	QFETCH(QString, newText);
-	
+
 	edView->editor->setText(text, false);
-	if (start==end) 
+	if (start==end)
 		edView->editor->setCursor(edView->editor->document()->cursor(start,0,start,1));
-	else 
+	else
 		edView->editor->setCursor(edView->editor->document()->cursor(start,0,end+1,0));
 	edView->insertHardLineBreaks(length,false,false);
     edView->editor->document()->setLineEndingDirect(QDocument::Unix,true);
 	QEQUAL(edView->editor->document()->text(), newText);
-	
+
 	if (start!=end) { //repeat with different cursor position
 		edView->editor->setText(text, false);
 		edView->editor->setCursor(edView->editor->document()->cursor(start,1,end,1));
@@ -102,10 +102,7 @@ void LatexEditorViewTest::inMathEnvironment(){
 	QFETCH(QString, inmath);
 	edView->editor->setText(text);
 
-    do{
         edView->document->SynChecker.waitForQueueProcess(); // wait for syntax checker to finish (as it runs in a parallel thread)
-        QApplication::processEvents(QEventLoop::AllEvents,10); // SyntaxChecker posts events for rechecking other lines
-    }while(edView->document->SynChecker.queuedLines());
 
 	QDocumentCursor c = edView->editor->document()->cursor(0,0);
 	for (int i=0;i<inmath.size();i++) {

--- a/src/tests/syntaxcheck_t.cpp
+++ b/src/tests/syntaxcheck_t.cpp
@@ -19,7 +19,7 @@ void SyntaxCheckTest::checktabular_data(){
 	QTest::addColumn<int>("row");
 	QTest::addColumn<int>("col");
 	QTest::addColumn<QString>("expectedMessage");
-	
+
 	//-------------cursor without selection--------------
     QTest::newRow("all okay")
 		<< "\\begin{tabular}{ll}\na&b\\\\\nc&d\\\\\ne&f\\\\\n\\end{tabular}\n"
@@ -167,7 +167,7 @@ void SyntaxCheckTest::checktabular(){
 	QFETCH(int, row);
 	QFETCH(int, col);
 	QFETCH(QString, expectedMessage);
-	
+
 	expectedMessage = QApplication::translate("SyntaxCheck", qPrintable(expectedMessage));
 
 	bool inlineSyntaxChecking = edView->getConfig()->inlineSyntaxChecking;
@@ -176,10 +176,7 @@ void SyntaxCheckTest::checktabular(){
 	edView->getConfig()->inlineSyntaxChecking = edView->getConfig()->realtimeChecking = true;
 
 	edView->editor->setText(text, false);
-	do{
-        edView->document->SynChecker.waitForQueueProcess(); // wait for syntax checker to finish (as it runs in a parallel thread)
-		QApplication::processEvents(QEventLoop::AllEvents,10); // SyntaxChecker posts events for rechecking other lines
-    }while(edView->document->SynChecker.queuedLines());
+	edView->document->SynChecker.waitForQueueProcess(); // wait for syntax checker to finish (as it runs in a parallel thread)
 	StackEnvironment env;
     edView->document->getEnv(row,env);
     QDocumentLineHandle *prev=edView->document->line(row-1).handle();
@@ -188,7 +185,7 @@ void SyntaxCheckTest::checktabular(){
           remainder=prev->getCookieLocked(QDocumentLine::LEXER_REMAINDER_COOKIE).value<TokenStack >();
     QString message=edView->document->SynChecker.getErrorAt(edView->document->line(row).handle(),col,env,remainder);
 	QEQUAL(message, expectedMessage);
-	
+
 	edView->getConfig()->inlineSyntaxChecking = inlineSyntaxChecking;
 	edView->getConfig()->realtimeChecking = realtimeChecking;
 }
@@ -257,10 +254,7 @@ void SyntaxCheckTest::checkkeyval(){
 
     edView->editor->setText(text, false);
     LatexDocument *doc=edView->getDocument();
-    do{
-        doc->SynChecker.waitForQueueProcess(); // wait for syntax checker to finish (as it runs in a parallel thread)
-        QApplication::processEvents(QEventLoop::AllEvents,10); // SyntaxChecker posts events for rechecking other lines
-    }while(doc->SynChecker.queuedLines());
+    doc->SynChecker.waitForQueueProcess(); // wait for syntax checker to finish (as it runs in a parallel thread)
 
     QDocumentLineHandle *dlh=doc->line(1).handle();
     QList<QFormatRange> formats=dlh->getOverlays(LatexEditorView::syntaxErrorFormat);
@@ -304,10 +298,7 @@ void SyntaxCheckTest::checkArguments(){
 
     edView->editor->setText(text, false);
     LatexDocument *doc=edView->getDocument();
-    do{
-        doc->SynChecker.waitForQueueProcess(); // wait for syntax checker to finish (as it runs in a parallel thread)
-        QApplication::processEvents(QEventLoop::AllEvents,10); // SyntaxChecker posts events for rechecking other lines
-    }while(doc->SynChecker.queuedLines());
+    doc->SynChecker.waitForQueueProcess(); // wait for syntax checker to finish (as it runs in a parallel thread)
 
     bool synError=false;
     for(int i=0;i<doc->lineCount();i++){


### PR DESCRIPTION
As mentioned in https://github.com/texstudio-org/texstudio/issues/918 there is a race condition in the `SyntaxCheck::waitForQueueProcess`. This race condition causes any tests that use this method to return prematurely. This happens mostly when the CPU load is high and when it happens tests start failing like this:

```
PASS   : SyntaxCheckTest::checkkeyval(key/value, with -, error key)
FAIL!  : SyntaxCheckTest::checkkeyval(key/value,error value) '(!formats.isEmpty())==(error)' returned FALSE. (equal failed: got "0" !=expected "1" )
   Loc: [src/tests/syntaxcheck_t.cpp(267)]
FAIL!  : SyntaxCheckTest::checkkeyval(key/value, with -, error val) '(!formats.isEmpty())==(error)' returned FALSE. (equal failed: got "0" !=expected "1" )
   Loc: [src/tests/syntaxcheck_t.cpp(267)]
PASS   : SyntaxCheckTest::checkkeyval(2 key/value)
FAIL!  : SyntaxCheckTest::checkkeyval(2 key/value,error key) '(!formats.isEmpty())==(error)' returned FALSE. (equal failed: got "0" !=expected "1" )
   Loc: [src/tests/syntaxcheck_t.cpp(267)]
FAIL!  : SyntaxCheckTest::checkkeyval(2 key/value,error value) '(!formats.isEmpty())==(error)' returned FALSE. (equal failed: got "0" !=expected "1" )
   Loc: [src/tests/syntaxcheck_t.cpp(267)]
PASS   : SyntaxCheckTest::checkkeyval(2 key/value,composite key)
PASS   : SyntaxCheckTest::checkkeyval(yathesis without options)
PASS   : SyntaxCheckTest::checkkeyval(yathesis with valid option)
FAIL!  : SyntaxCheckTest::checkkeyval(yathesis with ilegal option) '(!formats.isEmpty())==(error)' returned FALSE. (equal failed: got "0" !=expected "1" )
   Loc: [src/tests/syntaxcheck_t.cpp(267)]
PASS   : SyntaxCheckTest::checkkeyval(article)
```
The above errors are just an example but in general it affects the tests in
`SyntaxCheckTest::checkkeyval`
`SyntaxCheckTest::checktabular`
`SyntaxCheckTest::checkArguments`
`LatexEditorViewTest::inMathEnvironment`

I have described in https://github.com/texstudio-org/texstudio/issues/918 what exactly is causing the race condtion.

The proposed PR fixes the issue by making the following changes:
1. Replaces `SyntaxCheck::stopped` with a command message dequeue and a state variable.
2. The command dequeue allows sending three different commands to the `SyntaxCheck` worker thread: PAUSE, UNPAUSE, STOP.
3. The pause/unpause commands allow pausing/unpausing of the worker thread which in turn allows avoiding the race condition that happens with the existing code.

There is also another minor multithreading issue with the current code - currently `SyntaxCheck::stop` is a variable shared between the different threads, but it is not protected. Ideally it should be either protected by a lock or even better marked as atomic. I don't think that the non-atomic variable really causes any issues because any modern processor handles word-sized variables in an atomic way, but it is still better to be on the safe side and mark them explicitly as atomic. So the PR makes the replacement variable SyntaxCheck::mState of `QAtomicInt` type.

I tried overloading the CPU while running tests the modified version of `SyntaxCheck` and could not reproduce the test errors. So the race condition is either fixed or just better hidden :-)