### PR TITLE
store appdata to /usr/share/metainfo

### DIFF
--- a/texstudio.pro
+++ b/texstudio.pro
@@ -168,7 +168,7 @@ unix:!macx {
     icon.path = $${DATADIR}/icons/hicolor/scalable/apps
     icon.files = utilities/texstudio.svg
     isEmpty(NO_APPDATA) {
-        appdata.path = $${DATADIR}/appdata
+        appdata.path = $${DATADIR}/metainfo
         appdata.files = utilities/texstudio.appdata.xml
         INSTALLS += appdata
     }


### PR DESCRIPTION
/usr/share/appdata/texstudio.appdata.xml
is deprecated and should be changed to
/usr/share/metainfo/texstudio.appdata.xml

See section

    2.1.2. Filesystem locations
    https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html

(Ticket on Gentoo Bug Tracker https://bugs.gentoo.org/709464)
Closes: #1044