### PR TITLE
Update usermanual_en.html

### DIFF
--- a/utilities/manual/usermanual_en.html
+++ b/utilities/manual/usermanual_en.html
@@ -1492,7 +1492,7 @@ The following list is a rough overview of the defaults keyboard shortcuts. Depen
 	<li>Go to previous change : Ctrl+H</li>
 	<li>Go to to next change : Ctrl+Shift+H</li>
 	<li>Go to Bookmark 0..9 : Ctrl+1..9</li>		<!-- 04/26/2022 it is assumed that Ctrl+0 would make problems, s. #2275 -->
-	<li>Toggle Bookmark 0..9 : Ctrl+Shift+1..9</li>		<!-- 04/26/2022 it is assumed that Ctrl+Shift+0 would make problems, s. #2275 -->
+	<li>Toggle Bookmark 0..9 : Ctrl+Shift+0..9</li>
 	<li>Set Unnamed Bookmark : Ctrl+Shift+B</li>
 	<li>Next Marker : Ctrl+Down</li>
 	<li>Previous Marker : Ctrl+Up</li>

--- a/utilities/manual/usermanual_en.html
+++ b/utilities/manual/usermanual_en.html
@@ -1465,8 +1465,8 @@ The following list is a rough overview of the defaults keyboard shortcuts. Depen
 	<li>New : Ctrl+N</li>
 	<li>Open : Ctrl+O</li>
 	<li>Save : Ctrl+S</li>
-	<li>Save as: Ctrl+Alt+S</li>
-	<li>Save all: Ctrl+Shift+Alt+S</li>
+	<li>Save as : Ctrl+Alt+S</li>
+	<li>Save all : Ctrl+Shift+Alt+S</li>
 	<li>Close : Ctrl+W</li>
 	<li>Print Source Code : Ctrl+P</li>
 	<li>Exit : Ctrl+Q</li>
@@ -1487,15 +1487,15 @@ The following list is a rough overview of the defaults keyboard shortcuts. Depen
 	<li>Find : Ctrl+F</li>
 	<li>Find next : F3 / Ctrl+G</li>
 	<li>Find prev : Shift+F3 / Ctrl+Shift+G</li>
-	<li>Replace : CTrl+R</li>
+	<li>Replace : Ctrl+R</li>
 	<li>Go to line : Ctrl+G</li>
-	<li>Go to previous change: Ctrl+H</li>
-	<li>Go to to next change: Ctrl+Shift+H</li>
-	<li>Go to Bookmark 0..9: Ctrl+0..9</li>
-	<li>Set Bookmark 0..9: Ctrl+Shift+0..9</li>
-	<li>Set Unnamed Bookmark: Ctrl+Shift+B</li>
-	<li>Next Marker: Ctrl+Down</li>
-	<li>Previous Marker: Ctrl+Up</li>
+	<li>Go to previous change : Ctrl+H</li>
+	<li>Go to to next change : Ctrl+Shift+H</li>
+	<li>Go to Bookmark 0..9 : Ctrl+1..9</li>		<!-- 04/26/2022 it is assumed that Ctrl+0 would make problems, s. #2275 -->
+	<li>Toggle Bookmark 0..9 : Ctrl+Shift+1..9</li>		<!-- 04/26/2022 it is assumed that Ctrl+Shift+0 would make problems, s. #2275 -->
+	<li>Set Unnamed Bookmark : Ctrl+Shift+B</li>
+	<li>Next Marker : Ctrl+Down</li>
+	<li>Previous Marker : Ctrl+Up</li>
 	<li>Go Back : Alt+Left</li>
 	<li>Go Forward : Alt+Right</li>
 	<li>Insert Unicode Character : Ctrl+Alt+U</li>
@@ -1503,21 +1503,21 @@ The following list is a rough overview of the defaults keyboard shortcuts. Depen
 </li>
 <li> "Idefix" menu :
 	<ul>
-	<li>Erase Word/Cmd/Env: Alt+Del</li>
-	<li>Paste as LaTeX: Ctrl+Shift+V</li>
+	<li>Erase Word/Cmd/Env : Alt+Del</li>
+	<li>Paste as LaTeX : Ctrl+Shift+V</li>
 	<li>Show preview : Alt+P</li>
 	<li>Comment : Ctrl+T</li>
 	<li>Uncomment : Ctrl+U</li>
-	<li>Next Latex Error: Ctrl+Shift+Down</li>
-	<li>Previous Latex Error: Ctrl+Shift+Up</li>
-	<li>Next Latex Bad Box: Shift+Alt+Down</li>
-	<li>Previous Latex Bad Box: Shift+Alt+Up</li>
-	<li>Go to definition: Ctrl+Alt+F</li>
-	<li>Normal Completion: Ctrl+Space</li>
-	<li>\begin Completion: Ctrl+Alt+Space</li>
-	<li>Normal Text Completion: Alt+Shift+Space</li>
-	<li>Close Last Open Environment: Alt+Return</li>
-	<li>Remove Placeholders: Ctrl+Shift+K</li>
+	<li>Next Latex Error : Ctrl+Shift+Down</li>
+	<li>Previous Latex Error : Ctrl+Shift+Up</li>
+	<li>Next Latex Bad Box : Shift+Alt+Down</li>
+	<li>Previous Latex Bad Box : Shift+Alt+Up</li>
+	<li>Go to definition : Ctrl+Alt+F</li>
+	<li>Normal Completion : Ctrl+Space</li>
+	<li>\begin Completion : Ctrl+Alt+Space</li>
+	<li>Normal Text Completion : Alt+Shift+Space</li>
+	<li>Close Last Open Environment : Alt+Return</li>
+	<li>Remove Placeholders : Ctrl+Shift+K</li>
 	</ul>
 </li>
 


### PR DESCRIPTION
- removed Ctrl+0 and Ctrl+Shift+0 for Go to / Toggle (not Set) Bookmarks, not working and will not be changed
- fixed typo CTrl
- inconsistent usage of colon in 4.13