### PR TITLE
Fix build warnings for obsolete Qt methods

### DIFF
--- a/src/bibtexdialog.h
+++ b/src/bibtexdialog.h
@@ -16,6 +16,7 @@ struct BibTeXType {
 		mandatoryFields(other.mandatoryFields), optionalFields(other.optionalFields) {}
 	BibTeXType (const QString &d, const QString &n, const QStringList &mf, const QStringList &of):
 		name(n), description(d), mandatoryFields(mf), optionalFields(of) {}
+	BibTeXType & operator= (const BibTeXType &other) = default; // Silence -Wdeprecated-copy
 };
 
 

--- a/src/fileselector.cpp
+++ b/src/fileselector.cpp
@@ -1,4 +1,5 @@
 #include "fileselector.h"
+#include "utilsUI.h"
 
 FileSelector::FileSelector(QWidget *parent, bool multiselect) :
 	QWidget(parent), multiselect(multiselect)
@@ -58,7 +59,7 @@ void FileSelector::setCentered()
 		}*/
 		QFontMetrics fm = list->fontMetrics();
 		for (int i = 0; i < rawFiles.size(); i++)
-			fsw = qMax(fsw, fm.width(rawFiles[i]) + scrollbarwidth );
+			fsw = qMax(fsw, UtilsUi::getFmWidth(fm, rawFiles[i]) + scrollbarwidth );
 		fsw = qMin(fsw, s.width());
 
 		setGeometry(s.width() / 2 - fsw / 2 + p.x(), s.height() / 8 + p.y(), fsw, s.height() / 2);

--- a/src/latexcompleter.cpp
+++ b/src/latexcompleter.cpp
@@ -764,12 +764,12 @@ public:
 			for (int i = 0; i < cw.placeHolders[0].size(); i++) {
 				QString temp = firstLine.mid(p, cw.placeHolders[0][i].offset - p);
                 painter->drawText(r, Qt::AlignLeft | Qt::AlignTop | Qt::TextSingleLine, temp);
-				r.setLeft(r.left() + fmn.width(temp));
+				r.setLeft(r.left() + UtilsUi::getFmWidth(fmn, temp));
 				temp = firstLine.mid(cw.placeHolders[0][i].offset, cw.placeHolders[0][i].length);
 				painter->setFont(fPlHolder);
 				painter->setPen(plHolderColor);
                 painter->drawText(r, Qt::AlignLeft | Qt::AlignTop | Qt::TextSingleLine, temp);
-				r.setLeft(r.left() + fmi.width(temp) + 1);
+				r.setLeft(r.left() + UtilsUi::getFmWidth(fmi, temp) + 1);
 				p = cw.placeHolders[0][i].offset + cw.placeHolders[0][i].length;
 				painter->setFont(fNormal);
 				painter->setPen(normalColor);
@@ -1435,7 +1435,7 @@ void LatexCompleter::adjustWidget()
 	const QList<CompletionWord> &words = listModel->getWords();
 	for (int i = 0; i < words.size(); i++) {
 		if (words[i].lines.empty() || words[i].placeHolders.empty()) continue;
-		int temp = fm.width(words[i].lines[0]) + words[i].placeHolders[0].size() + 10;
+		int temp = UtilsUi::getFmWidth(fm, words[i].lines[0]) + words[i].placeHolders[0].size() + 10;
 		if (temp > newWordMax) newWordMax = temp;
 	}
 	maxWordLen = newWordMax;

--- a/src/latexeditorview.cpp
+++ b/src/latexeditorview.cpp
@@ -2880,7 +2880,7 @@ void LatexEditorViewConfig::settingsChanged()
 		}
 
 	bool lettersHaveDifferentWidth = false, sameLettersHaveDifferentWidth = false;
-	int letterWidth = fms.first().width('a');
+	int letterWidth = UtilsUi::getFmWidth(fms.first(), 'a');
 
 	const QString lettersToCheck("abcdefghijklmnoqrstuvwxyzABCDEFHIJKLMNOQRSTUVWXYZ_+ 123/()=.,;#");
 	QVector<QMap<QChar, int> > widths;
@@ -2889,13 +2889,13 @@ void LatexEditorViewConfig::settingsChanged()
 	foreach (const QChar &c, lettersToCheck) {
 		for (int fmi = 0; fmi < fms.size(); fmi++) {
 			const QFontMetrics &fm = fms[fmi];
-			int currentWidth = fm.width(c);
+			int currentWidth = UtilsUi::getFmWidth(fm, c);
 			widths[fmi].insert(c, currentWidth);
 			if (currentWidth != letterWidth) lettersHaveDifferentWidth = true;
 			QString testString;
 			for (int i = 1; i < 10; i++) {
 				testString += c;
-				int stringWidth = fm.width(testString);
+				int stringWidth = UtilsUi::getFmWidth(fm, testString);
 				if (stringWidth % i != 0) sameLettersHaveDifferentWidth = true;
 				if (currentWidth != stringWidth / i) sameLettersHaveDifferentWidth = true;
 			}
@@ -2909,7 +2909,7 @@ void LatexEditorViewConfig::settingsChanged()
 			int expectedWidth = 0;
 			for (int i = 0; i < ligatures[l].size() && !sameLettersHaveDifferentWidth; i++) {
 				expectedWidth += widths[fmi].value(ligatures[l][i]);
-				if (expectedWidth != fms[fmi].width(ligatures[l].left(i + 1))) sameLettersHaveDifferentWidth = true;
+				if (expectedWidth != UtilsUi::getFmWidth(fms[fmi], ligatures[l].left(i + 1))) sameLettersHaveDifferentWidth = true;
 			}
 		}
 	}

--- a/src/latexlogwidget.cpp
+++ b/src/latexlogwidget.cpp
@@ -32,11 +32,11 @@ LatexLogWidget::LatexLogWidget(QWidget *parent) :
 	QFontMetrics fm(QApplication::font());
 	errorTable->setSelectionBehavior(QAbstractItemView::SelectRows);
 	errorTable->setSelectionMode(QAbstractItemView::SingleSelection);
-	errorTable->setColumnWidth(0, fm.width("> "));
-	errorTable->setColumnWidth(1, 20 * fm.width("w"));
-	errorTable->setColumnWidth(2, fm.width("WarningW"));
-	errorTable->setColumnWidth(3, fm.width("Line WWWWW"));
-	errorTable->setColumnWidth(4, 20 * fm.width("w"));
+	errorTable->setColumnWidth(0, UtilsUi::getFmWidth(fm, "> "));
+	errorTable->setColumnWidth(1, 20 * UtilsUi::getFmWidth(fm, "w"));
+	errorTable->setColumnWidth(2, UtilsUi::getFmWidth(fm, "WarningW"));
+	errorTable->setColumnWidth(3, UtilsUi::getFmWidth(fm, "Line WWWWW"));
+	errorTable->setColumnWidth(4, 20 * UtilsUi::getFmWidth(fm, "w"));
 	connect(errorTable, SIGNAL(clicked(const QModelIndex &)), this, SLOT(clickedOnLogModelIndex(const QModelIndex &)));
 
 	errorTable->horizontalHeader()->setStretchLastSection(true);

--- a/src/latexoutputfilter.cpp
+++ b/src/latexoutputfilter.cpp
@@ -18,6 +18,7 @@
 //  - use KileDocument::Extensions
 
 #include "latexoutputfilter.h"
+#include "utilsUI.h"
 
 
 QColor LatexLogEntry::textColors[LT_MAX] = {QColor(Qt::black), QColor(230, 32, 32), QColor(234, 136, 32), QColor(58, 58, 230), QColor(Qt::darkBlue)};
@@ -91,13 +92,13 @@ QString LatexLogEntry::niceMessage(bool richFormat) const
 
 		QFont f = QToolTip::font();
 		QFontMetrics fm(f);
-		width = fm.width(message, beginBold);
-		width += fm.width(message.mid(endBold));
+		width = UtilsUi::getFmWidth(fm, message, beginBold);
+		width += UtilsUi::getFmWidth(fm, message.mid(endBold));
 		f.setBold(true);
 		fm = QFontMetrics(f);
-		width += fm.width(message.mid(beginBold, endBold - beginBold));
+		width += UtilsUi::getFmWidth(fm, message.mid(beginBold, endBold - beginBold));
 	} else {
-		width = QFontMetrics(QToolTip::font()).width(message);
+		width = UtilsUi::getFmWidth(QFontMetrics(QToolTip::font()), message);
 	}
 
 	return QString("<tr><td style=\"color: %1\">%2</td><td width=\"%3\"><nobr>%4</nobr></td>").arg(textColors[type].name()).arg(pre).arg(width).arg(fmtMsg);

--- a/src/pdfviewer/PDFDocks.cpp
+++ b/src/pdfviewer/PDFDocks.cpp
@@ -1000,7 +1000,7 @@ void PDFClockDock::paintEvent(QPaintEvent *event)
 	f.setPixelSize(r.height());
 	p.setFont(f);
 	p.setPen(textColor);
-	int labelWidth = p.fontMetrics().width("9999 min");
+	int labelWidth = UtilsUi::getFmWidth(p.fontMetrics(), "9999 min");
 	QRect textRect = rect();
 	textRect.setWidth(labelWidth);
 	p.drawText(textRect, Qt::AlignHCenter | Qt::AlignVCenter, text);

--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -2689,7 +2689,7 @@ void PDFDocument::init(bool embedded)
 
 	leCurrentPage = new QLineEdit(toolBar);
 	leCurrentPage->setMaxLength(5);
-	leCurrentPage->setFixedWidth(fontMetrics().width("#####"));
+	leCurrentPage->setFixedWidth(UtilsUi::getFmWidth(fontMetrics(), "#####"));
 	leCurrentPageValidator = new QIntValidator(1, 99999, leCurrentPage);
 	leCurrentPage->setValidator(leCurrentPageValidator);
 	leCurrentPage->setText("1");
@@ -2730,7 +2730,7 @@ void PDFDocument::init(bool embedded)
 	scaleButton->setToolTip(tr("Scale"));
 	scaleButton->setPopupMode(QToolButton::InstantPopup);
 	scaleButton->setAutoRaise(true);
-	scaleButton->setMinimumWidth(statusBar()->fontMetrics().width("OOOOOO"));
+	scaleButton->setMinimumWidth(UtilsUi::getFmWidth(statusBar()->fontMetrics(), "OOOOOO"));
 	scaleButton->setText("100%");
 	statusBar()->addPermanentWidget(scaleButton);
 	QList<int> levels = QList<int>() << 25 << 50 << 75 << 100 << 150 << 200 << 300 << 400;
@@ -3202,7 +3202,7 @@ retryNow:
                 int maxDigits = 1 + qFloor(log10(pdfWidget->realNumPages()));
 		//if (maxDigits < 2) maxDigits = 2;
 		leCurrentPage->setMaxLength(maxDigits);
-		leCurrentPage->setFixedWidth(fontMetrics().width(QString(maxDigits + 1, '#')));
+		leCurrentPage->setFixedWidth(UtilsUi::getFmWidth(fontMetrics(), QString(maxDigits + 1, '#')));
 		leCurrentPageValidator->setTop(pdfWidget->realNumPages());
 		//qDebug() << pdfWidget->realNumPages() << maxDigits << fontMetrics().width(QString(maxDigits+1, '#'));
 

--- a/src/qcodeedit/lib/document/qdocument.cpp
+++ b/src/qcodeedit/lib/document/qdocument.cpp
@@ -2670,7 +2670,7 @@ int QDocumentLineHandle::cursorToXNoLock(int cpos) const
 	const QVector<QFont>& fonts = m_doc->impl()->m_fonts;
 
 	if ( (composited.count() < cpos) || fonts.isEmpty() ){
-		int result=QFontMetrics(*QDocumentPrivate::m_font).width(m_text.left(cpos));
+		int result=UtilsUi::getFmWidth(QFontMetrics(*QDocumentPrivate::m_font), m_text.left(cpos));
 		return result;
 	}
 
@@ -2688,10 +2688,10 @@ int QDocumentLineHandle::cursorToXNoLock(int cpos) const
 			int taboffset = ncolsToNextTabStop(column, tabStop);
 
 			column += taboffset;
-			cwidth = fm.width(' ') * taboffset;
+			cwidth = UtilsUi::getFmWidth(fm, ' ') * taboffset;
 		} else {
 			++column;
-			cwidth = fm.width(c);
+			cwidth = UtilsUi::getFmWidth(fm, c);
 		}
 
 		screenx += cwidth;
@@ -2775,10 +2775,10 @@ int QDocumentLineHandle::xToCursor(int xpos) const
 				int taboffset = ncolsToNextTabStop(column, tabStop);
 
 				column += taboffset;
-				cwidth = fm.width(' ') * taboffset;
+				cwidth = UtilsUi::getFmWidth(fm, ' ') * taboffset;
 			} else {
 				++column;
-				cwidth = fm.width(m_text.at(idx));
+				cwidth = UtilsUi::getFmWidth(fm, m_text.at(idx));
 			}
 
 			int mid = (x + (cwidth / 2) + 1);
@@ -7572,7 +7572,7 @@ void QDocumentPrivate::updateStaticCaches(const QPaintDevice *pd)
 
 		// need to get the font metrics in the context of the paint device to get correct UI scaling
 		QFontMetrics fm = QFontMetrics(*m_font, const_cast<QPaintDevice *>(pd));
-		m_spaceWidth = fm.width(' ');
+		m_spaceWidth = UtilsUi::getFmWidth(fm, ' ');
 		m_ascent = fm.ascent();
 		m_descent = fm.descent();
 		m_lineHeight = fm.height();
@@ -7668,7 +7668,7 @@ int QDocumentPrivate::textWidth(int fid, const QString& text){
 	}
 
 	if ( containsSurrogates || (m_workArounds & QDocument::DisableWidthCache) )
-		return m_fontMetrics[fid].width(text);
+		return UtilsUi::getFmWidth(m_fontMetrics[fid], text);
 
 	int rwidth=0;
 
@@ -7676,7 +7676,7 @@ int QDocumentPrivate::textWidth(int fid, const QString& text){
 	foreach(const QChar& c, text){
 		const int *cwidth;
 		if (!cache->valueIfThere(c, cwidth))
-			cwidth = cache->insert(c,m_fontMetrics[fid].width(c));
+			cwidth = cache->insert(c,UtilsUi::getFmWidth(m_fontMetrics[fid], c));
 		rwidth+=*cwidth;
 	}
 	return rwidth;
@@ -7712,8 +7712,8 @@ int QDocumentPrivate::textWidthSingleLetterFallback(int fid, const QString& text
 		const int *cwidth;
 		if (!cache->valueIfThere(char_id, cwidth)) {
 			int nwidth;
-			if (cat == QChar::Other_Surrogate) nwidth = m_fontMetrics[fid].width(QString(lastSurrogate)+c);
-			else nwidth = m_fontMetrics[fid].width(c);
+			if (cat == QChar::Other_Surrogate) nwidth = UtilsUi::getFmWidth(m_fontMetrics[fid], QString(lastSurrogate)+c);
+			else nwidth = UtilsUi::getFmWidth(m_fontMetrics[fid], c);
 			cwidth = cache->insert(char_id, nwidth);
 		}
 		rwidth+=*cwidth;
@@ -7740,8 +7740,8 @@ void QDocumentPrivate::drawText(QPainter& p, int fid, const QColor& baseColor, b
 		const QPixmap* px;
 		if (!cache->valueIfThere(char_id, px)){
 			int cw;
-			if (cat == QChar::Other_Surrogate) cw = m_fontMetrics[fid].width(QString(lastSurrogate)+c);
-			else cw = m_fontMetrics[fid].width(c);
+			if (cat == QChar::Other_Surrogate) cw = UtilsUi::getFmWidth(m_fontMetrics[fid], QString(lastSurrogate)+c);
+			else cw = UtilsUi::getFmWidth(m_fontMetrics[fid], c);
 			QPixmap pm(cw,m_lineSpacing);
 			pm.fill(QColor::fromRgb(255,255,255,0)); //transparent background (opaque background would be twice as fast, but then we need much more pixmaps)
 			QPainter pmp(&pm);

--- a/src/qcodeedit/lib/widgets/qcalltip.cpp
+++ b/src/qcodeedit/lib/widgets/qcalltip.cpp
@@ -3,7 +3,7 @@
 ** Copyright (C) 2006-2009 fullmetalcoder <fullmetalcoder@hotmail.fr>
 **
 ** This file is part of the Edyuk project <http://edyuk.org>
-** 
+**
 ** This file may be used under the terms of the GNU General Public License
 ** version 3 as published by the Free Software Foundation and appearing in the
 ** file GPL.txt included in the packaging of this file.
@@ -14,6 +14,7 @@
 ****************************************************************************/
 
 #include "qcalltip.h"
+#include "utilsUI.h"
 
 /*!
 	\file qcalltip.cpp
@@ -35,7 +36,7 @@ QCallTip::QCallTip(QWidget *p)
 
 QCallTip::~QCallTip()
 {
-	
+
 }
 
 QStringList QCallTip::tips() const
@@ -54,78 +55,78 @@ static int arrowWidth = 14;
 void QCallTip::paintEvent(QPaintEvent *e)
 {
 	Q_UNUSED(e)
-	
+
 	QPainter p(this);
 	QFontMetrics fm = fontMetrics();
-	
+
 	m_up = m_down = QRect();
-	
+
 	bool bPrev = m_index, bNext = (m_index + 1) < m_tips.count();
 	int offset = 3, whalf = arrowWidth / 2 - 3; //, hhalf = height() / 2;
-	
-	QRect bg(0, 0, fm.width(m_tips.at(m_index)) + 6, fm.height());
-	
+
+	QRect bg(0, 0, UtilsUi::getFmWidth(fm, m_tips.at(m_index)) + 6, fm.height());
+
 	if ( bPrev )
 	{
 		bg.setWidth(bg.width() + arrowWidth);
 	}
-	
+
 	if ( bNext )
 	{
 		bg.setWidth(bg.width() + arrowWidth);
 	}
-	
+
 	p.fillRect(bg, QColor(0xca, 0xff, 0x70));
 	//p.drawRect(bg);
-	
+
 	p.save();
-	
+
 	p.setPen(QColor(0x00, 0x00, 0x00));
 	p.drawLine(0, height() - 1, bg.width() - 1, height() - 1);
 	p.drawLine(bg.width() - 1, height() - 1, bg.width() - 1, 0);
-	
+
 	p.setPen(QColor(0xc0, 0xc0, 0xc0));
 	p.drawLine(0, height() - 1, 0, 0);
 	p.drawLine(0, 0, bg.width() - 1, 0);
-	
+
 	p.restore();
-	
+
 	int top = height() / 3, bottom = height() - height() / 3;
-	
+
 	if ( bPrev )
 	{
 		int x = offset + arrowWidth / 2 - 1;
-		
+
 		QPoint pts[] = {
 			QPoint(x - whalf, bottom),
 			QPoint(x + whalf, bottom),
 			QPoint(x, top)
 		};
-		
+
 		p.drawPolygon(pts, sizeof(pts) / sizeof(QPoint), Qt::WindingFill);
-		
+
 		m_up = QRect(offset, 0, offset + arrowWidth, height());
 		offset += arrowWidth;
 	}
-	
+
 	if ( bNext )
 	{
 		int x = offset + arrowWidth / 2 - 1;
-		
+
 		QPoint pts[] = {
 			QPoint(x - whalf, top),
 			QPoint(x + whalf, top),
 			QPoint(x, bottom)
 		};
-		
+
 		p.drawPolygon(pts, sizeof(pts) / sizeof(QPoint), Qt::WindingFill);
-		
+
 		m_down = QRect(offset, 0, offset + arrowWidth, height());
 		offset += arrowWidth;
 	}
-	
+
 	p.drawText(offset, fm.ascent() + 2, m_tips.at(m_index));
-	
+
 	setFixedSize(bg.size() + QSize(1, 1));
 }
 
@@ -134,90 +135,90 @@ void QCallTip::keyPressEvent(QKeyEvent *e)
 	if ( e->modifiers() & (Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier) )
 	{
 		close();
-		
+
 		if ( parentWidget() )
 			parentWidget()->setFocus();
-		
+
 		e->ignore();
 		return;
 	}
-	
+
 	QString prefix, text = e->text();
-	
+
 	switch ( e->key() )
 	{
 		case Qt::Key_Escape :
 			close();
-			
+
 			if ( parentWidget() )
 				parentWidget()->setFocus();
-			
+
 			e->accept();
 			break;
-			
+
 		case Qt::Key_Enter :
 		case Qt::Key_Return :
 		case Qt::Key_Tab :
 			//hide();
-			
+
 			close();
-			
+
 			if ( parentWidget() )
 				parentWidget()->setFocus();
-			
+
 			e->ignore();
-			
+
 			break;
-			
+
 		case Qt::Key_Up :
-			
+
 			if ( m_index )
 				--m_index;
-			
+
 			e->accept();
 			update();
 			break;
-			
+
 		case Qt::Key_Down :
-			
+
 			if ( (m_index + 1) < m_tips.count() )
 				++m_index;
-			
+
 			e->accept();
 			update();
 			break;
-			
+
 		case Qt::Key_Backspace :
-			
+
 			close();
-			
+
 			if ( parentWidget() )
 				parentWidget()->setFocus();
-			
+
 			e->ignore();
 			break;
-			
+
 		case Qt::Key_Shift :
 		case Qt::Key_Alt :
 		case Qt::Key_Control :
 			e->ignore();
 			break;
-			
+
 		default:
-			
+
 			if ( text.count() && text.at(0).isPrint() )
 			{
-				
+
 			} else {
 				close();
-				
+
 				if ( parentWidget() )
 					parentWidget()->setFocus();
-				
+
 			}
-			
+
 			e->ignore();
-			
+
 			break;
 	}
 }
@@ -230,12 +231,12 @@ void QCallTip::focusInEvent(QFocusEvent *e)
 void QCallTip::focusOutEvent(QFocusEvent *e)
 {
 	QWidget::focusOutEvent(e);
-	
+
 	close();
-	
+
 	if ( parentWidget() )
 		parentWidget()->setFocus();
-	
+
 }
 
 void QCallTip::mousePressEvent(QMouseEvent *e)
@@ -254,14 +255,14 @@ void QCallTip::mousePressEvent(QMouseEvent *e)
 		++m_index;
 	} else {
 		close();
-		
+
 		if ( parentWidget() )
 			parentWidget()->setFocus();
-		
+
 	}
-	
+
 	e->accept();
-	
+
 	update();
 }
 

--- a/src/qcodeedit/lib/widgets/qlinenumberpanel.cpp
+++ b/src/qcodeedit/lib/widgets/qlinenumberpanel.cpp
@@ -3,7 +3,7 @@
 ** Copyright (C) 2006-2009 fullmetalcoder <fullmetalcoder@hotmail.fr>
 **
 ** This file is part of the Edyuk project <http://edyuk.org>
-** 
+**
 ** This file may be used under the terms of the GNU General Public License
 ** version 3 as published by the Free Software Foundation and appearing in the
 ** file GPL.txt included in the packaging of this file.
@@ -14,11 +14,12 @@
 ****************************************************************************/
 
 #include "qlinenumberpanel.h"
+#include "utilsUI.h"
 
 /*!
 	\file qlinenumberpanel.cpp
 	\brief Implementation of the QLineNumberPanel class
-	
+
 	\see QLineNumberPanel
 */
 
@@ -55,7 +56,7 @@ QLineNumberPanel::QLineNumberPanel(QWidget *p)
 */
 QLineNumberPanel::~QLineNumberPanel()
 {
-	
+
 }
 
 /*!
@@ -75,7 +76,7 @@ bool QLineNumberPanel::isVerboseMode() const
 }
 
 /*!
-	
+
 */
 void QLineNumberPanel::setVerboseMode(bool y)
 {
@@ -99,13 +100,13 @@ void QLineNumberPanel::editorChange(QEditor *e)
 					this	, SLOT  ( update() ) );
 		disconnect( editor()->document(), SIGNAL( fontChanged(QFont) ),
 					this	, SLOT  ( setFont_slot(QFont) ) );
-		
+
 	}
-	
+
 	if ( e )
 	{
-		setFixedWidth(fontMetrics().width(QString::number(e->document()->lines())) + 5);
-		
+		setFixedWidth(UtilsUi::getFmWidth(fontMetrics(), QString::number(e->document()->lines())) + 5);
+
 		connect(e	, SIGNAL( cursorPositionChanged() ),
 				this, SLOT  ( update() ) );
 
@@ -124,13 +125,13 @@ bool QLineNumberPanel::paint(QPainter *p, QEditor *e)
 			0x21B3
 			0x2937
 	*/
-	
+
 	QFont f(font());
 	f.setWeight(QFont::Bold);
 	const QFontMetrics sfm(f);
     bool specialFontUsage=false;
     QFont specialFont(font());
-	
+
 	#ifndef WIN32
 	static const QChar wrappingArrow(0x2937);
     const QFontMetrics specialSfm(sfm);
@@ -149,64 +150,64 @@ bool QLineNumberPanel::paint(QPainter *p, QEditor *e)
 	const QFontMetrics specialSfm(specialFont);
 	specialFontUsage=true;
 	#endif
-	
+
 	int max = e->document()->lines();
 	if(max<100) max=100; // always reserve 3 line number columns to avoid ugly jumping of width
 	QString s_width=QString::number(max);
 	s_width.fill('6');
-	const int panelWidth = sfm.width(s_width) + 5;
+	const int panelWidth = UtilsUi::getFmWidth(sfm, s_width) + 5;
 	setFixedWidth(panelWidth);
-		
+
 	int n, posY,
 		as = QFontMetrics(e->document()->font()).ascent(),
 		ls = e->document()->getLineSpacing(),
 		pageBottom = e->viewport()->height(),
 		contentsY = e->verticalOffset();
-	
+
 	QString txt;
 	QDocument *d = e->document();
 	const int cursorLine = e->cursor().lineNumber();
-	
+
 	n = d->lineNumber(contentsY);
 	posY = as + 2 + d->y(n) - contentsY;
-	
+
 	//qDebug("first = %i; last = %i", first, last);
 	//qDebug("beg pos : %i", posY);
-	
+
 	for ( ; ; ++n )
 	{
 		//qDebug("n = %i; pos = %i", n, posY);
 		QDocumentLine line = d->line(n);
-		
+
 		if ( line.isNull() || ((posY - as) > pageBottom) )
 			break;
-		
+
 		if ( line.isHidden() )
 			continue;
-		
+
 		bool draw = true;
-		
+
 		if ( !m_verbose )
 		{
 			draw = !((n + 1) % 10) || !n || !line.marks().empty();
 		}
-		
+
 		txt = QString::number(n + 1);
-		
+
 		if ( n == cursorLine )
 		{
 			draw = true;
-			
+
 			p->save();
 			QFont f = p->font();
 			f.setWeight(QFont::Bold);
 
 			p->setFont(f);
 		}
-		
-		if ( draw ) 
+
+		if ( draw )
 		{
-			p->drawText(width() - 2 - sfm.width(txt),
+			p->drawText(width() - 2 - UtilsUi::getFmWidth(sfm, txt),
 						posY,
 						txt);
             if(specialFontUsage){
@@ -216,34 +217,34 @@ bool QLineNumberPanel::paint(QPainter *p, QEditor *e)
                 	p->setFont(specialFont);
             	}
             }
-		
+
 			for ( int i = 1; i < line.lineSpan(); ++i )
-				p->drawText(width() - 2 - specialSfm.width(wrappingArrow), posY + i * ls, wrappingArrow);
+				p->drawText(width() - 2 - UtilsUi::getFmWidth(specialSfm, wrappingArrow), posY + i * ls, wrappingArrow);
 
             if(specialFontUsage){
-                if (line.lineSpan()>1) 
+                if (line.lineSpan()>1)
                     p->restore();
             }
 		} else {
 			int yOff = posY - (as + 1) + ls / 2;
-			
+
 			if ( (n + 1) % 5 )
 				p->drawPoint(width() - 5, yOff);
 			else
 				p->drawLine(width() - 7, yOff, width() - 2, yOff);
 		}
-				
+
 		if ( n == cursorLine )
 		{
 			p->restore();
 		}
-		
+
 		posY += ls * line.lineSpan();
 	}
-	
+
 	//p->setPen(Qt::DotLine);
 	//p->drawLine(width()-1, 0, width()-1, pageBottom);
-	
+
 	//setFixedWidth(sfm.width(txt) + 5);
 	return true;
 }

--- a/src/qcodeedit/lib/widgets/qstatuspanel.cpp
+++ b/src/qcodeedit/lib/widgets/qstatuspanel.cpp
@@ -15,6 +15,7 @@
 
 #include "qstatuspanel.h"
 #include "utilsSystem.h"
+#include "utilsUI.h"
 
 /*!
 	\file qstatuspanel.cpp
@@ -148,7 +149,7 @@ bool QStatusPanel::paint(QPainter *p, QEditor *e)
 		}
 	}
 	p->drawText(xpos, ascent, s);
-	xpos += fm.width(s) + 10;
+	xpos += UtilsUi::getFmWidth(fm, s) + 10;
 
 	bool displayModifyIcon = false; // we never need this, because it's displayed in the editor tab.
 	int sz = qMin(height(), _mod.height());
@@ -168,19 +169,19 @@ bool QStatusPanel::paint(QPainter *p, QEditor *e)
 	} else {
 		xpos += sz + 10;
 	}
-	xpos += fm.width(timeDiff);
+	xpos += UtilsUi::getFmWidth(fm, timeDiff);
 	xpos += 20;
-	
+
 	s = editor()->flag(QEditor::Overwrite) ? tr("OVERWRITE") : tr("INSERT");
 	p->drawText(xpos, ascent, s);
-	xpos += fm.width(s) + 10;
+	xpos += UtilsUi::getFmWidth(fm, s) + 10;
 
 	m_conflictSpot = 0;
 
 	if ( editor()->isInConflict() )
 	{
 		s =  tr("Conflict");
-		int w = fm.width(s) + 30;
+		int w = UtilsUi::getFmWidth(fm, s) + 30;
 
 		if ( xpos + w + _warn.width() < width() )
 		{
@@ -194,7 +195,7 @@ bool QStatusPanel::paint(QPainter *p, QEditor *e)
 	}
 
 	setFixedHeight(fontMetrics().lineSpacing() + 4);
-	
+
 	if(!e->displayModifyTime() && timer){
 		disconnect(timer, SIGNAL(timeout()), this, SLOT(update()));
 		delete timer;
@@ -207,7 +208,7 @@ bool QStatusPanel::paint(QPainter *p, QEditor *e)
 		timer->start(1000);
 	}
 	//QTimer::singleShot(1000, this, SLOT( update() ) );
-	
+
 	return true;
 }
 
@@ -231,7 +232,7 @@ void QStatusPanel::mousePressEvent(QMouseEvent *e)
 void QStatusPanel::mouseReleaseEvent(QMouseEvent *e)
 {
 	Q_UNUSED(e)
-	
+
 	editor()->setFocus();
 }
 

--- a/src/searchresultwidget.cpp
+++ b/src/searchresultwidget.cpp
@@ -214,7 +214,7 @@ void SearchTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
 	QVariant vLineNumber = index.data(SearchResultModel::LineNumberRole);
 	if (vLineNumber.isValid()) {
 		int hPadding = 1;
-		int lwidth = painter->fontMetrics().width("00000") + 2 * hPadding;
+		int lwidth = UtilsUi::getFmWidth(painter->fontMetrics(), "00000") + 2 * hPadding;
 		QRect lineNumberRect = QRect(r.left(), r.top(), lwidth, r.height());
 		if (!isSelected) {
 			painter->fillRect(lineNumberRect, option.palette.window());
@@ -231,12 +231,12 @@ void SearchTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
 	foreach (SearchMatch match, matches) {
 		// text before match
 		QString part = text.mid(pos, match.pos - pos);
-		int w = painter->fontMetrics().width(part);
+		int w = UtilsUi::getFmWidth(painter->fontMetrics(), part);
 		painter->drawText(r, Qt::AlignLeft | Qt::AlignTop | Qt::TextSingleLine, part);
 		r.setLeft(r.left() + w + 1);
 		// matched text
 		part = text.mid(match.pos, match.length);
-		w = painter->fontMetrics().width(part);
+		w = UtilsUi::getFmWidth(painter->fontMetrics(), part);
 		painter->save();
         if(darkMode){
             painter->fillRect(QRect(r.left(), r.top(), w, r.height()), QBrush(QColor(255, 239, 11)));

--- a/src/symbolpanel/symbolwidget.cpp
+++ b/src/symbolpanel/symbolwidget.cpp
@@ -3,6 +3,7 @@
 #include "symbollistview.h"
 #include "proxymodels.h"
 #include "configmanagerinterface.h"
+#include "utilsUI.h"
 #include <QSortFilterProxyModel>
 
 
@@ -120,7 +121,7 @@ void SymbolWidget::setupSearchArea(QVBoxLayout *vLayout)
 	int width = 0;
 	QFontMetrics fm = fontMetrics();
 	foreach (const QString &name, categoryNames.values()) {
-		width = qMax(width, fm.width(name) + 20);
+		width = qMax(width, UtilsUi::getFmWidth(fm, name) + 20);
 	}
 	categoryFilterButton->setMinimumWidth(width);
 	hLayout->addWidget(categoryFilterButton);

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -1523,7 +1523,7 @@ void Texstudio::createStatusBar()
 	statusTbLanguage->setToolTip(tr("Language"));
 	statusTbLanguage->setPopupMode(QToolButton::InstantPopup);
 	statusTbLanguage->setAutoRaise(true);
-	statusTbLanguage->setMinimumWidth(status->fontMetrics().width("OOOOOOO"));
+	statusTbLanguage->setMinimumWidth(UtilsUi::getFmWidth(status->fontMetrics(), "OOOOOOO"));
 	connect(&spellerManager, SIGNAL(dictPathChanged()), this, SLOT(updateAvailableLanguages()));
 	connect(&spellerManager, SIGNAL(defaultSpellerChanged()), this, SLOT(updateAvailableLanguages()));
 	updateAvailableLanguages();
@@ -1536,7 +1536,7 @@ void Texstudio::createStatusBar()
 	statusTbEncoding->setText(tr("Encoding") + "  ");
 	statusTbEncoding->setPopupMode(QToolButton::InstantPopup);
 	statusTbEncoding->setAutoRaise(true);
-	statusTbEncoding->setMinimumWidth(status->fontMetrics().width("OOOOO"));
+	statusTbEncoding->setMinimumWidth(UtilsUi::getFmWidth(status->fontMetrics(), "OOOOO"));
 
 	QSet<int> encodingMibs;
 	foreach (const QString &s, configManager.commonEncodings) {

--- a/src/unicodeinsertion.cpp
+++ b/src/unicodeinsertion.cpp
@@ -1,4 +1,5 @@
 #include "unicodeinsertion.h"
+#include "utilsUI.h"
 
 QString unicodePointToString(unsigned int u)
 {
@@ -29,7 +30,7 @@ void QLineEditWithMetaText::paintEvent ( QPaintEvent *ev)
 	QPainter p(this);
 	QFontMetrics fm(font());
 	p.setPen(QApplication::palette().windowText().color().lighter(50));
-	p.drawText(width() - fm.width(metaText) - 5, (height() + fm.height()) / 2 - 2, metaText);
+	p.drawText(width() - UtilsUi::getFmWidth(fm, metaText) - 5, (height() + fm.height()) / 2 - 2, metaText);
 
 }
 

--- a/src/utilsUI.cpp
+++ b/src/utilsUI.cpp
@@ -114,7 +114,7 @@ QToolButton *createComboToolButton(QWidget *parent, const QStringList &list, con
 		QString text = list[i];
 		//QIcon icon = (i<icons.length()) ? icons[i] : QIcon();
 		QAction *mAction = mMenu->addAction(text, receiver, member);
-		max = qMax(max, fm.width(text + "        "));
+		max = qMax(max, getFmWidth(fm, text + "        "));
 		if (i == defaultIndex) {
 			combo->setDefaultAction(mAction);
 			defaultSet = true;
@@ -358,5 +358,38 @@ void resizeInFontHeight(QWidget *w, int width, int height)
 	//qDebug() << "resizeInFontHeight new size:" << newSize.width() / (float) h << newSize.height() / (float) h;
 	w->resize(newSize);
 }
+
+/*!
+ * \brief Given font metrics return pixel size of a character
+ * \param[in] fm Font metrics
+ * \param[in] ch Character
+ * \returns Returns pixel size of character
+ */
+int getFmWidth(const QFontMetrics &fm, QChar ch)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+	return fm.horizontalAdvance(ch);
+#else
+	return fm.width(ch);
+#endif
+}
+
+/*!
+ * \brief Given font metrics return pixel size of a text string
+ * \param[in] fm Font metrics
+ * \param[in] text Text string
+ * \param[in] len Only calculate width of the first len characters of the string. If not specified,
+ * then -1 is assumed which means calculate width of the whole string.
+ * \returns Returns pixel size of the text string
+ */
+int getFmWidth(const QFontMetrics &fm, const QString &text, int len)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+	return fm.horizontalAdvance(text, len);
+#else
+	return fm.width(text, len);
+#endif
+}
+
 
 }  // namespace UtilsUi

--- a/src/utilsUI.h
+++ b/src/utilsUI.h
@@ -38,6 +38,10 @@ void enableTouchScrolling(QWidget *w, bool enable = true);
 
 void resizeInFontHeight(QWidget *w, int width, int height);
 
+// Given font metrics returns the text pixel size
+int getFmWidth(const QFontMetrics &fm, QChar ch);
+int getFmWidth(const QFontMetrics &fm, const QString &text, int len = -1);
+
 }  // namespace UtilsUi
 
 #endif // UTILSUI_H


### PR DESCRIPTION
This PR fixes some of the build warnings for Qt 5.11.0+ with GCC9
It replaces calls to the deprecated method `QFontMetrics::width()` with calls to a custom function
`UtilsUi::getFmWidth()`. The latter function calls:
1. `QFontMetrics::horizontalAdvance()` on Qt 5.11.0+
2. `QFontMetrics::width()` before Qt 5.11.0
This fixes about 40-50% of all the build warnings.

The PR also fixes a `-Wdeprecated-copy` warning when assigning to `BibTeXType`

There are still quite a few build warnings (mostly calling Qt obsolete methods) but I will provide separate PRs once I find clean ways to fix those warnings.