### PR TITLE
Minor cleanup in latexparsing.cpp

### DIFF
--- a/src/latexparser/latexparsing.cpp
+++ b/src/latexparser/latexparsing.cpp
@@ -746,7 +746,7 @@ bool latexDetermineContexts2(QDocumentLineHandle *dlh, TokenStack &stack, Comman
     }
     dlh->setCookie(QDocumentLine::LEXER_REMAINDER_COOKIE, QVariant::fromValue<TokenStack>(stack));
     dlh->setCookie(QDocumentLine::LEXER_COMMANDSTACK_COOKIE, QVariant::fromValue<CommandStack>(commandStack));
-    dlh->setCookie(QDocumentLine::LEXER_COMMENTSTART_COOKIE, QVariant::fromValue<QPair<int,int> >({commentStart,-1}));
+    dlh->setCookie(QDocumentLine::LEXER_COMMENTSTART_COOKIE, QVariant::fromValue<QPair<int,int> >({commentStart, Token::unknownComment}));
     dlh->unlock();
 
     bool remainderChanged = (stack != oldRemainder) || (commandStack != oldCommandStack) ;

--- a/src/latexparser/latexparsing.cpp
+++ b/src/latexparser/latexparsing.cpp
@@ -218,7 +218,7 @@ bool latexDetermineContexts2(QDocumentLineHandle *dlh, TokenStack &stack, Comman
             Token tk3 = tl.at(i + 2);
             if (tk2.type == Token::openBrace && tk3.type == Token::word) {
                 QString env = line.mid(tk3.start, tk3.length);
-                if (lp.possibleCommands["%verbatimEnv"].contains(env)) { // incomplete check if closing correspondents to open !
+                if (lp.possibleCommands["%verbatimEnv"].contains(env)) { // incomplete check if closing corresponds to open !
                     verbatimMode = false;
                     stack.pop();
                 } else
@@ -246,7 +246,7 @@ bool latexDetermineContexts2(QDocumentLineHandle *dlh, TokenStack &stack, Comman
             }else{
                 if(tk.type==Token::closeBrace){
                     Token tk1=stack.pop();
-                    if(!stack.isEmpty() && stack.top().subtype==Token::definition){ // check if more than openBrace/defintion are on the stack, if yes , juts pop it and continue in definition mode
+                    if(!stack.isEmpty() && stack.top().subtype==Token::definition){ // check if more than openBrace/defintion are on the stack, if yes , just pop it and continue in definition mode
                         tk.subtype=Token::definition;
                         lexed << tk;
                         level=tk1.level; // restore original level
@@ -328,7 +328,7 @@ bool latexDetermineContexts2(QDocumentLineHandle *dlh, TokenStack &stack, Comman
                     }
 
                 }
-                if ((cd.args > 0 || cd.optionalArgs > 0 || cd.bracketArgs > 0 ) && tk.subtype != Token::def) { // don't interpret commands in defintion (\newcommand{def})
+                if ((cd.args > 0 || cd.optionalArgs > 0 || cd.bracketArgs > 0 ) && tk.subtype != Token::def) { // don't interpret commands in definition (\newcommand{def})
                     cd.optionalCommandName=command;
                     commandStack.push(cd);
                 }
@@ -405,7 +405,7 @@ bool latexDetermineContexts2(QDocumentLineHandle *dlh, TokenStack &stack, Comman
             continue;
         }
 	    if (Token::tkClose().contains(tk.type)) {
-		// special treament for brackets as they don't have any syntaxtical meaning except with some commands
+		// special treament for brackets as they don't have any syntactic meaning except with some commands
             if (tk.type == Token::closeBracket || tk.type == Token::greater ) {
                 if (stack.isEmpty())
                     continue;


### PR DESCRIPTION
While working on the .tex code formatter I came across a few minor issues in latexparsing.cpp

1. When we create a line cookie of type `LEXER_COMMENTSTART_COOKIE`, the comment type by default should be `Token::unknownComment`. Currently the code sets it to -1. It is getting away with that because we never directly check for `unknownComment` (or `-1` for that matter) anywhere else in the code. Still I think it is better to use a meaningful enum since it makes clearer the meaning of the variable.
2. A few typos in the C++ comments that I noticed.