### PR TITLE
mark grid menu entry after canceling Grid Dialog

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -3521,6 +3521,21 @@ void PDFDocument::setGrid()
 			pdfWidget->setGridSize(x, y);
 			globalConfig->gridx = x;
 			globalConfig->gridy = y;
+		} else {
+			// set grid menu entry checked
+			QString gs=QString("%1x%2").arg(globalConfig->gridx).arg(globalConfig->gridy);
+			bool found=false;
+			for(QAction *a:actionGroupGrid->actions()){
+				if(a->property("grid").toString()==gs){
+					a->setChecked(true);
+					found=true;
+					break;
+				}
+			}
+			if(!found){
+				// if no other grid action fits, use custom
+				actionCustom->setChecked(true);
+			}
 		}
 	} else {
 		int p = gs.indexOf("x");


### PR DESCRIPTION
As discussed [here](https://github.com/texstudio-org/texstudio/commit/05e561aa390366d8df49287476395f2b4f10eaeb#commitcomment-74580745) this PR fixes the problem after canceling the custom grid dialog that entry _Custom Grid..._ is checked in the menu instead of a normal grid when possible. Code used is same by @sunderme in 2e7a5b3, thx.