### PR TITLE
show screen dpi in Pdf Viewer Config

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -394,6 +394,10 @@ ConfigDialog::ConfigDialog(QWidget *parent): QDialog(parent,Qt::Dialog|Qt::Windo
     // adapt icon size to dpi
     double dpi=QGuiApplication::primaryScreen()->logicalDotsPerInch();
     double scale=dpi/96;
+	int systemdpi = qRound(QGuiApplication::primaryScreen()->physicalDotsPerInch()); // main screen dpi
+	if (systemdpi < 10 || dpi > 1000)
+		systemdpi = 96;
+	QString labelSystemdpi = tr("Screen Resolution") + " (" + tr("System") + QString(": %1 dpi").arg(systemdpi) + "):";
 
 	setModal(true);
 	ui.setupUi(this);
@@ -580,6 +584,7 @@ ConfigDialog::ConfigDialog(QWidget *parent): QDialog(parent,Qt::Dialog|Qt::Windo
 	ui.comboBoxPreviewMode->removeItem(l - 1);
 	// maybe add some possibility to disable some preview modes in poppler mode
 #endif
+	ui.labelScreenResolution->setText(labelSystemdpi);
 
 	// set-up GUI scaling
 	connect(ui.tbRevertIcon, SIGNAL(clicked()), this, SLOT(revertClicked()));

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -4269,9 +4269,9 @@ them here.</string>
                </widget>
               </item>
               <item row="4" column="0">
-               <widget class="QLabel" name="label_27">
+               <widget class="QLabel" name="labelScreenResolution">
                 <property name="text">
-                 <string>Screen Resolution:</string>
+                 <string notr="true">&lt;ScreenResolution&gt;</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
This PR enhances diplay of the Pdf Viewer Config dialog, which now presents the system screen resolution (s, same line where you set the value). So the user need not calculate the correct value in case she uses a different display or has changed the value for some reason.

### Example
![grafik](https://user-images.githubusercontent.com/102688820/172716982-841364a2-9a15-4683-b108-bd8968d2e2c5.png)


