### PR TITLE
notice current update level (issue #2244)

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -1154,7 +1154,7 @@ void ConfigDialog::importDictionary()
 
 void ConfigDialog::updateCheckNow()
 {
-	UpdateChecker::instance()->check(false);
+	UpdateChecker::instance()->check(false, ui.comboBoxUpdateLevel->currentIndex());
 }
 
 void ConfigDialog::refreshLastUpdateTime()

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -585,7 +585,7 @@
                  <string> days</string>
                 </property>
                 <property name="minimum">
-                 <number>1</number>
+                 <number>0</number>
                 </property>
                 <property name="value">
                  <number>7</number>

--- a/src/updatechecker.h
+++ b/src/updatechecker.h
@@ -18,7 +18,7 @@ public:
 	static QString lastCheckAsString();
 	QString latestVersion() { return latestStableVersion.versionNumber; }  // returns the version number retrieved in last check(), empty if no check has been performed so far
 	void autoCheck();
-	void check(bool m_silent = true);
+	void check(bool m_silent = true, int currentComboBoxUpdateLevel = -1);
 
 signals:
 	void checkCompleted();


### PR DESCRIPTION
This PR fixes #2244 stating that in Config dialog/General the update button did not notice changes to the update level combo box, because the information had been taken from the config manager. This can be highly misleading. As a workaround close config manager, since config manager is updated only after closing the dialog (because one could press cancel). Check button now uses the current value of the combo box. This PR addresses the original part of the issue.

In addition:
- Bugfix: Searching release candidates has to stop after first hit, and same for development versions. Otherwise current dev will be beta1, even so beta2 exists, for example. This is because search starts at latest version (reverse search).
- Enhancement: The time for next run of auto update had minimal value of 1day which will suffice in most cases. But if someone wants txs to check on every start, value 0 is now available.
- Enhancement: Text in the window is now selectable with the mouse in case you want to copy it to the clipboard.
