### PR TITLE
cwl: fix arg-spec for `\LogHook` and `\RemoveFromHook`, add variants

### DIFF
--- a/completion/latex-dev.cwl
+++ b/completion/latex-dev.cwl
@@ -14,6 +14,7 @@
 \AfterEndEnvironment{environment}{code}#*
 \ArgumentSpecification#*
 \AtBeginDocument{code}#*
+\AtBeginDocument[label]{code}#*
 \AtBeginDvi{code}#*
 \AtBeginEnvironment[label]{environment}{code}#*
 \AtBeginEnvironment{environment}{code}#*
@@ -29,6 +30,7 @@
 \AtBeginShipoutUpperLeft{code}#*
 \AtBeginShipoutUpperLeftForeground{code}#*
 \AtEndDocument{code}#*
+\AtEndDocument[label]{code}#*
 \AtEndDvi{code}#*
 \AtEndEnvironment[label]{environment}{code}#*
 \AtEndEnvironment{environment}{code}#*

--- a/completion/latex-dev.cwl
+++ b/completion/latex-dev.cwl
@@ -165,7 +165,7 @@
 \LoadClassWithOptions{class}#*u
 \LoadClassWithOptions{class}[release]#*u
 \LoadFontDefinitionFile{encoding}{family}#*
-\LogHook#*
+\LogHook{hook}#*
 \MakeRobust{cmd}#*
 \MessageBreak#*
 \NeedsTeXFormat{format}#*
@@ -216,7 +216,8 @@
 \RawParEnd#*
 \RawShipout#*
 \ReadonlyShipoutCounter#*
-\RemoveFromHook{hook}{label}#*
+\RemoveFromHook{hook}#*
+\RemoveFromHook{hook}[label]#*
 \RenewCommandCopy{cmd}{def}#d
 \RenewDocumentCommand{cmd}{args}{def}#d
 \RenewDocumentEnvironment{envname}{args}{begdef}{enddef}#N


### PR DESCRIPTION
 - Like `\ShowHook{<hook>}`, `\LogHook{<hook>}` accepts a mandatory argument, which is missing in the current cwl file.
 - The `<label>` of `\RemoveFromHook{<hook>}[<label>]` is optional, which is currently denoted as mandatory arg.

This PR fixes these two minor problems and adds two command variants, just for the completeness.