### PR TITLE
fix search page display

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -3692,7 +3692,7 @@ void PDFDocument::search(const QString &searchText, bool backwards, bool increme
 			if (pageIdx < 0 || pageIdx >= pdfWidget->realNumPages())
 				return;
 
-			statusBar()->showMessage(tr("Searching for") + QString(" '%1' (Page %2)").arg(searchText).arg(pageIdx), 1000);
+			statusBar()->showMessage(tr("Searching for") + QString(" '%1' (Page %2)").arg(searchText).arg(pageIdx+1), 1000);
 
             std::unique_ptr<Poppler::Page> page(document->page(pageIdx));
 			if (!page)


### PR DESCRIPTION
this PR fixes page display with search result, which shows current page index

**Example:** Searched word _Rätsel_ is on first page.
Before fix:
![grafik](https://user-images.githubusercontent.com/102688820/170590541-ef9c983f-e09b-414e-b523-f63bc267ce4b.png)

After fix:
![grafik](https://user-images.githubusercontent.com/102688820/170590743-e5475bbe-f254-4051-8e2b-61025fe90482.png)
