### PR TITLE
`babel-french` opening quote `\og ` replaced by `\og{}`

### DIFF
--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -1810,7 +1810,7 @@ Then you can select a new shortcut by one of the following ways:
             </item>
             <item>
              <property name="text">
-              <string>French Quotes (babel): \og \fg{}</string>
+              <string>French Quotes (babel): \og{} \fg{}</string>
              </property>
             </item>
             <item>

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -2111,7 +2111,7 @@ void ConfigManager::updateUserMacroMenu()
     // update quote replacement
 	const int autoQuoteCount = 10;
 	if (replaceQuotes >= 1 && replaceQuotes < autoQuoteCount) {
-		static const char *open[autoQuoteCount] = {"",  "``", "\"<", "\"`", "\\og ",  "\">", "\\enquote{", "\xE2\x80\x9C" /*“*/, ",,", "\u201E"};
+		static const char *open[autoQuoteCount] = {"",  "``", "\"<", "\"`", "\\og{}",  "\">", "\\enquote{", "\xE2\x80\x9C" /*“*/, ",,", "\u201E"};
 		static const char *close[autoQuoteCount] = {"", "''", "\">", "\"'", "\\fg{}", "\"<", "}"         , "\xE2\x80\x9D" /*”*/, "''", "\u201D"};
 		completerConfig->userMacros.append(Macro(TXS_AUTO_REPLACE_QUOTE_OPEN, QString::fromUtf8(open[replaceQuotes]), "", "(?language:latex)(?<=\\s|[(:]|^)\""));
 		completerConfig->userMacros.append(Macro(TXS_AUTO_REPLACE_QUOTE_CLOSE, QString::fromUtf8(close[replaceQuotes]), "", "(?language:latex)(?<=\\S)\""));

--- a/translation/texstudio_ar.ts
+++ b/translation/texstudio_ar.ts
@@ -1359,7 +1359,7 @@ Then you can select a new shortcut by one of the following ways:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
+        <source>French Quotes (babel): \og{} \fg{}</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/translation/texstudio_br.ts
+++ b/translation/texstudio_br.ts
@@ -1376,8 +1376,8 @@ A-benn neuze e c&apos;hallit diuzañ ur verradenn nevez gant unan eus an doareo�
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Klochedigoù Gall (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Klochedigoù Gall (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_ca.ts
+++ b/translation/texstudio_ca.ts
@@ -1376,8 +1376,8 @@ Llavors podreu seleccionar una drecera nova de qualsevol de les maneres següent
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Cometes franceses (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Cometes franceses (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_cs.ts
+++ b/translation/texstudio_cs.ts
@@ -1376,8 +1376,8 @@ Potom můžete vybrat novou klávesovou zkratku jedním z následujících způs
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Francouzské uvozovky (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Francouzské uvozovky (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_de.ts
+++ b/translation/texstudio_de.ts
@@ -1375,8 +1375,8 @@ Ein neuer Tastenkürzel kann mit einer der drei folgenden Methoden gewählt werd
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Französische Anführungszeichen (babel):  \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Französische Anführungszeichen (babel):  \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_el.ts
+++ b/translation/texstudio_el.ts
@@ -1374,8 +1374,8 @@ Then you can select a new shortcut by one of the following ways:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Γαλλικά εισαγωγικά (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Γαλλικά εισαγωγικά (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_en.ts
+++ b/translation/texstudio_en.ts
@@ -1361,7 +1361,7 @@ Then you can select a new shortcut by one of the following ways:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
+        <source>French Quotes (babel): \og{} \fg{}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translation/texstudio_es.ts
+++ b/translation/texstudio_es.ts
@@ -1376,8 +1376,8 @@ Esto cambia la escala de las barras de herramientas verticales (para pantallas d
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Comillas Francesas (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Comillas Francesas (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_fa.ts
+++ b/translation/texstudio_fa.ts
@@ -1359,7 +1359,7 @@ Then you can select a new shortcut by one of the following ways:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
+        <source>French Quotes (babel): \og{} \fg{}</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/translation/texstudio_fr.ts
+++ b/translation/texstudio_fr.ts
@@ -1377,8 +1377,8 @@ Ensuite, vous pouvez sélectionner un nouveau raccourci par l&apos;une des trois
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Guillemets français (babel) : \og  \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Guillemets français (babel) : \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_hu.ts
+++ b/translation/texstudio_hu.ts
@@ -1375,8 +1375,8 @@ Then you can select a new shortcut by one of the following ways:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Francia idézőjelek (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Francia idézőjelek (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_id_ID.ts
+++ b/translation/texstudio_id_ID.ts
@@ -1359,8 +1359,8 @@ Then you can select a new shortcut by one of the following ways:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Kutipan Bahasa Prancis (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Kutipan Bahasa Prancis (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_ie.ts
+++ b/translation/texstudio_ie.ts
@@ -1360,8 +1360,8 @@ Then you can select a new shortcut by one of the following ways:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Francesi (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Francesi (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_it.ts
+++ b/translation/texstudio_it.ts
@@ -1376,8 +1376,8 @@ Poi, puoi selezionare una nuova scorciatoia da tastiera in uno dei modi seguenti
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Francesi (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Francesi (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_ja.ts
+++ b/translation/texstudio_ja.ts
@@ -1377,8 +1377,8 @@ Then you can select a new shortcut by one of the following ways:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>フランス語の引用符(babel型): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>フランス語の引用符(babel型): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_ko.ts
+++ b/translation/texstudio_ko.ts
@@ -1371,7 +1371,7 @@ Then you can select a new shortcut by one of the following ways:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
+        <source>French Quotes (babel): \og{} \fg{}</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/translation/texstudio_ko_KR.ts
+++ b/translation/texstudio_ko_KR.ts
@@ -1371,8 +1371,8 @@ Then you can select a new shortcut by one of the following ways:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>프랑스어 따옴표 (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>프랑스어 따옴표 (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_nb_NO.ts
+++ b/translation/texstudio_nb_NO.ts
@@ -1359,8 +1359,8 @@ Then you can select a new shortcut by one of the following ways:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Franske anførselstegn (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Franske anførselstegn (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_nl.ts
+++ b/translation/texstudio_nl.ts
@@ -1366,8 +1366,8 @@ Then you can select a new shortcut by one of the following ways:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Franse aanhalingstekens (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Franse aanhalingstekens (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_pl.ts
+++ b/translation/texstudio_pl.ts
@@ -1374,8 +1374,8 @@ Można wtedy wybrać nowy skrót na kilka sposobów:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Francuski cudzysłów (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Francuski cudzysłów (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_pt.ts
+++ b/translation/texstudio_pt.ts
@@ -1376,8 +1376,8 @@ Pode depois escolher um novo atalho de uma das seguintes formas:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Aspas francesas (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Aspas francesas (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_pt_BR.ts
+++ b/translation/texstudio_pt_BR.ts
@@ -1376,8 +1376,8 @@ Então você pode selecionar um novo atalho das seguintes maneiras:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Aspas francesas (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Aspas francesas (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_ru.ts
+++ b/translation/texstudio_ru.ts
@@ -1347,7 +1347,7 @@ Then you can select a new shortcut by one of the following ways:
     </message>
     <message>
         <location filename="configdialog.ui" line="1670"/>
-        <source>French Quotes (babel): \og \fg{}</source>
+        <source>French Quotes (babel): \og{} \fg{}</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/translation/texstudio_ru_RU.ts
+++ b/translation/texstudio_ru_RU.ts
@@ -1378,8 +1378,8 @@ Then you can select a new shortcut by one of the following ways:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Французские кавычки (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Французские кавычки (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_sk.ts
+++ b/translation/texstudio_sk.ts
@@ -1376,8 +1376,8 @@ Potom môžete vybrať novú klávesovú skratku jedným z nasledujúcich spôso
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Francúzske úvodzovky (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Francúzske úvodzovky (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_sv.ts
+++ b/translation/texstudio_sv.ts
@@ -1372,8 +1372,8 @@ Then you can select a new shortcut by one of the following ways:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Franska citationstecken (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Franska citationstecken (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_tr_TR.ts
+++ b/translation/texstudio_tr_TR.ts
@@ -1376,8 +1376,8 @@ Ardından aşağıdaki yöntemlerden birini kullanarak yeni bir kısayol atayabi
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Fransız türü tırnaklar (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Fransız türü tırnaklar (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_ug.ts
+++ b/translation/texstudio_ug.ts
@@ -1376,8 +1376,8 @@ Then you can select a new shortcut by one of the following ways:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>فىرانسۇسچە نەقىل: (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>فىرانسۇسچە نەقىل: (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_uk.ts
+++ b/translation/texstudio_uk.ts
@@ -1376,8 +1376,8 @@ Then you can select a new shortcut by one of the following ways:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Французькі лапки (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Французькі лапки (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_vi.ts
+++ b/translation/texstudio_vi.ts
@@ -1372,8 +1372,8 @@ Sau đó, bạn có thể chọn một phím tắt mới theo một trong các c
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>Trích dẫn tiếng Pháp (babel): \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>Trích dẫn tiếng Pháp (babel): \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>

--- a/translation/texstudio_zh_CN.ts
+++ b/translation/texstudio_zh_CN.ts
@@ -1376,8 +1376,8 @@ Then you can select a new shortcut by one of the following ways:
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1813"/>
-        <source>French Quotes (babel): \og \fg{}</source>
-        <translation>法语引号： \og \fg{}</translation>
+        <source>French Quotes (babel): \og{} \fg{}</source>
+        <translation>法语引号： \og{} \fg{}</translation>
     </message>
     <message>
         <location filename="../src/configdialog.ui" line="1818"/>


### PR DESCRIPTION
This change mode according to the author of the package's directive.