### PR TITLE
Update Info.plist

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -9,6 +9,7 @@
 			<array>
 				<string>tex</string>
 				<string>TEX</string>
+				<string>tikz</string>
 				<string>bib</string>
 				<string>BIB</string>
 				<string>sty</string>


### PR DESCRIPTION
macOS finder doesn't show the TeXstudio icon for .tikz files unless it is defined here. Finder just shows a generic file icon (blank paper sheet) and that can be confusing. One could mistake .tikz files for .log or other files that show a generic icon and these could be trashed accidentally if you clean up TeX folder manually.