### PR TITLE
[cwl] fix wrong order of classifiers

### DIFF
--- a/completion/latex-dev.cwl
+++ b/completion/latex-dev.cwl
@@ -52,12 +52,12 @@
 \IfFileExists{file}{then}{else}#*
 \InputIfFileExists{file}{then}{else}#*
 \LastDeclaredEncoding#*
-\LoadClass[optionlist]{class}#u*
-\LoadClass[optionlist]{class}[release]#u*
-\LoadClass{class}#u*
-\LoadClass{class}[release]#u*
-\LoadClassWithOptions{class}#u*
-\LoadClassWithOptions{class}[release]#u*
+\LoadClass[optionlist]{class}#*u
+\LoadClass[optionlist]{class}[release]#*u
+\LoadClass{class}#*u
+\LoadClass{class}[release]#*u
+\LoadClassWithOptions{class}#*u
+\LoadClassWithOptions{class}[release]#*u
 \NeedsTeXFormat{format}#*
 \NeedsTeXFormat{format}[release]#*
 \OptionNotUsed#*
@@ -77,12 +77,12 @@
 \ProvidesPackage{name}#*
 \ProvidesPackage{name}[release info]#*
 \ProvideTextCommand{cmd}{encoding}[num][default]{definition}#*
-\RequirePackage[optionlist]{package}#u*
-\RequirePackage[optionlist]{package}[release]#u*
+\RequirePackage[optionlist]{package}#*u
+\RequirePackage[optionlist]{package}[release]#*u
 \RequirePackage{package}#u
-\RequirePackage{package}[release]#u*
-\RequirePackageWithOptions{package}#u*
-\RequirePackageWithOptions{package}[release]#u*
+\RequirePackage{package}[release]#*u
+\RequirePackageWithOptions{package}#*u
+\RequirePackageWithOptions{package}[release]#*u
 # counter, lengths and dimens
 \setcounter{counter}{value}#*
 \setlanguage{language}#*

--- a/completion/latex-document.cwl
+++ b/completion/latex-document.cwl
@@ -520,10 +520,10 @@
 \left\Downarrow#mM
 \left\Updownarrow#mM
 \left.#m
-\left)#m*
-\left]#mM*
-\left\rangle#mM*
-\left\rbrace#mM*
+\left)#*m
+\left]#*mM
+\left\rangle#*mM
+\left\rbrace#*mM
 \right#mK
 \right)#m
 \right]#m
@@ -543,10 +543,10 @@
 \right\Downarrow#mM
 \right\Updownarrow#mM
 \right.#m
-\right(#m*
-\right[#mM*
-\right\langle#m*
-\right\lbrace#m*
+\right(#*m
+\right[#*mM
+\right\langle#*m
+\right\lbrace#*m
 #repl:\"a ä
 #repl:\"o ö
 #repl:\"u ü

--- a/completion/mathpartir.cwl
+++ b/completion/mathpartir.cwl
@@ -7,9 +7,9 @@
 \inferrule{premises}{conclusions}#m
 \inferrule[label%text]{premises}{conclusions}#m
 \inferrule*[options%keyvals]{premises}{conclusions}#m
-\infer{premises}{conclusions}#m*
-\infer[label%text]{premises}{conclusions}#m*
-\infer*[options%keyvals]{premises}{conclusions}#m*
+\infer{premises}{conclusions}#*m
+\infer[label%text]{premises}{conclusions}#*m
+\infer*[options%keyvals]{premises}{conclusions}#*m
 #keyvals:\inferrule*,\infer*
 width=##L
 narrower=%<scale%>

--- a/completion/tex.cwl
+++ b/completion/tex.cwl
@@ -433,7 +433,7 @@
 \bot#m
 \bowtie#m
 \brace#*m
-\bracevert#m*
+\bracevert#*m
 \brack#*m
 \break#*
 \breve{a}#m

--- a/completion/yathesis.cwl
+++ b/completion/yathesis.cwl
@@ -183,7 +183,7 @@ juniorresearcher*
 #
 # Misc
 \ordernumber[numéro d'ordre]#n
-\ordernumber#n*
+\ordernumber#*n
 #
 #keyvals:\maketitle
 nofrontcover
@@ -253,13 +253,13 @@ welsh
 \makefrontepigraphs#n
 \makefrontepigraphs*#n
 \begin{abstract}#n
-\begin{abstract}[intitulé alternatif%text]#n*
+\begin{abstract}[intitulé alternatif%text]#*n
 \end{abstract}#n
 \makeabstract#n
 \newglssymbol{label}{symbole}{nom}{description%text}#n
 \newglssymbol[classement]{label}{symbole}{nom}{description%text}#n
-\tableofcontents#n*
-\tableofcontents[précision%keyvals]#n*
+\tableofcontents#*n
+\tableofcontents[précision%keyvals]#*n
 #
 #keyvals:\tableofcontents
 depth=#part,chapter,section,subsection,subsubsection,paragraph,subparagraph
@@ -310,4 +310,4 @@ name=
 #
 # Customization
 #
-\expression{label}{valeur (en français)%text}{valeur (en anglais)%text}#n*
+\expression{label}{valeur (en français)%text}{valeur (en anglais)%text}#*n


### PR DESCRIPTION
From user manual, sec. 4.14.3, if multiple classifiers are used, `*` should be the first one. For exampleg `\LoadClass{class}#u*` should be `\LoadClass{class}#*u`.

For users, this PR fixes the problem that commands like `\LoadClass` are marked unrecognized.