### PR TITLE
simplify copy pos to clipboard

### DIFF
--- a/src/pdfviewer/PDFDocument.h
+++ b/src/pdfviewer/PDFDocument.h
@@ -242,7 +242,7 @@ public slots:
 	void fitWindow(bool checked = true);
 	void setTool(int tool);
 	void syncWindowClick(const QPoint &p, bool activate);
-	void callGetPosFromClick(const QPoint &p);
+	void getPosFromClick(const QPoint &p);
 	void syncCurrentPage(bool activate);
 	void fixedScale(qreal scale = 1.0);
 	void setImage(QPixmap img, int pageNr);
@@ -253,7 +253,6 @@ signals:
 	void changedZoom(qreal);
 	void changedScaleOption(autoScaleOption);
 	void syncClick(int, const QPointF &, bool activate); //page position in page coordinates
-	void getPosFromCLick(const QPointF &);
 
 protected:
 	virtual void paintEvent(QPaintEvent *event);
@@ -470,7 +469,6 @@ private slots:
 	void enableZoomActions(qreal);
 	void adjustScaleActions(autoScaleOption);
 	void syncClick(int page, const QPointF &pos, bool activate);
-	void getPosFromCLick(const QPointF &pos);
 	void stopReloadTimer();
 	void reloadWhenIdle();
 	void idleReload();


### PR DESCRIPTION
This PR fixes a problem with ctrl+shift+click, which copies page coodinates in cm to the clippboard

- prev. version did not copy from pages on first grid view (i.e. realPageIndex = 0) in case of grid with 2 columns (2<sup>nd</sup> function received page = -1 from pageFromPos)

**Fix:** Merged separate functions, no more Signals. Working example after fix:

![grafik](https://user-images.githubusercontent.com/102688820/170883098-878ab4b2-261d-46d0-8c21-47ed0e1d7f6e.png)

**Btw:** renamed callGetPosFromClick to getPosClick