### PR TITLE
add `\/` to latexparser.cpp

### DIFF
--- a/src/latexparser/latexparser.cpp
+++ b/src/latexparser/latexparser.cpp
@@ -52,8 +52,8 @@ void LatexParser::init()
     possibleCommands["tabular"] = QSet<QString>{"&" };
     possibleCommands["array"] = QSet<QString>{ "&" };
     possibleCommands["tabbing"] = QSet<QString>{"\\<" , "\\>" , "\\=" , "\\+"};
-    possibleCommands["normal"] = QSet<QString>{ "\\\\" , "\\_" , "\\-" , "$" , "$$" , "\\$" , "\\#" , "\\{" , "\\}" , "\\S" , "\\'" , "\\`" , "\\^" , "\\=" , "\\." , "\\u" , "\\v" , "\\H" , "\\t" , "\\c" , "\\d" , "\\b" , "\\o" , "\\O" , "\\P" , "\\l" , "\\L" , "\\&" , "\\~" , "\\" , "\\," , "\\%" , "\\\"", "\\," , "\\!" , "\\;" , "\\:"};
-    possibleCommands["math"] = QSet<QString>{ "_" , "^" , "\\$" , "\\#" , "\\{" , "\\}" , "\\S" , "\\," , "\\!" , "\\;" , "\\:" , "\\\\" , "\\ " , "\\|"};
+    possibleCommands["normal"] = QSet<QString>{ "\\\\" , "\\_" , "\\-" , "$" , "$$" , "\\$" , "\\#" , "\\{" , "\\}" , "\\S" , "\\'" , "\\`" , "\\^" , "\\=" , "\\." , "\\u" , "\\v" , "\\H" , "\\t" , "\\c" , "\\d" , "\\b" , "\\o" , "\\O" , "\\P" , "\\l" , "\\L" , "\\&" , "\\~" , "\\" , "\\," , "\\%" , "\\\"", "\\," , "\\!" , "\\;" , "\\:" , "\\/"};
+    possibleCommands["math"] = QSet<QString>{ "_" , "^" , "\\$" , "\\#" , "\\{" , "\\}" , "\\S" , "\\," , "\\!" , "\\;" , "\\:" , "\\/" , "\\\\" , "\\ " , "\\|"};
     possibleCommands["%definition"] = QSet<QString>{ "\\newcommand" , "\\renewcommand" , "\\newcommand*" , "\\renewcommand*" , "\\providecommand" , "\\newlength" , "\\let"};
     possibleCommands["%usepackage"] = QSet<QString>{ "\\usepackage" , "\\documentclass" };
     possibleCommands["%graphics"] = QSet<QString>{ "\\includegraphics" };


### PR DESCRIPTION
Add italic correction primitive `\/` to recognized list in latexparser.cpp. It is currently marked as invalid in settings where it shouldn't be, as shown below:
<img width="60" alt="Screenshot 2022-05-15 125334" src="https://user-images.githubusercontent.com/61854785/168491445-bf8d1ed0-95b4-454c-aac2-bb22dbfc7418.png">
