### PR TITLE
make top, here and force the default positioning

### DIFF
--- a/src/insertgraphics.cpp
+++ b/src/insertgraphics.cpp
@@ -531,7 +531,7 @@ void InsertGraphicsConfig::readSettings(QSettings &settings)
 	center = settings.value("/center", true).toBool();
 	useFigure = settings.value("/useFigure", true).toBool();
 	captionBelow = settings.value("/captionBelow", true).toBool();
-	placement = settings.value("/placement", "").toString();
+	placement = settings.value("/placement", "!th").toString();
 	spanTwoCols = settings.value("/spanTwoCols", false).toBool();
 	settings.endGroup();
 }


### PR DESCRIPTION
I'm not sure if this is just me, but I almost always want this configuration so my images don't appear in a random location, outside their context. So my proposal is to change the default positioning setting for the insert graphics widget to !th