### PR TITLE
Fix "Open External Terminal" on Windows

### DIFF
--- a/src/execprogram.cpp
+++ b/src/execprogram.cpp
@@ -2,18 +2,24 @@
 #include "utilsSystem.h"
 
 ExecProgram::ExecProgram(void) :
+#ifdef Q_OS_WIN
+	m_winProcModifier(nullptr),
+#endif
 	m_normalRun(false),
 	m_exitCode(-1)
 {
 }
 
-ExecProgram::ExecProgram(const QString &progNameAndArguments, const QString &additionalSearchPaths, const QString &workingDirectory) :
-	m_program(progNameAndArguments),
+ExecProgram::ExecProgram(const QString &shellCommandLine, const QString &additionalSearchPaths, const QString &workingDirectory) :
 	m_additionalSearchPaths(additionalSearchPaths),
 	m_workingDirectory(workingDirectory),
+#ifdef Q_OS_WIN
+	m_winProcModifier(nullptr),
+#endif
 	m_normalRun(false),
 	m_exitCode(-1)
 {
+	setProgramAndArguments(shellCommandLine);
 }
 
 ExecProgram::ExecProgram(const QString &progName, const QStringList &arguments, const QString &additionalSearchPaths, const QString &workingDirectory) :
@@ -21,9 +27,78 @@ ExecProgram::ExecProgram(const QString &progName, const QStringList &arguments, 
 	m_arguments(arguments),
 	m_additionalSearchPaths(additionalSearchPaths),
 	m_workingDirectory(workingDirectory),
+#ifdef Q_OS_WIN
+	m_winProcModifier(nullptr),
+#endif
 	m_normalRun(false),
 	m_exitCode(-1)
 {
+}
+
+/*!
+ * \brief Basic command-line parser
+ * \details Basic command-line parser that splits a command-line into program name and arguments list.
+ * The parsed program name and arguments are stored in class member variables.
+ * TODO: Improve the parser. We need to add proper quotes processing based on the OS type (UNIX/Win).
+ * \param[in] shellCommandLine Shell command line that should be parsed.
+ */
+void ExecProgram::setProgramAndArguments(const QString &shellCommandLine)
+{
+	static QRegularExpression rxLeadingSpace("\\s*");
+	Q_ASSERT(rxLeadingSpace.isValid());
+	static QRegularExpression rxOneToken(
+		"("
+			"[^[:space:]\"']+|"		// Non-whitespace string without any quotes
+			"\"[^\"]*\"|"			// Double-quoted string
+			"'[^']*'|"			// Single-quoted string
+			"\"[^[:space:]\"]*(?=[^\"]*$)|"	// ERROR: Non-whitespace string starting with a double-quote. No other double-quotes until the end.
+			"'[^[:space:]']*(?=[^']*$)"	// ERROR: Non-whitespace string starting with a single-quote. No other single-quotes until the end.
+		")+",
+		QRegularExpression::DontCaptureOption
+	);
+	Q_ASSERT(rxOneToken.isValid());
+
+	QStringList tokens;
+	int length = shellCommandLine.length();
+	int offset = 0;
+	for (;;) {
+		if (offset >= length) {
+			break;
+		}
+		QRegularExpressionMatch matchLeadingSpace = rxLeadingSpace.match(
+			shellCommandLine,
+			offset,
+			QRegularExpression::NormalMatch,
+			QRegularExpression::AnchoredMatchOption
+		);
+		offset += matchLeadingSpace.capturedLength(0);
+		if (offset >= length) {
+			break;
+		}
+		QRegularExpressionMatch matchOneToken = rxOneToken.match(
+			shellCommandLine,
+			offset,
+			QRegularExpression::NormalMatch,
+			QRegularExpression::AnchoredMatchOption
+		);
+		if (matchOneToken.hasMatch() == false) {
+			// We should never reach this point
+			Q_ASSERT(false);
+			break;
+		}
+		offset += matchOneToken.capturedLength(0);
+		QString oneToken = matchOneToken.captured(0);
+		oneToken.remove('"').remove('\'');
+		tokens.push_back(oneToken);
+	}
+	if (tokens.isEmpty()) {
+		m_program = "";
+		m_arguments.clear();
+	} else {
+		m_program = tokens.front();
+		tokens.pop_front();
+		m_arguments = tokens;
+	}
 }
 
 bool ExecProgram::execAndWait(void)
@@ -46,6 +121,35 @@ void ExecProgram::execAndNoWait(QProcess &proc) const
 	if (!m_workingDirectory.isEmpty()) {
 		proc.setWorkingDirectory(m_workingDirectory);
 	}
+	setWinProcModifier(proc);
+	QString pathOrig = pathExtend();
+	proc.start(m_program, m_arguments);
+	pathSet(pathOrig);
+}
+
+bool ExecProgram::execDetached(void) const
+{
+	bool execResult;
+
+	QString pathOrig = pathExtend();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+	QProcess proc;
+	proc.setProgram(m_program);
+	proc.setArguments(m_arguments);
+	if (!m_workingDirectory.isEmpty()) {
+		proc.setWorkingDirectory(m_workingDirectory);
+	}
+	setWinProcModifier(proc);
+	execResult = proc.startDetached();
+#else
+	execResult = QProcess::startDetached(m_program, m_arguments, m_workingDirectory);
+#endif
+	pathSet(pathOrig);
+	return execResult;
+}
+
+QString ExecProgram::pathExtend(void) const
+{
 	QChar pathSep = getPathListSeparator();
 	QString pathOrig = QString::fromLocal8Bit(qgetenv("PATH"));
 	// We add the path from getEnvironmentPath() because it can be extended by shell startup scripts
@@ -53,14 +157,22 @@ void ExecProgram::execAndNoWait(QProcess &proc) const
 	if (!m_additionalSearchPaths.isEmpty()) {
 		pathExtended += pathSep + m_additionalSearchPaths;
 	}
-	qputenv("PATH", pathExtended.toLocal8Bit());
-	// If there are no arguments specified separately assume that the program name
-	// also contains all the arguments (if any)
-    if(m_arguments.isEmpty()){
-        proc.start(m_program);
-    }else{
-        proc.start(m_program, m_arguments);
-    }
+	pathSet(pathExtended);
+	return pathOrig;
+}
 
-	qputenv("PATH", pathOrig.toLocal8Bit());
+void ExecProgram::pathSet(const QString &path)
+{
+	qputenv("PATH", path.toLocal8Bit());
+}
+
+void ExecProgram::setWinProcModifier(QProcess &proc) const
+{
+#ifdef Q_OS_WIN
+	if (m_winProcModifier) {
+		proc.setCreateProcessArgumentsModifier(m_winProcModifier);
+	}
+#else
+	Q_UNUSED(proc)
+#endif
 }

--- a/src/execprogram.h
+++ b/src/execprogram.h
@@ -7,23 +7,33 @@ class ExecProgram
 {
 public:
 	ExecProgram(void);
-	ExecProgram(const QString &progNameAndArguments, const QString &additionalSearchPaths, const QString &workingDirectory = QString());
+	ExecProgram(const QString &shellCommandLine, const QString &additionalSearchPaths, const QString &workingDirectory = QString());
 	ExecProgram(const QString &progName, const QStringList &arguments, const QString &additionalSearchPaths = QString(), const QString &workingDirectory = QString());
 
 	bool execAndWait(void);
 	void execAndNoWait(QProcess &proc) const;
+	bool execDetached(void) const;
 
 	// Input parameters
 	QString m_program;
 	QStringList m_arguments;
 	QString m_additionalSearchPaths;
 	QString m_workingDirectory;
+#ifdef Q_OS_WIN
+	QProcess::CreateProcessArgumentModifier m_winProcModifier;
+#endif
 
 	// Output parameters. Only assigned by synchronous execAndWait
 	bool m_normalRun; // If false then program either did not run or crashed
 	int m_exitCode;
 	QString m_standardOutput;
 	QString m_standardError;
+
+private:
+	void setProgramAndArguments(const QString &progNameAndArguments);
+	QString pathExtend(void) const;
+	static void pathSet(const QString &path);
+	void setWinProcModifier(QProcess &proc) const;
 };
 
 #endif // EXECPROGRAM_H


### PR DESCRIPTION
This PR fixes https://github.com/texstudio-org/texstudio/issues/1094

Basically the problem is that on Windows we have to pass `CREATE_NEW_CONSOLE` when creating the new process. Qt only supports that kind of Windows-specific flags since Qt 5.7 (`QProcess::setCreateProcessArgumentsModifier`). I assume that we need compatibility with Qt versions 5.7, so I switched to Windows-specific code similar to the one that we had before.

This PR also adds support for `ExecProgram::execDetached()` which is a wrapper for `QProcess::startDetached()`. It is used when opening a terminal under Linux.

Given that we no longer use `BuildManager::runCommand()`, we no longer can rely on its success/error reporting, so this PR also does some basic success/error reporting in the log window.