### PR TITLE
move hot spot of magnifier cursor to center of the glass

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -611,7 +611,7 @@ PDFWidget::PDFWidget(bool embedded)
 	}
 
     if (magnifierCursor == nullptr) {
-		magnifierCursor = new QCursor(QPixmap(getRealIconFile("magnifier")).scaled(32, 32, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+		magnifierCursor = new QCursor(QPixmap(getRealIconFile("magnifier")).scaled(32, 32, Qt::KeepAspectRatio, Qt::SmoothTransformation),10,10);
 		zoomInCursor = new QCursor(QPixmap(getRealIconFile("zoom-in")).scaled(32, 32, Qt::KeepAspectRatio, Qt::SmoothTransformation));
 		zoomOutCursor = new QCursor(QPixmap(getRealIconFile("zoom-out")).scaled(32, 32, Qt::KeepAspectRatio, Qt::SmoothTransformation));
 	}


### PR DESCRIPTION
Today the hot spot for custom cursors is set in the middle of the cursor image area (for ex. 32x32 pixels) by default. For the magnifier this point lies where the glass and the handle touch. Naturally one would expect that the center of the glass would be the hot spot. This would avoid a shift between the original and the zoomed pdf image.

In the following two images the center of the glass of the cursor is always positioned at the center of the green 2x2 square. Then the magnifier is activated by pressing left mouse button. Currently this results in an asymmetry because of the image shift (in N-W-direction):

![grafik](https://user-images.githubusercontent.com/102688820/178086864-41241f45-b509-413c-afea-995318d008e4.png)

In fact the hot spot lies approximately in the center of the lower right green square. If we explicitly set the hot spot to (10,10) in line 614, the symmetry of the result is very good (which shows that the hot spot lies in the center of the magnifier glass):

![grafik](https://user-images.githubusercontent.com/102688820/178086938-097015fc-60f7-4466-85f0-2a3c823aa21f.png)
