### PR TITLE
fix typo "reular" (2 files)

### DIFF
--- a/utilities/manual/CHANGELOG.txt
+++ b/utilities/manual/CHANGELOG.txt
@@ -8,7 +8,7 @@ TeXstudio 4.2.3
 - remember window state (maximized/normal) of config dialog
 - fix (and speed-up) miktex package detection
 - fix handling apostrophed words better in spellchecker (#2179)
-- reular expression in extended search behave the same as in normal search
+- regular expression in extended search behave the same as in normal search
 - more cwls
 
 

--- a/utilities/texstudio.metainfo.xml
+++ b/utilities/texstudio.metainfo.xml
@@ -57,7 +57,7 @@
           <li>remember window state (maximized/normal) of config dialog</li>
           <li>fix (and speed-up) miktex package detection</li>
           <li>fix handling apostrophed words better in spellchecker (#2179)</li>
-          <li>reular expression in extended search behave the same as in normal search</li>
+          <li>regular expression in extended search behave the same as in normal search</li>
           <li>more cwls</li>
         </ul>
       </description>


### PR DESCRIPTION
corrects typo "reular" to "regular" in changelog.txt and texstudio.metainfo.xml