### PR TITLE
Adds a --miktex command line option

### DIFF
--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -9,6 +9,7 @@
 #include "userquickdialog.h"
 
 #ifdef Q_OS_WIN32
+#include "configmanager.h"
 #include "windows.h"
 #endif
 
@@ -800,6 +801,7 @@ QString getMiKTeXBinPathInternal()
 		static const QStringList candidates = QStringList() << "C:\\miktex\\miktex\\bin"
 															<< "C:\\tex\\texmf\\miktex\\bin"
 															<< "C:\\miktex\\bin"
+															<< ConfigManager::miktexSearchDir
 															<< QString(qgetenv("LOCALAPPDATA")) + "\\Programs\\MiKTeX 2.9\\miktex\\bin";
 		foreach (const QString &path, candidates)
 			if (QDir(path).exists()) {

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -346,6 +346,9 @@ QTextCodec *ConfigManager::newFileEncoding = nullptr;
 QString ConfigManager::configDirOverride;
 bool ConfigManager::dontRestoreSession=false;
 int ConfigManager::RUNAWAYLIMIT=30;
+#ifdef Q_OS_WIN32
+QString ConfigManager::miktexSearchDir = "<search>";
+#endif
 
 QString getText(QWidget *w)
 {

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -347,7 +347,7 @@ QString ConfigManager::configDirOverride;
 bool ConfigManager::dontRestoreSession=false;
 int ConfigManager::RUNAWAYLIMIT=30;
 #ifdef Q_OS_WIN32
-QString ConfigManager::miktexSearchDir = "<search>";
+QString ConfigManager::latexSearchDir;
 #endif
 
 QString getText(QWidget *w)

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -246,7 +246,7 @@ public:
     static bool dontRestoreSession;
     static int RUNAWAYLIMIT;
 #ifdef Q_OS_WIN32
-	static QString miktexSearchDir;
+	static QString latexSearchDir;
 #endif
 private:
 	void setupDirectoryStructure();

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -245,6 +245,9 @@ public:
 	static QString configDirOverride;
     static bool dontRestoreSession;
     static int RUNAWAYLIMIT;
+#ifdef Q_OS_WIN32
+	static QString miktexSearchDir;
+#endif
 private:
 	void setupDirectoryStructure();
 	void moveCwls();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,6 +145,10 @@ QStringList parseArguments(const QStringList &args, bool &outStartAlways)
 			else if ((cmdArgument == "--debug-logfile") && (++i < args.count()))
 				debugLoggerStart(args[i]);
 #endif
+#ifdef Q_OS_WIN32
+			else if (cmdArgument == "--miktex" && (++i < args.count()))
+				ConfigManager::miktexSearchDir = args[i]; 
+#endif
 			else
 				cmdLine << cmdArgument;
 		} else
@@ -170,6 +174,9 @@ bool handleCommandLineOnly(const QStringList &cmdLine) {
                             << "  --version                 show version number\n"
 #ifdef DEBUG_LOGGER
 							<< "  --debug-logfile pathname  write debug messages to pathname\n"
+#endif
+#ifdef Q_OS_WIN32
+							<< "  --miktex DIR               search for latex like MiKTeX in given directory\n"
 #endif
 							;
 		return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -146,8 +146,10 @@ QStringList parseArguments(const QStringList &args, bool &outStartAlways)
 				debugLoggerStart(args[i]);
 #endif
 #ifdef Q_OS_WIN32
-			else if (cmdArgument == "--miktex" && (++i < args.count()))
-				ConfigManager::miktexSearchDir = args[i]; 
+			else if (cmdArgument == "--latex" && (++i < args.count())) {
+				ConfigManager::latexSearchDir = args[i];
+				if (ConfigManager::latexSearchDir.endsWith("\\")) ConfigManager::latexSearchDir.resize(ConfigManager::latexSearchDir.length() - 1);
+			}
 #endif
 			else
 				cmdLine << cmdArgument;
@@ -176,7 +178,7 @@ bool handleCommandLineOnly(const QStringList &cmdLine) {
 							<< "  --debug-logfile pathname  write debug messages to pathname\n"
 #endif
 #ifdef Q_OS_WIN32
-							<< "  --miktex DIR               search for latex like MiKTeX in given directory\n"
+							<< "  --latex DIR               search for latex like MiKTeX/TeXLive in given directory\n"
 #endif
 							;
 		return true;


### PR DESCRIPTION
The --miktex option can be used to specify a path to search for the MiKTeX binaries. Helpful for Issue #1109.