### PR TITLE
cwl: add missing arg for lrbox env

### DIFF
--- a/completion/latex-document.cwl
+++ b/completion/latex-document.cwl
@@ -50,7 +50,7 @@
 \begin{Large}
 \begin{large}
 \begin{list}{label}{spacing}
-\begin{lrbox}
+\begin{lrbox}{box}
 \begin{math}#\math
 \begin{matrix}#m\array
 \begin{minipage}[position][height][inner pos]{width}


### PR DESCRIPTION
`lrbox` env requires a mandatory arg representing the box register that will store the env content. 

Check its doc: https://latexref.xyz/lrbox.html.