### PR TITLE
partly fix #277

### DIFF
--- a/src/latexpackage.cpp
+++ b/src/latexpackage.cpp
@@ -631,6 +631,7 @@ Token::TokenType tokenTypeFromCwlArg(QString arg, QString definition)
 		if (suffix == "%todo") return Token::todo;
 		if (suffix == "%l") return Token::width;
 		if (suffix == "%cmd") return Token::def;
+		if (suffix == "%formula") return Token::formula;
 		if (suffix == "%keyvals") return Token::keyValArg;
 		if ((suffix == "%envname") && definition.contains('N')) return Token::newTheorem;
 		if (suffix == "%ref") return Token::labelRef;


### PR DESCRIPTION
In the cwl format, add a '%formula' suffix
to allow users to specify that a field with an
arbitrary name should be treated as a math field.