### PR TITLE
Macros - HTypes

### DIFF
--- a/src/hunspell/affixmgr.cxx
+++ b/src/hunspell/affixmgr.cxx
@@ -1598,7 +1598,7 @@ struct hentry* AffixMgr::compound_check(const std::string& word,
   // add a time limit to handle possible
   // combinatorical explosion of the overlapping words
 
-  HUNSPELL_THREAD_LOCAL clock_t timelimit;
+  thread_local clock_t timelimit;
 
   if (wordnum == 0)
       timelimit = clock();
@@ -2204,7 +2204,7 @@ int AffixMgr::compound_check_morph(const char* word,
   // add a time limit to handle possible
   // combinatorical explosion of the overlapping words
 
-  HUNSPELL_THREAD_LOCAL clock_t timelimit;
+  thread_local clock_t timelimit;
 
   if (wordnum == 0)
       timelimit = clock();

--- a/src/hunspell/hashmgr.cxx
+++ b/src/hunspell/hashmgr.cxx
@@ -708,7 +708,7 @@ int HashMgr::hash(const char* word) const {
   for (int i = 0; i < 4 && *word != 0; i++)
     hv = (hv << 8) | (*word++);
   while (*word != 0) {
-    ROTATE(hv, ROTATE_LEN);
+    hv = rotate(hv,RotateLength);
     hv ^= (*word++);
   }
   return (unsigned long)hv % tablesize;

--- a/src/hunspell/htypes.hxx
+++ b/src/hunspell/htypes.hxx
@@ -38,28 +38,23 @@
 #ifndef Header_HTypes
 #define Header_HTypes
 
-#define ROTATE_LEN 5
 
-#define ROTATE(v, q) \
-  (v) = ((v) << (q)) | (((v) >> (32 - q)) & ((1 << (q)) - 1));
+const long RotateLength = 5;
+
+inline long rotate(long v,long q){
+    return (v << q) | ((v >> (32 - q)) & ((1 << q) - 1));
+}
 
 // hentry options
-#define H_OPT (1 << 0)          // is there optional morphological data?
-#define H_OPT_ALIASM (1 << 1)   // using alias compression?
-#define H_OPT_PHON (1 << 2)     // is there ph: field in the morphological data?
-#define H_OPT_INITCAP (1 << 3)  // is dictionary word capitalized?
-
-// see also csutil.hxx
-#define HENTRY_WORD(h) &(h->word[0])
+const char
+    H_OPT = (1 << 0),           // is there optional morphological data?
+    H_OPT_ALIASM = (1 << 1),    // using alias compression?
+    H_OPT_PHON = (1 << 2),      // is there ph: field in the morphological data?
+    H_OPT_INITCAP = (1 << 3);   // is dictionary word capitalized?
 
 // approx. number  of user defined words
-#define USERWORD 1000
+const int USERWORD = 1000;
 
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900)
-#  define HUNSPELL_THREAD_LOCAL thread_local
-#else
-#  define HUNSPELL_THREAD_LOCAL static
-#endif
 
 struct hentry {
   unsigned char blen;    // word length in bytes
@@ -71,5 +66,10 @@ struct hentry {
   char var;      // bit vector of H_OPT hentry options
   char word[1];  // variable-length word (8-bit or UTF-8 encoding)
 };
+
+// see also csutil.hxx
+inline char * HENTRY_WORD(const hentry * h){
+    return (char *) & (h -> word[0]);
+}
 
 #endif


### PR DESCRIPTION
[Discussion]: https://github.com/texstudio-org/texstudio/discussions/1841

Expanded `HUNSPELL_THREAD_LOCAL` as it will always be `thread_local`.

Replaced macros `HENTRY_WORD` and `ROTATE` with inline functions.

Replaced macro constants with constants.

[Discussion] relating to this pull request.