### PR TITLE
Fix missing error popup on update check fail

### DIFF
--- a/src/updatechecker.cpp
+++ b/src/updatechecker.cpp
@@ -51,7 +51,7 @@ void UpdateChecker::check(bool silent)
 	QNetworkReply *reply = networkManager->get(request);
 	connect(reply, SIGNAL(finished()), this, SLOT(onRequestCompleted()));
 	if (!silent)
-		connect(reply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onRequestError()));
+		connect(reply, &QNetworkReply::errorOccurred, this, &UpdateChecker::onRequestError);
 }
 
 void UpdateChecker::onRequestError()

--- a/src/updatechecker.cpp
+++ b/src/updatechecker.cpp
@@ -50,8 +50,13 @@ void UpdateChecker::check(bool silent)
 	request.setRawHeader("User-Agent", "TeXstudio Update Checker");
 	QNetworkReply *reply = networkManager->get(request);
 	connect(reply, SIGNAL(finished()), this, SLOT(onRequestCompleted()));
-	if (!silent)
+	if (!silent) {
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+		connect(reply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onRequestError()));
+#else
 		connect(reply, &QNetworkReply::errorOccurred, this, &UpdateChecker::onRequestError);
+#endif
+    }
 }
 
 void UpdateChecker::onRequestError()


### PR DESCRIPTION
Relates to issue #1969. Only fixes missing error popup but does not fix missing DLLs.