### PR TITLE
init custom Grid dialog with current values

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -1919,6 +1919,11 @@ void PDFWidget::goLast()
 	getScrollArea()->goToPage(realNumPages() - 1);
 }
 
+int PDFWidget::gridRows() const
+{
+	return gridy;
+}
+
 void PDFWidget::goForward()
 {
 	if (pageHistoryIndex + 1 < pageHistory.size()) {
@@ -2627,7 +2632,7 @@ void PDFDocument::setupMenus(bool embedded)
     menuFile=configManager->newManagedMenu(menuroot,menubar,"pdf/file",QApplication::translate("PDFDocument", "&File"));
     menuEdit_2=configManager->newManagedMenu(menuroot,menubar,"pdf/edit",QApplication::translate("PDFDocument", "&Edit"));
     menuView=configManager->newManagedMenu(menuroot,menubar,"pdf/view",QApplication::translate("PDFDocument", "&View"));
-    menuGrid=configManager->newManagedMenu(menuView,nullptr,"pdf/view/grid",QApplication::translate("PDFDocument", "Grid"));
+    menuGrid=configManager->newManagedMenu(menuView,nullptr,"pdf/view/grid",QApplication::translate("PDFDocument", "Grid (x,y)"));
     menuWindow=configManager->newManagedMenu(menuroot,menubar,"pdf/window",QApplication::translate("PDFDocument", "&Window"));
     menuEdit=configManager->newManagedMenu(menuroot,menubar,"pdf/config",QApplication::translate("PDFDocument", "&Configure"));
     menuHelp=configManager->newManagedMenu(menuroot,menubar,"pdf/help",QApplication::translate("PDFDocument", "&Help"));
@@ -3442,7 +3447,9 @@ void PDFDocument::setGrid()
 	QString gs = sender()->property("grid").toString();
 	if (gs == "xx") {
 		UniversalInputDialog d;
-		int x = 1, y = 1;
+		int x, y;
+		x = pdfWidget->gridCols();
+		y = pdfWidget->gridRows();
 		d.addVariable(&x , "X-Grid:");
 		d.addVariable(&y , "Y-Grid:");
 		if (d.exec()) {

--- a/src/pdfviewer/PDFDocument.h
+++ b/src/pdfviewer/PDFDocument.h
@@ -183,6 +183,7 @@ public:
 	Q_INVOKABLE int realNumPages() const;
 	Q_INVOKABLE int pageStep();
 	Q_INVOKABLE int gridCols() const;
+	Q_INVOKABLE int gridRows() const;
 	Q_INVOKABLE int gridRowHeight() const;
 	Q_INVOKABLE int gridBorder() const;
 	Q_INVOKABLE PDFDocument *getPDFDocument();


### PR DESCRIPTION
This PR enhances usage of the custom grid dialog. To reproduce follow instructions:

1. open pdf doc with more than 4 pages in windowed (internal) pdf-viewer
2. menu settings: uncheck Continuous and Single Page Step.
3. setup a grid with 1 row and 2 columns. At first it is not clear what to choose in the Grid menu. Choose 2x1, not 1x2.
4. choose Custom... from Grid menu. Dialog shows with value1 for both x and y. To add a second line to the grid we have to change both values.

**Enhancement:** Initialize the custom Grid dialog to the current grid values.

**Example:** Assume you have a current custom grid of 4x2 and you want to change this to 4x1. This can easily be done now by changing size of y:
![grafik](https://user-images.githubusercontent.com/102688820/170471698-7eefc53f-e994-4ef4-9099-d8fc87453c8d.png)

**Btw:** To clarify the meaning of the sublist items, menu Grid now shows as Grid (x,y). So one can clearly distinguish that 2x1 is not the terminology from matrices in math (rows x columns):
![grafik](https://user-images.githubusercontent.com/102688820/170475567-f4ab8604-a9d3-4a73-be29-b3349e8c3bfe.png)
