### PR TITLE
fix issue #2142

### DIFF
--- a/completion/attachfile.cwl
+++ b/completion/attachfile.cwl
@@ -135,14 +135,14 @@ vtex
 xetex
 #endkeyvals
 
-\attachfile{file}
-\attachfile[options%keyvals]{file}
+\attachfile{file}#i
+\attachfile[options%keyvals]{file}#i
 \noattachfile
 \noattachfile[options%keyvals]
 \notextattachfile{text}
 \notextattachfile[options%keyvals]{text}
-\textattachfile{file}{text}
-\textattachfile[options%keyvals]{file}{text}
+\textattachfile{file}{text}#i
+\textattachfile[options%keyvals]{file}{text}#i
 \attachfilesetup{options%keyvals}
 
 #keyvals:\attachfile,\attachfilesetup,\noattachfile,\notextattachfile,\textattachfile

--- a/completion/attachfile2.cwl
+++ b/completion/attachfile2.cwl
@@ -12,14 +12,14 @@
 #include:hyperref
 #include:hycolor
 
-\attachfile{file}
-\attachfile[options%keyvals]{file}
+\attachfile{file}#i
+\attachfile[options%keyvals]{file}#i
 \noattachfile
 \noattachfile[options%keyvals]
 \notextattachfile{text}
 \notextattachfile[options%keyvals]{text}
-\textattachfile{file}{text}
-\textattachfile[options%keyvals]{file}{text}
+\textattachfile{file}{text}#i
+\textattachfile[options%keyvals]{file}{text}#i
 \attachfilesetup{options%keyvals}
 
 #keyvals:\usepackage/attachfile2#c,\attachfile,\attachfilesetup,\noattachfile,\notextattachfile,\textattachfile

--- a/completion/bezierplot.cwl
+++ b/completion/bezierplot.cwl
@@ -4,5 +4,12 @@
 #include:iftex
 #include:xparse
 
-\bezierplot{function%formula}
-\bezierplot[xmin][xmax][ymin][ymax][samples]{function%formula}
+\bezierplot{function%definition}
+\bezierplot[xmin][xmax]{function%definition}
+\bezierplot[xmin][xmax][ymin][ymax]{function%definition}
+\bezierplot[xmin][xmax][ymin][ymax][samples]{function%definition}
+\xbezierplot{function%definition}#S
+\xbezierplot[xmin][xmax]{function%definition}#S
+\xbezierplot[xmin][xmax][ymin][ymax]{function%definition}#S
+\xbezierplot[xmin][xmax][ymin][ymax][samples]{function%definition}#S
+\xpandblinpt#S

--- a/completion/csvsimple-l3.cwl
+++ b/completion/csvsimple-l3.cwl
@@ -1,8 +1,8 @@
 # csvsimple-l3 package
 # Matthew Bertucci 2/3/2022 for v2.3.0
 
-\csvreader{file}{assignments%definition}{command list%definition}
-\csvreader[options%keyvals]{file}{assignments%definition}{command list%definition}
+\csvreader{file}{assignments%definition}{command list%definition}#i
+\csvreader[options%keyvals]{file}{assignments%definition}{command list%definition}#i
 
 \csvcoli#*
 \csvcolii#*
@@ -12,25 +12,25 @@
 
 \csvloop{options%keyvals}
 
-\csvautotabular{file}
-\csvautotabular[options%keyvals]{file}
-\csvautotabular*{file}
-\csvautotabular*[options%keyvals]{file}
+\csvautotabular{file}#i
+\csvautotabular[options%keyvals]{file}#i
+\csvautotabular*{file}#i
+\csvautotabular*[options%keyvals]{file}#i
 
-\csvautolongtable{file}
-\csvautolongtable[options%keyvals]{file}
-\csvautolongtable*{file}
-\csvautolongtable*[options%keyvals]{file}
+\csvautolongtable{file}#i
+\csvautolongtable[options%keyvals]{file}#i
+\csvautolongtable*{file}#i
+\csvautolongtable*[options%keyvals]{file}#i
 
-\csvautobooktabular{file}
-\csvautobooktabular[options%keyvals]{file}
-\csvautobooktabular*{file}
-\csvautobooktabular*[options%keyvals]{file}
+\csvautobooktabular{file}#i
+\csvautobooktabular[options%keyvals]{file}#i
+\csvautobooktabular*{file}#i
+\csvautobooktabular*[options%keyvals]{file}#i
 
-\csvautobooklongtable{file}
-\csvautobooklongtable[options%keyvals]{file}
-\csvautobooklongtable*{file}
-\csvautobooklongtable*[options%keyvals]{file}
+\csvautobooklongtable{file}#i
+\csvautobooklongtable[options%keyvals]{file}#i
+\csvautobooklongtable*{file}#i
+\csvautobooklongtable*[options%keyvals]{file}#i
 
 \csvset{options%keyvals}
 
@@ -48,7 +48,7 @@
 \thecsvcolumncount
 \thecsvinputline
 
-\csvsortingrule{name}{file}
+\csvsortingrule{name}{file}#i
 \csvdatacollection
 \csvexpval%<\macro%>
 \csvexpnot%<\macro%>

--- a/completion/embedall.cwl
+++ b/completion/embedall.cwl
@@ -24,8 +24,8 @@ compat
 \embedsource
 \embedsource[options%keyvals]
 
-\embedinput{file}#*
-\embedinput[options%keyvals]{file}#*
+\embedinput{file}#*i
+\embedinput[options%keyvals]{file}#*i
 
 #keyvals:\embedsource#c,\embedinput#c
 filespec=

--- a/completion/embedfile.cwl
+++ b/completion/embedfile.cwl
@@ -9,8 +9,8 @@
 #include:kvdefinekeys
 #include:pdfescape
 
-\embedfile{file}
-\embedfile[options%keyvals]{file}
+\embedfile{file}#i
+\embedfile[options%keyvals]{file}#i
 \embedfilesetup{options%keyvals}
 
 #keyvals:\embedfile#c,\embedfilesetup#c

--- a/completion/fancyvrb.cwl
+++ b/completion/fancyvrb.cwl
@@ -76,12 +76,12 @@ aftersave={%<code%>}
 \LUseVerbatim*[options%keyvals]{name}
 
 # writing and reading verbatim files
-\VerbatimInput{file}
-\VerbatimInput[options%keyvals]{file}
-\BVerbatimInput{file}
-\BVerbatimInput[options%keyvals]{file}
-\LVerbatimInput{file}
-\LVerbatimInput[options%keyvals]{file}
+\VerbatimInput{file}#i
+\VerbatimInput[options%keyvals]{file}#i
+\BVerbatimInput{file}#i
+\BVerbatimInput[options%keyvals]{file}#i
+\LVerbatimInput{file}#i
+\LVerbatimInput[options%keyvals]{file}#i
 \begin{VerbatimOut}{file name}#V
 \end{VerbatimOut}
 

--- a/completion/ffcode.cwl
+++ b/completion/ffcode.cwl
@@ -13,7 +13,7 @@ nonumbers
 nocn
 #endkeyvals
 
-\ff{code}
+\ff{code%definition}
 \begin{ffcode}#V
 \end{ffcode}#V
 \begin{ffcode*}{%<minted options%>}#V

--- a/completion/filecontentsdef.cwl
+++ b/completion/filecontentsdef.cwl
@@ -28,9 +28,9 @@
 
 \filecontentsexec{code}
 
-\begin{filecontentshere}{file}
+\begin{filecontentshere}{file}#V
 \end{filecontentshere}
-\begin{filecontentshere*}{file}
+\begin{filecontentshere*}{file}#V
 \end{filecontentshere*}
 \filecontentsheremacro
 

--- a/completion/graphicxbox.cwl
+++ b/completion/graphicxbox.cwl
@@ -1,9 +1,9 @@
 # graphicxbox package
 # Matthew Bertucci 11/2/2021 for v1.0
 
-\graphicxbox{graphic}{box content%text}
-\graphicxbox[graphicx options]{graphic}{box content%text}
-\fgraphicxbox{color}{graphic}{box content%text}
-\fgraphicxbox{color}[graphicx options]{graphic}{box content%text}
-\fgraphicxbox[model]{color}{graphic}{box content%text}
-\fgraphicxbox[model]{color}[graphicx options]{graphic}{box content%text}
+\graphicxbox{imagefile}{box content%text}#g
+\graphicxbox[graphicx options]{imagefile}{box content%text}#g
+\fgraphicxbox{color}{imagefile}{box content%text}#g
+\fgraphicxbox{color}[graphicx options]{imagefile}{box content%text}#g
+\fgraphicxbox[model]{color spec}{imagefile}{box content%text}#g
+\fgraphicxbox[model]{color spec}[graphicx options]{imagefile}{box content%text}#g

--- a/completion/import.cwl
+++ b/completion/import.cwl
@@ -1,15 +1,18 @@
 # tbraun
 # 2006/30/05
+# updated 2022/03/03 for v6.2
 
-\import{full path}{file}
-\import*{full path}{file}
-\inputfrom{full path}{file}
-\inputfrom*{full path}{file}
-\subimport{relative path}{file}
-\subimport*{relative path}{file}
-\subinputfrom{relative path}{file}
-\subinputfrom*{relative path}{file}
-\includefrom{full path}{file}
-\includefrom*{full path}{file}
-\subincludefrom{relative path}{file}
-\subincludefrom*{relative path}{file}
+\import{full path%definition}{file}#i
+\inputfrom{full path%definition}{file}#i
+\subimport{relative path%definition}{file}#i
+\subinputfrom{relative path%definition}{file}#i
+\includefrom{full path%definition}{file}#i
+\subincludefrom*{relative path%definition}{file}#i
+
+# obsolete starred commands
+\import*{full path%definition}{file}#Si
+\inputfrom*{full path%definition}{file}#Si
+\subimport*{relative path%definition}{file}#Si
+\subinputfrom*{relative path%definition}{file}#Si
+\includefrom*{full path%definition}{file}#Si
+\subincludefrom{relative path%definition}{file}#Si

--- a/completion/interpreter.cwl
+++ b/completion/interpreter.cwl
@@ -1,6 +1,6 @@
 # interpreter package
 # Matthew Bertucci 11/6/2021 for v1.2
 
-\interpretfile{language}{file}
+\interpretfile{language}{file}#i
 \interpretergobble{arg}#*
 \interpreterinput{file}#*i

--- a/completion/intopdf.cwl
+++ b/completion/intopdf.cwl
@@ -3,7 +3,7 @@
 
 #include:hyperref
 
-\attachandlink{file}{description}{link text}
-\attachandlink[filespec]{file}{description}{link text}
-\attachandlink{file}[mime-type]{description}{link text}
-\attachandlink[filespec]{file}[mime-type]{description}{link text}
+\attachandlink{file}{description}{link text}#i
+\attachandlink[filespec]{file}{description}{link text}#i
+\attachandlink{file}[mime-type]{description}{link text}#i
+\attachandlink[filespec]{file}[mime-type]{description}{link text}#i

--- a/completion/listings.cwl
+++ b/completion/listings.cwl
@@ -196,8 +196,8 @@ XSLT
 \begin{lstlisting}#V
 \begin{lstlisting}[options%keyvals]#V
 \end{lstlisting}
-\lstinputlisting{file}
-\lstinputlisting[options%keyvals]{file}
+\lstinputlisting{file}#i
+\lstinputlisting[options%keyvals]{file}#i
 
 #keyvals:\lstset,\lstinline,\begin{lstlisting},\lstinputlisting,\lstMakeShortInline,\lstdefinelanguage,\lstdefinestyle
 inputpath=%<path%>

--- a/completion/moreverb.cwl
+++ b/completion/moreverb.cwl
@@ -6,8 +6,8 @@
 \begin{verbatimtab}#V
 \begin{verbatimtab}[tab width]#V
 \end{verbatimtab}
-\verbatimtabinput{file}
-\verbatimtabinput[tab width]{file}
+\verbatimtabinput{file}#i
+\verbatimtabinput[tab width]{file}#i
 \verbatimtabsize#*
 \begin{listing}{start line}#V
 \begin{listing}[interval]{start line}#V
@@ -15,8 +15,8 @@
 \begin{listingcont}#V
 \end{listingcont}
 \listinglabel#*
-\listinginput{start line}{file}
-\listinginput[interval]{start line}{file}
+\listinginput{start line}{file}#i
+\listinginput[interval]{start line}{file}#i
 \begin{verbatimwrite}{file}#V
 \end{verbatimwrite}
 \begin{boxedverbatim}#V

--- a/completion/pdfoverlay.cwl
+++ b/completion/pdfoverlay.cwl
@@ -3,12 +3,13 @@
 
 #include:graphicx
 
-\pdfoverlaySetPDF{pdf file}
+\pdfoverlaySetPDF{pdf file%definition}
 
 \pdfoverlaySetGraphicsOptions{options%keyvals}
 
 #keyvals:\pdfoverlaySetGraphicsOptions
-bb=
+alt={%<alt text%>}
+bb=%<llx lly urx ury%>
 bbllx=
 bblly=
 bburx=
@@ -17,25 +18,25 @@ natwidth=
 natheight=
 hiresbb#true,false
 pagebox=#mediabox,cropbox,bleedbox,trimbox,artbox
-viewport=
-trim=
-angle=
+viewport=%<llx lly urx ury%>
+trim=%<llx lly urx ury%>
+angle=%<degrees%>
 origin=
 width=##L
 height=##L
 totalheight=##L
 keepaspectratio#true,false
-scale=
+scale=%<factor%>
 clip#true,false
 draft#true,false
-type=
-ext=
-read=
+type=%<file type%>
+ext=%<file extension%>
+read=%<read-file extension%>
 command=
 quiet
-page=
+page=%<page number%>
 interpolate#true,false
-decodearray=
+decodearray={%<color array%>}
 #endkeyvals
 
 \pdfoverlayIncludeToPage{page number}

--- a/completion/pdfpages.cwl
+++ b/completion/pdfpages.cwl
@@ -20,16 +20,16 @@ nodemo
 enable-survey
 #endkeyvals
 
-\includepdf[options%keyvals]{filename}
-\includepdf{filename}
-\includepdfmerge[options%keyvals]{file-list}
-\includepdfmerge{file-list}
+\includepdf[options%keyvals]{filename%definition}
+\includepdf{filename%definition}
+\includepdfmerge[options%keyvals]{file-list%definition}
+\includepdfmerge{file-list%definition}
 \includepdfset{global options%keyvals}
 \threadinfodict#*
 \AddToSurvey#*
 
 #keyvals:\includepdf,includepdfmerge,\includepdfset
-pages=
+pages={%<page range%>}
 nup=%<xnup%>x%<ynup%>
 landscape#true,false
 delta=%<delx%> %<dely%>
@@ -62,34 +62,45 @@ lastpage=%<page number%>
 link#true,false
 linkname=%<default linkname%>
 thread#true,false
-threadname=
+threadname=%<name%>
 linktodoc#true,false
-linkfit=
+linkfit=#Fit,FitH,FitV,FitB,FitBH,FitBV,Region
 linktodocfit=
 newwindow#true,false
-linkfilename=
-addtotoc=
-addtolist=
+linkfilename=%<name%>
+addtotoc={%<page num,section,level,heading,label%>}
+addtolist={%<page num,type,heading,label%>}
 survey#true,false
 survey-nolink#true,false
-xr-prefix=
+xr-prefix=%<prefix%>
+# options passed to \includegraphics
+alt={%<alt text%>}
+bb=%<llx lly urx ury%>
+bbllx=
+bblly=
+bburx=
+bbury=
+natwidth=
+natheight=
+hiresbb#true,false
 pagebox=#mediabox,cropbox,bleedbox,trimbox,artbox
-viewport=
-trim=
-angle=
+viewport=%<llx lly urx ury%>
+trim=%<llx lly urx ury%>
+angle=%<degrees%>
 origin=
 width=##L
 height=##L
 totalheight=##L
 keepaspectratio#true,false
-scale=
+scale=%<factor%>
 clip#true,false
 draft#true,false
-type=
-ext=
-read=
+type=%<file type%>
+ext=%<file extension%>
+read=%<read-file extension%>
 command=
 quiet
-page=
+page=%<page number%>
 interpolate#true,false
+decodearray={%<color array%>}
 #endkeyvals

--- a/completion/pst-3dplot.cwl
+++ b/completion/pst-3dplot.cwl
@@ -121,8 +121,10 @@ fillstyle=%<style%>
 linecolor=#%color
 #endkeyvals
 
-\fileplotThreeD{datafile%definition}
-\fileplotThreeD[options%keyvals]{datafile%definition}
+\fileplotThreeD{datafile}#i
+\fileplotThreeD{file}#Si
+\fileplotThreeD[options%keyvals]{datafile}#i
+\fileplotThreeD[options%keyvals]{file}#Si
 \dataplotThreeD{data object}
 \dataplotThreeD[options%keyvals]{data object}
 \listplotThreeD{data object}

--- a/completion/pst-plot.cwl
+++ b/completion/pst-plot.cwl
@@ -20,8 +20,8 @@
 \dataplot{macro}
 \end{psgraph}
 \endpsgraph#*
-\fileplot[options%keyvals]{file}
-\fileplot{file}
+\fileplot[options%keyvals]{file}#i
+\fileplot{file}#i
 \ifSpecialLabelsDone#*
 \listplot[options%keyvals]{list}
 \listplot{data}
@@ -43,8 +43,8 @@
 \psCoordinates[options%keyvals](x,y)
 \psdataplot[options%keyvals]{macro}#*
 \psdataplot{macro}#*
-\psfileplot[options%keyvals]{file}#*
-\psfileplot{file}#*
+\psfileplot[options%keyvals]{file}#*i
+\psfileplot{file}#*i
 \psFixpoint[%<options%>]{%<x0%>}{%<f(x)%>}{%<n%>}
 \psFixpoint{%<x0%>}{%<f(x)%>}{%<n%>}
 \psgraph(x0,y0)(x1,y1)(x2,y2){xlength%l}{ylength%l}#*
@@ -81,8 +81,8 @@
 \psplotstyle#*
 \psPutXLabel{arg}#*
 \psPutYLabel{arg}#*
-\psreadDataColumn[options%keyvals]{colNo}{delim}{macro%cmd}{file}#d
-\psreadDataColumn{colNo}{delim}{macro%cmd}{file}#d
+\psreadDataColumn[options%keyvals]{colNo}{delim}{macro%cmd}{file%definition}#d
+\psreadDataColumn{colNo}{delim}{macro%cmd}{file%definition}#d
 \psResetPlotValues#*
 \psrotatebox{angle}{contents}#*
 \PSTplotLoaded#S
@@ -110,7 +110,7 @@
 \psyTick[options%keyvals]{rotation}(y value){label}
 \psyTick{rotation}(y value){label}
 \psyticklinestyle#*
-\readdata{macro%cmd}{file}#d
+\readdata{macro%cmd}{file%definition}#d
 \savedata{macro%cmd}[data]#d
 \setDefaulthLabels#*
 \setDefaultvLabels#*

--- a/completion/sverb.cwl
+++ b/completion/sverb.cwl
@@ -8,7 +8,7 @@
 \begin{listing*}{end string}
 \begin{verbwrite}{file}#V
 \end{verbwrite}
-\verbinput{file}
+\verbinput{file}#i
 \begin{demo}{title}
 \begin{demo}[shape%keyvals]{title}
 \end{demo}

--- a/completion/tcolorbox.cwl
+++ b/completion/tcolorbox.cwl
@@ -464,8 +464,8 @@ tcbcoltitle#B
 \tcbincludegraphics{imagefile}#g
 \tcbincludegraphics[options%keyvals]{imagefile}#g
 \imagename
-\tcbincludepdf{file}
-\tcbincludepdf[options%keyvals]{file}
+\tcbincludepdf{file}#i
+\tcbincludepdf[options%keyvals]{file}#i
 \imagepage
 \pdfpages
 

--- a/completion/verbatimbox.cwl
+++ b/completion/verbatimbox.cwl
@@ -9,10 +9,10 @@
 \begin{myverbbox}{token%cmd}#d\verbatim
 \begin{myverbbox}[pre-commands]{token%cmd}#d\verbatim
 \end{myverbbox}
-\verbfilebox{file}
-\verbfilebox[pre-commands]{file}
+\verbfilebox{file}#i
+\verbfilebox[pre-commands]{file}#i
 \theverbbox
-\theverbbox[t]
+\theverbbox[t]%|
 \boxtopsep#*
 \boxbottomsep#*
 \addvbuffer{object}
@@ -20,5 +20,5 @@
 \begin{verbnobox}#V
 \begin{verbnobox}[pre-commands]#V
 \end{verbnobox}
-\verbfilenobox{file}
-\verbfilenobox[pre-commands]{file}
+\verbfilenobox{file}#i
+\verbfilenobox[pre-commands]{file}#i

--- a/completion/verbatimcopy.cwl
+++ b/completion/verbatimcopy.cwl
@@ -8,9 +8,11 @@ compatibility
 enquotefilenames
 #endkeyvals
 
-\setOutputDir{directory}
-\VerbatimCopy{input file}{output file}
+\setOutputDir{directory%definition}
+\VerbatimCopy{input file}{output file}#i
+\VerbatimCopy{file}{file}#Si
 
-\OldsetOutputDir{directory}#*
-\OldVerbatimCopy{input file}{output file}#*
+\OldsetOutputDir{directory%definition}#*
+\OldVerbatimCopy{input file}{output file}#*i
+\OldVerbatimCopy{file}{file}#Si
 \VCverbaction{arg1}{arg2}#*


### PR DESCRIPTION
Fixes #2142, adds similar functionality for commands in packages `attachfile`, `attachfile2`, `csvsimple-l3`, `embedall`, `embedfile`, `fancyvrb`, `import`, `interpreter`, `intopdf`, `moreverb`, `pst-3dplot`, `pst-plot`, `sverb`, `tcolorbox`, `verbatimbox`, and `verbatimcopy`. Other small fixes.