### PR TITLE
Raise maximum number of macros

### DIFF
--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -336,6 +336,7 @@ bool ManagedProperty::readFromObject(const QObject *w)
 }
 #undef READ_FROM_OBJECT
 
+const int ConfigManager::MAX_NUM_MACROS;
 QTextCodec *ConfigManager::newFileEncoding = nullptr;
 QString ConfigManager::configDirOverride;
 bool ConfigManager::dontRestoreSession=false;
@@ -1008,7 +1009,7 @@ QSettings *ConfigManager::readSettings(bool reread)
         QDir dir(joinPath(configBaseDir,"macro"));
         if(dir.exists()){
             // use file based macros
-            for (int i = 0; i < 1000; i++) {
+            for (int i = 0; i < ConfigManager::MAX_NUM_MACROS; i++) {
                 QString fileName=joinPath(configBaseDir,"macro",QString("Macro_%1.txsMacro").arg(i));
                 if(QFile(fileName).exists()){
                     Macro macro;
@@ -1020,7 +1021,7 @@ QSettings *ConfigManager::readSettings(bool reread)
             }
         }else{
             if (config->value("Macros/0").isValid()) {
-                for (int i = 0; i < 1000; i++) {
+                for (int i = 0; i < ConfigManager::MAX_NUM_MACROS; i++) {
                     QStringList ls = config->value(QString("Macros/%1").arg(i)).toStringList();
                     if (ls.isEmpty()) break;
                     completerConfig->userMacros.append(Macro(ls));

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -34,6 +34,8 @@ class ConfigManager: public QObject, public ConfigManagerInterface
 	Q_OBJECT
 
 public:
+    static const int MAX_NUM_MACROS = 5000;
+
     ConfigManager(QObject *parent = nullptr);
 	~ConfigManager();
 

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -9099,7 +9099,7 @@ void Texstudio::loadProfile()
 				config->setValue(key, profile->value(key));
 			}
 			// handle macros
-			for (int i = 0; i < 1000; i++) {
+			for (int i = 0; i < ConfigManager::MAX_NUM_MACROS; i++) {
 			    QStringList ls = profile->value(QString("texmaker/Macros/%1").arg(i)).toStringList();
 			    if (ls.isEmpty()) break;
 			    if (!macro) { //remove old values


### PR DESCRIPTION
Currently, the maximum number of macros that can be created is hard-coded as 1000. This change introduces a central constant for this number and raises it to 5000. Perhaps this limit should also be documented somewhere?

In case you’re wondering what the use case for this could be, I’m using macros to enable easy input of Unicode characters (e.g. typing “\psi ” triggers a macro and gives “ψ”), mostly for the purposes of `unicode-math`. Since there are a lot of Unicode characters (see [`unicode-math-table.tex`](https://github.com/wspr/unicode-math/blob/master/unicode-math-table.tex)), it can be quite easy to reach the current limit of 1000 macros at one macro per character. Now, perhaps there is another way to do this which requires fewer macros, but the restriction to 1000 is arbitrary/undocumented, so this seems like the simplest way to accommodate users who try something similar as I did.