### PR TITLE
arm 32 and 64 bit support for Linux and NetBSD ( fixes #739 )

### DIFF
--- a/src/debug/debughelper.cpp
+++ b/src/debug/debughelper.cpp
@@ -58,7 +58,7 @@ struct SimulatedCPU {
 	char *frame;  //e.g. ebp, r11
 	char *stack;  //e.g. esp, r13
 #if defined(CPU_IS_ARM) || defined(CPU_IS_ARM64) || defined(CPU_IS_MIPS) || defined(CPU_IS_PPC) || defined(CPU_IS_SPARC32)
-	char *returnTo;  //lr/r14
+	char *returnTo;  //lr/r14(arm)/x30(arm64)
 #endif
 
 	inline void push(char *value)
@@ -531,13 +531,13 @@ QString print_backtrace(const QString &message)
 #elif defined(CPU_IS_ARM64) && defined(__linux__)
 #define PC_FROM_UCONTEXT(context) (context)->uc_mcontext.pc
 #define STACK_FROM_UCONTEXT(context) (context)->uc_mcontext.sp
-#define FRAME_FROM_UCONTEXT(context) (context)->uc_mcontext.regs[29]
-#define RETURNTO_FROM_UCONTEXT(context) (context)->uc_mcontext.regs[30]
+#define FRAME_FROM_UCONTEXT(context) (context)->uc_mcontext.regs[29] // X29 is the frame pointer
+#define RETURNTO_FROM_UCONTEXT(context) (context)->uc_mcontext.regs[30] // X30 is the link register 
 #elif (defined(CPU_IS_ARM64) || defined(CPU_IS_ARM)) && defined (__NetBSD__)
 #define PC_FROM_UCONTEXT(context) (context)->uc_mcontext.__gregs[_REG_PC]
 #define STACK_FROM_UCONTEXT(context) (context)->uc_mcontext.__gregs[_REG_SP]
 #define FRAME_FROM_UCONTEXT(context) (context)->uc_mcontext.__gregs[_REG_FP]
-#define RETURNTO_FROM_UCONTEXT(context) (context)->uc_mcontext.regs[_REG_LR]
+#define RETURNTO_FROM_UCONTEXT(context) (context)->uc_mcontext.__gregs[_REG_LR]
 #elif defined(CPU_IS_IA64)
 #define PC_FROM_UCONTEXT(context) (context)->_u._mc.sc_ip
 #define STACK_FROM_UCONTEXT(context) (context)->_u._mc.sc_gr[12] //is that register 12?
@@ -1175,7 +1175,7 @@ recover:
 }
 
 #elif defined(CPU_IS_ARM) || defined(CPU_IS_ARM64) || defined(CPU_IS_MIPS)
-//todo: does this work on mips?
+//todo: does this work on arm or mips?
 void SimulatedCPU::call(char *value)     //bl
 {
 	returnTo = pc + CALL_INSTRUCTION_SIZE;

--- a/src/debug/debughelper.cpp
+++ b/src/debug/debughelper.cpp
@@ -528,16 +528,16 @@ QString print_backtrace(const QString &message)
 #define STACK_FROM_UCONTEXT(context) (context)->uc_mcontext.arm_sp
 #define FRAME_FROM_UCONTEXT(context) (context)->uc_mcontext.arm_fp
 #define RETURNTO_FROM_UCONTEXT(context) (context)->uc_mcontext.arm_lr
-#elif defined(CPU_IS_ARM)
-#define PC_FROM_UCONTEXT(context) (context)->uc_mcontext.__gregs[_REG_R15]
-#define STACK_FROM_UCONTEXT(context) (context)->uc_mcontext.__gregs[_REG_R13]
-#define FRAME_FROM_UCONTEXT(context) (context)->uc_mcontext.__gregs[_REG_R11]
-#define RETURNTO_FROM_UCONTEXT(context) (context)->uc_mcontext.__gregs[_REG_R14]
 #elif defined(CPU_IS_ARM64) && defined(__linux__)
 #define PC_FROM_UCONTEXT(context) (context)->uc_mcontext.pc
 #define STACK_FROM_UCONTEXT(context) (context)->uc_mcontext.sp
 #define FRAME_FROM_UCONTEXT(context) (context)->uc_mcontext.regs[29]
 #define RETURNTO_FROM_UCONTEXT(context) (context)->uc_mcontext.regs[30]
+#elif (defined(CPU_IS_ARM64) || defined(CPU_IS_ARM)) && defined (__NetBSD__)
+#define PC_FROM_UCONTEXT(context) (context)->uc_mcontext.__gregs[_REG_PC]
+#define STACK_FROM_UCONTEXT(context) (context)->uc_mcontext.__gregs[_REG_SP]
+#define FRAME_FROM_UCONTEXT(context) (context)->uc_mcontext.__gregs[_REG_FP]
+#define RETURNTO_FROM_UCONTEXT(context) (context)->uc_mcontext.regs[_REG_LR]
 #elif defined(CPU_IS_IA64)
 #define PC_FROM_UCONTEXT(context) (context)->_u._mc.sc_ip
 #define STACK_FROM_UCONTEXT(context) (context)->_u._mc.sc_gr[12] //is that register 12?


### PR DESCRIPTION
Tested on Ubuntu 20.04 aarch64 build, and Raspberry Pi OS Buster (arm 32 bit).
I've not had much luck testing on NetBSD—the AMI image I was using had standard processes dying for no apparent reason, however once I get my monitor I will test. In the mean time I have double checked it against the definition of mcontext used in NetBSD per https://github.com/NetBSD/src/blob/bf21c9368813f0484e699e8472967c8dc2ca4f68/sys/arch/arm/include/mcontext.h#L108 and fixed a typo in one case and double checked it through a code review so I'm pretty confident it will work.