### PR TITLE
AppData: Fill in newer release info

### DIFF
--- a/utilities/texstudio.appdata.xml
+++ b/utilities/texstudio.appdata.xml
@@ -54,6 +54,58 @@
   <update_contact>texstudio-list_at_lists.sourceforge.net</update_contact>
   
   <releases>
+    <release date="2020-09-01" version="3.0.1">
+      <description>
+      <p>Changes:</p>
+      <ul>
+	<li>fix glitch in mopdern style (#1238 , triangle missing)</li>
+	<li>fix equation preview (#1234)</li>
+	<li>fix commands with quotes (#1225 &amp; #1169)</li>
+	<li>fix syntax marker in darkmode (#1224)</li>
+      </ul>
+      </description>
+    </release>
+    <release date="2020-08-24" version="3.0.0">
+      <description>
+      <p>Changes:</p>
+      <ul>
+	<li>speed up document parsing, should result in faster document load times</li>
+	<li>spell checking is done asynchronously</li>
+	<li>custom verbatim/math env highlighting abandoned for a cwl based approach</li>
+	<li>better dark-mode support</li>
+	<li>qt4 support abandoned</li>
+      </ul>
+      </description>
+    </release>
+    <release date="2020-01-18" version="2.12.22">
+      <description>
+      <p>Changes:</p>
+      <ul>
+	<li>fixes garbled symbols in OSX</li>
+	<li>fix crash when changing magic language comment</li>
+	<li>fix pdf search path handling</li>
+      </ul>
+      </description>
+    </release>
+    <release date="2020-01-13" version="2.12.20">
+      <description>
+      <p>Changes:</p>
+      <ul>
+	<li>fixes a problem with replacing when search highlight is activated</li>
+      </ul>
+      </description>
+    </release>
+    <release date="2019-12-26" version="2.12.18">
+      <description>
+      <p>Changes:</p>
+      <ul>
+	<li>bug fixes</li>
+	<li>some cwl added</li>
+	<li>correct handling of \string~ in filenames in \include</li>
+	<li>search can handle more regexp (greedy/lazy) since it has been changed to QRegularExpression on QT5 (no change on QT4)</li>
+      </ul>
+      </description>
+    </release>
     <release date="2019-04-07" version="2.12.16"/>
     <release date="2018-11-27" version="2.12.14"/>
     <release date="2018-11-12" version="2.12.12"/>


### PR DESCRIPTION
This commit adds release tags up to version 3.0.1. It also adds the
corresponding changelogs from 2.2.18 upwards.

The appdata file was missing the release info for some newer releases.
This results for example in wrong displayed version numbers in flatpak
since it just uses the latest release tag.