### PR TITLE
Attempt to fix issue #1036

### DIFF
--- a/src/latexdocument.h
+++ b/src/latexdocument.h
@@ -194,7 +194,7 @@ public:
     static int syntaxErrorFormat,spellErrorFormat;
 
 	bool languageIsLatexLike() const;
-	void reCheckSyntax(int linenr = 0, int count = -1);
+	void reCheckSyntax(int lineStart = 0, int lineNum = -1);
 	QString getErrorAt(QDocumentLineHandle *dlh, int pos, StackEnvironment previous, TokenStack stack);
 
 	void getEnv(int lineNumber, StackEnvironment &env); // get Environment for syntax checking, number of cols is now part of env

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -4349,12 +4349,16 @@ void Texstudio::updateStructure(bool initial, LatexDocument *doc, bool hidden)
 		doc = currentEditorView()->document;
 	if (initial) {
 		doc->patchStructure(0, -1);
+		// execute QCE highlting
+		doc->parent->enablePatch(false);
+		doc->highlight();
+		doc->parent->enablePatch(true);
 
-        bool previouslyEmpty=doc->localMacros.isEmpty();
+		bool previouslyEmpty=doc->localMacros.isEmpty();
 		doc->updateMagicCommentScripts();
 		configManager.completerConfig->userMacros << doc->localMacros;
-        if(!doc->localMacros.isEmpty() || !previouslyEmpty)
-            updateUserMacros();
+		if(!doc->localMacros.isEmpty() || !previouslyEmpty)
+			updateUserMacros();
 	} else {
 		// updateStructure() rebuilds the complete structure model. Therefore, all expansion states in the view are lost
 		// to work around this, we save the a tag (unique idetifier) of all expanded entries and restore the expansion state after update


### PR DESCRIPTION
This PR attempts to fix https://github.com/texstudio-org/texstudio/issues/1036
The user reported high CPU usage happening at random moments while editing a large file.
I (sort of) reproduced the problem on my computer, but in my case the high CPU usage appeared each time immediately after the .tex file was loaded by TXS.
Since the file(s) provided by the user seem to be copyrighted material and I don't know whether he autorizes its distribution, I have prepared a sample file that demonstrates the issue:

[slow_syntax_check.tex.txt](https://github.com/texstudio-org/texstudio/files/4698983/slow_syntax_check.tex.txt)

After opening the file in TXS on my computer the CPU load jumps to about 130% and stays so forever (or until you close the document).
Also if you open the file and scroll to the bottom of the file you can see how on the last line
```
\end{document}
```
The `document` environment name stays red forever, which means that the syntax checker never actually completes and never marks the environment name as valid.

After investigating the issue it seems that the problem is caused by a combination of the following two facts:

1. When syntax check is started for a group of lines, each line is queued separately in the syntax checker through `SyntaxCheck::putLine()`. Each queued line can force the next line to be queued if the environment stack has changed (in these cases the `checkNextLine` signal is sent).
2. When `SyntaxCheck::run()` checks if the next line should be checked through the `checkNextLine` signal, the check is made through using the previously stored environment stack from the previous line (`newLine.prevEnv`).
However this previously stored environment is not fetched at the moment when the check is made but instead it is taken from `newLine.prevEnv` which is the value taken at the moment when `SyntaxCheck::putLine()` was called.

The combination of 1 and 2 means that when we do a full re-check of a file which has `N` lines, this means that we have `N` waves of syntax checked lines that overlap and mess each other's environment stacks and never stop until they reach the end of the file, thus requiring approximately `(N^2)/2` lines to be syntax checked.

Imagine the following file

```
\documentclass{amsart}
\begin{document}
$
1+2
$
\end{document}
```

At step one we would start with empty env. stacks for the lines:

```
<empty>
<empty>
<empty>
<empty>
<empty>
<empty>
```

At step two, after each "wave" (total of 6 syntax checks) has moved we would have the following env. stacks

```
normal
normal
normal
normal
normal
normal
```

Then after each wave moves again (total of 5 syntax checks) we would have the following env. stacks

```
normal
normal/document
normal/math
normal
normal/math
normal
```

Then after one iteration (4 syntax checks) we would have

```
normal
normal/document
normal/document/math
normal/math
normal/math
normal/math
```

Then after 3 syntax checks we would have

```
normal
normal/document
normal/document/math
normal/document/math
normal
normal/math
```

Then after 2 syntax checks we would have

```
normal
normal/document
normal/document/math
normal/document/math
normal/document
normal/math
```

And finally after 1 syntax check we would have

```
normal
normal/document
normal/document/math
normal/document/math
normal/document
normal/document
```

It is possible that I got some of the values in the above example incorrect, but hopefully it demonstrates the problem and how exactly 1 and 2 combine to cause the problem.
For a file of about 65,000 lines, we get up to 2 billion syntax checks until the "waves" stop.

I think the problem can be resolved either by fixing 1 or by fixing 2.

Fixing 1 means that instead of starting N waves, we just remove the environment stack cookie for the updated lines and only queue the first line that has to be updated.
Fixing 2 would imply changing the code in `SyntaxCheck::run()` so that it would fetch the environment and tokens for the previous line on the spot instead of fetching them from `newLine`.

I decided to fix the problem by fixing 1.

The proposed patch seems to fix the problem (you can test it with the supplied sample file). However the issue seems complex enough, so I would appreciate if the other develope(s) review it and validate the solution.
