### PR TITLE
override ctrl+c shortcut snitching

### DIFF
--- a/src/toolwidgets.cpp
+++ b/src/toolwidgets.cpp
@@ -147,7 +147,7 @@ TerminalWidget::TerminalWidget(QWidget *parent): QWidget(parent)
 	layout->setSpacing(0);
 	layout->setMargin(0);
 	setLayout(layout);
-	this->installEventFilter(this);
+	installEventFilter(this);
 	initQTermWidget();
 }
 

--- a/src/toolwidgets.cpp
+++ b/src/toolwidgets.cpp
@@ -147,8 +147,36 @@ TerminalWidget::TerminalWidget(QWidget *parent): QWidget(parent)
 	layout->setSpacing(0);
 	layout->setMargin(0);
 	setLayout(layout);
-
+	this->installEventFilter(this);
 	initQTermWidget();
+}
+
+TerminalWidget::~TerminalWidget()
+{
+	delete qTermWidget;
+	delete layout;
+}
+
+/*
+ * Overrides QShortcuts snitching these key combos
+ * in case the TerminalWidget has focus.
+ */
+bool TerminalWidget::eventFilter(QObject *watched, QEvent *event)
+{
+	if (event->type() == QEvent::ShortcutOverride) {
+		QKeyEvent *keyEvent = static_cast<QKeyEvent*>(event);
+		if (keyEvent->modifiers().testFlag(Qt::ControlModifier)
+			&& ( (keyEvent->key() == 'C')
+			|| (keyEvent->key() == 'D')
+			|| (keyEvent->key() == 'L')
+			|| (keyEvent->key() == 'X')
+			|| (keyEvent->key() == 'Y')
+			|| (keyEvent->key() == 'V') ) ) {
+			event->accept();
+			return true;
+		}
+	}
+	return QWidget::eventFilter(watched, event);
 }
 
 void TerminalWidget::qTermWidgetFinished()

--- a/src/toolwidgets.h
+++ b/src/toolwidgets.h
@@ -50,10 +50,12 @@ class TerminalWidget : public QWidget
 
 public:
     explicit TerminalWidget(QWidget *parent = nullptr);
+    ~TerminalWidget();
 	void setCurrentFileName(const QString &filename);
 	void updateSettings(bool noreset=false);
+	bool eventFilter(QObject *watched, QEvent *event);
 
-public slots:
+private slots:
 	void qTermWidgetFinished();
 
 private :


### PR DESCRIPTION
Issue: Ctrl+C is something I considered should really work in the terminal, otherwise somebody may get really mad about some accidental started destructive operation they cant stop.

While at it added some other key combos, that don't make sense when focusing the terminal.

Also had forgotten a proper destructor, oops