### PR TITLE
Replace calls to obsolete screen geometry methods.

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -554,7 +554,7 @@ ConfigDialog::ConfigDialog(QWidget *parent): QDialog(parent), checkboxInternalPD
 	connect(ui.tbRevertSymbol, SIGNAL(clicked()), this, SLOT(revertClicked()));
 
 	// limit dialog size
-	QRect screen = QApplication::desktop()->screenGeometry();
+	QRect screen = QGuiApplication::primaryScreen()->geometry();
 	if (!screen.isEmpty()) {
 		int nwidth = width(), nheight = height();
 		if (nwidth > screen.width()) nwidth = screen.width();

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -695,7 +695,7 @@ ConfigManager::ConfigManager(QObject *parent): QObject (parent),
 	registerOption("Preview/SegmentPreviewScalePercent", &segmentPreviewScalePercent, 150, &pseudoDialog->spinBoxSegmentPreviewScalePercent);
 
 	//pdf preview
-	QRect screen = QApplication::desktop()->availableGeometry();
+	QRect screen = QGuiApplication::primaryScreen()->availableGeometry();
 	registerOption("Geometries/PdfViewerLeft", &pdfDocumentConfig->windowLeft, screen.left() + screen.width() * 2 / 3);
 	registerOption("Geometries/PdfViewerTop", &pdfDocumentConfig->windowTop, screen.top() + 10);
 	registerOption("Geometries/PdfViewerWidth", &pdfDocumentConfig->windowWidth, screen.width() / 3 - 26);

--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -2332,8 +2332,7 @@ PDFDocument::PDFDocument(PDFDocumentConfig *const pdfConfig, bool embedded)
         int &y = globalConfig->windowTop;
         int &w = globalConfig->windowWidth;
         int &h = globalConfig->windowHeight;
-        int screenNumber = QApplication::desktop()->screenNumber(QPoint(x, y));
-        QRect screen = QApplication::desktop()->availableGeometry(screenNumber);
+        QRect screen = UtilsUi::getAvailableGeometryAt(QPoint(x, y));
         // add some tolerance, as fullscreen seems to have negative coordinate (KDE, Win7 ...)
         screen.adjust(-8, -8, +8, +8);
         if (!screen.contains(x, y)) {
@@ -3411,14 +3410,13 @@ void PDFDocument::updateDisplayState(DisplayFlags displayFlags)
 
 void PDFDocument::arrangeWindows(bool tile)
 {
-	QDesktopWidget *desktop = QApplication::desktop();
-	for (int screenIndex = 0; screenIndex < desktop->numScreens(); ++screenIndex) {
+	foreach (const QScreen *screen, QGuiApplication::screens()) {
 		QWidgetList windows;
 		foreach (QWidget *widget, QApplication::topLevelWidgets())
 			if (!widget->isHidden() && qobject_cast<QMainWindow *>(widget))
 				windows << widget;
 		if (windows.size() > 0)
-			(*(tile ? &tileWindowsInRect : &stackWindowsInRect)) (windows, desktop->availableGeometry(screenIndex));
+			(*(tile ? &tileWindowsInRect : &stackWindowsInRect)) (windows, screen->availableGeometry());
 	}
 }
 

--- a/src/smallUsefulFunctions.cpp
+++ b/src/smallUsefulFunctions.cpp
@@ -948,7 +948,7 @@ QString getImageAsText(const QPixmap &AImage, const int w)
 void showTooltipLimited(QPoint pos, QString text, int relatedWidgetWidth)
 {
 	text.replace("\t", "    "); //if there are tabs at the position in the string, qt crashes. (13707)
-	QRect screen = QApplication::desktop()->availableGeometry(pos);
+	QRect screen = UtilsUi::getAvailableGeometryAt(pos);
 	// estimate width of coming tooltip
 	// rather dirty code
 	bool textWillWarp = Qt::mightBeRichText(text);

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -3972,13 +3972,12 @@ void Texstudio::readSettings(bool reread)
 
     config->beginGroup("texmaker");
 
-    QRect screen = QApplication::desktop()->availableGeometry();
+    QRect screen = QGuiApplication::primaryScreen()->availableGeometry();
     int w = config->value("Geometries/MainwindowWidth", screen.width() - 100).toInt();
     int h = config->value("Geometries/MainwindowHeight", screen.height() - 100).toInt() ;
     int x = config->value("Geometries/MainwindowX", screen.x() + 10).toInt();
     int y = config->value("Geometries/MainwindowY", screen.y() + 10).toInt() ;
-    int screenNumber = QApplication::desktop()->screenNumber(QPoint(x, y));
-    screen = QApplication::desktop()->availableGeometry(screenNumber);
+    screen = UtilsUi::getAvailableGeometryAt(QPoint(x, y));
     if (!screen.contains(x, y)) {
         // top left is not on screen
         x = screen.x() + 10;
@@ -8018,7 +8017,7 @@ void Texstudio::previewAvailable(const QString &imageFile, const PreviewSource &
 		else
 			p = currentEditorView()->editor->mapToGlobal(currentEditorView()->editor->mapFromContents(currentEditorView()->editor->cursor().documentPosition()));
 
-		QRect screen = QApplication::desktop()->screenGeometry();
+		QRect screen = QGuiApplication::primaryScreen()->geometry();
 		int w = pixmap.width();
 		if (w > screen.width()) w = screen.width() - 2;
 		if (!fromPDF) {
@@ -8133,7 +8132,7 @@ void Texstudio::showImgPreview(const QString &fname)
 		p = currentEditorView()->getHoverPosistion();
 		//else
 		//    p=currentEditorView()->editor->mapToGlobal(currentEditorView()->editor->mapFromContents(currentEditorView()->editor->cursor().documentPosition()));
-		QRect screen = QApplication::desktop()->screenGeometry();
+		QRect screen = QGuiApplication::primaryScreen()->geometry();
 		QPixmap img(imageName);
 		int w = qMin(img.width(), configManager.editorConfig->maxImageTooltipWidth);
 		w = qMin(w, screen.width() - 8);
@@ -8170,7 +8169,7 @@ void Texstudio::showImgPreviewFinished(const QPixmap &pm, int page)
 	p = currentEditorView()->getHoverPosistion();
 	//else
 	//    p=currentEditorView()->editor->mapToGlobal(currentEditorView()->editor->mapFromContents(currentEditorView()->editor->cursor().documentPosition()));
-	QRect screen = QApplication::desktop()->screenGeometry();
+	QRect screen = QGuiApplication::primaryScreen()->geometry();
 	int w = pm.width();
 	if (w > screen.width()) w = screen.width() - 2;
 	QString text;

--- a/src/utilsUI.cpp
+++ b/src/utilsUI.cpp
@@ -391,5 +391,23 @@ int getFmWidth(const QFontMetrics &fm, const QString &text, int len)
 #endif
 }
 
+/*!
+ * \brief Return the screen geometry for a given point
+ * \param[in] pos Position
+ * \returns The screen geometry at the given point
+ */
+QRect getAvailableGeometryAt(const QPoint &pos)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+	QScreen *pScreen = QGuiApplication::screenAt(pos);
+	if (pScreen == nullptr) {
+		return QRect();
+	}
+	return pScreen->availableGeometry();
+#else
+	return QApplication::desktop()->availableGeometry(pos);
+#endif
+}
+
 
 }  // namespace UtilsUi

--- a/src/utilsUI.h
+++ b/src/utilsUI.h
@@ -42,6 +42,9 @@ void resizeInFontHeight(QWidget *w, int width, int height);
 int getFmWidth(const QFontMetrics &fm, QChar ch);
 int getFmWidth(const QFontMetrics &fm, const QString &text, int len = -1);
 
+// Return the screen geometry for a given point
+QRect getAvailableGeometryAt(const QPoint &pos);
+
 }  // namespace UtilsUi
 
 #endif // UTILSUI_H


### PR DESCRIPTION
This PR provides the next set of fixes for build warnings. It does the following two changes:

1. It replaces the obsolete calls to `QDesktopWidget::screenGeometry()` and `QDesktopWidget::availableGeometry()` with calls to methods of `GuiApplication::primaryScreen()`
2. It adds a custom function `UtilsUi::getAvailableGeometryAt()` which is used to replace calls to
`QDesktopWidget::availableGeometry(const QPoint &)`