### PR TITLE
cwl: remove args of two `fancyvrb` macros

### DIFF
--- a/completion/fancyvrb.cwl
+++ b/completion/fancyvrb.cwl
@@ -126,7 +126,7 @@ baseline=#b,c,t
 \FancyVerbVspace#*
 \FancyVerbStartNum#*
 \FancyVerbStopNum#*
-\FancyVerbGetLine{arg}#*
+\FancyVerbGetLine#*
 \FancyVerbDefineActive#*
 \FancyVerbFormatCom#*
 \FancyVerbSpace#*
@@ -134,7 +134,7 @@ baseline=#b,c,t
 \FancyVerbTab#*
 \FancyVerbRuleColor#*
 \SaveMVerb#*
-\FancyVerbGetVerb{arg}#*
+\FancyVerbGetVerb#*
 \SaveGVerb#*
 \UseMVerb#*
 \pUseMVerb#*


### PR DESCRIPTION
In `fancyvrb` package,
- `\FancyVerbGetLine` has its first and the only argument delimited by `^^M` (the carriage return character)
- `\FancyVerbGetVerb` is redefined (in a local group) every time when `\Save(G)Verb{name}<delim char>code<delim char>` is used and has its second argument delimited by the `<delim char>`.

They both cannot be simpliy recorded in the form `\cmd{arg1}{arg2}`. Hence this PR removes their arguments, which are introduced in PR #2028.