### PR TITLE
Port the Fedora 31 patch that fixes build of TXS 2.12.16 on ARM

### DIFF
--- a/src/debug/debughelper.cpp
+++ b/src/debug/debughelper.cpp
@@ -522,16 +522,12 @@ QString print_backtrace(const QString &message)
 #define FRAME_FROM_UCONTEXT(context) (context)->uc_mcontext.gp_regs[31] //not always used
 #define RETURNTO_FROM_UCONTEXT(context) (context)->uc_mcontext.gp_regs[34]
 #elif defined(CPU_IS_ARM)
-/*
+
 #define PC_FROM_UCONTEXT(context) (context)->uc_mcontext.arm_pc
 #define STACK_FROM_UCONTEXT(context) (context)->uc_mcontext.arm_sp
 #define FRAME_FROM_UCONTEXT(context) (context)->uc_mcontext.arm_fp
 #define RETURNTO_FROM_UCONTEXT(context) (context)->uc_mcontext.arm_lr
-*/
-#define PC_FROM_UCONTEXT(context) (context)->uc_mcontext.__gregs[_REG_R15]
-#define STACK_FROM_UCONTEXT(context) (context)->uc_mcontext.__gregs[_REG_R13]
-#define FRAME_FROM_UCONTEXT(context) (context)->uc_mcontext.__gregs[_REG_R11]
-#define RETURNTO_FROM_UCONTEXT(context) (context)->uc_mcontext.__gregs[_REG_R14]
+
 #elif defined(CPU_IS_IA64)
 #define PC_FROM_UCONTEXT(context) (context)->_u._mc.sc_ip
 #define STACK_FROM_UCONTEXT(context) (context)->_u._mc.sc_gr[12] //is that register 12?


### PR DESCRIPTION
Based on the discussion at https://github.com/texstudio-org/texstudio/issues/739#issuecomment-651933671
I am providing a PR which ports the Fedora fix for ARM.
On the Fedora RPM page at
https://fedora.pkgs.org/31/fedora-x86_64/texstudio-2.12.16-2.fc31.x86_64.rpm.html
they provide a build for `armv7hl` and it is marked as `Official` so I guess that can probably can count as "verified build" for the fix.

If @matthewberryman can provide a better fix later then maybe we could use his PR afterwards.