### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/bintray.yml.off
+++ b/.github/workflows/bintray.yml.off
@@ -2,6 +2,9 @@ name: Limit bintray entries
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,9 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   build-win:
     name: win build (msys2)
@@ -499,6 +502,8 @@ jobs:
 
 
   release:
+    permissions:
+      contents: write  # for softprops/action-gh-release to create GitHub release
     name: Release
     needs: [build-win10, build-linux-win, build-linux-release, macosx] # macosx-qt5 is disabled
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     name: Linux-autoTests


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
