### PR TITLE
Allow quotes in executed program names and arguments

### DIFF
--- a/src/tests/execprogram_t.cpp
+++ b/src/tests/execprogram_t.cpp
@@ -17,19 +17,14 @@ void ExecProgramTest::commandLineParser_data(void)
 	QTest::newRow("only program") << "myprogram" << "myprogram" << QStringList();
 	QTest::newRow("single-quoted program with space") << "'my program'" << "my program" << QStringList();
 	QTest::newRow("double-quoted program with space") << "\"my program\"" << "my program" << QStringList();
-	QTest::newRow("program with internal single-quotes") << "/path/to/m'y prog'ram" << "/path/to/my program" << QStringList();
-	QTest::newRow("program with internal double-quotes") << "/path/to/m\"y prog\"ram" << "/path/to/my program" << QStringList();
-	QTest::newRow("multiple arguments") << "myprogram arg1 arg2 arg3" << "myprogram" << (QStringList() << "arg1" << "arg2" << "arg3");
-	QTest::newRow("argument with single-quoted whitespace") << "myprogram 'abc def' ghi" << "myprogram" << (QStringList() << "abc def" << "ghi");
-	QTest::newRow("argument with double-quoted whitespace") << "myprogram \"abc def\" ghi" << "myprogram" << (QStringList() << "abc def" << "ghi");
-	QTest::newRow("argument with adjacent quotes 1") << "myprogram ab\"cd\"\"ef\"ghi" << "myprogram" << (QStringList() << "abcdefghi");
-	QTest::newRow("argument with adjacent quotes 2") << "myprogram ab\"cd\"'ef'ghi" << "myprogram" << (QStringList() << "abcdefghi");
-	QTest::newRow("argument with adjacent quotes 3") << "myprogram ab'cd'\"ef\"ghi" << "myprogram" << (QStringList() << "abcdefghi");
-	QTest::newRow("argument with adjacent quotes 4") << "myprogram ab'cd''ef'ghi" << "myprogram" << (QStringList() << "abcdefghi");
-	QTest::newRow("double quote inside single quotes") << "myprogram a'b\"cde'f" << "myprogram" << (QStringList() << "abcdef");
-	QTest::newRow("single quote inside double quotes") << "myprogram a\"b'cde\"f" << "myprogram" << (QStringList() << "abcdef");
-	QTest::newRow("unbalanced single quote") << "myprogram abc de'f ghi" << "myprogram" << (QStringList() << "abc" << "def" << "ghi");
-	QTest::newRow("unbalanced double quote") << "myprogram abc de\"f ghi" << "myprogram" << (QStringList() << "abc" << "def" << "ghi");
+	QTest::newRow("program with arguments") << "\"my program\" arg1 arg2" << "my program" << (QStringList() << "arg1" << "arg2");
+	QTest::newRow("single-quoted arguments without separating space") << "\"my program\"'arg1''arg2'" << "my program" << (QStringList() << "arg1" << "arg2");
+	QTest::newRow("double-quoted arguments without separating space") << "\"my program\"\"arg1\"\"arg2\"" << "my program" << (QStringList() << "arg1" << "arg2");
+	QTest::newRow("mixed-quoted arguments without separating space") << "\"my program\"\"arg1\"'arg2'" << "my program" << (QStringList() << "arg1" << "arg2");
+	QTest::newRow("single-quoted argument with double-quote") << "myprogram 'a\"rg1'" << "myprogram" << (QStringList() << "a\"rg1");
+	QTest::newRow("double-quoted argument with single-quote") << "myprogram \"a'rg1\"" << "myprogram" << (QStringList() << "a'rg1");
+	QTest::newRow("single-quoted argument with escaped single-quote") << "myprogram 'a\\'rg1'" << "myprogram" << (QStringList() << "a'rg1");
+	QTest::newRow("double-quoted argument with escaped double-quote") << "myprogram \"a\\\"rg1\"" << "myprogram" << (QStringList() << "a\"rg1");
 }
 
 void ExecProgramTest::commandLineParser(void)


### PR DESCRIPTION
This PR fixes the issue mentioned in https://github.com/texstudio-org/texstudio/issues/1169#issuecomment-680991788 where it was reported that `ExecProgram::setProgramAndArguments()` swallows single and double quotes in the program name and arguments.

After the fix the following program names and arguments are supported:

1. A string without any whitespace, without any single quotes, without any double-quotes, e.g.
```
/my/program arg1 arg2 arg2
```

2. A single-quoted string that can contain whitespace, single quotes or double quotes. Whitespace and double-quotes are supported without any escaping. Single quotes should be backslash-escaped (i.e. \' )
For example:
```
/my/program 'arg2="name"' 'arg3=\'other\''
```

3. A double-quoted string that can contain whitespace or single quotes. Whitespace and single-quotes don't need any escaping. Double quotes inside double quotes are not supported (even when escaped) for compatibility with previous behavior.
For example:
```
sed -i 's/ab/"gh"/' text.txt
```

I tested the last example with `sed` by replacing the external PDF viewer with it and it worked correctly on the test file `text.txt`

The reason why double quotes cannot be supported when escaped inside double quotes is that inside `BuildManager::parseExtendedCommandLine` we have the following code:

```
QStringList BuildManager::parseExtendedCommandLine(QString str, const QFileInfo &mainFile, const QFileInfo &currentFile, int currentline)
{
	...
	// need to reformat literal quotes before the file insertion logic, because ?a"
	// might be extended to "C:\somepath\" which would then be misinterpreted as an
	// literal quote at the end.
	if (config->getOption("Tools/SupportShellStyleLiteralQuotes", true).toBool()) {
		str = ProcessX::reformatShellLiteralQuotes(str);
	}
	...
}
```
The config option `Tools/SupportShellStyleLiteralQuotes` seems to be always enabled so effectively, before `BuildManager::parseExtendedCommandLine` passes the command-line to `ExecProgram`, it always replaces `\"` (backslash-escaped double-quote) with `"""` (triple double-quote). So `ExecProgram::setProgramAndArguments()` never sees the backslash-escaped double-quote.

I did not want to get rid of the code in `BuildManager::parseExtendedCommandLine` that replaces the backslash-escaped double-quote with triple double-quote because I did not want to make too big changes.
This does not allow us to use double quotes inside double quotes, but it is mostly OK, since we can use double quotes inside single quotes (like in the sed example. If we need both double and single quotes in an argument we can use something like `program arg='value\'value"value'`, that is enclose the argument in single quotes, use double quotes inside and use backslash-escaped single quotes inside.

Any comments or suggestions for this PR are welcome.