### PR TITLE
Log the current thread ID in the debug logger

### DIFF
--- a/src/debug/debuglogger.cpp
+++ b/src/debug/debuglogger.cpp
@@ -75,9 +75,10 @@ void DebugLogger::logMessage (QtMsgType msgType, const char *file, unsigned int 
 	}
 	fprintf (
 		m_logHandle,
-		"[%s][%lld][%s:%u][%s]: %s\n",
+		"[%s][%lld,0x%p][%s:%u][%s]: %s\n",
 		QDateTime::currentDateTime().toString(Qt::ISODateWithMs).toLocal8Bit().constData(),
 		static_cast<long long int>(QCoreApplication::applicationPid()),
+		QThread::currentThreadId(),
 		file ? file : "???",
 		line,
 		levelName,


### PR DESCRIPTION
This PR adds logging of the current thread ID to the debug logger. It is a minor improvement useful when investigating multi-threaded issues. I had to add it when investigating the syntax checker issue (because the syntax checker uses multiple threads).