### PR TITLE
Create multiple issue templates to seperate features from bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,3 +1,8 @@
+---
+name: Bug Template
+about: Use this template if you are reporting a bug
+labels: 'type:bug'
+---
 <!-- add as much describing information about your issue as necessary -->
 <!-- remove empty sections -->
 ### Environment
@@ -5,6 +10,8 @@
 - Qt: <!-- SEE THE ABOUT SCREEN IN TXS -->
 - OS: <!-- Windows(7,8,10), Mac, Linux (Distribution), ... -->
 - TeX distribution: <!-- miktex, texlive, ... -->
+- TeXstudio installed from: <!-- source or binary -->
+- Compiler version (if compiling from source): <!-- name and version of used compiler -->
 
 ### Expected behavior
 
@@ -13,5 +20,4 @@
 
 
 ### How to reproduce
-
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Use this template for raising a feature request
+labels: 'type:feature'
+---
+<!-- add as much describing information about your feature request as necessary -->
+<!-- remove empty sections -->
+### Environment
+- TeXstudio: <!-- VERSION 	-->
+- Qt: <!-- SEE THE ABOUT SCREEN IN TXS -->
+- OS: <!-- Windows(7,8,10), Mac, Linux (Distribution), ... -->
+- TeX distribution: <!-- miktex, texlive, ... -->
+- Are you willing to contribute it: <!-- yes/no -->
+
+### Describe the feature and the current behavior/state
+
+### Who will benefit with this feature?
+
+### Any Other info
+

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,14 @@
+---
+name: Other Template
+about: Use this template if you are not reporting a bug and not raising a feature request
+---
+### Environment
+- TeXstudio: <!-- VERSION 	-->
+- Qt: <!-- SEE THE ABOUT SCREEN IN TXS -->
+- OS: <!-- Windows(7,8,10), Mac, Linux (Distribution), ... -->
+- TeX distribution: <!-- miktex, texlive, ... -->
+- TeXstudio installed from: <!-- source or binary -->
+- Compiler version (if compiling from source): <!-- name and version of used compiler -->
+
+### Description
+<!-- add as much describing information about your issue as necessary -->


### PR DESCRIPTION
I have created different templates for bugs and new features. This makes it easier to keep the requests apart.

I would then revise #1442 again and create two entries or a submenu with two entries, which then pre-selects the respective template. In addition, it is perhaps possible per query variable already pass the system information.