### PR TITLE
Macro - SmallUsefulFunctions

### DIFF
--- a/src/smallUsefulFunctions.h
+++ b/src/smallUsefulFunctions.h
@@ -35,13 +35,9 @@
 // pos = indexMin(s.indexOf('A'), s.indexOf('B'))
 // pos is negative if s does not contain neither A nor B
 
-#define universal template <typename Type> constexpr inline const Type &
-
-universal indexMin(const Type & a,const Type & b){
+constexpr const int & indexMin(const int & a,const int & b){
     return (a < 0 || b < 0) ? qMax(a,b) : qMin(a,b);
 }
-
-#undef universal
 
 
 struct CommandArgument {


### PR DESCRIPTION
[Discussion]: https://github.com/texstudio-org/texstudio/discussions/1841

Replaced macro `indexMin` with constexpr in the same style of qMax / qMin.
Made it more readable by using a **local** macro.

[Discussion] relating to this pull request.