### PR TITLE
Added cut, copy and paste functionality to the Array and Tabular Wizard.

### DIFF
--- a/src/arraydialog.cpp
+++ b/src/arraydialog.cpp
@@ -120,7 +120,7 @@ void ArrayDialog::keyPressEvent(QKeyEvent *event)
         int end_row = list[0]->row();
         int start_col = list[0]->column();
         int end_col = list[0]->column();
-        for (QTableWidgetItem *item : list)
+        for(QTableWidgetItem *item : list)
         {
             if (item->row() < start_row)
             {
@@ -140,9 +140,9 @@ void ArrayDialog::keyPressEvent(QKeyEvent *event)
             }
         }
 
-        for (int row=start_row; row <= end_row; ++row)
+        for(int row=start_row; row <= end_row; ++row)
         {
-            for (int col=start_col; col <= end_col; ++col)
+            for(int col=start_col; col <= end_col; ++col)
             {
                 QTableWidgetItem *item = ui.tableWidget->item(row, col);
                 copied_text += item->text();
@@ -182,7 +182,7 @@ void ArrayDialog::keyPressEvent(QKeyEvent *event)
         int end_row = list[0]->row();
         int start_col = list[0]->column();
         int end_col = list[0]->column();
-        for (QTableWidgetItem *item : list)
+        for(QTableWidgetItem *item : list)
         {
             if (item->row() < start_row)
             {
@@ -202,9 +202,9 @@ void ArrayDialog::keyPressEvent(QKeyEvent *event)
             }
         }
 
-        for (int row=start_row; row <= end_row; ++row)
+        for(int row=start_row; row <= end_row; ++row)
         {
-            for (int col=start_col; col <= end_col; ++col)
+            for(int col=start_col; col <= end_col; ++col)
             {
                 QTableWidgetItem *item = ui.tableWidget->item(row, col);
                 copied_text += item->text();
@@ -244,7 +244,7 @@ void ArrayDialog::keyPressEvent(QKeyEvent *event)
 
         int cur_row = starting_row;
         int cur_col = starting_col;
-        for (QString row : rows)
+        for(const QString &row : rows)
         {
             if (cur_row >= ui.tableWidget->rowCount())
             {
@@ -253,7 +253,7 @@ void ArrayDialog::keyPressEvent(QKeyEvent *event)
             }
 
             QList<QString> cols = row.split('\t');
-            for (QString col : cols)
+            for(const QString &col : cols)
             {
                 if (cur_col >= ui.tableWidget->columnCount())
                 {
@@ -287,7 +287,7 @@ void ArrayDialog::keyPressEvent(QKeyEvent *event)
     if (event->key() == Qt::Key_Delete)
     {
         QList<QTableWidgetItem *> list = ui.tableWidget->selectedItems();
-        for (QTableWidgetItem* i : list)
+        for(QTableWidgetItem* i : list)
         {
             i->setText("");
         }

--- a/src/arraydialog.cpp
+++ b/src/arraydialog.cpp
@@ -90,3 +90,206 @@ void ArrayDialog::newRows(int num) {
 void ArrayDialog::newColumns(int num) {
 	ui.tableWidget->setColumnCount(num);
 }
+
+void ArrayDialog::keyPressEvent(QKeyEvent *event)
+{
+    // Table Copy
+    // This code captures the cells text values and puts them to clipboard.
+    // Data is tab spaced for pasting into spreadsheet applications such as LibreOffice Calc.
+    if ((event->modifiers() == Qt::CTRL) && (event->key() == Qt::Key_C))
+    {
+        // Check to ensure selection exists.
+        QItemSelectionModel *selection_model = ui.tableWidget->selectionModel();
+        if (selection_model)
+        {
+            QModelIndexList indexList = selection_model->selectedIndexes();
+            if (indexList.count() <= 0)
+            {
+                return;
+            }
+        }
+        else
+        {
+            return;
+        }
+
+        QString copied_text = "";
+        QList<QTableWidgetItem *> list = ui.tableWidget->selectedItems();
+
+        int start_row = list[0]->row();
+        int end_row = list[0]->row();
+        int start_col = list[0]->column();
+        int end_col = list[0]->column();
+        for (QTableWidgetItem *item : list)
+        {
+            if (item->row() < start_row)
+            {
+                start_row = item->row();
+            }
+            if (item->row() > end_row)
+            {
+                end_row = item->row();
+            }
+            if (item->column() < start_col)
+            {
+                start_col = item->column();
+            }
+            if (item->column() > end_col)
+            {
+                end_col = item->column();
+            }
+        }
+
+        for (int row=start_row; row <= end_row; ++row)
+        {
+            for (int col=start_col; col <= end_col; ++col)
+            {
+                QTableWidgetItem *item = ui.tableWidget->item(row, col);
+                copied_text += item->text();
+                if (col < ui.tableWidget->columnCount() - 1)
+                {
+                    copied_text += "\t";
+                }
+            }
+            copied_text += "\n";
+        }
+        QClipboard *clipboard = QGuiApplication::clipboard();
+        clipboard->setText(copied_text);
+    }
+
+    // Cut
+    if ((event->modifiers() == Qt::CTRL) && (event->key() == Qt::Key_X))
+    {
+        // Check to ensure selection exists.
+        QItemSelectionModel *selection_model = ui.tableWidget->selectionModel();
+        if (selection_model)
+        {
+            QModelIndexList indexList = selection_model->selectedIndexes();
+            if (indexList.count() <= 0)
+            {
+                return;
+            }
+        }
+        else
+        {
+            return;
+        }
+
+        QString copied_text = "";
+        QList<QTableWidgetItem *> list = ui.tableWidget->selectedItems();
+
+        int start_row = list[0]->row();
+        int end_row = list[0]->row();
+        int start_col = list[0]->column();
+        int end_col = list[0]->column();
+        for (QTableWidgetItem *item : list)
+        {
+            if (item->row() < start_row)
+            {
+                start_row = item->row();
+            }
+            if (item->row() > end_row)
+            {
+                end_row = item->row();
+            }
+            if (item->column() < start_col)
+            {
+                start_col = item->column();
+            }
+            if (item->column() > end_col)
+            {
+                end_col = item->column();
+            }
+        }
+
+        for (int row=start_row; row <= end_row; ++row)
+        {
+            for (int col=start_col; col <= end_col; ++col)
+            {
+                QTableWidgetItem *item = ui.tableWidget->item(row, col);
+                copied_text += item->text();
+                item->setText("");
+                if (col < ui.tableWidget->columnCount() - 1)
+                {
+                    copied_text += "\t";
+                }
+            }
+            copied_text += "\n";
+        }
+        QClipboard *clipboard = QGuiApplication::clipboard();
+        clipboard->setText(copied_text);
+    }
+
+    // Table Paste
+    // Allows pasting of cell data from spreadsheet applications such as LibreOffice Calc.
+    if ((event->modifiers() == Qt::CTRL) && (event->key() == Qt::Key_V))
+    {
+        QClipboard *clipboard = QGuiApplication::clipboard();
+        QString pasted_text = clipboard->text();
+        QList<QString> rows = pasted_text.split('\n');
+
+        // Get indexes of currently selected cells.
+        int starting_row = 0;
+        int starting_col = 0;
+        QItemSelectionModel *selection_model = ui.tableWidget->selectionModel();
+        if (selection_model)
+        {
+            QModelIndexList indexList = selection_model->selectedIndexes();
+            if (indexList.count() > 0)
+            {
+                starting_row = selection_model->selectedIndexes().begin()->row();
+                starting_col = selection_model->selectedIndexes().begin()->column();
+            }
+        }
+
+        int cur_row = starting_row;
+        int cur_col = starting_col;
+        for (QString row : rows)
+        {
+            if (cur_row >= ui.tableWidget->rowCount())
+            {
+                ui.tableWidget->setRowCount(ui.tableWidget->rowCount() + 1);
+                ui.spinBoxRows->setValue(ui.spinBoxRows->value() + 1);
+            }
+
+            QList<QString> cols = row.split('\t');
+            for (QString col : cols)
+            {
+                if (cur_col >= ui.tableWidget->columnCount())
+                {
+                    ui.tableWidget->setColumnCount(ui.tableWidget->columnCount() + 1);
+                    ui.spinBoxColumns->setValue(ui.spinBoxColumns->value() + 1);
+                }
+
+                // Adds new item if copied size is larger than table size.
+                QTableWidgetItem *new_item = new QTableWidgetItem();
+                ui.tableWidget->setItem(cur_row, cur_col, new_item);
+
+                QTableWidgetItem *item = ui.tableWidget->item(cur_row, cur_col);
+                if (item) // Checks if item is a null pointer (item doesn't exist)
+                {
+                    item->setText(col);
+                    ++cur_col;
+                }
+                else
+                {
+                    QTableWidgetItem *newItem = new QTableWidgetItem();
+                    newItem->setText(col);
+                }
+            }
+            ++cur_row;
+            cur_col = starting_col;
+        }
+    }
+
+    // Table Delete Cells
+    // This feature allows cells to be deleted by selecting and clicking the delete key.
+    if (event->key() == Qt::Key_Delete)
+    {
+        QList<QTableWidgetItem *> list = ui.tableWidget->selectedItems();
+        for (QTableWidgetItem* i : list)
+        {
+            i->setText("");
+        }
+    }
+}

--- a/src/arraydialog.cpp
+++ b/src/arraydialog.cpp
@@ -226,7 +226,7 @@ void ArrayDialog::keyPressEvent(QKeyEvent *event)
     {
         QClipboard *clipboard = QGuiApplication::clipboard();
         QString pasted_text = clipboard->text();
-        QList<QString> rows = pasted_text.split('\n');
+        QList<QString> rows = pasted_text.split('\n', Qt::SkipEmptyParts);
 
         // Get indexes of currently selected cells.
         int starting_row = 0;

--- a/src/arraydialog.cpp
+++ b/src/arraydialog.cpp
@@ -226,7 +226,12 @@ void ArrayDialog::keyPressEvent(QKeyEvent *event)
     {
         QClipboard *clipboard = QGuiApplication::clipboard();
         QString pasted_text = clipboard->text();
+
+#if (QT_VERSION>=QT_VERSION_CHECK(5,14,0))
         QList<QString> rows = pasted_text.split('\n', Qt::SkipEmptyParts);
+#else
+        QList<QString> rows = pasted_text.split('\n', QString::SkipEmptyParts);
+#endif
 
         // Get indexes of currently selected cells.
         int starting_row = 0;

--- a/src/arraydialog.h
+++ b/src/arraydialog.h
@@ -28,6 +28,7 @@ public:
 protected slots:
 	void newRows(int num);
 	void newColumns(int num);
+    void keyPressEvent(QKeyEvent *event);
 };
 
 #endif

--- a/src/tabdialog.cpp
+++ b/src/tabdialog.cpp
@@ -549,7 +549,12 @@ void TabDialog::keyPressEvent(QKeyEvent *event)
     {
         QClipboard *clipboard = QGuiApplication::clipboard();
         QString pasted_text = clipboard->text();
+
+#if (QT_VERSION>=QT_VERSION_CHECK(5,14,0))
         QList<QString> rows = pasted_text.split('\n', Qt::SkipEmptyParts);
+#else
+        QList<QString> rows = pasted_text.split('\n', QString::SkipEmptyParts);
+#endif
 
         // Get indexes of currently selected cells.
         int starting_row = 0;

--- a/src/tabdialog.cpp
+++ b/src/tabdialog.cpp
@@ -413,3 +413,206 @@ spancolor.setAlphaF( 0.2 );*/
 		}
 	}
 }
+
+void TabDialog::keyPressEvent(QKeyEvent *event)
+{
+    // Table Copy
+    // This code captures the cells text values and puts them to clipboard.
+    // Data is tab spaced for pasting into spreadsheet applications such as LibreOffice Calc.
+    if ((event->modifiers() == Qt::CTRL) && (event->key() == Qt::Key_C))
+    {
+        // Check to ensure selection exists.
+        QItemSelectionModel *selection_model = ui.tableWidget->selectionModel();
+        if (selection_model)
+        {
+            QModelIndexList indexList = selection_model->selectedIndexes();
+            if (indexList.count() <= 0)
+            {
+                return;
+            }
+        }
+        else
+        {
+            return;
+        }
+
+        QString copied_text = "";
+        QList<QTableWidgetItem *> list = ui.tableWidget->selectedItems();
+
+        int start_row = list[0]->row();
+        int end_row = list[0]->row();
+        int start_col = list[0]->column();
+        int end_col = list[0]->column();
+        for (QTableWidgetItem *item : list)
+        {
+            if (item->row() < start_row)
+            {
+                start_row = item->row();
+            }
+            if (item->row() > end_row)
+            {
+                end_row = item->row();
+            }
+            if (item->column() < start_col)
+            {
+                start_col = item->column();
+            }
+            if (item->column() > end_col)
+            {
+                end_col = item->column();
+            }
+        }
+
+        for (int row=start_row; row <= end_row; ++row)
+        {
+            for (int col=start_col; col <= end_col; ++col)
+            {
+                QTableWidgetItem *item = ui.tableWidget->item(row, col);
+                copied_text += item->text();
+                if (col < ui.tableWidget->columnCount() - 1)
+                {
+                    copied_text += "\t";
+                }
+            }
+            copied_text += "\n";
+        }
+        QClipboard *clipboard = QGuiApplication::clipboard();
+        clipboard->setText(copied_text);
+    }
+
+    // Cut
+    if ((event->modifiers() == Qt::CTRL) && (event->key() == Qt::Key_X))
+    {
+        // Check to ensure selection exists.
+        QItemSelectionModel *selection_model = ui.tableWidget->selectionModel();
+        if (selection_model)
+        {
+            QModelIndexList indexList = selection_model->selectedIndexes();
+            if (indexList.count() <= 0)
+            {
+                return;
+            }
+        }
+        else
+        {
+            return;
+        }
+
+        QString copied_text = "";
+        QList<QTableWidgetItem *> list = ui.tableWidget->selectedItems();
+
+        int start_row = list[0]->row();
+        int end_row = list[0]->row();
+        int start_col = list[0]->column();
+        int end_col = list[0]->column();
+        for (QTableWidgetItem *item : list)
+        {
+            if (item->row() < start_row)
+            {
+                start_row = item->row();
+            }
+            if (item->row() > end_row)
+            {
+                end_row = item->row();
+            }
+            if (item->column() < start_col)
+            {
+                start_col = item->column();
+            }
+            if (item->column() > end_col)
+            {
+                end_col = item->column();
+            }
+        }
+
+        for (int row=start_row; row <= end_row; ++row)
+        {
+            for (int col=start_col; col <= end_col; ++col)
+            {
+                QTableWidgetItem *item = ui.tableWidget->item(row, col);
+                copied_text += item->text();
+                item->setText("");
+                if (col < ui.tableWidget->columnCount() - 1)
+                {
+                    copied_text += "\t";
+                }
+            }
+            copied_text += "\n";
+        }
+        QClipboard *clipboard = QGuiApplication::clipboard();
+        clipboard->setText(copied_text);
+    }
+
+    // Table Paste
+    // Allows pasting of cell data from spreadsheet applications such as LibreOffice Calc.
+    if ((event->modifiers() == Qt::CTRL) && (event->key() == Qt::Key_V))
+    {
+        QClipboard *clipboard = QGuiApplication::clipboard();
+        QString pasted_text = clipboard->text();
+        QList<QString> rows = pasted_text.split('\n');
+
+        // Get indexes of currently selected cells.
+        int starting_row = 0;
+        int starting_col = 0;
+        QItemSelectionModel *selection_model = ui.tableWidget->selectionModel();
+        if (selection_model)
+        {
+            QModelIndexList indexList = selection_model->selectedIndexes();
+            if (indexList.count() > 0)
+            {
+                starting_row = selection_model->selectedIndexes().begin()->row();
+                starting_col = selection_model->selectedIndexes().begin()->column();
+            }
+        }
+
+        int cur_row = starting_row;
+        int cur_col = starting_col;
+        for (QString row : rows)
+        {
+            if (cur_row >= ui.tableWidget->rowCount())
+            {
+                ui.tableWidget->setRowCount(ui.tableWidget->rowCount() + 1);
+                ui.spinBoxRows->setValue(ui.spinBoxRows->value() + 1);
+            }
+
+            QList<QString> cols = row.split('\t');
+            for (QString col : cols)
+            {
+                if (cur_col >= ui.tableWidget->columnCount())
+                {
+                    ui.tableWidget->setColumnCount(ui.tableWidget->columnCount() + 1);
+                    ui.spinBoxColumns->setValue(ui.spinBoxColumns->value() + 1);
+                }
+
+                // Adds new item if copied size is larger than table size.
+                QTableWidgetItem *new_item = new QTableWidgetItem();
+                ui.tableWidget->setItem(cur_row, cur_col, new_item);
+
+                QTableWidgetItem *item = ui.tableWidget->item(cur_row, cur_col);
+                if (item) // Checks if item is a null pointer (item doesn't exist)
+                {
+                    item->setText(col);
+                    ++cur_col;
+                }
+                else
+                {
+                    QTableWidgetItem *newItem = new QTableWidgetItem();
+                    newItem->setText(col);
+                }
+            }
+            ++cur_row;
+            cur_col = starting_col;
+        }
+    }
+
+    // Table Delete Cells
+    // This feature allows cells to be deleted by selecting and clicking the delete key.
+    if (event->key() == Qt::Key_Delete)
+    {
+        QList<QTableWidgetItem *> list = ui.tableWidget->selectedItems();
+        for (QTableWidgetItem* i : list)
+        {
+            i->setText("");
+        }
+    }
+}

--- a/src/tabdialog.cpp
+++ b/src/tabdialog.cpp
@@ -549,7 +549,7 @@ void TabDialog::keyPressEvent(QKeyEvent *event)
     {
         QClipboard *clipboard = QGuiApplication::clipboard();
         QString pasted_text = clipboard->text();
-        QList<QString> rows = pasted_text.split('\n');
+        QList<QString> rows = pasted_text.split('\n', Qt::SkipEmptyParts);
 
         // Get indexes of currently selected cells.
         int starting_row = 0;

--- a/src/tabdialog.cpp
+++ b/src/tabdialog.cpp
@@ -443,7 +443,7 @@ void TabDialog::keyPressEvent(QKeyEvent *event)
         int end_row = list[0]->row();
         int start_col = list[0]->column();
         int end_col = list[0]->column();
-        for (QTableWidgetItem *item : list)
+        for(QTableWidgetItem *item : list)
         {
             if (item->row() < start_row)
             {
@@ -463,9 +463,9 @@ void TabDialog::keyPressEvent(QKeyEvent *event)
             }
         }
 
-        for (int row=start_row; row <= end_row; ++row)
+        for(int row=start_row; row <= end_row; ++row)
         {
-            for (int col=start_col; col <= end_col; ++col)
+            for(int col=start_col; col <= end_col; ++col)
             {
                 QTableWidgetItem *item = ui.tableWidget->item(row, col);
                 copied_text += item->text();
@@ -505,7 +505,7 @@ void TabDialog::keyPressEvent(QKeyEvent *event)
         int end_row = list[0]->row();
         int start_col = list[0]->column();
         int end_col = list[0]->column();
-        for (QTableWidgetItem *item : list)
+        for(QTableWidgetItem *item : list)
         {
             if (item->row() < start_row)
             {
@@ -525,9 +525,9 @@ void TabDialog::keyPressEvent(QKeyEvent *event)
             }
         }
 
-        for (int row=start_row; row <= end_row; ++row)
+        for(int row=start_row; row <= end_row; ++row)
         {
-            for (int col=start_col; col <= end_col; ++col)
+            for(int col=start_col; col <= end_col; ++col)
             {
                 QTableWidgetItem *item = ui.tableWidget->item(row, col);
                 copied_text += item->text();
@@ -567,7 +567,7 @@ void TabDialog::keyPressEvent(QKeyEvent *event)
 
         int cur_row = starting_row;
         int cur_col = starting_col;
-        for (QString row : rows)
+        for(const QString &row : rows)
         {
             if (cur_row >= ui.tableWidget->rowCount())
             {
@@ -576,7 +576,7 @@ void TabDialog::keyPressEvent(QKeyEvent *event)
             }
 
             QList<QString> cols = row.split('\t');
-            for (QString col : cols)
+            for(const QString &col : cols)
             {
                 if (cur_col >= ui.tableWidget->columnCount())
                 {
@@ -610,7 +610,7 @@ void TabDialog::keyPressEvent(QKeyEvent *event)
     if (event->key() == Qt::Key_Delete)
     {
         QList<QTableWidgetItem *> list = ui.tableWidget->selectedItems();
-        for (QTableWidgetItem* i : list)
+        for(QTableWidgetItem* i : list)
         {
             i->setText("");
         }

--- a/src/tabdialog.h
+++ b/src/tabdialog.h
@@ -52,6 +52,7 @@ private slots:
   void showRowSettings(int row);
   void showColRowSettings(int row,int column);
   void updateTableWidget();
+  void keyPressEvent(QKeyEvent *event);
 private:
   QStringList alignlist;
   QStringList alignlistLabels;


### PR DESCRIPTION
# Cut / Copy / Paste Tabular Wizard
## Previous Issue
Users needed to manually type in each field, it did not allow cut/copy/paste/delete like a normal spreadsheet application.  This prevented users from quickly putting tables in from other applications.
## Solution
Added additional functions
Users can now cut / copy / paste / delete their selection in the Array and Tabular Wizard windows.  This data is normally tab separated.

The following shortcuts now work on the tables:

CTRL + C = COPY
CTRL + X = CUT
DELETE = DELETE
CTRL + V = PASTE