### PR TITLE
Set prerelease conditionally

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -88,7 +88,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        prerelease: true
+        prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
         files: |
           texstudio-${{ steps.package.outputs.GIT_VERSION }}-win-qt5.exe
           texstudio-${{ steps.package.outputs.GIT_VERSION }}-win-portable-qt5.zip
@@ -142,7 +142,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        prerelease: true      
+        prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
         files: texstudio-${{ steps.package.outputs.GIT_VERSION }}-x86_64.AppImage
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN }}
@@ -194,7 +194,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        prerelease: true      
+        prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
         files: texstudio-${{ steps.package.outputs.GIT_VERSION }}-osx.dmg
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN }}


### PR DESCRIPTION
Commit https://github.com/texstudio-org/texstudio/commit/1c871dc73af6a16afbeac387087b0aceac0a2890 forced pre-release, which made the title of release emails always contain word "Pre-release", like "[texstudio-org/texstudio] Pre-release 3.1.0 - 3.1.0".

This PR sets pre-release conditionally, only when `github.ref` contains one of `alpha`, `beta`, and `rc`.

Related Doc: [Context and expression syntax for GitHub Actions](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions)