### PR TITLE
Hotfix: limit PDF render threads to 1. Prevents frequent crashes for some users.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -190,9 +190,6 @@ int main(int argc, char **argv)
 #if QT_VERSION >= QT_VERSION_CHECK(5,6,0)
 	QApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
 #endif
-
-	QThreadPool::globalInstance()->setMaxThreadCount(1);
-
 	// This is a dummy constructor so that the programs loads fast.
 	TexstudioApp a(appId, argc, argv);
 	bool startAlways = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -190,6 +190,9 @@ int main(int argc, char **argv)
 #if QT_VERSION >= QT_VERSION_CHECK(5,6,0)
 	QApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
 #endif
+
+	QThreadPool::globalInstance()->setMaxThreadCount(1);
+
 	// This is a dummy constructor so that the programs loads fast.
 	TexstudioApp a(appId, argc, argv);
 	bool startAlways = false;

--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -3086,7 +3086,7 @@ retryNow:
         renderManager = nullptr;
 	}
 
-	renderManager = new PDFRenderManager(this);
+	renderManager = new PDFRenderManager(this, 1);
 	renderManager->setCacheSize(globalConfig->cacheSizeMB);
 	renderManager->setLoadStrategy(int(globalConfig->loadStrategy));
 	PDFRenderManager::Error error = PDFRenderManager::NoError;


### PR DESCRIPTION
HOTFIX 
Git diff contributed by @astoeckel in #1409 . Thank you for your contribution.

This commit limits the render threads to 1 in PDF generation. This prevents frequent crashing for users with high core counts, where the (undiagnosed; suspected) threading issue appears to be worse. 

For me, `texstudio` was crashing ~30% of the time the PDF was generated. This commit has eliminated the crashing completely. **I do not notice any difference in the render time**, so I wonder whether the multithreaded PDF generation is needed or working anyway. I haven't looked into it. All I know is that a working `texstudio` is better than one that crashes every third compile.