### PR TITLE
Fix missing text in multicolumn language selection for Adwaita Dark (issue #1988)

### DIFF
--- a/src/adwaita-qt/style/adwaitastyle.cpp
+++ b/src/adwaita-qt/style/adwaitastyle.cpp
@@ -4779,7 +4779,7 @@ bool Style::drawMenuItemControl(const QStyleOption *option, QPainter *painter, c
     }
 
     // We want to always to keep the space for checkbox
-    contentsRect.setLeft(Metrics::CheckBox_Size + Metrics::MenuItem_ItemSpacing);
+    contentsRect.setLeft(rect.left() - 1 + Metrics::CheckBox_Size + Metrics::MenuItem_ItemSpacing);
 
     CheckBoxState checkState(menuItemOption->checked ? CheckOn : CheckOff);
     const QColor &outline(palette.windowText().color());


### PR DESCRIPTION
Fixes #1988

First column starts at rect.left() == 1, so I kept this consistent.
When looking at the [current source of the original (?) implementation](https://github.com/FedoraQt/adwaita-qt/blob/85670f8f2f61fd10f867d55555282d0951925160/src/style/adwaitastyle.cpp#L5029) this is omitted.

Screenshots:
![missingtext](https://user-images.githubusercontent.com/12809516/145283919-77d6c5e6-09fe-4df0-9d7e-6990fedef747.PNG)
![fixed](https://user-images.githubusercontent.com/12809516/145283914-276f46b7-2815-421e-aab1-7f9eb4197cb7.PNG)
