### PR TITLE
cwl: ignore comment line in keyvals list

### DIFF
--- a/src/latexpackage.cpp
+++ b/src/latexpackage.cpp
@@ -134,7 +134,7 @@ LatexPackage loadCwlFile(const QString fileName, LatexCompleterConfig *config, Q
 				continue;
 			}
 
-			if (!keyvals.isEmpty()) {
+			if (!keyvals.isEmpty() && !line.startsWith("#")) {
 				// read keyval (name stored in "keyvals")
 				QStringList l_cmds=keyvals.split(',');
 				QString key;


### PR DESCRIPTION
Currently, the following cwl input causes empty autocomplete pop-up for `\cmd{<cursor pos>}`:
```
\cmd{options%keyvals}
#keyvals
# comment
key1
key2
#endkeyvals
```

This problem is reported, for example in https://github.com/texstudio-org/texstudio/pull/1119#issuecomment-638473385. This pr tries to fix it.

The only cwl keyword that is treated below the treatment for keyvals list is `#repl:`. Maybe it should be moved above?