### PR TITLE
add file extension "synctex.gz" to cleandialog

### DIFF
--- a/src/cleandialog.cpp
+++ b/src/cleandialog.cpp
@@ -4,7 +4,7 @@
 #include "configmanager.h"
 #include "utilsUI.h"
 
-QString CleanDialog::defaultExtensions = "log,aux,dvi,lof,lot,bit,idx,glo,bbl,bcf,ilg,toc,ind,out,blg,fdb_latexmk,fls";
+QString CleanDialog::defaultExtensions = "log,aux,dvi,lof,lot,bit,idx,glo,bbl,bcf,ilg,toc,ind,out,blg,fdb_latexmk,fls,synctex.gz";
 QString CleanDialog::currentExtensions = CleanDialog::defaultExtensions;
 int CleanDialog::scopeID = 0;
 


### PR DESCRIPTION
`*.synctex.gz` files are the default aux file created by `synctex` program, when `*.tex` files are compiled with option `-synctex=1`, which is set by default in texstudio.

This pr adds `synctex.gz` to the list of file extensions shown in "Clean Auxiliary File" dialog.