### PR TITLE
Improve debug logger

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -186,10 +186,10 @@ bool handleCommandLineOnly(const QStringList &cmdLine) {
 int main(int argc, char **argv)
 {
 	QString appId = generateAppId();
-	// This is a dummy constructor so that the programs loads fast.
 #if QT_VERSION >= QT_VERSION_CHECK(5,6,0)
-    QApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
+	QApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
 #endif
+	// This is a dummy constructor so that the programs loads fast.
 	TexstudioApp a(appId, argc, argv);
 	bool startAlways = false;
 	QStringList cmdLine = parseArguments(QCoreApplication::arguments(), startAlways);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,12 +141,12 @@ QStringList parseArguments(const QStringList &args, bool &outStartAlways)
 			}
 			else if (cmdArgument == "--config" && (++i < args.count()))
 				ConfigManager::configDirOverride = args[i];
-			else if (cmdArgument.startsWith("-"))
-				cmdLine << cmdArgument;
 #ifdef DEBUG_LOGGER
-			else if ((cmdArgument == "-debug-logfile" || cmdArgument == "--debug-logfile") && (++i < args.count()))
-				cmdLine << "--debug-logfile" << args[i];
+			else if ((cmdArgument == "--debug-logfile") && (++i < args.count()))
+				debugLoggerStart(args[i]);
 #endif
+			else if (cmdArgument.startsWith('-'))
+				cmdLine << cmdArgument;
 		} else
 			cmdLine << QFileInfo(cmdArgument).absoluteFilePath();
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,7 +145,7 @@ QStringList parseArguments(const QStringList &args, bool &outStartAlways)
 			else if ((cmdArgument == "--debug-logfile") && (++i < args.count()))
 				debugLoggerStart(args[i]);
 #endif
-			else if (cmdArgument.startsWith('-'))
+			else
 				cmdLine << cmdArgument;
 		} else
 			cmdLine << QFileInfo(cmdArgument).absoluteFilePath();

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -6720,9 +6720,6 @@ void Texstudio::executeCommandLine(const QStringList &args, bool realCmdLine)
 		if (args[i] == "--pdf-viewer-only") pdfViewerOnly = true;
 		if (args[i] == "--page") page = args[++i].toInt() - 1;
 #endif
-#ifdef DEBUG_LOGGER
-		if (args[i] == "--debug-logfile") debugLoggerStart(args[++i]);
-#endif
 	}
 
 #ifndef NO_POPPLER_PREVIEW


### PR DESCRIPTION
This PR improves the debug logger framework slightly by moving the start of the debug logger earlier in the TXS initialization process.

While investigating https://github.com/texstudio-org/texstudio/issues/1036 I used the debug logger framework and I came across a problem with it. At the moment the debug logger activates after the constructor `Texstudio::Texstudio()` is invoked. In that constructor the previous session is restored and the `SyntaxCheck` thread is started. Thus currently the debug logger is not suitable for logging events that happen early on, e.g. `SyntaxCheck::run` events that happen early on.

This PR moves the start of the debug logger earlier before the call to `Texstudio::Texstudio()`.