### PR TITLE
cwl: mod fontspec, add unicode-math

### DIFF
--- a/completion.qrc
+++ b/completion.qrc
@@ -224,6 +224,7 @@
 <file>completion/tocloft.cwl</file>
 <file>completion/todonotes.cwl</file>
 <file>completion/ulem.cwl</file>
+<file>completion/unicode-math.cwl</file>
 <file>completion/units.cwl</file>
 <file>completion/unravel.cwl</file>
 <file>completion/upgreek.cwl</file>

--- a/completion/fontspec.cwl
+++ b/completion/fontspec.cwl
@@ -18,6 +18,10 @@
 \setmainfont[font features%keyvals]{font}
 \setmainfont{font}[font features%keyvals]
 \setmainfont[font features%keyvals]{font}[font features%keyvals]#*
+\setromanfont{font}
+\setromanfont[font features%keyvals]{font}
+\setromanfont{font}[font features%keyvals]
+\setromanfont[font features%keyvals]{font}[font features%keyvals]#*
 \setsansfont{font}
 \setsansfont[font features%keyvals]{font}
 \setsansfont{font}[font features%keyvals]
@@ -120,7 +124,7 @@
 
 ## common keyvals list, 
 ## both cmds and keys are in alphabetic order, except for engine specific keys
-#keyvals:\addfontfeature,\addfontfeatures,\defaultfontfeatures,\fontspec,\newfontface,\newfontfamily,\providefontface,\providefontfamily,\renewfontface,\renewfontfamily,\setboldmathrm,\setfontface,\setfontfamily,\setmainfont,\setmathrm,\setmathsf,\setmathtt,\setmonofont,\setsansfont
+#keyvals:\addfontfeature,\addfontfeatures,\defaultfontfeatures,\fontspec,\newfontface,\newfontfamily,\providefontface,\providefontfamily,\renewfontface,\renewfontfamily,\setboldmathrm,\setfontface,\setfontfamily,\setmainfont,\setmathrm,\setmathsf,\setmathtt,\setmonofont,\setromanfont,\setsansfont
 Alternate
 Annotation
 AutoFakeBold

--- a/completion/fontspec.cwl
+++ b/completion/fontspec.cwl
@@ -15,81 +15,81 @@
 
 ## Sec. II.1 Main commands
 \setmainfont{font}
-\setmainfont[font features%keyvals]{font}
+\setmainfont[font features]{font}
 \setmainfont{font}[font features%keyvals]
-\setmainfont[font features%keyvals]{font}[font features%keyvals]#*
+\setmainfont[font features]{font}[font features%keyvals]#*
 \setromanfont{font}
-\setromanfont[font features%keyvals]{font}
+\setromanfont[font features]{font}
 \setromanfont{font}[font features%keyvals]
-\setromanfont[font features%keyvals]{font}[font features%keyvals]#*
+\setromanfont[font features]{font}[font features%keyvals]#*
 \setsansfont{font}
-\setsansfont[font features%keyvals]{font}
+\setsansfont[font features]{font}
 \setsansfont{font}[font features%keyvals]
-\setsansfont[font features%keyvals]{font}[font features%keyvals]#*
+\setsansfont[font features]{font}[font features%keyvals]#*
 \setmonofont{font}
-\setmonofont[font features%keyvals]{font}
+\setmonofont[font features]{font}
 \setsansfont{font}[font features%keyvals]
-\setsansfont[font features%keyvals]{font}[font features%keyvals]#*
+\setsansfont[font features]{font}[font features%keyvals]#*
 
 \newfontfamily{cmd}{font}#d
-\newfontfamily{cmd}[font features%keyvals]{font}#d
+\newfontfamily{cmd}[font features]{font}#d
 \newfontfamily{cmd}{font}[font features%keyvals]#d
-\newfontfamily{cmd}[font features%keyvals]{font}[font features%keyvals]#*d
+\newfontfamily{cmd}[font features]{font}[font features%keyvals]#*d
 \setfontfamily{cmd}{font}#d
-\setfontfamily{cmd}[font features%keyvals]{font}#d
+\setfontfamily{cmd}[font features]{font}#d
 \setfontfamily{cmd}{font}[font features%keyvals]#d
-\setfontfamily{cmd}[font features%keyvals]{font}[font features%keyvals]#*d
+\setfontfamily{cmd}[font features]{font}[font features%keyvals]#*d
 \renewfontfamily{cmd}{font}#d
-\renewfontfamily{cmd}[font features%keyvals]{font}#d
+\renewfontfamily{cmd}[font features]{font}#d
 \renewfontfamily{cmd}{font}[font features%keyvals]#d
-\renewfontfamily{cmd}[font features%keyvals]{font}[font features%keyvals]#*d
+\renewfontfamily{cmd}[font features]{font}[font features%keyvals]#*d
 \providefontfamily{cmd}{font}#d
-\providefontfamily{cmd}[font features%keyvals]{font}#d
+\providefontfamily{cmd}[font features]{font}#d
 \providefontfamily{cmd}{font}[font features%keyvals]#d
-\providefontfamily{cmd}[font features%keyvals]{font}[font features%keyvals]#*d
+\providefontfamily{cmd}[font features]{font}[font features%keyvals]#*d
 
 \fontspec{font}
-\fontspec[font features%keyvals]{font}
+\fontspec[font features]{font}
 \fontspec{font}[font features%keyvals]
-\fontspec[font features%keyvals]{font}[font features%keyvals]#*
+\fontspec[font features]{font}[font features%keyvals]#*
 
 ## Sec. II.2 Font selection
 \IfFontExistsTF{font name}{true}{false}
 
 ## Sec. II.4 Commands to select single font faces
 \newfontface{cmd}{font}#d
-\newfontface{cmd}[font features%keyvals]{font}#d
+\newfontface{cmd}[font features]{font}#d
 \newfontface{cmd}{font}[font features%keyvals]#d
-\newfontface{cmd}[font features%keyvals]{font}[font features%keyvals]#*d
+\newfontface{cmd}[font features]{font}[font features%keyvals]#*d
 \setfontface{cmd}{font}#d
-\setfontface{cmd}[font features%keyvals]{font}#d
+\setfontface{cmd}[font features]{font}#d
 \setfontface{cmd}{font}[font features%keyvals]#d
-\setfontface{cmd}[font features%keyvals]{font}[font features%keyvals]#*d
+\setfontface{cmd}[font features]{font}[font features%keyvals]#*d
 \renewfontface{cmd}{font}#d
-\renewfontface{cmd}[font features%keyvals]{font}#d
+\renewfontface{cmd}[font features]{font}#d
 \renewfontface{cmd}{font}[font features%keyvals]#d
-\renewfontface{cmd}[font features%keyvals]{font}[font features%keyvals]#*d
+\renewfontface{cmd}[font features]{font}[font features%keyvals]#*d
 \providefontface{cmd}{font}#d
-\providefontface{cmd}[font features%keyvals]{font}#d
+\providefontface{cmd}[font features]{font}#d
 \providefontface{cmd}{font}[font features%keyvals]#d
-\providefontface{cmd}[font features%keyvals]{font}[font features%keyvals]#*d
+\providefontface{cmd}[font features]{font}[font features%keyvals]#*d
 
 \setmathrm{font}
-\setmathrm[font features%keyvals]{font}
+\setmathrm[font features]{font}
 \setmathrm{font}[font features%keyvals]
-\setmathrm[font features%keyvals]{font}[font features%keyvals]#*
+\setmathrm[font features]{font}[font features%keyvals]#*
 \setmathsf{font}
-\setmathsf[font features%keyvals]{font}
+\setmathsf[font features]{font}
 \setmathsf{font}[font features%keyvals]
-\setmathsf[font features%keyvals]{font}[font features%keyvals]#*
+\setmathsf[font features]{font}[font features%keyvals]#*
 \setmathtt{font}
-\setmathtt[font features%keyvals]{font}
+\setmathtt[font features]{font}
 \setmathtt{font}[font features%keyvals]
-\setmathtt[font features%keyvals]{font}[font features%keyvals]#*
+\setmathtt[font features]{font}[font features%keyvals]#*
 \setboldmathrm{font}
-\setboldmathrm[font features%keyvals]{font}
+\setboldmathrm[font features]{font}
 \setboldmathrm{font}[font features%keyvals]
-\setboldmathrm[font features%keyvals]{font}[font features%keyvals]#*
+\setboldmathrm[font features]{font}[font features%keyvals]#*
 
 ## Sec. III.1 Default settings
 \defaultfontfeatures{font features%keyvals}

--- a/completion/fontspec.cwl
+++ b/completion/fontspec.cwl
@@ -15,41 +15,41 @@
 
 ## Sec. II.1 Main commands
 \setmainfont{font}
-\setmainfont[font features]{font}
+\setmainfont[font features]{font}*
 \setmainfont{font}[font features%keyvals]
 \setmainfont[font features]{font}[font features%keyvals]#*
 \setromanfont{font}
-\setromanfont[font features]{font}
+\setromanfont[font features]{font}*
 \setromanfont{font}[font features%keyvals]
 \setromanfont[font features]{font}[font features%keyvals]#*
 \setsansfont{font}
-\setsansfont[font features]{font}
+\setsansfont[font features]{font}*
 \setsansfont{font}[font features%keyvals]
 \setsansfont[font features]{font}[font features%keyvals]#*
 \setmonofont{font}
-\setmonofont[font features]{font}
+\setmonofont[font features]{font}*
 \setsansfont{font}[font features%keyvals]
 \setsansfont[font features]{font}[font features%keyvals]#*
 
 \newfontfamily{cmd}{font}#d
-\newfontfamily{cmd}[font features]{font}#d
+\newfontfamily{cmd}[font features]{font}#*d
 \newfontfamily{cmd}{font}[font features%keyvals]#d
 \newfontfamily{cmd}[font features]{font}[font features%keyvals]#*d
 \setfontfamily{cmd}{font}#d
-\setfontfamily{cmd}[font features]{font}#d
+\setfontfamily{cmd}[font features]{font}#*d
 \setfontfamily{cmd}{font}[font features%keyvals]#d
 \setfontfamily{cmd}[font features]{font}[font features%keyvals]#*d
 \renewfontfamily{cmd}{font}#d
-\renewfontfamily{cmd}[font features]{font}#d
+\renewfontfamily{cmd}[font features]{font}#*d
 \renewfontfamily{cmd}{font}[font features%keyvals]#d
 \renewfontfamily{cmd}[font features]{font}[font features%keyvals]#*d
 \providefontfamily{cmd}{font}#d
-\providefontfamily{cmd}[font features]{font}#d
+\providefontfamily{cmd}[font features]{font}#*d
 \providefontfamily{cmd}{font}[font features%keyvals]#d
 \providefontfamily{cmd}[font features]{font}[font features%keyvals]#*d
 
 \fontspec{font}
-\fontspec[font features]{font}
+\fontspec[font features]{font}#*
 \fontspec{font}[font features%keyvals]
 \fontspec[font features]{font}[font features%keyvals]#*
 
@@ -58,36 +58,36 @@
 
 ## Sec. II.4 Commands to select single font faces
 \newfontface{cmd}{font}#d
-\newfontface{cmd}[font features]{font}#d
+\newfontface{cmd}[font features]{font}#*d
 \newfontface{cmd}{font}[font features%keyvals]#d
 \newfontface{cmd}[font features]{font}[font features%keyvals]#*d
 \setfontface{cmd}{font}#d
-\setfontface{cmd}[font features]{font}#d
+\setfontface{cmd}[font features]{font}#*d
 \setfontface{cmd}{font}[font features%keyvals]#d
 \setfontface{cmd}[font features]{font}[font features%keyvals]#*d
 \renewfontface{cmd}{font}#d
-\renewfontface{cmd}[font features]{font}#d
+\renewfontface{cmd}[font features]{font}#*d
 \renewfontface{cmd}{font}[font features%keyvals]#d
 \renewfontface{cmd}[font features]{font}[font features%keyvals]#*d
 \providefontface{cmd}{font}#d
-\providefontface{cmd}[font features]{font}#d
+\providefontface{cmd}[font features]{font}#*d
 \providefontface{cmd}{font}[font features%keyvals]#d
 \providefontface{cmd}[font features]{font}[font features%keyvals]#*d
 
 \setmathrm{font}
-\setmathrm[font features]{font}
+\setmathrm[font features]{font}#*
 \setmathrm{font}[font features%keyvals]
 \setmathrm[font features]{font}[font features%keyvals]#*
 \setmathsf{font}
-\setmathsf[font features]{font}
+\setmathsf[font features]{font}#*
 \setmathsf{font}[font features%keyvals]
 \setmathsf[font features]{font}[font features%keyvals]#*
 \setmathtt{font}
-\setmathtt[font features]{font}
+\setmathtt[font features]{font}#*
 \setmathtt{font}[font features%keyvals]
 \setmathtt[font features]{font}[font features%keyvals]#*
 \setboldmathrm{font}
-\setboldmathrm[font features]{font}
+\setboldmathrm[font features]{font}#*
 \setboldmathrm{font}[font features%keyvals]
 \setboldmathrm[font features]{font}[font features%keyvals]#*
 

--- a/completion/unicode-math.cwl
+++ b/completion/unicode-math.cwl
@@ -1,0 +1,78 @@
+# unicode-math package
+# rend3r, 6 Sep 2020
+# muzimuzhi, 7 Sep 2020
+
+# The 2946 math symbol commands listed in
+#     https://github.com/wspr/unicode-math/blob/master/unicode-math-table.tex
+# and documented in `texdoc unimath-symbols` are not recorded. Perhaps those
+# commonly used and not yet recorded in latex-document.cwl and amssymb.cwl can 
+# be added.
+
+#include:expl3
+#include:xparse
+#include:l3keys2e
+#include:fontspec
+#include:fix-cm
+#include:amsmath
+# NOTE: Load "amssymb.cwl" for auto-completion, not for actual code dependency.
+#include:amssymb
+
+\unimathsetup{options%keyvals}
+\setmathfont{font}
+\setmathfont[font features]{font}#*
+\setmathfont{font}[font features%keyvals]
+\setmathfont[font features]{font}[font features%keyvals]#*
+\setmathfontface{cmd}{font}#d
+\setmathfontface{cmd}[font features]{font}#*d
+\setmathfontface{cmd}{font}[font features%keyvals]#d
+\setmathfontface{cmd}[font features]{font}[font features%keyvals]#d
+\setoperatorfont{cmd}
+\NewNegationCommand{symbol or cmd}{definition}
+
+#keyvals:\unimathsetup
+normal-style=#ISO,TeX,french,upright,literal
+math-style=#ISO,TeX,french,upright,literal
+bold-style=#ISO,TeX,upright,literal
+sans-style=#italic,upright,literal
+nabla=#italic,upright,literal
+partial=#italic,upright,literal
+colon=#TeX,literal
+slash-delimiter=#ascii,frac,div
+active-frac=#small,normalsize
+mathrm=#text,sym
+mathup=#text,sym
+mathit=#text,sym
+mathsf=#text,sym
+mathbf=#text,sym
+mathtt=#text,sym
+trace=#on,debug,off
+warnings-off=
+#endkeyvals
+
+#keyvals:\setmathfont#c,\setmathfontface#c
+range=
+script-font=
+sscript-font=
+script-features=
+sscript-features=
+version=
+# and all the keys inherited from fontspec
+#endkeyvals
+
+\symnormal{text}#*m
+\symliteral{text}#*m
+\symbb{text}#*m
+\symbbit{text}#*m
+\symcal{text}#*m
+\symscr{text}#*m
+\symfrak{text}#*m
+\symsfup{text}#*m
+\symsfit{text}#*m
+\symbfsf{text}#*m
+\symbfup{text}#*m
+\symbfit{text}#*m
+\symbfcal{text}#*m
+\symbfscr{text}#*m
+\symbffrak{text}#*m
+\symbfsfup{text}#*m
+\symbfsfit{text}#*m


### PR DESCRIPTION
Main changes
 - add `\setromanfont` to `fontspec.cwl`
 - new file `unicode-math.cwl` based on @rend3r's draft in https://github.com/texstudio-org/texstudio/issues/1250#issuecomment-687671683 

Closes #1250