### PR TITLE
[cwl] move all plaintex-only macros to plaintex.cwl

### DIFF
--- a/completion/plaintex.cwl
+++ b/completion/plaintex.cwl
@@ -1,4 +1,52 @@
-\ttfam#*
-\bffam#*
-\itfam#*m
-\slfam#*
+\advancepageno
+\beginsection
+\bffam
+\bye
+\cleartabs
+\endinsert
+\eqalignno{%<line%> \cr %<line%> \cr}#m
+\eqalign{%<line%> \cr %<line%> \cr}#m
+\fivebf
+\fivei
+\fiverm
+\fivesy
+\folio
+\footline
+\hang#n
+\headline
+\itemitem{mark}
+\itfam#m
+\leqalignno{%<line%> \cr %<line%> \cr}#m
+\magnification
+\midinsert
+\midinsert%<vertical mode material%>\endinsert
+\nopagenumbers
+\normalbottom
+\oldstyle#t
+\pageinsert
+\pageinsert%<vertical mode material%>\endinsert
+\pageno
+\plainoutput
+\proclaim
+\settabs
+\seveni
+\sevenrm
+\sevensy
+\slfam
+\supereject
+\tabalign
+\tenbf
+\tenex
+\teni
+\tenit
+\tenrm
+\tensl
+\tensy
+\tentt
+\textindent{mark}
+\topglue
+\topinsert
+\topinsert%<vertical mode material%>\endinsert
+\ttfam
+\ttraggedright
+\vfootnote{mark}{text}

--- a/completion/plaintex.cwl
+++ b/completion/plaintex.cwl
@@ -7,6 +7,7 @@
 \bffam
 \bye
 \cleartabs
+\columns
 \endinsert
 \eqalignno{%<line%> \cr %<line%> \cr}#m
 \eqalign{%<line%> \cr %<line%> \cr}#m
@@ -49,6 +50,7 @@
 \tentt
 \textindent{mark}
 \topglue
+\topins
 \topinsert
 \topinsert%<vertical mode material%>\endinsert
 \ttfam

--- a/completion/plaintex.cwl
+++ b/completion/plaintex.cwl
@@ -1,3 +1,7 @@
+# plaintex format
+# macros available in plain tex format only
+# muzimuzhi, 8-10 Aug 2020
+
 \advancepageno
 \beginsection
 \bffam

--- a/completion/tex.cwl
+++ b/completion/tex.cwl
@@ -818,7 +818,6 @@
 ## PART 3. Miscellany, those missing in _impatient_
 ##
 \centering
-\columns#*
 \footins#*
 \footnoterule#*
 \interdisplaylinepenalty#*
@@ -827,7 +826,6 @@
 \leavevmode#*
 \patterns{patterns}#*
 \removelastskip#*
-\topins#*
 
 
 ##

--- a/completion/tex.cwl
+++ b/completion/tex.cwl
@@ -1,6 +1,6 @@
 # tex/latex mode: tex primitives and plain tex macros
 # dani/8.1.2004
-# muzimuzhi/20 Aug 2019, 4 Nov 2019, 13 Nov 2019
+# muzimuzhi/20 Aug 2019, 4 Nov 2019, 13 Nov 2019, 10 Aug 2020
 
 ##
 ## References
@@ -312,7 +312,6 @@
 \string#*
 \tabskip#*
 \textfont#*
-\textindent#*
 \textstyle#*
 \the#*
 \thickmuskip#*
@@ -367,7 +366,7 @@
 \xspaceskip
 \year#*
 
-## 2.2 plain tex macros
+## 2.2 plain tex macros that are defined in latex
 \aa#n
 \AA#n
 \active#*

--- a/completion/tex.cwl
+++ b/completion/tex.cwl
@@ -372,7 +372,6 @@
 \AA#n
 \active#*
 \acute{a}#m
-\advancepageno#*
 \ae#n
 \AE#n
 \aleph#m
@@ -392,7 +391,6 @@
 \b{o}#n
 \backslash#m
 \bar{a}#m
-\bigennsection#*
 \beta#m
 \bf#*
 \bgroup#*
@@ -438,7 +436,6 @@
 \breve{a}#m
 \buildrel#*
 \bullet#m
-\bye#*
 \c{o}#n
 \cal#*
 \cap#m
@@ -451,7 +448,6 @@
 \chi#m
 \choose#*m
 \circ#m
-\cleartabs#*
 \clubsuit#m
 \colon#m
 \cong#m
@@ -493,27 +489,18 @@
 \empty#*
 \emptyset#m
 \endgraf#*
-\endinsert#*
 \endline#*
 \enskip#*
 \enspace#*
 \epsilon#m
-\eqalign{%<line%> \cr %<line%> \cr}#*m
-\eqalignno{%<line%> \cr %<line%> \cr}#*m
 \equiv#m
 \eta#m
 \exists#m
 \exp#m
 \filbreak#*
-\fivebf#*
-\fivei#*
-\fiverm#*
-\fivesy#*
 \flat#m
 \fmtname#*
 \fmtversion#*
-\folio#*
-\footline#*
 \footnote{text}#
 \forall#m
 \frenchspacing#*
@@ -528,10 +515,8 @@
 \goodbreak#*
 \grave{a}#m
 \H{o}#n
-\hang#*n
 \hat{a}#m
 \hbar#m
-\headline#*
 \heartsuit#m
 \hglue#*
 \hidewidth#*
@@ -552,7 +537,6 @@
 \iota#m
 \it#*
 \item
-\itemitem#*
 \j#n
 \jmath#m
 \jot#*
@@ -579,7 +563,6 @@
 \leftrightarrow#m
 \Leftrightarrow#m
 \leq#m
-\leqalignno{%<line%> \cr %<line%> \cr}#*m
 \lfloor#m
 \lg#m
 \lgroup#m
@@ -603,7 +586,6 @@
 \loop#*
 \lor#m
 \lq#*n
-\magnification#*
 \magstep#*
 \magstephalf#*
 \mapsto#m
@@ -616,7 +598,6 @@
 \medskip#*
 \medskipamount#*
 \mid#m
-\midinsert#*
 \min#m
 \mit#*m
 \models#m
@@ -661,10 +642,8 @@
 \nobreak#*
 \nointerlineskip#*
 \nonfrenchspacing#*
-\nopagenumbers#*
 \normalbaselines#*
 \normalbaselineskip#*
-\normalbottom#*
 \normallineskip#*
 \normallineskiplimit#*
 \not#m
@@ -681,7 +660,6 @@
 \OE#n
 \offinterlineskip#*
 \oint#m
-\oldstyle#t
 \omega#m
 \Omega#m
 \ominus#m
@@ -694,8 +672,6 @@
 \overrightarrow{text}#m
 \owns#m
 \P#n
-\pageinsert#*
-\pageno#*
 \parallel#m
 \partial#m
 \perp#m
@@ -704,7 +680,6 @@
 \Phi#m
 \pi#m
 \Pi#m
-\plainoutput#*
 \pm#m
 \pmatrix{%<line%> \cr %<line%> \cr}#*m
 \pmod#m
@@ -712,7 +687,6 @@
 \prec#m
 \preceq#m
 \prime#m
-\proclaim#*
 \prod#m
 \propto#m
 \psi#m
@@ -749,10 +723,6 @@
 \searrow#m
 \sec#m
 \setminus#m
-\settabs#*
-\seveni#*
-\sevenrm#*
-\sevensy#*
 \sharp#m
 \showhyphens{space separated words}#*
 \sigma#m
@@ -788,26 +758,15 @@
 \succeq#m
 \sum#m
 \sup#m
-\supereject#*
 \supset#m
 \supseteq#m
 \surd#m
 \swarrow#m
 \t{oo}#n
-\tabalign#*T
 \tan#m
 \tanh#m
 \tau#m
-\tenbf#*
-\tenex#*
-\teni#*
-\tenit#*
-\tenrm#*
-\tensl#*
-\tensy#*
-\tentt#*
 \TeX#n
-\textindent#*
 \theta#m
 \Theta#m
 \thinspace
@@ -815,14 +774,11 @@
 \times#m
 \to#m
 \top#m
-\topglue#*
-\topinsert#*
 \tracingall#*
 \triangle#m
 \triangleleft#m
 \triangleright#m
 \tt#*
-\ttraggedright
 \u{o}#n
 \underbar{text}#*
 \underbrace{text}#m
@@ -846,7 +802,6 @@
 \vee#m
 \vert#m
 \Vert#m
-\vfootnote{text}#*
 \vglue#*
 \vphantom{text}
 \wedge#m
@@ -961,9 +916,6 @@
 # others
 \begingroup%<..%>\endgroup#*
 \bgroup%<..%>\egroup#*
-\midinsert%<vertical mode material%>\endinsert#*
-\pageinsert%<vertical mode material%>\endinsert#*
-\topinsert%<vertical mode material%>\endinsert#*
 \root %<arg1%> \of %<arg2%>#*m
 \settabs %<number%> \columns#*
 \settabs \+ %<sample line%> \cr#*


### PR DESCRIPTION
This pr follows discussions in https://github.com/texstudio-org/texstudio/pull/1200#discussion_r467325762. That is, move all the plaintex-only macros from `tex.cwl` to `plaintex.cwl`.

 - The 1st and 3rd commits only moved lines between files, hence the total lines of insertions and deletions are equal.
 - The 2nd commit did some misc changes.
    - `\textindent` was recorded in `tex.cwl` twice prior to this pr, and it was moved to `plaintex.cwl` in 1st commit. Hence the second record can be safely removed.

PS: plain TeX format is defined in file `plain.tex`, which is locally located in path returned by runing `kpsewhich plain.tex` and in [`base` package](https://ctan.org/pkg/base) of CTAN.