### PR TITLE
Fix a crash when the internal terminal widget is closed

### DIFF
--- a/src/toolwidgets.cpp
+++ b/src/toolwidgets.cpp
@@ -188,6 +188,7 @@ void TerminalWidget::qTermWidgetFinished()
 {
 	// in case the shell closed the widget is reinitiated
 	delete qTermWidget;
+	qTermWidget = nullptr; // Prevent double-delete of terminal widget
 	initQTermWidget();
 }
 


### PR DESCRIPTION
This PR fixes a crash that occurs when the internal terminal widget is closed.
It resolves issue https://github.com/texstudio-org/texstudio/issues/1251