### PR TITLE
set pageOffset by mouse click on grid column

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -564,7 +564,7 @@ PDFWidget::PDFWidget(bool embedded)
 	, currentTool(kNone)
 	, usingTool(kNone)
 	, singlePageStep(true)
-	, gridx(1), gridy(1)
+	, gridx(1), gridy(1), pageOffset(0)
 	, forceUpdate(false)
 	, highlightPage(-1)
     , pdfdocument(nullptr)
@@ -804,9 +804,10 @@ void PDFWidget::paintEvent(QPaintEvent *event)
 			}
 
 			int curGrid = 0;
-			if (getPageOffset() && realPageIndex == 0) {
-				painter.drawRect(gridPageRect(0));
-				curGrid++;
+			if (realPageIndex == 0) {
+				for (; curGrid < getPageOffset(); curGrid++ ) {
+					painter.drawRect(gridPageRect(curGrid));
+				}
 			}
 			foreach (int pageNr, pages) {
 				QRect basicGrid = gridPageRect(curGrid++);
@@ -890,13 +891,14 @@ void PDFWidget::useDraggableTool(PDFDraggableTool* tool, const QMouseEvent *inEv
 // Mouse control for the various tools:
 // * magnifier
 //   - ctrl-click to sync
-//   - click to use magnifier
-//   - shift-click to zoom in
+//   - click to use magnifier (custom magnifier cursor)
+//   - shift-click to zoom in (custom plus sign cursor)
+//   - alt-click to zoom out (custom minus sign cursor)
 //   - shift-click and drag to zoom to selected area
-//   - alt-click to zoom out
 // * scroll (hand)
 //   - ctrl-click to sync
-//   - click and drag to scroll
+//   - shift-click to set pageOffset to gridColumn (ArrowCursor)
+//   - click and drag to scroll	(ClosedHandCursor)
 //   - double-click to use magnifier
 // * select area (crosshair)
 //   - ctrl-click to sync
@@ -945,8 +947,12 @@ void PDFWidget::mousePressEvent(QMouseEvent *event)
 	}
 
 	mouseDownModifiers = event->modifiers();
-	if (mouseDownModifiers & Qt::ControlModifier) {
+	if ((mouseDownModifiers & Qt::ControlModifier) && !(mouseDownModifiers & Qt::ShiftModifier)) {
 		// ctrl key - this is a sync click, don't handle the mouseDown here
+	} else if ((mouseDownModifiers & Qt::ControlModifier) && (mouseDownModifiers & Qt::ShiftModifier)) {
+		// ctrl + shift keys -> copy page coordinates in cm to clipboard
+	} else if ((mouseDownModifiers & Qt::ShiftModifier) && currentTool == kScroll) {
+		// shift key with scroll hand -> set pageOffset
 	} else if (currentTool != kPresentation) {
 		QPointF scaledPos;
 		int pageNr;
@@ -1071,6 +1077,7 @@ void PDFWidget::getPosFromClick(const QPoint &p){
 	QString tmp;
 	QTextStream(&tmp) << "" << pos.x() * ptToCm  << ", " << height- pos.y() * ptToCm;
 	clipboard->setText(tmp);
+	//qDebug() << "Position: " << qPrintable(tmp) << "\n";
 }
 
 void PDFWidget::mouseReleaseEvent(QMouseEvent *event)
@@ -1118,6 +1125,12 @@ void PDFWidget::mouseReleaseEvent(QMouseEvent *event)
 				if (event->modifiers() & Qt::ControlModifier)
 					syncWindowClick(event->pos(), true);
 				break;
+			}
+			// Shift-click (in scroll mode) on page or grid to set pageOffset to gridColumn
+			if ((currentTool == kScroll) && (mouseDownModifiers & Qt::ShiftModifier)) {
+				if (event->modifiers() & Qt::ShiftModifier) {
+					setPageOffsetClick(event->pos());
+				}
 			}
 			// check whether to zoom
 			if (currentTool == kMagnifier) {
@@ -1534,12 +1547,16 @@ void PDFWidget::updateCursor()
 	if (usingTool != kNone)
 		return;
 
+	Qt::KeyboardModifiers mods = QApplication::keyboardModifiers();
 	switch (currentTool) {
-	case kScroll:
-		setCursor(Qt::OpenHandCursor);
-		break;
+	case kScroll: {
+		if ((mods & Qt::ShiftModifier) && !(mods & Qt::ControlModifier))
+			setCursor(Qt::ArrowCursor);
+		else
+			setCursor(Qt::OpenHandCursor);
+	}
+	break;
 	case kMagnifier: {
-		Qt::KeyboardModifiers mods = QApplication::keyboardModifiers();
 		if (mods & Qt::AltModifier)
 			setCursor(*zoomOutCursor);
 		else if (mods & Qt::ShiftModifier)
@@ -1818,9 +1835,41 @@ PDFDocument *PDFWidget::getPDFDocument()
 	return doc;
 }
 
+void PDFWidget::setPageOffset(int offset, bool setAsDefault, bool refresh){
+	int lastPageOffset = pageOffset;
+	if (0 <= offset && offset < gridx)
+		pageOffset = offset;
+	else {
+		pageOffset = gridx - 1;
+		globalConfig->pageOffset = pageOffset;
+	}
+	if (!setAsDefault)
+		globalConfig->pageOffset = pageOffset;
+
+	if (!refresh)
+		return;
+	int delta = pageOffset - lastPageOffset;
+	if (delta != 0) {
+		PDFScrollArea	*scrollArea = getScrollArea();
+		if (!scrollArea->getContinuous())
+			scrollArea->goToPage(realPageIndex - delta);	// keep position
+		reloadPage();
+		emit scrollArea->resized();
+		scrollArea->updateScrollBars();
+	}
+}
+
+void PDFWidget::setPageOffsetClick(const QPoint &p){
+	int pi = gridPageIndex(p);
+	if (pi < 0 || singlePageStep) return;
+	int pageOffset = pi % gridx;
+	setPageOffset(pageOffset, false, true);
+}
+
 int PDFWidget::getPageOffset() const
 {
-	int pageOffset = (!singlePageStep) && (gridCols() == 2) ? 1 : 0;
+	if (singlePageStep)
+		return 0;
 	return pageOffset;
 }
 
@@ -1830,6 +1879,13 @@ void PDFWidget::setGridSize(int gx, int gy, bool setAsDefault)
 		return;
 	gridx = gx;
 	gridy = gy;
+	if (gridx == 1)
+		setPageOffset(0, true, true);
+	else if (gridx == 2 && gridy == 1)
+		setPageOffset(1, false, true);
+	else
+		setPageOffset(globalConfig->pageOffset, true, true);
+
 	if (setAsDefault)
 		return;
 	int pi = realPageIndex;
@@ -2070,15 +2126,17 @@ void PDFWidget::doPageDialog()
 
 int PDFWidget::normalizedPageIndex(int p)
 {
-	if (p > 0) return  p - (p + getPageOffset()) % pageStep();
-	else return p;
+	int nPI = p - (p + getPageOffset()) % pageStep();  // this gives numbers from sequence a_n := -pageOffset + n * pageStep. We have a_0 = -pageOffset <= 0. For n > 0 inequality a_n > 0 holds.
+	if (nPI < 0)
+		nPI = 0;	// let a_0 = 0
+	return nPI;
 }
 
 void PDFWidget::goToPageDirect(int p, bool sync)
 {
 	if (p < 0) p = 0;
 	if (p >= realNumPages()) p = realNumPages() - 1;
-    p = normalizedPageIndex(p);
+	p = normalizedPageIndex(p);
 	if (p != realPageIndex && !document.isNull()) { //the first condition is important: it prevents a recursive sync crash
 		if (p >= 0 && p < realNumPages()) {
 			realPageIndex = p;
@@ -2401,10 +2459,6 @@ QRect PDFWidget::pageRect(int page) const
     int realSizeH =  qRound(dpi * scaleFactor / 72.0 * popplerPage->pageSizeF().height());
 	int xOffset = (grect.width() - realSizeW) / 2;
 	int yOffset = (grect.height() - realSizeH) / 2;
-	if (gridx == 2 && getPageOffset() == 1) {
-		if (page & 1) xOffset *= 2;
-		else xOffset = 0;
-	}
 	return QRect(grect.left() + xOffset, grect.top() + yOffset, realSizeW, realSizeH);
 }
 
@@ -3004,6 +3058,8 @@ void PDFDocument::init(bool embedded)
 		conf->registerOption("Preview/GridX", &globalConfig->gridx, 1);
 		conf->registerOption("Preview/GridY", &globalConfig->gridy, 1);
 		pdfWidget->setGridSize(globalConfig->gridx, globalConfig->gridy, true);
+		conf->registerOption("Preview/PageOffset", &globalConfig->pageOffset, 0);
+		pdfWidget->setPageOffset(globalConfig->pageOffset, true);
         // set grid menu entry checked
         QString gs=QString("%1x%2").arg(globalConfig->gridx).arg(globalConfig->gridy);
         bool found=false;
@@ -3027,6 +3083,7 @@ void PDFDocument::init(bool embedded)
         conf->linkOptionToObject(&globalConfig->continuous, actionContinuous, LO_NONE);
 	} else {
 		pdfWidget->setGridSize(1, 1, true);
+		pdfWidget->setPageOffset(0, true);
 		pdfWidget->setSinglePageStep(true);
 		scrollArea->setContinuous(true);
 	}

--- a/src/pdfviewer/PDFDocument.h
+++ b/src/pdfviewer/PDFDocument.h
@@ -178,6 +178,8 @@ public:
     Q_INVOKABLE void reloadPage(bool sync = true);
 	void updateStatusBar();
 	void setGridSize(int gx, int gy, bool setAsDefault = false);
+	void setPageOffset(int offset, bool setAsDefault = false, bool refresh = false);
+	void setPageOffsetClick(const QPoint &p);
 	Q_INVOKABLE int visiblePages() const;
 	Q_INVOKABLE int pseudoNumPages() const;
 	Q_INVOKABLE int realNumPages() const;
@@ -335,7 +337,7 @@ private:
 	int		usingTool;	// the tool actually being used in an ongoing mouse drag
 	bool		singlePageStep;
 
-	int gridx, gridy;
+	int gridx, gridy, pageOffset;
 
 	bool forceUpdate;
 

--- a/src/pdfviewer/PDFDocument_config.h
+++ b/src/pdfviewer/PDFDocument_config.h
@@ -43,7 +43,7 @@ struct PDFDocumentConfig {
 	bool followFromCursor, followFromScroll, syncViews;
 	bool invertColors;
 	bool grayscale;
-	int gridx, gridy;
+	int gridx, gridy, pageOffset;
 };
 
 #endif // PDFDOCUMENT_CONFIG_H


### PR DESCRIPTION
This PR resolves #2190 (enhancement request) in that it supports to choose/set offset to the right for page 1 by using shift+click on the grid's rectangles. This mode of operation is signaled by changing the cursor to ArrowCursor on pressing shift. You must enable _Scroll_ (s. hand icon in toolbar) in txs to use this feature.

The grid rectangle you click on need not contain a page of the document and you need not to scroll up to page 1. After the click the value of variable pageOffset is set such that page 1 of the document is moved left/right to that column you clicked. Grid rectangles before page 1 stay empty.

Anything said before applies to grids of any size. By this we circumvent easily the restriction that has been imposed to grids with two columns, where page 1 has always been moved to the 2<sup>nd</sup> column (this is now the default, when setting up grid 2x1). The value of pageOffset is stored in the ini file. If you setup a grid that is too narrow for the current pageOffset, then pageOffset is reset to rightmost column. As pageOffset is an index, it counts columns starting from 0 for first column. In any case inequality 0 <= pageOffset < gridx holds, where gridx is the number of columns of the grid. Since embedded viewer is forced to use gridx = 1, you (currently) can't use this feature there.

**Btw:** A small enhancement to normalizedPageIndex will map all page indices p of the first grid to realPageIndex = 0. The current version maps p = 0 to 0. If everything is correct then this should be enough. But it may happen that someone tries to normalize a page index greater one (there can be many on a bigger grid) that should have normalizedIndex = 0. But in this case the normalization would miss the special case that -pageOffset should be mapped to 0.

## Examples

Open a document in windowed (and internal) pdf-viewer. Uncheck single page step (otherwise pageOffset = 0), choose a grid of size 2x2 and enable _Scroll_ mode. By default title page is to the left:
   
![grafik](https://user-images.githubusercontent.com/102688820/170892908-ee969570-3583-4203-bbd5-647c2c7fcddc.png)
There are equal images on page 2 and 3. They belong together (same with pages 4 and 5, and so on). To present them side by side, we change operation mode by pressing shift key such that the cursor changes to arrow (move mouse a small amount):

![grafik](https://user-images.githubusercontent.com/102688820/170893247-60e97730-8265-400c-8fe1-e2d1fc9ea4b6.png)
      Page offset changes after pressing (on page to the right ) and releasing the left mouse button. Release shift key:

![grafik](https://user-images.githubusercontent.com/102688820/170893368-6a66d59b-2d61-4c51-915f-9b5164c24416.png)
We can check Continuous mode in the View menu and scroll down a little bit, so we can see next pair of images side by side:

![grafik](https://user-images.githubusercontent.com/102688820/170893457-bd64f775-66c6-40d2-8f57-45ea08f34dbc.png)
We wish to better use the area in the canvas. So we decide to use a grid of 4x2 (use Custom... in Grid menu):

![grafik](https://user-images.githubusercontent.com/102688820/170893660-f4185bc9-a89c-4d13-bc16-3694746bebed.png)
Maybe we are still not satisfied since the first line holds more than the title page. Also to keep pages 2 and 3 together we have to move the title page to the end of line. With shift+click we get:

![grafik](https://user-images.githubusercontent.com/102688820/170893747-cc02c1f1-ab0e-4a85-953b-bec1be5673c3.png)
Now we uncheck Continuos and choose a grid of 6x2. Since the first page is still in the 4<sup>th</sup> column, we have 3+6 pages in the first grid and 10 pages on the next grid (from a total of 19 pages, s. image), leaving free 2 grid rectangles. This can be seen, when we jump to the end:

![grafik](https://user-images.githubusercontent.com/102688820/170894228-bf0abf98-f11a-45aa-bd37-6b18cf980071.png)
To fill up the last line we move first page from 4<sup>th</sup> to 6<sup>th</sup> column. For this we can click on the last page in the first row shown in the previous image or on the rectangle below it without a page (imagine missing pages at the end, same at the beginning):

![grafik](https://user-images.githubusercontent.com/102688820/170894569-1d4e7608-7a9e-4e5c-b6fd-508731f17293.png)
And the result is as expected:

![grafik](https://user-images.githubusercontent.com/102688820/170894654-fae9ed34-5837-40c2-87f7-e5026f43f73e.png)
If we stop txs now, we find in the ini file:
```
Preview\GridX=6
Preview\GridY=2
Preview\PageOffset=5
```
