### PR TITLE
Add PDFRenderEngineStressTest

### DIFF
--- a/src/tests/pdfrenderengine_stress_t.cpp
+++ b/src/tests/pdfrenderengine_stress_t.cpp
@@ -1,0 +1,53 @@
+/***************************************************************************
+ *   copyright       : (C) 2021 by Andreas Stöckel                         *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QT_NO_DEBUG
+
+#include <pdfviewer/pdfrendermanager.h>
+
+#include <QThread>
+#include <QtTest/QtTest>
+#include <iostream>
+#include <random>
+
+#include "pdfrenderengine_stress_t.h"
+
+void PDFRenderEngineStressTest::test_multithreading()
+{
+	const size_t N_THREADS = 8; // Can trigger the bug more roboustly with 16
+	const size_t N_IT = 100;
+	const size_t N_REPEAT = 1000;
+
+	std::default_random_engine re(5892190);  // Random engine with fixed seed
+	std::uniform_int_distribution<int> dist_page(0, 20);
+
+	for (size_t j = 0; j < N_REPEAT; j++) {
+		PDFRenderManager manager(this, N_THREADS);
+		PDFRenderManager::Error err = PDFRenderManager::NoError;
+
+		// Fetch the test document here:
+		// http://compneuro.uwaterloo.ca/files/publications/stoeckel.2020c.pdf
+		manager.loadDocument("stoeckel.2020c.pdf", err, "");
+		manager.setCacheSize(0);  // Keep nothing in the cache
+
+		for (size_t i = 0; i < N_IT; i++) {
+			std::cerr << "\rIteration " << (j * N_IT + i) << "/"
+			          << (N_REPEAT * N_IT) << std::flush;
+
+			// Submit a render job with no receiver object
+			manager.renderToImage(dist_page(re), nullptr, "");
+
+			// Process signal/slot events
+			QCoreApplication::processEvents();
+		}
+	}
+}
+
+#endif  // QT_NO_DEBUG

--- a/src/tests/pdfrenderengine_stress_t.h
+++ b/src/tests/pdfrenderengine_stress_t.h
@@ -1,0 +1,31 @@
+/***************************************************************************
+ *   copyright       : (C) 2021 by Andreas Stöckel                         *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef PDFRENDERENGINE_STRESS_T_H
+#define PDFRENDERENGINE_STRESS_T_H
+
+#ifndef QT_NO_DEBUG
+
+#include "mostQtHeaders.h"
+#include <QtTest/QtTest>
+
+/**
+ * Implements a stress test triggering issue #1409, i.e., a crash in
+ * Poppler.
+ */
+class PDFRenderEngineStressTest: public QObject
+{
+	Q_OBJECT
+private slots:
+	void test_multithreading();
+};
+
+#endif  // QT_NO_DEBUG
+#endif  // PDFRENDERENGINE_STRESS_T_H

--- a/src/tests/testmanager.cpp
+++ b/src/tests/testmanager.cpp
@@ -17,6 +17,7 @@
 #include "latexeditorview_t.h"
 #include "latexeditorview_bm.h"
 #include "latexstyleparser_t.h"
+#include "pdfrenderengine_stress_t.h"
 #include "scriptengine_t.h"
 #include "structureview_t.h"
 #include "tablemanipulation_t.h"
@@ -90,6 +91,7 @@ QString TestManager::execute(TestLevel level, LatexEditorView* edView, QCodeEdit
 		<< new LatexEditorViewTest(edView)
 		<< new LatexCompleterTest(edView)
 		<< new LatexStyleParserTest(level==TL_ALL)
+		<< new PDFRenderEngineStressTest()
 		<< new ScriptEngineTest(edView,level==TL_ALL)
 		<< new LatexEditorViewBenchmark(edView,level==TL_ALL)
 		<< new StructureViewTest(edView,edView->document,level==TL_ALL)

--- a/src/tests/tests.pri
+++ b/src/tests/tests.pri
@@ -14,6 +14,7 @@
 		src/tests/latexoutputfilter_t.cpp \
 		src/tests/latexparser_t.cpp \
 		src/tests/latexparsing_t.cpp \
+		src/tests/pdfrenderengine_stress_t.cpp \
 		src/tests/qcetestutil.cpp \
 		src/tests/qdocumentcursor_t.cpp \
 		src/tests/qdocumentline_t.cpp \
@@ -44,6 +45,7 @@
 		src/tests/latexparser_t.h \
 		src/tests/latexparsing_t.h \
 		src/tests/latexstyleparser_t.h \
+		src/tests/pdfrenderengine_stress_t.h \
 		src/tests/scriptengine_t.h \
 		src/tests/qeditor_t.h \
 		src/tests/buildmanager_t.h \


### PR DESCRIPTION
Implement a stress test for PDFRenderEngine evoking #1409.

*Do not merge!* This PR is not meant to be merged into `master`; but to share tools that facilitate hunting down the root cause of #1409.

See the discussion in #1463 for more detail.

**How to compile and run:**
```sh
# Clone this branch
git clone git@github.com:astoeckel/texstudio texstudio_pdfrenderengine_stress_test -b pdfrenderengine_stress_test
cd texstudio_pdfrenderengine_stress_test

# Download the test document
wget http://compneuro.uwaterloo.ca/files/publications/stoeckel.2020c.pdf

# Compile with unit tests enabled
qmake-qt5 CONFIG+=debug
make

# Run the unit tests
./texstudio --auto-tests --no-session
```

This should output something along the lines of
```
"/proc/139359/root"
Iteration 2334/100000texstudio: strtod_l.c:1497: ____strtod_l_internal: Assertion `numsize == 1 && n < d' failed.
Iteration 2335/100000Aborted (core dumped)
```

