### PR TITLE
Extend cwl of siunitx

### DIFF
--- a/completion/siunitx.cwl
+++ b/completion/siunitx.cwl
@@ -102,8 +102,8 @@
 \kV#*
 \kW#*
 \kWh#*
-\L
-\l
+\L#*
+\l#*
 \liter
 \litre
 \m#*
@@ -115,6 +115,7 @@
 \MeV#*
 \meV#*
 \mg#*
+\mJ#*
 \MHz#*
 \mHz#*
 \micro

--- a/completion/siunitx.cwl
+++ b/completion/siunitx.cwl
@@ -102,6 +102,8 @@
 \kV#*
 \kW#*
 \kWh#*
+\L
+\l
 \liter
 \litre
 \m#*
@@ -165,6 +167,7 @@
 \pg#*
 \pico
 \planckbar
+\pm#*
 \pmol#*
 \ps#*
 \pV#*
@@ -206,6 +209,7 @@
 \tothe{%<power%>}
 \uA#*
 \ug#*
+\uJ#*
 \uL#*
 \ul#*
 \um#*


### PR DESCRIPTION
I noticed a few abbreviation units from the manual were missing in the cwl of siunitx e.g. `\uJ`.