### PR TITLE
Macro - LatexEditorView

### DIFF
--- a/src/latexeditorview.cpp
+++ b/src/latexeditorview.cpp
@@ -1674,7 +1674,7 @@ void LatexEditorView::updateFormatSettings()
 		REQUIRE(QDocument::defaultFormatScheme());
 
         const void *formats[] = {
-            & environmentFormat , "enviroment" ,
+            & environmentFormat , "environment" ,
             & referenceMultipleFormat , "referenceMultiple" ,
             & referencePresentFormat , "referencePresent" ,
             & referenceMissingFormat , "referenceMissing" ,


### PR DESCRIPTION
[Discussion]: https://github.com/texstudio-org/texstudio/discussions/1841

Expanded the macro `F`.
While it **slightly** shortens the code,
it makes it far less readable and is far
from a necessity.


[Discussion] relating to this pull request.