### PR TITLE
Fixes the DisplayName being too long.

### DIFF
--- a/utilities/texstudio.nsi
+++ b/utilities/texstudio.nsi
@@ -208,7 +208,7 @@ createShortCut "$SMPROGRAMS\${APPNAME}.lnk" \
 "$INSTDIR\texstudio.exe" "" ""
 
 # Registry information for add/remove programs
-	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayName" "${APPNAME} - ${DESCRIPTION}"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayName" "${APPNAME}"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "QuietUninstallString" "$\"$INSTDIR\uninstall.exe$\" /S"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "InstallLocation" "$\"$INSTDIR$\""


### PR DESCRIPTION
Solves complaints in the https://github.com/microsoft/winget-pkgs repository, and complaints from other people about the DisplayName being too long in Control Panel.

Almost all applications have a DisplayName that isn't too long, i.e. `Microsoft OneDrive`; `Microsoft Teams`, etc.

This change was also done to make it a bit more consistent with other programs.