### PR TITLE
line numbers in any new tab not zoomed

### DIFF
--- a/src/qcodeedit/lib/widgets/qlinenumberpanel.cpp
+++ b/src/qcodeedit/lib/widgets/qlinenumberpanel.cpp
@@ -126,7 +126,7 @@ bool QLineNumberPanel::paint(QPainter *p, QEditor *e)
 			0x2937
 	*/
 
-	QFont f(font());
+	QFont f(e->document()->font());
 	f.setWeight(QFont::Bold);
     const QFontMetricsF sfm(f);
     bool specialFontUsage=false;
@@ -175,6 +175,8 @@ bool QLineNumberPanel::paint(QPainter *p, QEditor *e)
 	//qDebug("first = %i; last = %i", first, last);
 	//qDebug("beg pos : %i", posY);
 
+	f.setWeight(QFont::Normal);
+	p->setFont(f);
 	for ( ; ; ++n )
 	{
 		//qDebug("n = %i; pos = %i", n, posY);
@@ -200,7 +202,6 @@ bool QLineNumberPanel::paint(QPainter *p, QEditor *e)
 			draw = true;
 
 			p->save();
-			QFont f = p->font();
 			f.setWeight(QFont::Bold);
 
 			p->setFont(f);


### PR DESCRIPTION
This PR fixes #2232. This issue addresses following observation: The size of the line numbers in a new (ctrl+n) document doesn't match the zoom level (if it is different from 0) used in documents already open. But zoom level has to be the same over all open documents, it can't be set for each editor individually. Zoom level is changed by ctrl++ or ctrl+- (or in the view menu).

To reproduce:

1. Start txs without any documents open (just to keep it simple).
2. Check Editor Options: Enable any kind of Line Numbers (so not _No Line Numbers_). As an example choose Font Family _Consolas_ and Font Size _10 pt_. Confirme settings.
3. Open a new document and zoom in with ctrl++ 5 times (this number ensures that difference can easily be noticed). Observe how line number 1 increases in size from 10 pt to 15 pt.
4. Open a new document. You may notice that line number 1 seems to be to small in comparison to the first document (switch between the tabs with ctrl+PageUp) or enter text in the second document (has the same (!) size as in first document, since text is not affected). An image in #2232 shows this.
5. Zoom out once with ctrl+- in the second document. You may be aware that the line number increases instead of decreasing. Reason is that we decrease size of 10+5 pt to 10+4 pt for all documents. But second document used size 10 pt for the line number which now increases size as many as 40% to 14 pt.

The fix mainly chooses the font with the correct zoomed size (l. 129). After doing some calculations with the bold font the fix sets the weight of the font back to normal and sets this font for the painter. It is not sufficient to set the font when we need a bold font (old line 203). Bold font is used for the line number of the line with the cursor.