### PR TITLE
Restore the cursor shape properly when closing the PDF viewer

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -2999,6 +2999,15 @@ void PDFDocument::sideBySide()
 
 void PDFDocument::closeEvent(QCloseEvent *event)
 {
+	/*
+	 * Qt is buggy because it only restores the parent cursor shape if PDFWidget is the widget receiving the last mouse event
+	 * (qt_last_mouse_receiver). If we close the PDFWidget by pressing ESC while the zoom tool is the last mouse receiver,
+	 * the shape of the cursor will remain unchanged (magnifying glass, if we just closed the magnifier or blank if we closed
+	 * while using the magnifier). That is why we unset the PDFWidget's cursor, forcing Qt to restore the parent cursor shape.
+	 */
+	if (pdfWidget) {
+		pdfWidget->unsetCursor();
+	}
 	Q_ASSERT(globalConfig);
 	if (isVisible() && !embeddedMode) {
 		saveGeometryToConfig();


### PR DESCRIPTION
This PR is a fix for https://github.com/texstudio-org/texstudio/issues/1069
Effectively it is a workaround for what seems to be a Qt bug.