### PR TITLE
Macro - QCETestUtil

### DIFF
--- a/src/tests/qcetestutil.h
+++ b/src/tests/qcetestutil.h
@@ -1,16 +1,31 @@
 #ifndef Header_QCE_TestUtil
 #define Header_QCE_TestUtil
 #ifndef QT_NO_DEBUG
+
+#include "testutil.h"
+
 class QDocumentCursor;
+class QString;
+
 QString cur2str(const QDocumentCursor &c);
 
-//defines can determine the current position
-#define QCEEQUAL(c, expected) qceEqual(c, expected, Q__POSITION__)
-#define QCEMULTIEQUAL(c, d, expected) qceEqual(c, d, expected, Q__POSITION__)
-#define QCEEQUAL2(c, expected, message) qceEqual(c, expected, QString("%1 at %2").arg(message).arg(Q__POSITION__))
 
 void qceEqual(const QDocumentCursor& c, const QDocumentCursor& expected, const QString& message);
 //triple comparison, all three should be equal:
-void qceEqual(const QDocumentCursor& c, const QDocumentCursor& d, const QDocumentCursor& expected, const QString& message); 
+void qceEqual(const QDocumentCursor& c, const QDocumentCursor& d, const QDocumentCursor& expected, const QString& message);
+
+
+inline void QCEEQUAL(const QDocumentCursor & cursor,const QDocumentCursor & expected){
+    qceEqual(cursor,expected,Q__POSITION__);
+}
+
+inline void QCEMULTIEQUAL(const QDocumentCursor & cursorA,const QDocumentCursor & cursorB,const QDocumentCursor & expected){
+    qceEqual(cursorA,cursorB,expected,Q__POSITION__);
+}
+
+template <typename Type> inline void QCEEQUAL2(const QDocumentCursor & cursor,const QDocumentCursor & expected,Type message){
+    qceEqual(cursor,expected,QString("%1 at %2").arg(message).arg(Q__POSITION__));
+}
+
 #endif
 #endif


### PR DESCRIPTION
[Discussion]: https://github.com/texstudio-org/texstudio/discussions/1841

Replaced macros `QCEEQUAL`, `QCEMULTIEQUAL` and `QCEEQUAL2`
with inline functions.

Added include and QString declaration to fix missing import warnings.

[Discussion] relating to this pull request.