### PR TITLE
Disable CRASH_HANDLER to make it compile on RISC-V

### DIFF
--- a/src/debug/debughelper.cpp
+++ b/src/debug/debughelper.cpp
@@ -10,7 +10,9 @@
 #endif
 
 // disable backtrace on ARM as the code does not compile
-#if (defined(arm) || defined(__arm__))
+// disable backtrace on RISC-V. RISC-V does not support stack unwinding using frame pointer.
+// Recommended approach for RISC-V is dwarf cfi info.
+#if (defined(arm) || defined(__arm__) || defined(__riscv))
 #define NO_CRASH_HANDLER
 #endif
 


### PR DESCRIPTION
Backtrace using frame pointer does not work / is not supported for RISC-V.
Recommended approach is using dwarf cfi info or external lib like libunwind.

See also: riscv-software-src/riscv-tools#136