### PR TITLE
fix update check

### DIFF
--- a/src/tests/utilsversion_t.h
+++ b/src/tests/utilsversion_t.h
@@ -12,12 +12,141 @@ class VersionTest: public QObject{
 public:
 	VersionTest(bool executeAllTests) : allTests(executeAllTests) {}
 private slots:
+	void parseGitData_data() {
+		QTest::addColumn<QString>("gitData");
+		QTest::addColumn<QStringList>("list");
+		QTest::addColumn<bool>("valid");
+
+		// s. issue #2244
+		QTest::newRow("parseGitData")
+			<< QString( "[{\"ref\":\"refs/tags/3.1.2\",\"object\":{...}},")
+					+ "{\"ref\":\"refs/tags/4.0.0alpha1\",\"object\":{...}},"
+					+ "{\"ref\":\"refs/tags/4.0.0alpha2\",\"object\":{...}},"
+					+ "{\"ref\":\"refs/tags/4.0.0alpha3\",\"object\":{...}},"
+					+ "{\"ref\":\"refs/tags/4.0.0alpha4\",\"object\":{...}},"
+					+ "{\"ref\":\"refs/tags/4.0.0alpha5\",\"object\":{...}},"
+					+ "{\"ref\":\"refs/tags/4.0.0alpha6\",\"object\":{...}},"
+					+ "{\"ref\":\"refs/tags/4.0.0alpha7\",\"object\":{...}},"
+					+ "{\"ref\":\"refs/tags/4.0.0alpha8\",\"object\":{...}},"
+					+ "{\"ref\":\"refs/tags/4.0.0beta1\",\"object\":{...}},"
+					+ "{\"ref\":\"refs/tags/4.0.0beta2\",\"object\":{...}},"
+					+ "{\"ref\":\"refs/tags/4.0.0beta3\",\"object\":{...}},"
+					+ "{\"ref\":\"refs/tags/4.0.0rc1\",\"object\":{...}},"
+					+ "{\"ref\":\"refs/tags/4.0.0rc2\",\"object\":{...}}]"
+			<< QStringList({
+					"\"ref\":\"refs/tags/3.1.2\",\"object\":{...}",
+					"\"ref\":\"refs/tags/4.0.0alpha1\",\"object\":{...}",
+					"\"ref\":\"refs/tags/4.0.0alpha2\",\"object\":{...}",
+					"\"ref\":\"refs/tags/4.0.0alpha3\",\"object\":{...}",
+					"\"ref\":\"refs/tags/4.0.0alpha4\",\"object\":{...}",
+					"\"ref\":\"refs/tags/4.0.0alpha5\",\"object\":{...}",
+					"\"ref\":\"refs/tags/4.0.0alpha6\",\"object\":{...}",
+					"\"ref\":\"refs/tags/4.0.0alpha7\",\"object\":{...}",
+					"\"ref\":\"refs/tags/4.0.0alpha8\",\"object\":{...}",
+					"\"ref\":\"refs/tags/4.0.0beta1\",\"object\":{...}",
+					"\"ref\":\"refs/tags/4.0.0beta2\",\"object\":{...}",
+					"\"ref\":\"refs/tags/4.0.0beta3\",\"object\":{...}",
+					"\"ref\":\"refs/tags/4.0.0rc1\",\"object\":{...}",
+					"\"ref\":\"refs/tags/4.0.0rc2\",\"object\":{...}"
+			})
+			<< true;
+	}
+
+	void parseGitData() {
+		QFETCH(QString, gitData);
+		QFETCH(QStringList, list);
+		QFETCH(bool, valid);
+		QEQUAL(Version::parseGitData(gitData) == list, valid);
+	}
+
+	void parseVersionNumber_data() {
+		QTest::addColumn<QString>("version");
+		QTest::addColumn<QList<int>>("vList");
+		QTest::addColumn<bool>("valid");
+
+		QTest::newRow("parseVersionNumber1") << "2.3" << QList<int>({2,3,0}) << true;
+		QTest::newRow("parseVersionNumber2") << "" << QList<int>() << true;
+		QTest::newRow("parseVersionNumber3") << "12.3.11" << QList<int>({12,3,11}) << true;
+		QTest::newRow("parseVersionNumber4") << "4" << QList<int>({4,0,0}) << true;
+		QTest::newRow("parseVersionNumber5") << "-4.0.0" << QList<int>() << true;
+		QTest::newRow("parseVersionNumber6") << "4.5.6dev" << QList<int>() << true;
+		QTest::newRow("parseVersionNumber7") << "4..6" << QList<int>() << true;
+		QTest::newRow("parseVersionNumber8") << "4.5." << QList<int>() << true;
+		QTest::newRow("parseVersionNumber9") << "2.3.1.8" << QList<int>({2,3,1,8}) << true;
+	}
+
+	void parseVersionNumber() {
+		QFETCH(QString, version);
+		QFETCH(QList<int>, vList);
+		QFETCH(bool, valid);
+		QEQUAL(Version::parseVersionNumber(version) == vList, valid);
+	}
+
+	void stringVersion2Parts_data() {
+		QTest::addColumn<QString>("version");
+		QTest::addColumn<QStringList>("parts");
+		QTest::addColumn<bool>("valid");
+
+		QTest::newRow("versionParts1") << "4" << QStringList({"4","","",""}) << true;
+		QTest::newRow("versionParts2") << "4.3.0beta1" << QStringList({"4.3.0","beta","1",""}) << true;
+		QTest::newRow("versionParts3") << "4.3.0" << QStringList({"4.3.0","","",""}) << true;
+		QTest::newRow("versionParts4") << "4.3.0beta1-24-g5c925a387" << QStringList({"4.3.0","beta","1","24"}) << true;
+		QTest::newRow("versionParts5") << "4.3.0.beta1" << QStringList({}) << true;
+		QTest::newRow("versionParts6") << "4.3.0.beta1-24-g5c925a387" << QStringList({}) << true;
+	}
+
+	void stringVersion2Parts() {
+		QFETCH(QString, version);
+		QFETCH(QStringList, parts);
+		QFETCH(bool, valid);
+		QEQUAL(Version::stringVersion2Parts(version) == parts, valid);
+	}
+
+	void currentVersion_data() {
+		QTest::addColumn<bool>("valid");
+
+		QTest::newRow("currentVersion") << false;
+	}
+
+	void currentVersion() {
+		QFETCH(bool, valid);
+		QEQUAL(Version::current("4.3.0beta1-24-g5c925a387").Version::isEmpty(), valid);
+	}
+
+	void versionToString_data() {
+		QTest::addColumn<QString>("version");
+		QTest::addColumn<QString>("type");
+		QTest::addColumn<int>("rev");
+		QTest::addColumn<int>("commits");
+		QTest::addColumn<QString>("vString");
+		QTest::addColumn<bool>("valid");
+
+		QTest::newRow("versionToString1") << "2.3" << "stable" << 0 << 0 << "2.3" << true;
+		QTest::newRow("versionToString2") << "2.3.1" << "stable" << 1 << 0 << "2.3.1stable1" << true;
+		QTest::newRow("versionToString3") << "3.0.0" << "rc" << 1 << 0 << "3.0.0rc1" << true;
+		QTest::newRow("versionToString4") << "3.0.0" << "beta" << 2 << 0 << "3.0.0beta2" << true;
+		QTest::newRow("versionToString5") << "3.0.1" << "alpha" << 0 << 0 << "3.0.1alpha0" << true;
+		QTest::newRow("versionToString6") << "3.0.1" << "alpha" << 1 << 33 << "3.0.1alpha1-33" << true;
+		QTest::newRow("versionToString7") << "3.0.1" << "alpha" << 1 << 0 << "3.0.1alpha1" << true;
+	}
+
+	void versionToString() {
+		QFETCH(QString, version);
+		QFETCH(QString, type);
+		QFETCH(int, rev);
+		QFETCH(int, commits);
+		QFETCH(QString, vString);
+		QFETCH(bool, valid);
+		QEQUAL(Version::versionToString(Version(version,type,rev,commits)) == vString, valid);
+	}
+
 	void compareStringVersion_data() {
 		QTest::addColumn<QString>("ver1");
 		QTest::addColumn<QString>("ver2");
 		QTest::addColumn<int>("expectedResult");
 
-		QTest::newRow("equal") << "2.3" << "2.3" << (int) Version::Same;
+		QTest::newRow("equal0") << "2" << "2.0.0" << (int) Version::Same;
+		QTest::newRow("equal1") << "2.3" << "2.3" << (int) Version::Same;
 		QTest::newRow("equal2") << "2.3.1" << "2.3.1" << (int) Version::Same;
 		QTest::newRow("equal3") << "2" << "2.0" << (int) Version::Same;
 		QTest::newRow("equal4") << "2.3" << "2.3.0" << (int) Version::Same;
@@ -26,7 +155,7 @@ private slots:
 		QTest::newRow("major1") << "3" << "2.4" << (int) Version::Higher;
 		QTest::newRow("major2") << "3.0" << "2.4" << (int) Version::Higher;
 		QTest::newRow("major3") << "3.1" << "2.4" << (int) Version::Higher;
-		QTest::newRow("major4") << "3.1" << "2.4" << (int) Version::Higher;
+		QTest::newRow("major4") << "3.2" << "2.4" << (int) Version::Higher;
 		QTest::newRow("major4") << "3.0" << "2.4.2" << (int) Version::Higher;
 		QTest::newRow("revision1") << "2.4.1" << "2.4" << (int) Version::Higher;
 		QTest::newRow("revision2") << "2.4.2" << "2.4.1" << (int) Version::Higher;
@@ -34,8 +163,8 @@ private slots:
 		QTest::newRow("revision4") << "2.4.1" << "2.4.2" << (int) Version::Lower;
 		QTest::newRow("invalid") << "2.4b" << "2.4" << (int) Version::Invalid;
 		QTest::newRow("twodigit") << "2.10.0" << "2.9.4" << (int) Version::Higher;
-		QTest::newRow("additionalText") << "2.10.0 Release Candidate" << "2.10.0" << (int) Version::Same;
-        QTest::newRow("additionalText2") << "2.10.0-RC" << "2.10.0" << (int) Version::Same;
+		QTest::newRow("additionalText") << "2.10.0 Release Candidate" << "2.10.0" << (int) Version::Invalid;
+        QTest::newRow("additionalText2") << "2.10.0-RC" << "2.10.0" << (int) Version::Invalid;
 	}
 
 	void compareStringVersion() {
@@ -53,10 +182,11 @@ private slots:
 
 		QTest::newRow("valid1") << "2.3" << true;
 		QTest::newRow("valid2") << "2.3.1" << true;
-		QTest::newRow("valid3") << "3.0.0 (Development)" << true;
-		QTest::newRow("valid4") << "3.0.0-RC" << true;
+		QTest::newRow("valid3") << "3.0.0 (Development)" << false;
+		QTest::newRow("valid4") << "3.0.0-RC" << false;
 		QTest::newRow("valid5") << "3.0.0b" << false;
 		QTest::newRow("valid6") << "" << false;
+		QTest::newRow("valid7") << "-3.0.0" << false;
 	}
 
 	void isValid() {
@@ -64,7 +194,33 @@ private slots:
 		QFETCH(bool, valid);
 		QEQUAL(Version(version).isValid(), valid);
 	}
-	
+
+	void isValid2_data() {
+		QTest::addColumn<QString>("version");
+		QTest::addColumn<QString>("type");
+		QTest::addColumn<int>("rev");
+		QTest::addColumn<int>("commits");
+		QTest::addColumn<bool>("valid");
+
+		QTest::newRow("valid2.1") << "2.3" << "stable" << 0 << 0 << true;
+		QTest::newRow("valid2.2") << "2.3.1" << "Stable" << 1 << 0 << true;
+		QTest::newRow("valid2.3") << "3.0.0" << "development" << 1 << 1 << false;
+		QTest::newRow("valid2.4") << "3.0.0" << "RC" << 1 << 0 << true;
+		QTest::newRow("valid2.5") << "3.0.0" << "beta" << 2 << 0 << true;
+		QTest::newRow("valid2.6") << "3.0.1" << "alpha" << 0 << 0 << true;
+		QTest::newRow("valid2.7") << "3.0.1" << "alpha" << -1 << 0 << false;
+		QTest::newRow("valid2.8") << "3.0.1" << "alpha" << 1 << -2 << false;
+	}
+
+	void isValid2() {
+		QFETCH(QString, version);
+		QFETCH(QString, type);
+		QFETCH(int, rev);
+		QFETCH(int, commits);
+		QFETCH(bool, valid);
+		QEQUAL(Version(version,type,rev,commits).isValid(), valid);
+	}
+
 	void operatorLarger_data() {
 		QTest::addColumn<QString>("ver1");
 		QTest::addColumn<int>("rev1");
@@ -97,21 +253,23 @@ private slots:
         QTest::addColumn<QString>("ver1");
         QTest::addColumn<QString>("tp1");
         QTest::addColumn<int>("rev1");
+        QTest::addColumn<int>("commits1");
         QTest::addColumn<QString>("ver2");
         QTest::addColumn<QString>("tp2");
         QTest::addColumn<int>("rev2");
+        QTest::addColumn<int>("commits2");
         QTest::addColumn<bool>("expectedResult");
 
-        QTest::newRow("larger1") << "2.3.1" << "stable" << 100 << "2.3" << "stable" << 100 << true;
-        QTest::newRow("larger2") << "2.3.2" << "stable" << 100 << "2.3.1" << "stable" << 100 << true;
-        QTest::newRow("larger3") << "2.4.1" << "stable" << 100 << "2.3.4" << "stable" << 100 << true;
-        QTest::newRow("larger4") << "2.4.1" << "stable" << 100 << "2.4.1" << "beta" << 100 << true;
-        QTest::newRow("larger5") << "2.4.1" << "stable" << 100 << "2.4.1" << "release candidate" << 100 << true;
-        QTest::newRow("larger6") << "2.4.1" << "stable" << 100 << "2.4.1" << "development" << 100 << false;
-        QTest::newRow("larger7") << "2.4.1" << "beta" << 2 << "2.4.1" << "beta" << 1 << true;
-        QTest::newRow("larger8") << "2.4.1" << "release candidate" << 1 << "2.4.1" << "beta" << 5 << true;
-        QTest::newRow("larger9") << "2.4.1" << "release candidate" << 1 << "2.4.1" << "development" << 5 << true;
-        QTest::newRow("larger10") << "2.4.1" << "beta" << 1 << "2.4.1" << "development" << 5 << true;
+        QTest::newRow("larger1")  << "2.3.1" << "stable" <<   0 <<  0   << "2.3.0" << "stable" <<   0 <<  0 << true;
+        QTest::newRow("larger2")  << "2.3.2" << "stable" << 100 <<  0   << "2.3.1" << "stable" << 100 <<  0 << true;
+        QTest::newRow("larger3")  << "2.4.1" << "stable" << 100 <<  0   << "2.3.4" << "stable" << 100 <<  0 << true;
+        QTest::newRow("larger4")  << "2.4.1" << "stable" << 100 <<  0   << "2.4.1" << "beta"   << 100 <<  0 << true;
+        QTest::newRow("larger5")  << "2.4.1" << "stable" << 100 <<  0   << "2.4.1" << "rc"     << 100 <<  0 << true;
+        QTest::newRow("larger6")  << "2.4.1" << "stable" << 100 <<  0   << "2.4.1" << "stable" << 100 <<  0 << false;
+        QTest::newRow("larger7")  << "2.4.1" << "beta"   <<   2 <<  0   << "2.4.1" << "beta"   <<   1 <<  0 << true;
+        QTest::newRow("larger8")  << "2.4.1" << "rc"     <<   1 <<  0   << "2.4.1" << "beta"   <<   5 <<  0 << true;
+        QTest::newRow("larger9")  << "2.4.1" << "rc"     <<   1 <<  5   << "2.4.1" << "rc"     <<   1 <<  0 << true;
+        QTest::newRow("larger10") << "2.4.1" << "beta"   <<   1 <<  0   << "2.4.1" << "beta"   <<   1 << 17 << false;
 
     }
 
@@ -119,12 +277,14 @@ private slots:
         QFETCH(QString, ver1);
         QFETCH(QString, tp1);
         QFETCH(int, rev1);
+        QFETCH(int, commits1);
         QFETCH(QString, ver2);
         QFETCH(QString, tp2);
         QFETCH(int, rev2);
+        QFETCH(int, commits2);
         QFETCH(bool, expectedResult);
 
-        QEQUAL(Version(ver1, tp1, rev1) > Version(ver2, tp2, rev2), expectedResult);
+        QEQUAL(Version(ver1, tp1, rev1, commits1) > Version(ver2, tp2, rev2, commits2), expectedResult);
     }
 
 private:

--- a/src/utilsVersion.h
+++ b/src/utilsVersion.h
@@ -23,27 +23,27 @@ extern const char *TEXSTUDIO_GIT_REVISION;
 
 #include "mostQtHeaders.h"
 
-int gitRevisionToInt(const char *);
-
 class Version
 {
 public:
 	enum VersionCompareResult {Invalid = -2, Lower = -1, Same = 0, Higher = 1};
 	static VersionCompareResult compareStringVersion(const QString &v1, const QString &v2);
 	static VersionCompareResult compareIntVersion(const QList<int> &v1, const QList<int> &v2);
+	static QStringList parseGitData(const QString &data);
+	static QStringList stringVersion2Parts(const QString &str);
 	static QList<int> parseVersionNumber(const QString &versionNumber);
 	static bool versionNumberIsValid(const QString &versionNumber);
-    static int parseGitRevisionNumber(const QString &revision);
-
-	Version() : revision(0) {}
-	Version(QString number, int rev = 0) : versionNumber(number), revision(rev) {}
-    Version(QString number, QString tp,int rev = 0) : versionNumber(number), type(tp), revision(rev) {}
-	static Version current();
+	static QString versionToString(const Version &v);
+	Version() : revision(0), commitsAfter(0) {}
+	Version(QString number, int rev = 0) : versionNumber(number), type(QString("stable")), revision(rev), commitsAfter(0) {}
+    Version(QString number, QString tp, int rev = 0, int count = 0) : versionNumber(number), type(tp), revision(rev), commitsAfter(count) {}
+	static Version current(const QString &versionString = TEXSTUDIO_GIT_REVISION);
 
 	QString platform;       // "win" or "mac" or "linux"
 	QString versionNumber;  // "2.10.2"
-	QString type;           // "stable", "release candidate" or "development"
-    int revision;           // 5310, now changed to revision after tag as deliverd by "git describe"
+	QString type;           // "stable", "rc", "beta", "alpha"
+    int revision;           // 5310, now changed to revision after tag as delivered by "git describe"
+	int commitsAfter;       // commitsAfter == 24 for dev version 4.3.0beta1-24-g5c925a387, -nn- is missing iff commitsAfter == 0
 
 	bool operator > (const Version &other) const;
 


### PR DESCRIPTION
This PR fixes update check and enhances display of update check notification.
Related informations: Q&A #2413, Issue #2244

### Issues fixed

- Update check doesn't recognize released alpha versions, even when the update level is set to Development Versions in config dialog.
- Assume current version to be "4.3.0beta2-1-g5c925a387", a build of master one commit after 4.3.0beta2. Then txs lets revision be 1, so the internal version is 4.3.0beta1. Hence updater would display incorrectly a new 4.3.0beta2, even so the build is based on a commit after beta2. This could be irritating or misleading.

### Enhancements

- When txs is up-to-date then update notification now includes current version (as all other update notifications do).
- Update notifications now show type of versions (alpha, beta, rc, stable possible, but is not normally shown). This avoids messages like the following ones:

    ![grafik](https://user-images.githubusercontent.com/102688820/174054058-8d604535-45a2-41bd-b8bd-eb3ed8a5b798.png)
    (0) in first row is not the revision which is 1 (4.2.3rc1), so suggesting a stable version is running. But it is a release candidate that could be updated with next stable version or later beta1.

    If update level is set to stable then update check shows:

    ![grafik](https://user-images.githubusercontent.com/102688820/174054901-9b82de71-a9b9-4cae-a506-ab712bd0b8cf.png)
- If available, update notification also shows the commit number from the git revision. Ex. 4.3.0beta2-1 for 4.3.0beta2-1-g5c925a387 (s. above). This will not happen with officially released versions, since their git revisions lack that number (saying it is zero):

    ![grafik](https://user-images.githubusercontent.com/102688820/174511094-55625ee1-c2da-463b-8afc-093d173bec89.png)
- New function versionToString allows easy printing of version object's data in notifications:

    ![grafik](https://user-images.githubusercontent.com/102688820/174512307-b6c51f7c-c0cb-4482-b59d-7412e1353ae4.png)

- Extraction of data strings per version into a list of data strings is now done via a very small parser. This avoids needless lines to be parsed after splitting the JSON string from github api at commas.
- More tests available.
 
### Overview of code changes

utilsversion_t.h:
- test of new function parseGitData (simple parsing of git data)
- new test of function parseVersionNumber (string to list)
- test of new function stringVersion2Parts (split version string into string parts)
- new test of function current version
- test of new function versionToString (convert version object to string)
- new test of function isValid (validation of version)

utilsVersion.h:
- removed gitRevisionToInt
- removed parseGitRevisionNumber
- added function parseGitData (simple parsing of git data)
- added function stringVersion2Parts (split version string into string parts)
- added function versionToString (convert version object to string)
- new value commitsAfter

utilsVersion.cpp:
- removed gitRevisionToInt
- removed parseGitRevisionNumber
- added function parseGitData (simple parsing of git data)
- added function stringVersion2Parts (split version string into string parts)
- amend function current
- new function versionToString (convert version object to string)
- amend/simplify operator >
- accept alpha as a version tag type (development) and allow types in any case
- new value commitsAfter

updatechecker.cpp:
- use simple parser for git data
- accept alpha as a version tag type (development) and allow types in any case
- amend update notification