### PR TITLE
resize rows of error table to contents and some more

### DIFF
--- a/src/latexlog.cpp
+++ b/src/latexlog.cpp
@@ -44,7 +44,7 @@ QVariant LatexLogModel::data(const QModelIndex &index, int role) const
 	case 2: {
 		int line = log.at(index.row()).oldline;
 		if (line > 0)
-			return tr("line") + QString(" %1").arg(line);
+			return line;
 		return QString();
 	}
 	case 3:

--- a/src/latexlogwidget.cpp
+++ b/src/latexlogwidget.cpp
@@ -44,6 +44,11 @@ LatexLogWidget::LatexLogWidget(QWidget *parent) :
 	errorTable->setMinimumHeight(5 * rowHeight);
 	errorTable->setFrameShape(QFrame::NoFrame);
 	errorTable->setSortingEnabled(true);
+	errorTable->sortByColumn(-1,Qt::AscendingOrder);
+#if QT_VERSION >= QT_VERSION_CHECK(6,1,0)
+    errorTable->horizontalHeader()->setSortIndicatorClearable(true);
+#endif
+
 
 	proxyModel = new QSortFilterProxyModel(this);
 	proxyModel->setSourceModel(logModel);

--- a/src/latexlogwidget.cpp
+++ b/src/latexlogwidget.cpp
@@ -28,7 +28,6 @@ LatexLogWidget::LatexLogWidget(QWidget *parent) :
 
 	errorTable = new QTableView(this);
 	int rowHeight = getOptimalRowHeight(errorTable);
-	errorTable->verticalHeader()->setDefaultSectionSize(rowHeight);
 	QFontMetrics fm(QApplication::font());
 	errorTable->setSelectionBehavior(QAbstractItemView::SelectRows);
 	errorTable->setSelectionMode(QAbstractItemView::SingleSelection);
@@ -37,9 +36,11 @@ LatexLogWidget::LatexLogWidget(QWidget *parent) :
 	errorTable->setColumnWidth(2, UtilsUi::getFmWidth(fm, "WarningW"));
 	errorTable->setColumnWidth(3, UtilsUi::getFmWidth(fm, "Line WWWWW"));
 	errorTable->setColumnWidth(4, 20 * UtilsUi::getFmWidth(fm, "w"));
+	errorTable->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+	errorTable->horizontalHeader()->setSectionsMovable(true);
     connect(errorTable, SIGNAL(clicked(const QModelIndex&)), this, SLOT(clickedOnLogModelIndex(const QModelIndex&)));
+    connect(errorTable->horizontalHeader(), SIGNAL(sectionResized(int, int, int)), this, SLOT(resizeRows()));
 
-	errorTable->horizontalHeader()->setStretchLastSection(true);
 	errorTable->setMinimumHeight(5 * rowHeight);
 	errorTable->setFrameShape(QFrame::NoFrame);
 	errorTable->setSortingEnabled(true);
@@ -112,6 +113,10 @@ LatexLogWidget::LatexLogWidget(QWidget *parent) :
 	log->setVisible(false);
 }
 
+void LatexLogWidget::resizeRows()
+{
+	this->errorTable->resizeRowsToContents();
+}
 
 bool LatexLogWidget::loadLogFile(const QString &logname, const QString &compiledFileName, QTextCodec* fallbackCodec)
 {
@@ -151,19 +156,8 @@ bool LatexLogWidget::loadLogFile(const QString &logname, const QString &compiled
 
 		logpresent = true;
 
-		// workaround to https://sourceforge.net/p/texstudio/feature-requests/622/
-		// There seems to be a bug in Qt (4.8.4) that resizeRowsToContents() does not work correctly if
-		// horizontalHeader()->setStretchLastSection(true) and the tableView has not yet been shown
-		// when iterating through the columns to determine the maximal height, everything is fine
-		// until the last column. There the calculated height is too large.
-		// As a workaround we will temporarily deactivate column stretching.
-		// Note: To reproduce, you can call the viewer via The ViewLog button. When showing the viewer
-		// by clicking the ViewTab, the widget is shown before loading (so there the bug did not appear.)
-		bool visible = errorTable->isVisible();
-		if (!visible) errorTable->horizontalHeader()->setStretchLastSection(false);
 		errorTable->resizeColumnsToContents();
-		errorTable->resizeRowsToContents();
-		if (!visible) errorTable->horizontalHeader()->setStretchLastSection(true);
+		errorTable->horizontalHeader()->setStretchLastSection(true);
 
 		selectLogEntry(0);
 		emit logLoaded();

--- a/src/latexlogwidget.h
+++ b/src/latexlogwidget.h
@@ -45,6 +45,7 @@ private slots:
 	void setWidgetVisibleFromAction(bool visible);
 	void setInfo(const QString &message);
 	void filterChanged(bool);
+	void resizeRows();
 
 private:
 	LatexLogModel *logModel;


### PR DESCRIPTION
This PR will fix small issues with the Error Log Table and adds small enhancements:

####  How to reproduce issue
1. Compile a file and preview pdf (embedded) and adjust width of pdf-viewer such that messages don't fit in one line, close txs. Open txs, open Error Log Table, messages have line breaks:
![grafik](https://user-images.githubusercontent.com/102688820/180668914-8040df03-9a95-4b31-b837-2cf07e26e9c4.png)

2. Enlarge width of editor (or double click on the "message" header section's right edge) so message needs one line. but height doesn't decrease:
![grafik](https://user-images.githubusercontent.com/102688820/180669125-0a8cbb60-f5dc-4674-850f-9b10c407b289.png)
Also when you decrease width, heigth remains constant, even if more space is needed (for 3 lines or more).

4. Compile. Messages now show in one line, height of rows now as needed, no way to come back to line breaks if needed (even if you decrease width of "message" header section). To read message up to the end you have to scroll to the right:
![grafik](https://user-images.githubusercontent.com/102688820/180669430-a22e9d24-6ba5-4993-9e88-f6bb3351e4b3.png)
This should be the default look, also if you reopen txs (s. 1.)

5. The Log always indicates at first time that column File is sorted in descending order. But this is not true, files are listed in order they were encountered.

6. As the following image shows sorting by column Line is not correct. Due to the redundant string "line" in each field the entry is not treated as a number (two lines not correct, compare to the right after fix):
![grafik](https://user-images.githubusercontent.com/102688820/180842124-d44d6f3f-6d53-4ac4-9950-043e24acdc13.png) ![grafik](https://user-images.githubusercontent.com/102688820/180842779-1f4cacd7-5937-4bad-a969-8a390434855c.png)


#### Enhancements
1. It should be possible that line breaks (re)appear in last column by decreasing column width.
2. It should be possible to reorder columns, when you need to. Ex.: Column Type moved to the left (by dragging):
![grafik](https://user-images.githubusercontent.com/102688820/180670353-92b972d4-dab2-4dee-ba39-1af12327c7e2.png)
Note: How fare you have to drag is not that visible in default style (General Config), you may use Fusion style:
File header still white, not dragged far enough to switch:
![grafik](https://user-images.githubusercontent.com/102688820/180670975-61a25841-ce68-4f3c-a65a-eee393ad7c0a.png)
File header gray, dragged far enough to switch:
![grafik](https://user-images.githubusercontent.com/102688820/180671014-3bea790c-5941-482c-9096-2d8b561f4b88.png)
3. Keep natural ordering of rows and show no sort indicator for File column. Further allow disabling sort by multiple clicks on the column header (cycles up, down, off), but this is available since Qt6.1 only.

#### Implementation
Use section resize mode "resize to content" for rows. No default heigth needed.
Use signal sectionResized to resize rows to content.
Make horizontal header sections movable.
After loading error table let last column stretch.
Set sort by column to -1 to suppress sort indicator.
Set sort indicator clearable to true (if Qt version is at least 6.1.0).