### PR TITLE
Fix a bug that prevents mouse cursor from changing its look in the embedded PDF viewer

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -3231,6 +3231,7 @@ void PDFDocument::toggleAutoHideToolbars()
 	QAction *act = qobject_cast<QAction *>(sender());
 	if (act) {
 		globalConfig->autoHideToolbars = act->isChecked();
+		reloadSettings();
 	}
 }
 


### PR DESCRIPTION
There is a bug in TXS which causes it to disable mouse tracking events for the PDF viewer widget which in turns prevents the widget from updating its internal state. For example this bug prevents the cursor from changing to pointing hand when hovering over links in the internal PDF viewer.

How to reproduce:

1. Start TXS.
2. Open "Options / Configure TeXstudio..." then go to "Internal PDF viewer" and disable "Auto-hide Toolbars in Embedded Mode", then save the settings by clicking on the [OK] button.
3. Create a sample .tex file that has a link, e.g.
```
\documentclass{amsart}
\usepackage[unicode=true,bookmarks=false,breaklinks=false,pdfborder={0 0 1},backref=section,colorlinks=true]{hyperref}
\hypersetup{linkcolor=blue,citecolor=blue,filecolor=blue,urlcolor=blue,pdftitle=,pdfauthor=,pdfsubject=,pdfkeywords=}
\begin{document}
\url{https://www.google.com/}
\end{document}
```
4. Compile the document and view it in the embedded PDF viewer. Hover the mouse over the link to www.google.com to make sure that the cursor turns to a pointing hand when hovering over the link.
5. Open "Options / Configure TeXstudio..." and then close the configuration popup by clicking on the [Cancel] button.
6. Hover the mouse cursor in the embedded PDF viewer over the link to www.google.com and see that it no longer turns into a pointing hand when the cursor is over the link.

The problem happends because the following call chain happens that disables the mouse tracking for the PDFWidget:

```
#0  QWidget::setMouseTracking (this=0x1967790, enable=false) at ../../../include/qt5/QtWidgets/qwidget.h:814
#1  0x0000000000b6a3f2 in PDFDocument::setAutoHideToolbars (this=0x2cf15c0, enabled=false) at src/pdfviewer/PDFDocument.cpp:4208
#2  0x0000000000b5d4ef in PDFDocument::reloadSettings (this=0x2cf15c0) at src/pdfviewer/PDFDocument.cpp:2575
#3  0x0000000000962ffa in Texstudio::generalOptions (this=0x1770eb0) at src/texstudio.cpp:6561
```

The proposed PR fixes this bug.

EDIT:

I just added a fix for a second bug that was present the the code for the PDF viewer auto-hide button. This second bug can be reproduced by:

1. Start TXS and display some PDF in the embedded (internal) PDF viewer.
2. Disable PDF viewer auto-hiding of the toolbar. This can be done either from "Options / Configure TeXstudio... / Internal PDF viewer" or from the auto-hide button on the embedded PDF viewer toolbar.
3. Exit TXS.
4. Start TXS. The previous PDF will be displayed in the embedded PDF viewer and auto-hiding of the toolbar will be disabled.
5. Enable auto-hiding of the PDF viewer toolbars by clicking on the auto-hide button on the toolbar.

Even though auto-hiding is enabled it will not work correctly, that is the toolbar will be visible as long as the mouse pointer is hovering over the PDF in the embedded PDF viewer.

This second bug is fixed by calling `reloadSettings()` in `PDFDocument::toggleAutoHideToolbars`.