### PR TITLE
New Feature: getPosFromClick

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -2754,13 +2754,13 @@ void PDFDocument::getPosFromCLick(const QPointF &pos)
 {
 	int page = pdfWidget->pageFromPos(pos.toPoint());
 	if (page < 0) return;
-	float height = (pdfWidget->pageRect(page).height()/pdfWidget->totalScaleFactor()) / 28.45;
+	const float ptToCm = 2.54 / 72; // 1pt = 1/72 inch = 2.54/72 cm.
+	float height = (pdfWidget->pageRect(page).height()/pdfWidget->totalScaleFactor()) * ptToCm;
 	QClipboard *clipboard = QGuiApplication::clipboard();
 	QString tmp;
-	QTextStream(&tmp) << "" << pos.x() / 28.45  << "," << height- pos.y() / 28.45;
+	QTextStream(&tmp) << "" << pos.x() * ptToCm  << ", " << height- pos.y() * ptToCm;
 	clipboard->setText(tmp);
 	//qDebug() << "Position: " << qPrintable(tmp) << "\n";
-	
 }
 /*!
  * \brief the shortcuts will only be triggered if this widget has focus (used in embedded mode)

--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -20,7 +20,6 @@
 */
 
 #ifndef NO_POPPLER_PREVIEW
-
 #include "PDFDocument.h"
 #include "PDFDocks.h"
 //#include "FindDialog.h"
@@ -1059,6 +1058,13 @@ void PDFWidget::openAnnotationDialog(const PDFAnnotation *annon)
 	dlg->show();
 }
 
+void PDFWidget::callGetPosFromClick(const QPoint &p){
+	int page = pageFromPos(p);
+	if (page < 0) return;
+	QRect r = pageRect(page);
+	emit getPosFromCLick(QPointF(p - r.topLeft()) / totalScaleFactor());
+}
+
 void PDFWidget::mouseReleaseEvent(QMouseEvent *event)
 {
 	if (pdfdocument && pdfdocument->embeddedMode)
@@ -1092,11 +1098,17 @@ void PDFWidget::mouseReleaseEvent(QMouseEvent *event)
 				else if (event->button() == Qt::RightButton) goPrev();
 				break;
 			}
+			// ctrl-shift-click to get position
+			if ((mouseDownModifiers & Qt::ControlModifier) && (mouseDownModifiers & Qt::ShiftModifier)) {
+				if ((event->modifiers() & Qt::ControlModifier) && (event->modifiers() & Qt::ShiftModifier)) {
+					callGetPosFromClick(event->pos());
+				}
+				break;
+			}
 			// Ctrl-click to sync
 			if (mouseDownModifiers & Qt::ControlModifier) {
 				if (event->modifiers() & Qt::ControlModifier)
 					syncWindowClick(event->pos(), true);
-
 				break;
 			}
 			// check whether to zoom
@@ -1497,6 +1509,8 @@ void PDFWidget::syncWindowClick(const QPoint &p, bool activate)
 	emit syncClick(page, QPointF(p - r.topLeft()) / totalScaleFactor(), activate);
 
 }
+
+
 
 void PDFWidget::syncCurrentPage(bool activate)
 {
@@ -2733,7 +2747,21 @@ void PDFDocument::setupMenus(bool embedded)
 
     configManager->modifyManagedShortcuts("pdf");
 }
-
+/*
+ * Copies to clipboard position in cm captured from the pdf viewer (w.r.t. south west corner)
+ */
+void PDFDocument::getPosFromCLick(const QPointF &pos)
+{
+	int page = pdfWidget->pageFromPos(pos.toPoint());
+	if (page < 0) return;
+	float height = (pdfWidget->pageRect(page).height()/pdfWidget->totalScaleFactor()) / 28.45;
+	QClipboard *clipboard = QGuiApplication::clipboard();
+	QString tmp;
+	QTextStream(&tmp) << "" << pos.x() / 28.45  << "," << height- pos.y() / 28.45;
+	clipboard->setText(tmp);
+	//qDebug() << "Position: " << qPrintable(tmp) << "\n";
+	
+}
 /*!
  * \brief the shortcuts will only be triggered if this widget has focus (used in embedded mode)
  * \param actions
@@ -2994,6 +3022,7 @@ void PDFDocument::init(bool embedded)
 	connect(pdfWidget, SIGNAL(changedZoom(qreal)), this, SLOT(enableZoomActions(qreal)));
 	connect(pdfWidget, SIGNAL(changedScaleOption(autoScaleOption)), this, SLOT(adjustScaleActions(autoScaleOption)));
     connect(pdfWidget, SIGNAL(syncClick(int,const QPointF&,bool)), this, SLOT(syncClick(int,const QPointF&,bool)));
+    connect(pdfWidget, SIGNAL(getPosFromCLick(const QPointF&)), this, SLOT(getPosFromCLick(const QPointF&)));
 
 	if (actionZoom_In->shortcut() == QKeySequence("Ctrl++"))
         new QShortcut(QKeySequence("Ctrl+="), pdfWidget, SLOT(zoomIn()), Q_NULLPTR, Qt::WidgetShortcut);

--- a/src/pdfviewer/PDFDocument.h
+++ b/src/pdfviewer/PDFDocument.h
@@ -241,6 +241,7 @@ public slots:
 	void fitWindow(bool checked = true);
 	void setTool(int tool);
 	void syncWindowClick(const QPoint &p, bool activate);
+	void callGetPosFromClick(const QPoint &p);
 	void syncCurrentPage(bool activate);
 	void fixedScale(qreal scale = 1.0);
 	void setImage(QPixmap img, int pageNr);
@@ -251,6 +252,7 @@ signals:
 	void changedZoom(qreal);
 	void changedScaleOption(autoScaleOption);
 	void syncClick(int, const QPointF &, bool activate); //page position in page coordinates
+	void getPosFromCLick(const QPointF &);
 
 protected:
 	virtual void paintEvent(QPaintEvent *event);
@@ -467,6 +469,7 @@ private slots:
 	void enableZoomActions(qreal);
 	void adjustScaleActions(autoScaleOption);
 	void syncClick(int page, const QPointF &pos, bool activate);
+	void getPosFromCLick(const QPointF &pos);
 	void stopReloadTimer();
 	void reloadWhenIdle();
 	void idleReload();


### PR DESCRIPTION
ctrl+shift+leftClick on pdf view copies to clipboard the cursor coordinates x and y (in cm, w.r.t. bottom left corner of the page)

A detailed explanation of the motivation is given in #2324 and #2307 