### PR TITLE
Fix events processing in tests

### DIFF
--- a/src/syntaxcheck.cpp
+++ b/src/syntaxcheck.cpp
@@ -291,7 +291,8 @@ void SyntaxCheck::waitForQueueProcess(void)
 	linesBefore = mLinesEnqueuedCounter.fetchAndAddOrdered(0);
 	forever {
 		for (int i = 0; i < 2; ++i) {
-			QApplication::processEvents(QEventLoop::ExcludeUserInputEvents | QEventLoop::ExcludeSocketNotifiers, 1000); // Process queued checkNextLine events
+			QCoreApplication::processEvents(QEventLoop::AllEvents, 1000); 			// Process queued checkNextLine events
+			QCoreApplication::sendPostedEvents(Q_NULLPTR, QEvent::DeferredDelete);		// Deferred delete must be processed explicitly. Using 0 for event_type does not work.
 			wait(5); // Give the checkNextLine signal handler time to queue the next line
 		}
 		linesAfter = mLinesEnqueuedCounter.fetchAndAddOrdered(0);

--- a/src/syntaxcheck.cpp
+++ b/src/syntaxcheck.cpp
@@ -271,8 +271,12 @@ void SyntaxCheck::setFormats(QMap<QString, int> formatList)
     mLtxCommandLock.unlock();
 }
 
+#ifndef NO_TESTS
+
 /*!
-* \brief wait for queue to be empty. Used for self-test only.
+* \brief Wait for syntax checker to finish processing.
+* \details Wait for syntax checker to finish processing. This method should be used only in self-tests because
+* in some rare cases it could return too early before the syntax checker queue is fully processsed.
 */
 void SyntaxCheck::waitForQueueProcess(void)
 {
@@ -297,6 +301,8 @@ void SyntaxCheck::waitForQueueProcess(void)
 		linesBefore = linesAfter;
 	}
 }
+
+#endif
 
 /*!
 * \brief check if top-most environment in 'envs' is `name`

--- a/src/syntaxcheck.h
+++ b/src/syntaxcheck.h
@@ -101,7 +101,9 @@ public:
 	void stop();
 	void setErrFormat(int errFormat);
     QString getErrorAt(QDocumentLineHandle *dlh, int pos, StackEnvironment previous, TokenStack stack);
+#ifndef NO_TESTS
 	void waitForQueueProcess(void);
+#endif
 	static int containsEnv(const LatexParser &parser, const QString &name, const StackEnvironment &envs, const int id = -1);
 	int topEnv(const QString &name, const StackEnvironment &envs, const int id = -1);
 	bool checkCommand(const QString &cmd, const StackEnvironment &envs);

--- a/src/tests/qsearchreplacepanel_t.cpp
+++ b/src/tests/qsearchreplacepanel_t.cpp
@@ -347,10 +347,8 @@ void QSearchReplacePanelTest::findReplace(){
 				if (mes) QTest::closeMessageBoxLater(true,QMessageBox::Yes);
 				widget->bNext->click();
 				if (mes) QTest::messageBoxShouldBeClose();
-				QApplication::processEvents();
+				QTest::processPendingEvents();
 			}
-			//QApplication::processEvents();
-			//Sleep(1000);
 			QEQUAL2(ed->cursor().selectionStart().lineNumber(),move[1].toInt(),QString("%1 highlight-run: %2").arg(movements[i]).arg(highlightRun));
 			QEQUAL2(ed->cursor().selectionStart().columnNumber(),move[2].toInt(),QString("%1 highlight-run: %2").arg(movements[i]).arg(highlightRun));
 			QEQUAL2(ed->cursor().selectedText(),move[0],QString("%1 highlight-run: %2").arg(movements[i]).arg(highlightRun));
@@ -431,7 +429,7 @@ void QSearchReplacePanelTest::findSpecialCase2(){
 	 * event set QApplicationPrivate::active_window
 	 */
 	panel->activateWindow();
-	QApplication::processEvents(QEventLoop::ExcludeUserInputEvents | QEventLoop::ExcludeSocketNotifiers);
+	QTest::processPendingEvents();
 
 	//test if the current selection is used as search scope
 	for (int oldSel=0;oldSel<2;oldSel++){

--- a/src/tests/testmanager.cpp
+++ b/src/tests/testmanager.cpp
@@ -100,6 +100,8 @@ QString TestManager::execute(TestLevel level, LatexEditorView* edView, QCodeEdit
 	bool allPassed=true;
 	if (level!=TL_ALL)
 		tr="There are skipped tests. Please rerun with --execute-all-tests\n\n";
+	QCoreApplication *app = QCoreApplication::instance();
+	app->installNativeEventFilter(this);
 	for (int i=0; i <tests.size();i++){
 		emit newMessage(tests[i]->metaObject()->className());
 		qDebug()<<tests[i]->metaObject()->className();
@@ -107,6 +109,7 @@ QString TestManager::execute(TestLevel level, LatexEditorView* edView, QCodeEdit
 		tr+=res;
 		if (!res.contains(", 0 failed, 0 skipped")) allPassed=false;
 	}
+	app->removeNativeEventFilter(this);
 
 	tr+=QString("\nTotal testing time: %1 ms\n").arg(totalTestTime);
 
@@ -116,5 +119,10 @@ QString TestManager::execute(TestLevel level, LatexEditorView* edView, QCodeEdit
 	QFile(QFile::decodeName(tempResult)).remove();
 
 	return tr;
+}
+
+bool TestManager::nativeEventFilter(const QByteArray &eventType, void *message, long *result)
+{
+	return true;
 }
 #endif

--- a/src/tests/testmanager.cpp
+++ b/src/tests/testmanager.cpp
@@ -1,6 +1,6 @@
 #ifndef QT_NO_DEBUG
 #include "testmanager.h"
-//hel 
+//hel
 #include "smallUsefulFunctions_t.h"
 #include "latexparser_t.h"
 #include "latexparsing_t.h"
@@ -44,15 +44,15 @@ QString TestManager::performTest(QObject* obj){
 	argv[0]=(char*)"texstudio";
 	argv[1]=(char*)"-o";
 	argv[2]=tempResult;
-    QElapsedTimer timing;
-    timing.start();
+	QElapsedTimer timing;
+	timing.start();
 	QTest::qExec(obj,3,argv);
 	delete obj;
-    long long time = timing.elapsed();
+	long long time = timing.elapsed();
 	totalTestTime += time;
 	QString testTime = QString("Time: %1 ms\n\n" ).arg(time);
 	QFile f(QFile::decodeName(tempResult));
-	if (!f.open(QIODevice::ReadOnly)) 
+	if (!f.open(QIODevice::ReadOnly))
 		return "\n\n!!!!!!!!!!! Couldn't find test result !!!!!!!!!!!! \n\n";
 	return f.readAll()+testTime;
 }
@@ -64,23 +64,23 @@ QString TestManager::execute(TestLevel level, LatexEditorView* edView, QCodeEdit
 	QByteArray tfn = QFile::encodeName(tf.fileName());
 	tf.close();
 	tempResult = tfn.data();
-	
+
 	globalExecuteAllTests = level == TL_ALL;
-	
+
 	//codeedit, editor are passed as extra parameters and not extracted from edView, so we don't have
 	//to include latexeditorview.h here
 	totalTestTime = 0;
 	QString tr;
 	QList<QObject*> tests=QList<QObject*>()
-        << new SmallUsefulFunctionsTest()
-        << new LatexParserTest()
-        << new LatexParsingTest()
-        << new EncodingTest()
-        << new LatexOutputFilterTest()
+		<< new SmallUsefulFunctionsTest()
+		<< new LatexParserTest()
+		<< new LatexParsingTest()
+		<< new EncodingTest()
+		<< new LatexOutputFilterTest()
 		<< new BuildManagerTest(buildManager)
 		<< new CodeSnippetTest(editor)
 		<< new QDocumentLineTest()
-        << new QDocumentCursorTest(level==TL_AUTO)
+		<< new QDocumentCursorTest(level==TL_AUTO)
 		<< new QDocumentSearchTest(editor,level==TL_ALL)
 		<< new QSearchReplacePanelTest(codeedit,level==TL_ALL)
 		<< new QEditorTest(editor,level==TL_ALL)
@@ -92,29 +92,29 @@ QString TestManager::execute(TestLevel level, LatexEditorView* edView, QCodeEdit
 		<< new StructureViewTest(edView,edView->document,level==TL_ALL)
 		<< new TableManipulationTest(editor)
 		<< new SyntaxCheckTest(edView)
-        << new UpdateCheckerTest(level==TL_ALL)
+		<< new UpdateCheckerTest(level==TL_ALL)
 		<< new UtilsUITest(level==TL_ALL)
-        << new VersionTest(level==TL_ALL)
-        << new HelpTest()
-        << new UserMacroTest();
+		<< new VersionTest(level==TL_ALL)
+		<< new HelpTest()
+		<< new UserMacroTest();
 	bool allPassed=true;
 	if (level!=TL_ALL)
 		tr="There are skipped tests. Please rerun with --execute-all-tests\n\n";
 	for (int i=0; i <tests.size();i++){
 		emit newMessage(tests[i]->metaObject()->className());
-        qDebug()<<tests[i]->metaObject()->className();
+		qDebug()<<tests[i]->metaObject()->className();
 		QString res=performTest(tests[i]);
 		tr+=res;
 		if (!res.contains(", 0 failed, 0 skipped")) allPassed=false;
-	}	
-	
+	}
+
 	tr+=QString("\nTotal testing time: %1 ms\n").arg(totalTestTime);
-	
+
 	if (!allPassed)
 		tr="*** THERE SEEM TO BE FAILED TESTS! ***\n\n\n\n"+tr;
-	
+
 	QFile(QFile::decodeName(tempResult)).remove();
-	
+
 	return tr;
 }
 #endif

--- a/src/tests/testmanager.h
+++ b/src/tests/testmanager.h
@@ -2,12 +2,13 @@
 #define TESTMANAGER_H
 #ifndef QT_NO_DEBUG
 #include "mostQtHeaders.h"
+#include <QAbstractNativeEventFilter>
 //the only reason for this file is to separate the test headers from the remaining program
 class LatexEditorView;
 class QCodeEdit;
 class QEditor;
 class BuildManager;
-class TestManager : public QObject {
+class TestManager : public QObject, public QAbstractNativeEventFilter {
 	Q_OBJECT
 public:
 	enum TestLevel {TL_ALL, TL_FAST,TL_AUTO/*, TL_NONE*/};
@@ -16,6 +17,7 @@ signals:
 	void newMessage(const QString &m);
 private:
 	QString performTest(QObject* obj);
+	bool nativeEventFilter(const QByteArray &eventType, void *message, long *result);
 };
 
 #endif

--- a/src/tests/testmanager.h
+++ b/src/tests/testmanager.h
@@ -10,7 +10,7 @@ class BuildManager;
 class TestManager : public QObject {
 	Q_OBJECT
 public:
-    enum TestLevel {TL_ALL, TL_FAST,TL_AUTO/*, TL_NONE*/};
+	enum TestLevel {TL_ALL, TL_FAST,TL_AUTO/*, TL_NONE*/};
 	QString execute(TestLevel level, LatexEditorView *edView, QCodeEdit* codeedit, QEditor* editor, BuildManager* buildManager);
 signals:
 	void newMessage(const QString &m);

--- a/src/tests/testutil.cpp
+++ b/src/tests/testutil.cpp
@@ -11,8 +11,8 @@ MessageBoxCloser::MessageBoxCloser(bool mustExists, QMessageBox::StandardButton 
 void MessageBoxCloser::closeNow(){
 	deleteLater();
 	QWidget* messageWindow = QApplication::activeModalWidget();
-	if (!messageWindow) 
-		foreach (QWidget *widget, QApplication::topLevelWidgets()) 
+	if (!messageWindow)
+		foreach (QWidget *widget, QApplication::topLevelWidgets())
 			if (widget->isModal())
 				messageWindow=widget;
 	if (!messageWindow) {
@@ -26,7 +26,7 @@ void MessageBoxCloser::closeNow(){
 		default:
 			QTest::keyClick(messageWindow, Qt::Key_Escape);
 			break;
-	}	
+	}
     curCloser=nullptr;
 }
 void closeMessageBoxLater(bool mustExists, QMessageBox::StandardButton button){
@@ -36,7 +36,16 @@ void closeMessageBoxLater(bool mustExists, QMessageBox::StandardButton button){
 void messageBoxShouldBeClose(){
 	QVERIFY2(!curCloser, "MessageBox couldn't be closed");
 }
+
+/**
+ * \brief Process all pending events except for UI and network events.
+ */
+void processPendingEvents(void)
+{
+	QCoreApplication::processEvents(QEventLoop::AllEvents);
+	// Deferred delete must be processed explicitly. Using 0 for event_type does not work.
+	QCoreApplication::sendPostedEvents(Q_NULLPTR, QEvent::DeferredDelete);
+}
+
 }
 #endif
-
-

--- a/src/tests/testutil.h
+++ b/src/tests/testutil.h
@@ -22,11 +22,13 @@ public:
 private:
 	bool m_mustExists;
 	QMessageBox::StandardButton m_button;
-private slots: 
+private slots:
 	void closeNow();
 };
 void closeMessageBoxLater(bool mustExists=false, QMessageBox::StandardButton button=QMessageBox::NoButton);
 void messageBoxShouldBeClose();
+
+void processPendingEvents(void);
 }
 
 extern bool globalExecuteAllTests;


### PR DESCRIPTION
This PR fixes several minor issues with the handling of events while running tests.

1. Currently we try to ignore UI events while running tests by processing all events except for UI and network events
( `QApplication::processEvents(QEventLoop::ExcludeUserInputEvents | QEventLoop::ExcludeSocketNotifiers)` )
However there are several places where either QTest or Qt core framework internally processes all events including UI events.
Most notably this happens in `QTest::qWait()` and in the different Qt functions that show the message popups during search&replace testing.

As a result it is possible to crash TXS while it is running the tests by providing keyboard or mouse input. For example by running on Linux:

`textstudio --execute-all-tests`
then while tests are running, pressing CTRL+W several times at different moments while tests are running.

This will close the main tab in which the tests are running, so naturally TXS will crash with SIGSEGV when the testing framework tries to access the main document tab.

Same type of crash will happen is the mouse is clicked on the [x] button for the main tab.

I tried several approached at fixing this issue and the best one seems to be installing a native events filter inside TestManager. This filter only filters events coming from the physical keyboard and mouse and the synthetic events from the QTest framework are not affected. So this kind of fix is used in this

2. Another possible issue taken care by this PR is that while processing events by `QApplication::processEvents(...)` our current code does not take care of the posted events non-system events as recommended by the documentation at

https://doc.qt.io/qt-5/qcoreapplication.html#processEvents

This is mostly a problem with deferred deletes (`QEvent::DeferredDelete`) as documented by the above link. There is at least one place where we use deferred deletes in MessageBoxCloser::closeNow(). I do not know if skipping processing of deferred deletes is a problem besides not freeing memory early on, but I checked the source code for `QTest::qWait()` and copied I copied their code that processes `QEvent::DeferredDelete` into our custom function `QTest::processPendingEvents()`.

3. Additionally this PR adds ifdefs to `SyntaxCheck::waitForQueueProcess()` so it is only defined when tests are enabled. The documentation for this method is slightly expanded and processing for deferred deletes are added to that method too.