### PR TITLE
Luapreview

### DIFF
--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -180,7 +180,7 @@ public:
 	int deprecatedQuickmode;
 	QStringList deprecatedUserToolCommands, deprecatedUserToolNames;
 	QStringList userToolOrder, userToolDisplayNames;
-	enum Dvi2PngMode { DPM_DVIPNG, DPM_DVIPNG_FOLLOW, DPM_DVIPS_GHOSTSCRIPT, DPM_EMBEDDED_PDF};
+	enum Dvi2PngMode { DPM_DVIPNG, DPM_DVIPNG_FOLLOW, DPM_DVIPS_GHOSTSCRIPT, DPM_EMBEDDED_PDF, DPM_LUA_EMBEDDED_PDF};
 	Dvi2PngMode dvi2pngMode;
 	enum SaveFilesBeforeCompiling {SFBC_ALWAYS, SFBC_ONLY_CURRENT_OR_NAMED, SFBC_ONLY_NAMED};
 	SaveFilesBeforeCompiling saveFilesBeforeCompiling;

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -3811,6 +3811,11 @@ them here.</string>
                   <string>Preview with pdflatex</string>
                  </property>
                 </item>
+                <item>
+                 <property name="text">
+                  <string>Preview with lualatex</string>
+                 </property>
+                </item>
                </widget>
               </item>
               <item row="1" column="0">

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -1749,7 +1749,7 @@ bool ConfigManager::execConfigDialog(QWidget *parentToDialog)
         previewMode = static_cast<PreviewMode>(confDlg->ui.comboBoxPreviewMode->currentIndex());
         buildManager->dvi2pngMode = static_cast<BuildManager::Dvi2PngMode>(confDlg->ui.comboBoxDvi2PngMode->currentIndex());
 #ifdef NO_POPPLER_PREVIEW
-		if (buildManager->dvi2pngMode == BuildManager::DPM_EMBEDDED_PDF) {
+		if (buildManager->dvi2pngMode == BuildManager::DPM_EMBEDDED_PDF || buildManager->dvi2pngMode == BuildManager::DPM_LUA_EMBEDDED_PDF) {
 			buildManager->dvi2pngMode = BuildManager::DPM_DVIPNG; //fallback when poppler is not included
 		}
 #endif

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -8508,7 +8508,7 @@ void Texstudio::showPreview(const QString &text)
 	QStringList header;
 	for (int l = 0; l < m_endingLine; l++)
 		header << edView->editor->document()->line(l).text();
-	if (buildManager.dvi2pngMode == BuildManager::DPM_EMBEDDED_PDF) {
+	if (buildManager.dvi2pngMode == BuildManager::DPM_EMBEDDED_PDF || buildManager.dvi2pngMode == BuildManager::DPM_LUA_EMBEDDED_PDF) {
 		header << "\\usepackage[active,tightpage]{preview}"
 		       << "\\usepackage{varwidth}"
 		       << "\\AtBeginDocument{\\begin{preview}\\begin{varwidth}{\\linewidth}}"
@@ -8608,7 +8608,8 @@ QStringList Texstudio::makePreviewHeader(const LatexDocument *rootDoc)
 			header << newLine;
 		}
 	}
-	if ((buildManager.dvi2pngMode == BuildManager::DPM_EMBEDDED_PDF) && configManager.previewMode != ConfigManager::PM_EMBEDDED) {
+	if ((buildManager.dvi2pngMode == BuildManager::DPM_EMBEDDED_PDF || buildManager.dvi2pngMode == BuildManager::DPM_LUA_EMBEDDED_PDF)
+			&& configManager.previewMode != ConfigManager::PM_EMBEDDED) {
 		header << "\\usepackage[active,tightpage]{preview}"
 		       << "\\usepackage{varwidth}"
 		       << "\\AtBeginDocument{\\begin{preview}\\begin{varwidth}{\\linewidth}}"


### PR DESCRIPTION
Allow preview with lualatex.
Note: it seems that package tikz is source of an unresolved problem with format files (s. texstudio-org#2291). In this case disable "Precompile Preamble" in Preview options).
Main changes:
* configdialog.ui: "Preview with lualatex" in drop down list
* buildmanager.cpp: Amend lualatex (CMD_LUALATEX) with -fmt option to use format file. Added pair of braces in old code since compiler complained about ambiguity.