### PR TITLE
Bugfix for issue #1435

### DIFF
--- a/src/cursorhistory.cpp
+++ b/src/cursorhistory.cpp
@@ -58,8 +58,13 @@ bool CursorHistory::insertPos(QDocumentCursor cur, bool deleteBehindCurrent)
 		}
 	}
 
-    ++currentEntry;
-	history.insert(currentEntry, pos);
+	if (history.size() > 0) {
+		++currentEntry;
+		history.insert(currentEntry, pos);
+	}
+	else {
+		history.insert(history.begin(), pos);
+	}
 	updateNavActions();
 	return true;
 }


### PR DESCRIPTION
Checks if the history list is empty before incrementing the iterator, otherwise a memory access error occurs.

See issue #1435.