### PR TITLE
Sync change of spacing commands with latex2e

### DIFF
--- a/completion/amsmath.cwl
+++ b/completion/amsmath.cwl
@@ -100,12 +100,8 @@
 \leftroot{argument}
 \lvert#m
 \lVert#m
-\medspace
 \mod#
 \mspace{dimen}#m
-\negmedspace
-\negthickspace
-\negthinspace
 \nobreakdash
 \notag#m
 \numberwithin{env}{counter}
@@ -128,7 +124,6 @@
 \tbinom{above}{below}#m
 \text{text}#m
 \tfrac{%<num%:translatabe%>}{%<den%:translatable%>}#m
-\thickspace
 \underleftarrow{argument}#m
 \underleftrightarrow{argument}#m
 \underrightarrow{argument}#m

--- a/completion/latex-document.cwl
+++ b/completion/latex-document.cwl
@@ -286,9 +286,12 @@
 \mathunderscore#m
 \mathversion#*
 \mbox{text}
+\medspace
 \mdseries#*
 \multicolumn{cols}{pos}{text}
 \multiput(xcoord,ycoord)(xdelta,ydelta){copies}{object}#*/picture
+\negmedspace
+\negthickspace
 \newblock#*
 \newlabel
 \newlength{newlength%cmd}#d
@@ -447,6 +450,7 @@
 \thanks{text}
 \thicklines
 \thinlines
+\thickspace
 \thispagestyle{empty/plain/headings/myheadings}
 \time
 \tiny

--- a/completion/tex.cwl
+++ b/completion/tex.cwl
@@ -631,7 +631,7 @@
 \nearrow#m
 \ne#m
 \neg#m
-\negthinspace#*
+\negthinspace
 \neq#m
 \newbox#*
 \newbox{cmd}#dS
@@ -813,7 +813,7 @@
 \textindent#*
 \theta#m
 \Theta#m
-\thinspace#*
+\thinspace
 \tilde{a}#m
 \times#m
 \to#m

--- a/src/latexparser/latexparser.cpp
+++ b/src/latexparser/latexparser.cpp
@@ -52,7 +52,7 @@ void LatexParser::init()
     possibleCommands["tabular"] = QSet<QString>{"&" };
     possibleCommands["array"] = QSet<QString>{ "&" };
     possibleCommands["tabbing"] = QSet<QString>{"\\<" , "\\>" , "\\=" , "\\+"};
-    possibleCommands["normal"] = QSet<QString>{ "\\\\" , "\\_" , "\\-" , "$" , "$$" , "\\$" , "\\#" , "\\{" , "\\}" , "\\S" , "\\'" , "\\`" , "\\^" , "\\=" , "\\." , "\\u" , "\\v" , "\\H" , "\\t" , "\\c" , "\\d" , "\\b" , "\\o" , "\\O" , "\\P" , "\\l" , "\\L" , "\\&" , "\\~" , "\\" , "\\," , "\\%" , "\\\""};
+    possibleCommands["normal"] = QSet<QString>{ "\\\\" , "\\_" , "\\-" , "$" , "$$" , "\\$" , "\\#" , "\\{" , "\\}" , "\\S" , "\\'" , "\\`" , "\\^" , "\\=" , "\\." , "\\u" , "\\v" , "\\H" , "\\t" , "\\c" , "\\d" , "\\b" , "\\o" , "\\O" , "\\P" , "\\l" , "\\L" , "\\&" , "\\~" , "\\" , "\\," , "\\%" , "\\\"", "\\," , "\\!" , "\\;" , "\\:"};
     possibleCommands["math"] = QSet<QString>{ "_" , "^" , "\\$" , "\\#" , "\\{" , "\\}" , "\\S" , "\\," , "\\!" , "\\;" , "\\:" , "\\\\" , "\\ " , "\\|"};
     possibleCommands["%definition"] = QSet<QString>{ "\\newcommand" , "\\renewcommand" , "\\newcommand*" , "\renewcommand*" , "\\providecommand" , "\\newlength" , "\\let"};
     possibleCommands["%usepackage"] = QSet<QString>{ "\\usepackage" , "\\documentclass" };


### PR DESCRIPTION
From [this commit](https://github.com/latex3/latex2e/commit/890b583b589b53c308d5bb0ea1b273597cb2c56e) to LaTeX2e kernel,

> Originally \LaTeX{} only provided a small set of spacing commands
for use in text and math, some of the commands like \cs{;} were
only supported in manth mode. \texttt{amsmath} normalized  and
provided all of them in text and math. This code has now been
moved to the kernel so that it is generally available.

That change to LaTeX2e will take place at the next release of LaTeX2e. 

This pr moves affected commands from `amsmath.cwl` to `latex-document.cwl`, and appends affected control symbols (such as `\,`) to `possibleCommands["normal"]` to allow use in text mode.

A full list of affected spacing commands:
```tex
\,
\thinspace
\!
\negthinspace
\:
\medspace
\negmedspace
\;
\thickspace
\negthickspace
```