### PR TITLE
fix info in pdf-viewer docks (issue #2119)

### DIFF
--- a/src/pdfviewer/PDFDocks.cpp
+++ b/src/pdfviewer/PDFDocks.cpp
@@ -55,6 +55,7 @@ PDFDock::~PDFDock()
 
 void PDFDock::documentLoaded()
 {
+	filled = false;
 	if (!isHidden()) {
 		fillInfo();
 		filled = true;


### PR DESCRIPTION
This PR fixes #2199. The issue showed that information presented in the docks of the windowed pdf-viewer may be missing (pdfOutline) or be of a previous document (pdfOutline, pdfInfo, pdfOverview, ...). These docks can be enabled and disabled via menu Window/Show. The issue depends of the visibility of the docks at time you open the viewer or switch to another document.

The small change in code ensures that all docks are assumed not beeing filled when loading a new document, so data will be retrieved as necessary. Disabeling and (re) enabeling a dock will not reload data. In case that the document has no structure (chapter, ...) the pdfOutline shows _No TOC_.