### PR TITLE
Do not set a minimum size of the secondary toolbar icons

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -282,8 +282,8 @@ Texstudio::Texstudio(QWidget *parent, Qt::WindowFlags flags, QSplashScreen *spla
 	centralToolBar->setFloatable(false);
 	centralToolBar->setOrientation(Qt::Vertical);
 	centralToolBar->setMovable(false);
-    iconSize = qRound(qMax(16, configManager.guiSecondaryToolbarIconSize)*scale);
-    centralToolBar->setIconSize(QSize(iconSize, iconSize));
+	iconSize = qRound(configManager.guiSecondaryToolbarIconSize*scale);
+	centralToolBar->setIconSize(QSize(iconSize, iconSize));
 
 	editors = new Editors(centralFrame);
 	editors->setFocus();


### PR DESCRIPTION
This PR fixes https://github.com/texstudio-org/texstudio/issues/889
I could not reproduce the issue on Windows using the screen resolution and scaling on the user's computer. However removing the `qMax()` from the code fixed the issue for the user (he tried a custom version of TXS compiled without the toolbar size limitation).

Since we don't have that `qMax()` limitation in the other places where we update the secondary toolbar size, I guess removing it from the code that reads the initial settings shouldn't cause problems.