### PR TITLE
CD: run on pull requests

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,7 @@
 name: CD
 on:
   - push
+  - pull_request
 
 jobs:
   build-linux-win:
@@ -133,6 +134,7 @@ jobs:
         echo "::set-output name=GIT_VERSION::${GIT_VERSION}"        
         
     - name: Upload to Github Artifacts
+      if: github.event_name == 'push'
       uses: actions/upload-artifact@v2
       with:
         name: texstudio-linux


### PR DESCRIPTION
Run `cd.yml` on both pushes and pull requests, but upload to artifacts only on pushes.

Currently, pull requests won't trigger `cd.yml`, hence will not be tested by building/compiling. If a PR passes CI but breaks CD, then the problem will not be found until the PR is merged. This PR changed this behavior, hence roughly brought the conditions back to the ones before https://github.com/texstudio-org/texstudio/commit/f9c304620ec2e7c7858e7dc0f0d1d1de47f71fae.