### PR TITLE
manual: document cwl arg name "verbatimSymbol"

### DIFF
--- a/utilities/manual/usermanual_en.html
+++ b/utilities/manual/usermanual_en.html
@@ -1554,7 +1554,7 @@ Each line of a cwl file defines a command. Comment lines are possible and start 
   <li><code>#endkeyvals</code> (at start of line): end definition of keyvals, see graphicx.cwl in source code</li>
   <li><code>#ifOption:&lt;option&gt;</code> (at start of line): the following block is only loaded if &lt;option&gt; was used in the usepackage command, e.g. \usepackage[svgnames]{color} -> option=svgnames</li>
   <li><code>#endif</code> (at start of line): end conditional block</li>
-  <li><code>#</code> (at start of line with the exception of <code>#include,#repl,#keyvals or #endkeyvals </code>): This line is a comment and will be ignored.</li>
+  <li><code>#</code> (at start of line with the exception of <code>#include</code>, <code>#repl</code>, <code>#keyvals</code> or <code>#endkeyvals</code>): This line is a comment and will be ignored.</li>
   <li><code>#</code> (in the middle of a line): Separates the command from the classification</li>
 </ul>
 <p>cwl files should be encoded as UTF-8.</p>
@@ -1592,7 +1592,8 @@ Each line of a cwl file defines a command. Comment lines are possible and start 
   <li><code>%plain</code>: options ending with <code>%plain</code> are interpreted to have no special meaning. This way, you can e.g. define <code>label%plain</code> to have a placeholder named <code>label</code> without the semantics that it defines a label.</li>
   <li><code>beamertheme</code>: beamer theme, e.g. \usebeamertheme{beamertheme}</li>
   <li><code>keys</code>, <code>keyvals</code>, <code>%&lt;options%&gt;</code> or ends with <code>%keyvals</code>: key/value list</li>
-  <li><code>envname</code>, <code>environment name</code> or ends with <code>%envname</code>: environment name for \newtheorem, e.g. \newtheorem{envname}#N (classification N needs to be present !)</li>
+  <li><code>envname</code>, <code>environment name</code> or ends with <code>%envname</code>: environment name for \newtheorem, e.g. \newtheorem{envname}#N (classification N needs to be present!)</li>
+  <li><code>verbatimSymbol</code>: verbatim argument, e.g. <code>\verb|%&lt;text%&gt;|</code> and <code>\verb{verbatimSymbol}#S</code> from latex-document.cwl in source code.</li>
 </ul>
 <p>A %-suffix takes precedence over detection by name, i.e. an argument <code>file%text</code> will be treated as text not as file.</p>
 <h3>4.14.3 Classification format</h3>


### PR DESCRIPTION
Document new cwl arg name `verbatimSymbol` added in https://github.com/texstudio-org/texstudio/commit/f89f1d7dc99bcf8b3925975d1f2001751fc156c9.