### PR TITLE
Fix cwl

### DIFF
--- a/completion/comment.cwl
+++ b/completion/comment.cwl
@@ -4,7 +4,7 @@
 \begin{comment}#V
 \end{comment}
 \includecomment{envname}#N
-\excludecoment{envname}#N
+\excludecomment{envname}#N
 \CommentCutFile#*
 \ProcessCutFile#*
 \generalcomment{envname}{begdef}{enddef}#*N

--- a/completion/latex-dev.cwl
+++ b/completion/latex-dev.cwl
@@ -211,7 +211,6 @@
 \height#*L
 \partopsep#*L
 \parsep#*L
-\lineskiplimits#*
 \footheight#*L
 # pdftex specials
 \pdfoutput#*


### PR DESCRIPTION
Main changes:
 - `comment.cwl`, fix typo in `\specialcoment`, should contain double `m`. This should fix #1072.
 - `latex-dev.cwl`, remove undefined `\lineskiplimits`. `\lineskiplimit` is a primitive glue register, and is recorded in `tex.cwl`.