### PR TITLE
Fixed logical error that caused a new item to be created every time.

### DIFF
--- a/src/arraydialog.cpp
+++ b/src/arraydialog.cpp
@@ -266,10 +266,6 @@ void ArrayDialog::keyPressEvent(QKeyEvent *event)
                     ui.spinBoxColumns->setValue(ui.spinBoxColumns->value() + 1);
                 }
 
-                // Adds new item if copied size is larger than table size.
-                QTableWidgetItem *new_item = new QTableWidgetItem();
-                ui.tableWidget->setItem(cur_row, cur_col, new_item);
-
                 QTableWidgetItem *item = ui.tableWidget->item(cur_row, cur_col);
                 if (item) // Checks if item is a null pointer (item doesn't exist)
                 {
@@ -278,8 +274,10 @@ void ArrayDialog::keyPressEvent(QKeyEvent *event)
                 }
                 else
                 {
+                    // Creates new item if item doesn't exist.
                     QTableWidgetItem *newItem = new QTableWidgetItem();
                     newItem->setText(col);
+                    ui.tableWidget->setItem(cur_row, cur_col, newItem);
                 }
             }
             ++cur_row;

--- a/src/tabdialog.cpp
+++ b/src/tabdialog.cpp
@@ -589,10 +589,6 @@ void TabDialog::keyPressEvent(QKeyEvent *event)
                     ui.spinBoxColumns->setValue(ui.spinBoxColumns->value() + 1);
                 }
 
-                // Adds new item if copied size is larger than table size.
-                QTableWidgetItem *new_item = new QTableWidgetItem();
-                ui.tableWidget->setItem(cur_row, cur_col, new_item);
-
                 QTableWidgetItem *item = ui.tableWidget->item(cur_row, cur_col);
                 if (item) // Checks if item is a null pointer (item doesn't exist)
                 {
@@ -601,8 +597,10 @@ void TabDialog::keyPressEvent(QKeyEvent *event)
                 }
                 else
                 {
+                    // Adds new item if copied size is larger than table size.
                     QTableWidgetItem *newItem = new QTableWidgetItem();
                     newItem->setText(col);
+                    ui.tableWidget->setItem(cur_row, cur_col, newItem);
                 }
             }
             ++cur_row;


### PR DESCRIPTION
Currently iteration of the loop will allocate new memory.  It should only do so when the existing item does not exist (null pointer).  The logic was previously there but not implemented correctly.