### PR TITLE
Fix a build warning by removing an unused variable

### DIFF
--- a/src/grammarcheck.cpp
+++ b/src/grammarcheck.cpp
@@ -306,7 +306,6 @@ void GrammarCheck::process(int reqId)
 		}
 	}
 
-	bool backendAvailable = backend->isAvailable();
     LTStatus newstatus = backend->isWorking() ? LTS_Working : LTS_Error;
 	if (newstatus != ltstatus) {
 		ltstatus = newstatus;


### PR DESCRIPTION
Fix a build warning by removing the unused variable `backendAvailable` in `src/grammarcheck.cpp`