### PR TITLE
Fix a crash in ConfigDialog::metaFilterChanged()

### DIFF
--- a/src/configdialog.h
+++ b/src/configdialog.h
@@ -107,7 +107,6 @@ public:
 public slots:
 	void changePage(QListWidgetItem *current, QListWidgetItem *previous);
 private slots:
-	QListWidgetItem *createIcon(const QString &caption, const QIcon &icon, bool advancedOption = false);
 	void comboBoxWithPathEdited(const QString &newText);
 	void comboBoxWithPathHighlighted(const QString &newText);
 	void browseThesaurus();
@@ -149,6 +148,9 @@ private slots:
 	void revertClicked();
 
 private:
+	enum ContentsType {CONTENTS_BASIC, CONTENTS_ADVANCED, CONTENTS_DISABLED};
+
+	QListWidgetItem *createIcon(const QString &caption, const QIcon &icon, ContentsType contentsType = CONTENTS_BASIC);
 	bool askRiddle();
 	void hideShowAdvancedOptions(QWidget *w, bool on);
 	static bool metaFilterRecurseWidget(const QString &filter, QWidget *widget);


### PR DESCRIPTION
This is a fix for https://github.com/texstudio-org/texstudio/issues/1019

TXS crashes if terminal support is not built and the user tries to use the option filter in the config dialog.

The crash happens in `ConfigDialog::metaFilterChanged` on the line `ui.contentsWidget->item(i)->setHidden(!on);` 
because `ui.pagesWidget->count()` is 16 (terminal page settings exist in `configdialog.ui`)
on the other hand `ui.contentsWidget->count()` is 15 (terminal page content item is not added to the list through a call to `ConfigDialog::createIcon()`).

The proposed PR fixes the issue by always adding the terminal content item to the contents list, but when terminal is disabled during build then the contents item is kept always hidden in the config dialog. This is a hack and ideally we should not add the terminal configuration page when terminal is disabled, however it seems that Qt does not support conditional compiling of widgets from the .ui files.

Maybe the proper solution would be to implement some kind of XML parser/builder that would remove the terminal settings from `configdialog.ui`, but it would require lots of custom code for the XML parser/builder in the project file, or dependency on an external XML tool.