### PR TITLE
Preserve text indentation when pasting script code

### DIFF
--- a/src/usermenudialog.cpp
+++ b/src/usermenudialog.cpp
@@ -57,6 +57,7 @@ UserMenuDialog::UserMenuDialog(QWidget *parent,  QString name, QLanguageFactory 
 	//editor options
 	ui.tagEdit->setLayout(new QVBoxLayout());
 	codeedit = new QCodeEdit(ui.tagEdit);
+	codeedit->editor()->setFlag(QEditor::AdjustIndent, false);
     codeedit->editor()->document()->setCenterDocumentInEditor(false);
 	//QLineMarkPanel* lineMarkPanel=new QLineMarkPanel;
 	//QAction* lineMarkPanelAction=codeedit->addPanel(lineMarkPanel, QCodeEdit::West, false);


### PR DESCRIPTION
TXS has a minor bug. When pasting script code into the `Macros/Edit Macros.../LaTeX Content` editor control it will strip all leading whitespace thus removing any script code indentation. This behavior is a problem when the script is large and indentation is important.

This PR changes the corresponding `QEditor` behavior so that it preserves indentation.