### PR TITLE
detect screen dpi for config

### DIFF
--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -749,7 +749,9 @@ ConfigManager::ConfigManager(QObject *parent): QObject (parent),
 #if (QT_VERSION<QT_VERSION_CHECK(6,0,0))
     int dpi=QApplication::desktop()->logicalDpiX();
 #else
-    int dpi=72; // how to access main screen dpi?
+    int dpi = qRound(QGuiApplication::primaryScreen()->physicalDotsPerInch()); // main screen dpi
+	if (dpi < 10 || dpi > 1000)
+		dpi = 96;
 #endif
 	registerOption("Preview/DPI", &pdfDocumentConfig->dpi, dpi, &pseudoDialog->spinBoxPreviewDPI);
 	registerOption("Preview/Scale Option", &pdfDocumentConfig->scaleOption, 1, &pseudoDialog->comboBoxPreviewScale);


### PR DESCRIPTION
This PR enhances first start of txs. Instead of setting screen resolution to 72dpi it now uses [Qt](https://doc.qt.io/qt-6/qscreen.html#physicalDotsPerInch-prop) do determine screen resolution. This will avoid irritation, when user views pdf at 100% but finds displayed pages not in original size.

Resolves #2385 

![grafik](https://user-images.githubusercontent.com/102688820/172525514-03e9cff1-ad1c-4d90-97fd-32900be39a30.png)
