### PR TITLE
Package `fontspec` in comment in `LuaTeX` template

### DIFF
--- a/templates/template_Article_LuaLaTeX_French.tex
+++ b/templates/template_Article_LuaLaTeX_French.tex
@@ -1,7 +1,7 @@
 % !TXS template
 % !TeX TS-program = lualatex
 \documentclass[french]{article}
-\usepackage{fontspec}
+% \usepackage{fontspec}
 \usepackage[a4paper]{geometry}
 \usepackage{babel}
 \begin{document}


### PR DESCRIPTION
Package `fontspec` in comment in `LuaTeX` template, since not strictly necessary and slows down the compilation.