### PR TITLE
Add write locking to fix crashes when accessing document line cookies

### DIFF
--- a/src/latexdocument.cpp
+++ b/src/latexdocument.cpp
@@ -3279,11 +3279,10 @@ void LatexDocument::reCheckSyntax(int lineStart, int lineNum)
 
 	// Delete the environment cookies for the specified lines to force their re-check
 	for (int i = lineStart; i < lineEnd; ++i) {
-		QDocumentLineHandle *dlh = line(i).handle();
-		// Is it ever possible for dlh to be null ?
-		if (dlh) {
-			dlh->removeCookie(QDocumentLine::STACK_ENVIRONMENT_COOKIE);
-		}
+		// We rely on the fact that QDocumentLine::removeCookie() holds a write lock of the corresponding
+		// line handle while removing the cookie. Lack of write locking causes crashes due to simultaneous
+		// access from the syntax checker thread.
+		line(i).removeCookie(QDocumentLine::STACK_ENVIRONMENT_COOKIE);
 	}
 
 	// Enqueue the first line for syntax checking. The remaining lines will be enqueued automatically


### PR DESCRIPTION
This PR adds `QDocumentLine` write locks in `LatexDocument::reCheckSyntax()`

I changed that method while working on the fix for the high CPU load but forgot to add the write locking (although was planning to do so).

Noticed today that `texstudio --execute-all-tests` crashes if the tests run while the computer is heavily loaded with other tasks too. Investigation showed that crashes seem to be caused by the lack of locking in `LatexDocument::reCheckSyntax()`

Adding the locks fixes the crashes for me, but I guess we will have to keep an eye on the new code for a while.