### PR TITLE
minor cwl changes

### DIFF
--- a/completion/fancyvrb.cwl
+++ b/completion/fancyvrb.cwl
@@ -35,8 +35,8 @@
 \FancyVerbFormatLine#*
 \theFancyVerbLine#*
 
+\DefineVerbatimEnvironment{envname}{env type}{options%keyvals}
 \RecustomVerbatimEnvironment{envname}{env type}{options%keyvals}
-\RecustomVerbatimEnvironment{envname}{env type}{options%keyvals}#N
 \CustomVerbatimCommand{command}{cmd type}{options%keyvals}
 \RecustomVerbatimCommand{command}{cmd type}{options%keyvals}
 
@@ -74,7 +74,7 @@
 \begin{VerbatimOut}{file name}#V
 \end{VerbatimOut}
 
-#keyvals:\begin{Verbatim},\begin{Verbatim*},\begin{BVerbatim},\begin{BVerbatim*},\begin{LVerbatim},\begin{LVerbatim*},\fvset,\RecustomVerbatimEnvironment,\RecustomVerbatimEnvironment,\CustomVerbatimCommand,\RecustomVerbatimCommand,\UseVerb,\begin{SaveVerbatim},\UseVerbatim,\BUseVerbatim,\LUseVerbatim,\VerbatimInput,\BVerbatimInput,\LLVerbatimInput,\begin{VerbatimOut}
+#keyvals:\begin{Verbatim},\begin{Verbatim*},\begin{BVerbatim},\begin{BVerbatim*},\begin{LVerbatim},\begin{LVerbatim*},\fvset,\DefineVerbatimEnvironment,\RecustomVerbatimEnvironment,\CustomVerbatimCommand,\RecustomVerbatimCommand,\UseVerb,\begin{SaveVerbatim},\UseVerbatim,\BUseVerbatim,\LUseVerbatim,\VerbatimInput,\BVerbatimInput,\LLVerbatimInput,\begin{VerbatimOut}
 boxwidth
 baseline=#b,c,t
 commentchar=%<single char%>

--- a/completion/incgraph.cwl
+++ b/completion/incgraph.cwl
@@ -120,5 +120,5 @@ zerofill=%<digits%>
 
 \igrsetmatchvalue{key%plain}{value}
 \igrsetmatches{list}
-\igrifmatch{key}{then}{else}
+\igrifmatch{key%plain}{then}{else}
 \igrmakezerofill{macro}{digits}

--- a/completion/keyval.cwl
+++ b/completion/keyval.cwl
@@ -1,6 +1,6 @@
 # keyval package
 # muzimuzhi/10 Aug 2019 for keyval v1.15
 
-\define@key{family}{key}{code}
-\define@key{family}{key}[default]{code}
+\define@key{family}{key%plain}{code}
+\define@key{family}{key%plain}[default]{code}
 \setkeys{family}{keyvals}

--- a/completion/pgfkeys.cwl
+++ b/completion/pgfkeys.cwl
@@ -16,12 +16,12 @@
 \pgfkeysalso{key list}#*
 \pgfqkeysalso{default path}{key list}#*
 
-\pgfkeysdef{key}{code}#*
-\pgfkeysedef{key}{code}#*
-\pgfkeysdefnargs{key}{arg count}{code}#*
-\pgfkeysedefnargs{key}{arg count}{code}#*
-\pgfkeysdefargs{key}{arg pattern}{code}#*
-\pgfkeysedefargs{key}{arg pattern}{code}#*
+\pgfkeysdef{key%plain}{code}#*
+\pgfkeysedef{key%plain}{code}#*
+\pgfkeysdefnargs{key%plain}{arg count}{code}#*
+\pgfkeysedefnargs{key%plain}{arg count}{code}#*
+\pgfkeysdefargs{key%plain}{arg pattern}{code}#*
+\pgfkeysedefargs{key%plain}{arg pattern}{code}#*
 
 \pgfkeysdefaultpath#*
 \pgfkeyscurrentpath#*


### PR DESCRIPTION
Main changes:
 - Use arg-spec `key%plain` for arguments with name `key` that are not label/ref keys.
 - Add missing `\DefineVerbatimEnvironment` for `fancyvrb.cwl`. It was wrongly recorded as `\RecustomVerbatimEnvironment`.