### PR TITLE
CD: install poppler with qt5 on macOS

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,14 +70,14 @@ jobs:
         echo "::set-output name=TXS_VERSION::${TXS_VERSION}"
         echo "::set-output name=GIT_VERSION::${GIT_VERSION}"
         
-    - name: Deploy zip to Bintray
+    - name: Upload zip to GitHub Artifacts
       if: github.event_name == 'push'
       uses: actions/upload-artifact@v2
       with:
         name: texstudio-win-zip
         path: ./package-zip/texstudio-win-${{ steps.package.outputs.VERSION_NAME }}.zip
         
-    - name: Deploy as Artifact
+    - name: Upload to GitHub Artifacts
       if: github.event_name == 'push'
       uses: actions/upload-artifact@v2
       with:
@@ -150,8 +150,8 @@ jobs:
      
 ############################
       
-  macosx-bintray:
-    name: Mac OS X (Bintray)
+  macosx:
+    name: Mac OS X
     runs-on: macos-latest
 
     steps:
@@ -185,7 +185,7 @@ jobs:
         echo "::set-output name=TXS_VERSION::${TXS_VERSION}"
         echo "::set-output name=GIT_VERSION::${GIT_VERSION}"
         
-    - name: Deploy to Github artifacts
+    - name: Upload to Github artifacts
       if: github.event_name == 'push'
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -165,8 +165,7 @@ jobs:
         rm -f /usr/local/bin/2to3
         brew update > brew_update.log || { echo "::error::Updating homebrew failed"; cat brew_update.log; exit 1; }
         # install poppler with qt5
-        brew extract --version=21.03.0 poppler homebrew/cask
-        brew install poppler@21.03.0
+        brew install poppler
 
     - name: Configure
       run: /usr/local/opt/qt5/bin/qmake texstudio.pro CONFIG-=debug

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -164,16 +164,9 @@ jobs:
         # but prevents the homebrew install from succeeding
         rm -f /usr/local/bin/2to3
         brew update > brew_update.log || { echo "::error::Updating homebrew failed"; cat brew_update.log; exit 1; }
-        brew install qt5
-        brew install --only-dependencies poppler
-        wget https://poppler.freedesktop.org/poppler-21.03.0.tar.xz
-        tar xvf poppler-21.03.0.tar.xz
-        cd poppler-21.03.0
-        mkdir build
-        cd build
-        cmake ..
-        make -j 2
-        make install
+        # install poppler with qt5
+        brew extract --version=21.03.0 poppler homebrew/cask
+        brew install poppler@21.03.0
 
     - name: Configure
       run: /usr/local/opt/qt5/bin/qmake texstudio.pro CONFIG-=debug


### PR DESCRIPTION
This PR (re)enables the build of poppler-qt5 on homebrew, macOS. The key to build poppler-qt5, as I guess, is to use cmake args `-DENABLE_QT5=ON -DENABLE_QT6=OFF`, see https://github.com/Homebrew/homebrew-core/commit/eeb333044a1d1522e457ffd328a3f86e7b0e0157.

The `brew extract` approach proposed in current PR makes best use of homebrew, hence I think is better than other two approaches.
 - Compared to self downloading then building poppler in https://github.com/texstudio-org/texstudio/commit/f62e185a8cac5ef269d5c0f7970b31cf785f92e1, it makes use of configs in homebrew formular hence simplifies the `cd.yml`.
 - Compared to adding a static `poppler@version.rb` formular file as tried in https://github.com/texstudio-org/texstudio/discussions/1517#discussioncomment-427050, it is easier to upgrade poppler version once needed.


Related homebrew docs:
 - [`brew extract`](https://docs.brew.sh/Manpage#extract---version---force-formula-tap)