### PR TITLE
Support multi-piece arguments in ExecProgram::setProgramAndArguments

### DIFF
--- a/src/tests/execprogram_t.cpp
+++ b/src/tests/execprogram_t.cpp
@@ -18,9 +18,8 @@ void ExecProgramTest::commandLineParser_data(void)
 	QTest::newRow("single-quoted program with space") << "'my program'" << "my program" << QStringList();
 	QTest::newRow("double-quoted program with space") << "\"my program\"" << "my program" << QStringList();
 	QTest::newRow("program with arguments") << "\"my program\" arg1 arg2" << "my program" << (QStringList() << "arg1" << "arg2");
-	QTest::newRow("single-quoted arguments without separating space") << "\"my program\"'arg1''arg2'" << "my program" << (QStringList() << "arg1" << "arg2");
-	QTest::newRow("double-quoted arguments without separating space") << "\"my program\"\"arg1\"\"arg2\"" << "my program" << (QStringList() << "arg1" << "arg2");
-	QTest::newRow("mixed-quoted arguments without separating space") << "\"my program\"\"arg1\"'arg2'" << "my program" << (QStringList() << "arg1" << "arg2");
+	QTest::newRow("argument with multiple pieces") << "\"my program\" argname='piece1'\"piece2\"" << "my program" << (QStringList() << "argname=piece1piece2");
+	QTest::newRow("argument with multiple pieces and whitespace") << "\"my program\" 'piece 1'\"pi ece2\"piece3" << "my program" << (QStringList() << "piece 1pi ece2piece3");
 	QTest::newRow("single-quoted argument with double-quote") << "myprogram 'a\"rg1'" << "myprogram" << (QStringList() << "a\"rg1");
 	QTest::newRow("double-quoted argument with single-quote") << "myprogram \"a'rg1\"" << "myprogram" << (QStringList() << "a'rg1");
 	QTest::newRow("single-quoted argument with escaped single-quote") << "myprogram 'a\\'rg1'" << "myprogram" << (QStringList() << "a'rg1");


### PR DESCRIPTION
This PR updates `ExecProgram::setProgramAndArguments()` so that it supports arguments consisting of multiple pieces, e.g. `git  --pretty='%h %s@@@'`

This fixes the issue with git reported here:
https://github.com/texstudio-org/texstudio/pull/1231#issuecomment-682140150