### PR TITLE
Fix maximize of main window on Windows

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -345,12 +345,6 @@ Texstudio::Texstudio(QWidget *parent, Qt::WindowFlags flags, QSplashScreen *spla
 	restoreState(windowstate, 0);
 	//workaround as toolbar central seems not be be handled by windowstate
 	centralToolBar->setVisible(configManager.centralVisible);
-	if (tobemaximized) showMaximized();
-	if (tobefullscreen) {
-		showFullScreen();
-		restoreState(stateFullScreen, 1);
-		fullscreenModeAction->setChecked(true);
-	}
 
 	createStatusBar();
 	completer = nullptr;
@@ -358,7 +352,22 @@ Texstudio::Texstudio(QWidget *parent, Qt::WindowFlags flags, QSplashScreen *spla
 	updateMasterDocumentCaption();
 	setStatusMessageProcess(QString(" %1 ").arg(tr("Ready")));
 
-	show();
+	if (tobefullscreen) {
+		showFullScreen();
+		restoreState(stateFullScreen, 1);
+		fullscreenModeAction->setChecked(true);
+	} else if (tobemaximized) {
+#ifdef Q_OS_WIN
+		// Workaround a Qt/Windows bug which prevents too small windows from maximizing
+		// For more details see:
+		// https://stackoverflow.com/questions/27157312/qt-showmaximized-not-working-in-windows
+		// https://bugreports.qt.io/browse/QTBUG-77077
+		resize(800, 600);
+#endif
+		showMaximized();
+	} else {
+		show();
+	}
 	if (splash)
 		splash->raise();
 


### PR DESCRIPTION
This PR adds a workaround for a WinAPI bug. The bug prevents TXS from maximizing the main window when starting on Windows.
The TXS issue has been reported here https://github.com/texstudio-org/texstudio/issues/888#issuecomment-592526103

Basically WinAPI prevents correct maximize of windows that are too small vertically. This has been reported to the Qt developers here 
https://bugreports.qt.io/browse/QTBUG-77077 
However it seems that the Qt team does not want to workaround an issue which is caused by a WinAPI bug, so I guess we workaround it in TXS.

I remember coming across this same issue in 2002 and obviously not much has changed in the WinAPI since then :-)