### PR TITLE
new cwls

### DIFF
--- a/completion/byrne.cwl
+++ b/completion/byrne.cwl
@@ -1,0 +1,81 @@
+# byrne package
+# Matthew Bertucci 2022/07/06 for v0.2.2
+
+#include:xparse
+#include:ifmtarg
+#include:luamplib
+
+\defineNewPicture{MetaPost code}
+\defineNewPicture[offspring scale]{MetaPost code}
+\defineNewPicture[offspring scale][main scale]{MetaPost code}
+\drawCurrentPicture
+\defineFromCurrentPicture{vertical align}{picture name}{MetaPost code}
+\drawFromCurrentPicture{MetaPost code}
+\drawFromCurrentPicture[vertical align]{MetaPost code}
+\drawFromCurrentPicture[vertical align][picture name]{MetaPost code}
+\drawUnitLine{line name}
+\drawUnitLine[line second name]{line name}
+\drawProportionalLine{line name}
+\drawSizedLine{line name}
+\drawSizedLine[line second name]{line name}
+\drawUnitRay{line name}
+\drawUnitRay[ray name]{line name}
+\drawRightAngle
+\drawTwoRightAngles
+\drawAngle{angle name}
+\drawAngleWithSides{angle name}
+\drawPolygon{polygon name}
+\drawPolygon[vertical align]{polygon name}
+\drawPolygon[vertical align][new name]{polygon name}
+\drawCircle{circle name}
+\drawCircle[vertical align]{circle name}
+\drawCircle[vertical align][scale]{circle name}
+\drawArc{arc name}
+\drawArc[vertical align]{arc name}
+\drawArc[vertical align][scale]{arc name}
+\drawLine{line name}
+\drawLine[vertical align]{line name}
+\drawLine[vertical align][new name]{line name}
+\drawPointM{point name}
+\drawPointL{point name}
+\drawPointL[vertical align]{point name}
+\drawPointL[vertical align][lines to omit]{point name}
+\drawPoint{point name}
+\drawPoint[vertical align]{point name}
+\drawPoint[vertical align][lines to omit]{point name}
+
+# not documented
+\addToUndefineList{picture name}#*
+\CreateNewInstanceForPicturefalse#*
+\CreateNewInstanceForPicturetrue#*
+\currentInlinePicturePlacement#*
+\currentInstance#*
+\drawDefinedPicture{picture name}{align}#*
+\drawImageFromCurrentInstance{picture name}#*
+\drawMagnitude[vertical align][opt]{name}#*
+\drawMagnitude[vertical align]{name}#*
+\drawMagnitude{name}#*
+\drawProportionalIndLine{name}#*
+\drawProportionalRay{name}#*
+\drawSizedRay[opt]{name}#*
+\drawSizedRay{name}#*
+\drawUnitIndLine[opt]{name}#*
+\drawUnitIndLine{name}#*
+\formatImageName{picture name}#*
+\ifCreateNewInstanceForPicture#*
+\lastPict#*
+\middp#*
+\midht#*
+\mpInst#*
+\mpPost#*
+\mpPre#*
+\offsetPicture{top}{bottom}{arg}#*
+\pictOffsetBottom#*
+\pictOffsetTop#*
+\plal#S
+\sfA#S
+\sfB#S
+\tmpalignment#S
+\tmpmiddle#S
+\undefineList#*
+\unmarkPictAsReady{picture name}#*

--- a/completion/derivative.cwl
+++ b/completion/derivative.cwl
@@ -1,6 +1,7 @@
 # For derivative v1.1 (2021/06/03) by Simon Jensen.
 # URL: https://ctan.org/pkg/derivative?lang=en
 # Created by Brian Schubert (2021/08/03).
+# updated 2022/07/11 for v1.2
 
 #include:expl3
 #include:xparse
@@ -175,14 +176,16 @@ sep-eval-sp=%<<num>, <mspace>, or <delim>%>
 ### Derivative Switches (switch-)
 switch-*#true,false
 switch-/#true,false
+switch-sort#true,false
 
 ### Derivative Sort (sort-)
-sort-method={%<abs, number, sign, and/or symbol%>}
+sort-method={%<abs, lexical, number, sign, and/or symbol%>}
 sort-numerical=#auto,first,last,symbolic
 sort-abs-reverse#true,false
 sort-number-reverse#true,false
 sort-sign-reverse#true,false
 sort-symbol-reverse#true,false
+sort-lexical-reverse#true,false
 
 ### Derivative Miscellaneous
 fun#true,false

--- a/completion/inlinelabel.cwl
+++ b/completion/inlinelabel.cwl
@@ -1,10 +1,12 @@
 # inlinelabel package
-# Matthew Bertucci 2022/06/29 for v1.0
+# Matthew Bertucci 2022/07/09 for v1.2.1
 
 #include:amsmath
 
 #keyvals:\usepackage/inlinelabel#c
+nospace
 circled
+luacircled
 #endkeyvals
 
 #ifOption:circled
@@ -14,5 +16,13 @@ circled
 \equationref{label}#r
 #endif
 
+#ifOption:luacircled
+#include:luatexja-otf
+#include:refcount
+\circledref{label}#r
+\equationref{label}#r
+#endif
+
 \inlinelabel{label}#l
 \inlinelabel*{label}#l
+\equationreset

--- a/completion/precattl.cwl
+++ b/completion/precattl.cwl
@@ -1,0 +1,11 @@
+# precattl package
+# Matthew Bertucci 202207/11 for v0.0.0
+
+\precattlExec{token list}
+\precattlSet %<\tlvar%> {%<token list%>}
+\precattlSet{cmd}{token list}#Sd
+
+# not documented
+\execinside{arg}#*
+\execinsideSet{cmd}{arg}#*d
+\execinsideGset{cmd}{arg}#*d

--- a/completion/pst-magneticfield.cwl
+++ b/completion/pst-magneticfield.cwl
@@ -1,5 +1,5 @@
 # pst-magneticfield package
-# Matthew Bertucci 2/22/2022 for v1.16
+# Matthew Bertucci 2022/07/09 for v1.17
 
 #include:pstricks
 #include:pst-3d
@@ -46,6 +46,10 @@ showPoleLabels#true,false
 fontstyle=%<font commands%>
 magnetScale=%<factor%>
 #endkeyvals
+
+Red#B
+BrickRed#B
+Green#B
 
 \CalcIntermediaire#S
 \yA#S

--- a/completion/qrbill.cwl
+++ b/completion/qrbill.cwl
@@ -1,5 +1,5 @@
 # qrbill package
-# Matthew Bertucci 12/10/2021 for v1.03
+# Matthew Bertucci 2022/07/10 for v1.04
 
 #include:iftex
 #include:l3keys2e
@@ -27,11 +27,14 @@ separate=#false,text,symbol
 
 \QRbill
 \QRbill[data setup%keyvals]
+\QRbill*
+\QRbill*[data setup%keyvals]
 \qrbillsetdata{data setup%keyvals}
+\qrbillsetdata*{data setup%keyvals}
 \SetupQrBill{data setup%keyvals}
 \qrbillsetup{data setup%keyvals}#*
 
-#keyvals:\QRbill,\SetupQrBill,\qrbillsetdata,\qrbillsetup
+#keyvals:\QRbill,\QRbill*,\SetupQrBill,\qrbillsetdata,\qrbillsetdata*,\qrbillsetup
 QRType=
 Version=
 CodingType=
@@ -81,6 +84,8 @@ vatdetails=
 importvat=
 conditions=
 #endkeyvals
+
+\QRbillParseDate{year}{month}{day}
 
 \insertcreditor
 \insertcurrency

--- a/completion/rescansync.cwl
+++ b/completion/rescansync.cwl
@@ -1,0 +1,8 @@
+# rescansync package
+# Matthew Bertucci 202207/11 for v0.0.0
+
+\begin{rescansyncSaveenvPacked}{macro%cmd}#d
+\end{rescansyncSaveenvPacked}
+\rescansyncPacked{macro}
+\begin{rescansyncSaveenvghostPacked}{macro%cmd}#d
+\end{rescansyncSaveenvghostPacked}

--- a/completion/saveenv.cwl
+++ b/completion/saveenv.cwl
@@ -1,0 +1,11 @@
+# saveenv package
+# Matthew Bertucci 202207/11 for v0.0.0
+
+#include:precattl
+
+\begin{saveenv}{macro%cmd}#d
+\end{saveenv}
+\begin{saveenvghost}{macro%cmd}#d
+\end{saveenvghost}
+\begin{saveenvkeeplast}{macro%cmd}#d
+\end{saveenvkeeplast}

--- a/completion/zref-vario.cwl
+++ b/completion/zref-vario.cwl
@@ -1,8 +1,14 @@
 # zref-vario package
-# Matthew Bertucci 2/10/2022 for v0.1.2-alpha
+# Matthew Bertucci 2022/07/11 for v0.1.5
 
 #include:varioref
 #include:zref-clever
+
+\zvsetup{options%keyvals}
+
+#keyvals:\zvsetup
+pageprop=%<property%>
+#endkeyvals
 
 \zvref{label}#r
 \zvref[options%keyvals]{label}#r
@@ -35,6 +41,7 @@
 \zreftextfaraway*[options%keyvals]{label}#*r
 
 #keyvals:\zvref,\zvref*,\zvpageref,\zvpageref*,\zvrefrange,\zvrefrange*,\zvpagerefrange,\zvpagerefrange*,\zfullref,\zfullref*,\zreftextfaraway,\zreftextfaraway*
+# standard keys
 ref=#default,page,thecounter,title
 page
 typeset=#ref,name,both
@@ -46,17 +53,18 @@ typesort={%<type list%>}
 notypesort
 comp#true,false
 nocomp
+endrange=#ref,stripprefix,pagecomp,pagecomp2
 range#true,false
+rangetopair#true,false
 cap#true,false
 nocap
-capfirst
+capfirst#true,false
 abbrev#true,false
 noabbrev
 noabbrevfirst
 S
 hyperref=#auto,true,false
 nameinlink=#true,false,single,tsingle
-preposinlink#true,false
 lang=%<language%>
 d=%<declension case%>
 nudge=#true,false,ifdraft,iffinal
@@ -64,28 +72,27 @@ nudgeif=#multitype,comptosing,gender,all
 nonudge
 sg
 g=
-font=%<cmds%>
-titleref
+font=%<font commands%>
 note=%<text%>
 check={%<checks%>}
 vcheck={%<checks%>}
 countertype={%<<counter>%> = %<<type> list%>}
 counterresetters={%<counter list%>}
 counterresetby={%<<counter=encl counter> list%>}
-currentcounter
-tpairsep=
-tlistsep=
-tlastsep=
-notesep=
-namesep=
-pairsep=
-listsep=
-lastsep=
-rangesep=
-preref=
-postref=
-namefont=
-reffont=
+currentcounter=%<counter%>
+# "general" keys
+tpairsep={%<separator%>}
+tlistsep={%<separator%>}
+tlastsep={%<separator%>}
+notesep={%<separator%>}
+namesep={%<separator%>}
+pairsep={%<separator%>}
+listsep={%<separator%>}
+lastsep={%<separator%>}
+rangesep={%<separator%>}
+refbounds={%<preref*,preref,postref,postref*%>}
+namefont=%<name%>
+reffont=%<name%>
 #endkeyvals
 
 #keyvals:\zvref,\zvref*,\zvpageref,\zvpageref*,\zvrefrange,\zvrefrange*,\zvpagerefrange,\zvpagerefrange*


### PR DESCRIPTION
New cwls for `byrne`, `precattl`, `rescansync`, and `saveenv`.
Updated cwls for `derivative`, `inlinelabel`, `pst-magneticfield`, and `qrbill`.