### PR TITLE
fix #2208

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -73,7 +73,6 @@ bool PDFDocument::isMaybeCompiling = false;
 
 static const int GridBorder = 5;
 
-
 QPixmap convertImage(const QPixmap &pixmap, bool invertColors, bool convertToGray)
 {
 	if (pixmap.isNull()) return pixmap;
@@ -1874,12 +1873,13 @@ int PDFWidget::realNumPages() const
 int PDFWidget::pageStep()
 {
 	bool cont = getScrollArea()->getContinuous();
-	int result = 1;
-	if (singlePageStep && !cont) return 1;
+	int result;
 	if (cont) {
 		result = gridx;
 	} else {
-		if (!singlePageStep)
+		if (singlePageStep)
+			result = 1;
+		else
 			result = gridx * gridy;
 	}
 	return result;
@@ -1919,16 +1919,13 @@ void PDFWidget::goFirst()
 void PDFWidget::goPrev()
 {
 	if (document.isNull()) return;
-	getScrollArea()->goToPage(realPageIndex + getPageOffset() - pageStep());
+	getScrollArea()->goToPage(realPageIndex - pageStep());
 }
 
 void PDFWidget::goNext()
 {
 	if (document.isNull()) return;
-	int pageOffset = getPageOffset();
-	if (realPageIndex == 0 && pageOffset == 1)
-		pageOffset = -1;
-	getScrollArea()->goToPage(realPageIndex + pageOffset + pageStep());
+	getScrollArea()->goToPage(realPageIndex + pageStep());
 }
 
 void PDFWidget::goLast()
@@ -2061,7 +2058,7 @@ void PDFWidget::doPageDialog()
 
 int PDFWidget::normalizedPageIndex(int p)
 {
-	if (p > 0) return  p - (p - getPageOffset())  % pageStep();
+	if (p > 0) return  p - (p + getPageOffset()) % pageStep();
 	else return p;
 }
 


### PR DESCRIPTION
this PR fixes #2208, strange scroll behavior in windowed pdf-viewer. To reproduce follow instructions:

1. open document with n>3 pages in windowed pdf-viewer
2. Menu setup: uncheck Continuous and Single Page Step, choose grid 2x2 ( or custom 2x3, 2x4, ...)
2. you see the grid view filled with three pages:
```
-- p1
p2 p3
```
unvisible pages p4, p5, p6 ... Views are characterized by a page in the first line of the view (here p1). Pages in the same line give the same view. If possible we use the page at the start of the row to describe the view. In fact this is the way how the view is build.

3. click on next page (or cursor right/down key) and you get:
 ```
 p2 p3
 p4 p5
```
This is view of p2. This happens for all grids with two columns, because there is no p0. If you choose a number of grid columns other than 2, this does not happen, because there is always a page at the top left of the view (no beginning to the right). This leads to the presentation of pages we've already seen.

**Preview:** It is planned to generalize the page offset in the first line of pages from 0 or 1 to 0 <= page offset < grid columns applied to any grid. The current function underlying this would give some surprising results (shift of pages to the side, instead of always staying in the same column, etc.).

**Expectation** We want that the next page view is always the one of that page that immediately follows the last visible page of the current view. So in the above case it should be view p4, e.g.:
 ```
 p4 p5
 p6 p7
```
**Reason:** The method normalizedPageIndex calculates the page for the next view. But it is in error. It seems that for coping with this error, some strange calculations are done in methods goNext and goPrev. The calculation can easily be fixed and results in a dramatic simplification and clarification of the methods given.

Method goNext sets p as follows (do you think that addition of pageOffset is understandable/plausible?):
```
if (realPageIndex == 0 && pageOffset == 1)
		pageOffset = -1
	p = realPageIndex + pageOffset + pageStep
```
The wrong calculation of the normalized page index is:
```
p - (p - pageOffset) % pageStep
```
pageStep is the size of the grid, eg. the product gridSize = gridx * gridy.

**Example:** We examine the case 2x2 as described above. We have gridSize = 4, realPageIndex = 0 (which is used to identify the view), and pageOffset = 1, as the first page is at the top right. As usual counting starts from 0.
Since pageOffset is temporarily changed to -1 we find p = 0 + (-1) + 4 = 3. So the normalized page index is:
```
3 - (3 - 1) % 4 = 3 - 2 % 4 = 3 - 2 = 1
```
A page index of 1 means p2, so we will get page view p2. That's what we have seen above. Be aware that the calculus done is independant of the number of rows the grid has (while having 2 columns). In fact p = gridSize - 1. We normalize p (here pageOffset is 1):
```
(gridSize - 1) - ( (gridSize - 1) - 1) % gridSize = (gridSize - 1) - (gridSize -2) = 2 - 1 = 1
```
**Remark:** Since gridSize >= 2 it follows gridSize - 2 >= 0. % gives the rest upon division by gridSize. Since gridSize - 2 < gridSize, we see that the rest equals gridSize - 2.

This proofs that the next view is p2 (if there is p2).

**Fixing:** Now we fix this. Method goNext is changed to simply be (similar for goPrev):
```
p = realPageIndex + pageStep
```
and normalization is changed to the following by simply changing second minus to plus:
```
p - (p + pageOffset) % pageStep
```
Now let realPageIndex = 0, thus p = pageStep (_what ever the grid might be!_). Normaliziation gives (gridSize + pageOffset >= pageSize, so the division with rest removes gridSize, but no more since pageOffset < gridSize):
```
gridSize - (gridSize + pageOffset) % pageSize = gridSize - pageOffset
```
Be aware that this is the number of pages presented in view p1. But this equals the page index of the next page that is not visible. That's all! And from this we see, that this will even work if we generalize pageOffset, as stated above, since the only restriction for pageOffset used is 0 <= pageOffset < gridSize.

**Btw:** We simplify the odd logic of method pageStep to an equivalent logic. From this you can readily see that variable result will never be uninitialized at the end.