### PR TITLE
better accuracy for pageSize on fitWindow

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -1664,9 +1664,10 @@ void PDFWidget::updateCursor(const QPoint &pos)
 void PDFWidget::adjustSize()
 {
 	if (pages.empty()) return;
-	QSize pageSize = (maxPageSizeFDpiAdjusted() * scaleFactor).toSize();
-	pageSize.rwidth() = pageSize.rwidth() * gridx + (gridx - 1) * GridBorder;
-	pageSize.rheight() = pageSize.rheight() * gridy + (gridy - 1) * GridBorder;
+	QSizeF pageSizeF = (maxPageSizeFDpiAdjusted() * scaleFactor);
+	QSize pageSize;
+	pageSize.rwidth() = qRound(pageSizeF.rwidth() * gridx + (gridx - 1) * GridBorder);
+	pageSize.rheight() = qRound(pageSizeF.rheight() * gridy + (gridy - 1) * GridBorder);
 	if (pageSize != size()) {
 		PDFScrollArea *scrollArea = getScrollArea();
 		if (!scrollArea) return;


### PR DESCRIPTION
This PR fixes a problem (c.f. #2388) in the pdf-viewer when using fit to window. Reason: Calculating the scaled page size in screen dots is affected by loss of precision (integer arithmetic). Thus in some cases the size of the viewport is 1 pixel less than the result of the calculations. Srcolling 1 pixel appears instead of going to next/previous page.