### PR TITLE
disable backtrace on loongarch64 as code does not compile

### DIFF
--- a/src/debug/debughelper.cpp
+++ b/src/debug/debughelper.cpp
@@ -12,7 +12,7 @@
 // disable backtrace on ARM as the code does not compile
 // disable backtrace on RISC-V. RISC-V does not support stack unwinding using frame pointer.
 // Recommended approach for RISC-V is dwarf cfi info.
-#if (defined(arm) || defined(__arm__) || defined(__riscv))
+#if (defined(arm) || defined(__arm__) || defined(__riscv) || defined(__loongarch64))
 #define NO_CRASH_HANDLER
 #endif
 


### PR DESCRIPTION
./BUILD.sh need build release version.

Signed-off-by: wangming <wangming@loongson-pc>