### PR TITLE
custom grid: always check standards

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -3521,21 +3521,20 @@ void PDFDocument::setGrid()
 			pdfWidget->setGridSize(x, y);
 			globalConfig->gridx = x;
 			globalConfig->gridy = y;
-		} else {
-			// set grid menu entry checked
-			QString gs=QString("%1x%2").arg(globalConfig->gridx).arg(globalConfig->gridy);
-			bool found=false;
-			for(QAction *a:actionGroupGrid->actions()){
-				if(a->property("grid").toString()==gs){
-					a->setChecked(true);
-					found=true;
-					break;
-				}
+		}
+		// set grid menu entry checked
+		QString gs=QString("%1x%2").arg(globalConfig->gridx).arg(globalConfig->gridy);
+		bool found=false;
+		for(QAction *a:actionGroupGrid->actions()){
+			if(a->property("grid").toString()==gs){
+				a->setChecked(true);
+				found=true;
+				break;
 			}
-			if(!found){
-				// if no other grid action fits, use custom
-				actionCustom->setChecked(true);
-			}
+		}
+		if(!found){
+			// if no other grid action fits, use custom
+			actionCustom->setChecked(true);
 		}
 	} else {
 		int p = gs.indexOf("x");


### PR DESCRIPTION
after confirming custom grid dialog (like after canceling) check for suitable standard settings, because you may set x=2 and y=2: Observed while testing new 4.3.0beta2.