### PR TITLE
cwl: enable spell check in \parbox

### DIFF
--- a/completion/latex-document.cwl
+++ b/completion/latex-document.cwl
@@ -331,8 +331,8 @@
 \paragraph[short title]{title}#L5
 \paragraphmark
 \paragraph{title}#L5
-\parbox[position][height][inner-pos]{width}{contents}
-\parbox[position][height]{width}{contents}
+\parbox[position][height][inner-pos]{width}{text}
+\parbox[position][height]{width}{text}
 \parbox[position]{width}{text}
 \parbox{width}{text}
 \part*{title}#L0


### PR DESCRIPTION
Fixed an issue introduced in 711ca02.

Fixes #1766