### PR TITLE
cwl: fix arg-spec for `\AddToHook`

### DIFF
--- a/completion/latex-dev.cwl
+++ b/completion/latex-dev.cwl
@@ -6,7 +6,8 @@
 # commands with big Letters and others
 \AddEverypageHook{code}#*
 \AddThispageHook{code}#*
-\AddToHook{hook}{label}{code}#*
+\AddToHook{hook}{code}#*
+\AddToHook{hook}[label]{code}#*
 \AddToHookNext{hook}{code}#*
 \AfterEndEnvironment[label]{envname}{code}#*
 \AfterEndEnvironment{envname}{code}#*


### PR DESCRIPTION
`\AddToHook` has syntax
```tex
\AddToHook{<hook>}[<label>]{<code>}
```
in which the `<label>` is optional and delimited by `[...]`.

Currently `<label>` is recorded as a mandatory arg and this (tiny) PR fixes this.