### PR TITLE
new cwls

### DIFF
--- a/completion/analogclock.cwl
+++ b/completion/analogclock.cwl
@@ -1,0 +1,27 @@
+# analogclock package
+# Matthew Bertucci 2022/07/25 for v1.0
+
+#include:hyperref
+#include:xcolor
+#include:xkeyval
+#include:tikz
+
+#keyvals:\usepackage/analogclock#c
+timeinterval=%<integer%>
+#endkeyvals
+
+\initclock
+\analogclock
+\clocksizefactor{factor}
+\faceclock{integer}{color}
+
+# not documented
+\kk#S
+\sizebox#S
+\uu#S
+\colocafield{arg}#S
+\facebg#S
+\faceframe#S
+\face#S
+\clockskin#S
+\startclock#S

--- a/completion/babel.cwl
+++ b/completion/babel.cwl
@@ -234,9 +234,54 @@ autoload.options=
 \DJ
 \umlauthigh#*
 \umlautlow#*
+\umlautelow#S
 \latinencoding#*
 \latintext
 \textlatin{text}
+
+# miscellaneous (not for standard use)
+\adddialect#S
+\addlanguage#S
+\AfterBabelCommands{code}#S
+\allowhyphens#S
+\BabelDated{arg}#S
+\BabelDatedd{arg}#S
+\BabelDateDot#S
+\BabelDateM{arg}#S
+\BabelDateMM{arg}#S
+\BabelDateMMMM{arg}#S
+\BabelDateSpace#S
+\BabelDatey{arg}#S
+\BabelDateyy{arg}#S
+\BabelDateyyyy{arg}#S
+\BabelLanguages#S
+\BabelLower{uccode}{lccode}#S
+\BabelLowerMM{uccode-from}{uccode-to}{step}{lccode}#S
+\BabelLowerMO{uccode-from}{uccode-to}{step}{lccode}#S
+\BabelModifiers#S
+\BabelNonASCII#S
+\BabelNonText#S
+\BabelString#S
+\BabelStringsDefault#S
+\BabelText{arg}#S
+\BCPdata{arg}#S
+\EndBabelCommands#S
+\IfBabelLayout{layout}{true}{false}#S
+\IfBabelSelectorTF{selectors}{true}{false}#S
+\LdfInit{language}{captionslanguage}#S
+\loadlocalcfg{file}#Si
+\localename#S
+\ProvidesLanguage{language}#S
+\ProvidesLanguage{language}[release info]#S
+\SetCase[map-list]{to-upper-code}{to-lower-code}#S
+\SetCase{toupper-code}{tolower-code}#S
+\SetHyphenMap{to-lower-macros}#S
+\SetString{macro-name}{string}#S
+\SetStringLoop{macro-name}{string-list}#S
+\StartBabelCommands*{language-list}{category}#S
+\StartBabelCommands*{language-list}{category}[selector]#S
+\StartBabelCommands{language-list}{category}#S
+\StartBabelCommands{language-list}{category}[selector]#S
 
 ### albanian.ldf v1.0d ###
 #ifOption:albanian

--- a/completion/bxeepic.cwl
+++ b/completion/bxeepic.cwl
@@ -1,0 +1,104 @@
+# bxeepic package
+# Matthew Bertucci 2022/07/26 for v0.2
+
+#include:pict2e
+
+#keyvals:\usepackage/bxeepic#c
+safe
+nosafe
+# option passed to pict2e
+dvips
+xdvi
+dvipdf
+dvipdfm
+dvipdfmx
+pdftex
+luatex
+xetex
+dvipsone
+dviwindo
+oztex
+textures
+pctexps
+pctex32
+vtex
+original
+ltxarrows
+pstarrows
+debug
+hide
+#endkeyvals
+
+\bxGridLabelForm{real}#*
+\dashlines
+\dottedlines
+\drawlines
+\eepicdottedlines#*
+\epicbottomgridlabelsep#*
+\epicsidegridlabelsep#*
+\epictopgridlabelsep#*
+\flushjoin
+\noeepicdottedlines#*
+\spacewidth#*
+
+# from epic (commented out lines not supported)
+\multiputlist(x,y)(Δx,Δy){item1,item2,...}#/picture
+\multiputlist(x,y)(Δx,Δy)[pos]{item1,item2,...}#/picture
+\matrixput(x,y)(Δx1,Δy1){n1}(Δx2,Δy2){n2}{object}#/picture
+\grid(width,height)(Δwidth,Δheight)
+\grid(width,height)(Δwidth,Δheight)[x0,y0]
+\dottedline{%<dashgap%>}(%<x1,y1%>)(%<x2,y2%>)%<...(xN,yN)%>#/picture
+## \dottedline[%<character%>]{%<dashgap%>}(%<x1,y1%>)(%<x2,y2%>)%<...(xN,yN)%>#/picture
+\dashline{%<dashlength%>}(%<x1,y1%>)(%<x2,y2%>)%<...(xN,yN)%>#/picture
+## \dashline{%<dashlength%>}[%<dashgap%>](%<x1,y1%>)(%<x2,y2%>)%<...(xN,yN)%>#/picture
+\dashline[%<stretch%>]{%<dashlength%>}(%<x1,y1%>)(%<x2,y2%>)%<...(xN,yN)%>#/picture
+## \dashline[%<stretch%>]{%<dashlength%>}[%<dashgap%>](%<x1,y1%>)(%<x2,y2%>)%<...(xN,yN)%>#/picture
+\dashlinestretch#*
+\drawline(%<x1,y1%>)(%<x2,y2%>)%<...(xN,yN)%>#/picture
+\drawline[%<stretch%>](%<x1,y1%>)(%<x2,y2%>)%<...(xN,yN)%>#/picture
+\drawlinestretch#*
+\jput(x,y){object}#/picture
+\begin{dottedjoin}{dotgap}#/picture
+\begin{dottedjoin}[character]{dotgap}#/picture
+\end{dottedjoin}#/picture
+\begin{dashjoin}{dashlength}#/picture
+\begin{dashjoin}{dashlength}[dashgap]#/picture
+\begin{dashjoin}[stretch]{dashlength}#/picture
+\begin{dashjoin}[stretch]{dashlength}[dashgap]#/picture
+\end{dashjoin}#/picture
+\begin{drawjoin}#/picture
+\begin{drawjoin}[stretch]#/picture
+\end{drawjoin}#/picture
+\picsquare
+\putfile{file}{object}#i
+\dashjoin#S
+\dottedjoin#S
+\drawjoin#S
+\enddashjoin#S
+\enddottedjoin#S
+\enddrawjoin#S
+
+# from eepic
+\line(x,y){length}#/picture
+\circle{diameter}#/picture
+\circle*{diameter}#/picture
+\oval(width,height)#/picture
+\oval(width,height)[portion]#/picture
+\maxovaldiam#*
+\allinethickness{dimen}
+\Thicklines#/picture
+\path(%<x1,y1%>)(%<x2,y2%>)%<...(xN,yN)%>#/picture
+\spline(%<x1,y1%>)(%<x2,y2%>)%<...(xN,yN)%>#/picture
+\ellipse{x diameter}{y diameter}#/picture
+\ellipse*{x diameter}{y diameter}#/picture
+\arc{diameter}{start angle}{end angle}#/picture
+## \filltype{type%keyvals}#/picture
+## #keyvals:\filltype
+## black
+## white
+## shade
+## #endkeyvals
+## \blacken#*/picture
+## \whiten#*/picture
+## \shade#*/picture
+## \texture{hex nums}#*/picture

--- a/completion/class-ctxdoc.cwl
+++ b/completion/class-ctxdoc.cwl
@@ -1,5 +1,5 @@
 # ctxdoc class
-# Matthew Bertucci 2022-04-19 for release 2021-11-19
+# Matthew Bertucci 2022-07-26 for release 2022-06-07
 
 #include:expl3
 #include:class-l3doc
@@ -73,7 +73,9 @@ openbib
 \end{ctexexam}
 \ctexexamlabelref#*
 \thectexexam#*
-\ctexfixprevdepth#*
+\ctexsetverticalspacing#*
+\ctexfixverticalspacing#*
+\SideBySideExampleSet
 \exptarget
 \rexptarget
 \expstar

--- a/completion/ctex.cwl
+++ b/completion/ctex.cwl
@@ -1,11 +1,10 @@
 # ctex package
 # Darcy Hu <hot123tea123@gmail.com> 2016
 #modified zepinglee 30 Jan 2021
-# updated 13 Mar 2022 for v2.5.8
+# updated 26 June 2022 for v2.5.10
 
 #include:expl3
 #include:xparse
-#include:l3keys2e
 #include:zhnumber
 
 # package only keys

--- a/completion/feyn.cwl
+++ b/completion/feyn.cwl
@@ -1,5 +1,10 @@
 # feyn package
-# Matthew Bertucci 11/3/2021 for v0.4.1
+# Matthew Bertucci 2022/07/26 for v0.4.3
+
+#keyvals:\usepackage/feyn#c
+globalbang
+noglobalbang
+#endkeyvals
 
 \feyn{chars}#m
 \Feyn{chars}#m

--- a/completion/hvfloat.cwl
+++ b/completion/hvfloat.cwl
@@ -1,5 +1,5 @@
 # hvfloat package
-# Matthew Bertucci 4/3/2022 for v2.38
+# Matthew Bertucci 2022/07/26 for v2.40
 
 #include:caption
 #include:varwidth
@@ -14,6 +14,7 @@
 #include:ifoddpage
 #include:afterpage
 #include:stfloats
+#include:floatpag
 
 #keyvals:\usepackage/hvfloat#c
 fbox
@@ -144,6 +145,7 @@ decodearray={%<color array%>}
 \setPageObject#*
 \defhvstyle{name}{options}#S
 \hvFloatFileVersion#S
+\hvFloatFullWidth#*
 \hvObjectWidth#*
 \hvCapWidth#*
 \hvWideWidth#*

--- a/completion/jlreq-deluxe.cwl
+++ b/completion/jlreq-deluxe.cwl
@@ -1,0 +1,51 @@
+# jlreq-deluxe package
+# Matthew Bertucci 2022/07/26 for v0.4.0
+
+#include:expl3
+#include:l3keys2e
+#include:pxjodel
+
+#keyvals:\usepackage/jlreq-deluxe#c
+hanging_punctuation#true,false
+zenkakunibu_nibu#true,false
+# options passed to pxjodel pcakage
+prefix=%<string%>
+# options passed to otf package
+nomacros
+noreplace
+bold
+expert
+deluxe=false
+multi
+uplatex
+autodetect
+jis2004
+scale=%<factor%>
+#endkeyvals
+
+#ifOption:expert
+\rubydefault#*
+\rubyfamily
+\rubykatuji
+#endif
+
+#ifOption:multi
+#include:mlutf
+#include:mlcid
+#endif
+
+#ifOption:uplatex
+#include:uplatex
+#endif
+
+# from deluxe option of otf
+\mgdefault#*
+\propdefault#*
+\ebdefault#*
+\ltdefault#*
+\mathmg{text%plain}#m
+\mgfamily
+\textmg{text}
+\propshape
+\ebseries
+\ltseries

--- a/completion/robustglossary.cwl
+++ b/completion/robustglossary.cwl
@@ -1,0 +1,7 @@
+# robustglossary package
+# Matthew Bertucci 2022/07/26 for v2005/02/23
+
+\glopageref{number}
+\glostring#*
+\thegloctr#*
+\themaxgloctr#*

--- a/completion/robustindex.cwl
+++ b/completion/robustindex.cwl
@@ -1,0 +1,43 @@
+# robustindex package
+# Matthew Bertucci 2022/07/26 for v2019/01/25
+
+#include:makeidx
+
+#keyvals:\usepackage/robustindex#c
+multind
+#endkeyvals
+
+\gobblepageref
+\indexincontents
+\setindex{tag}
+\sindex{entry}
+\sindex[tag]{entry}
+
+\indexcapstyle{arg}#*
+
+# not documented
+\altsort#*
+\capitalsinindex{arg1}#*
+\cndhyprndxwrng#*
+\encpageref{arg1}{arg2}#*
+\extraheaders#*
+\findEndPageRange{arg1}#*
+\findencap{arg1}#*
+\gobbleindpageref#*
+\gobbletillnine#*
+\indexcapitalhead{arg1}#*
+\indexpreamble#*
+\indnr{arg1}#*
+\indpageref{arg1}#*
+\indstring#*
+\jmptonine#*
+\newindex{arg1}#*
+\olditem#S
+\robustchoice#*
+\robustcutpoint#*
+\theindexctr#*
+\themaxindctr#*
+\themultindctr#*
+\untilrobustcutpoint{arg1}#*
+\wrapindpageref{arg1}#*
+\wrappageref{arg}#*

--- a/completion/runcode.cwl
+++ b/completion/runcode.cwl
@@ -1,5 +1,5 @@
 # runcode package
-# Matthew Bertucci 2022/05/16 for v1.3
+# Matthew Bertucci 2022/07/26 for v1.5
 
 #include:morewrites
 #include:tcolorbox
@@ -16,9 +16,6 @@
 #include:amsmath
 #include:tikz
 #include:pdfcol
-
-# from utf8x option of inputenc
-#include:ucs
 
 #keyvals:\usepackage/runcode#c
 run

--- a/completion/showlabels.cwl
+++ b/completion/showlabels.cwl
@@ -1,5 +1,5 @@
 # showlabels package
-# Matthew Bertucci 10/13/2021 for v1.9
+# Matthew Bertucci 2022/07/26 for v1.9.2
 
 #keyvals:\usepackage/showlabels#c
 outer
@@ -17,6 +17,7 @@ final
 \showlabels[format cmds]{cmd name}
 
 \showlabelsinline
+\showlabelsmarginal 
 
 \showlabelsfont#*
 \showlabelsetlabel{arg}#*

--- a/completion/stickstootext.cwl
+++ b/completion/stickstootext.cwl
@@ -9,7 +9,6 @@
 #include:xkeyval
 
 #keyvals:\usepackage/stickstootext#c
-scale=%<factor%>
 scaled=%<factor%>
 lining
 lf

--- a/completion/stix2.cwl
+++ b/completion/stix2.cwl
@@ -270,8 +270,6 @@ upint
 \ddotseq#m
 \DDownarrow#m
 \Ddownarrow#m
-\Ddownarrow#m
-\DDownarrow#m
 \diagdown#m
 \diagup#m
 \diameter#m
@@ -1305,8 +1303,6 @@ upint
 \urtriangle#m
 \UUparrow#m
 \Uuparrow#m
-\Uuparrow#m
-\UUparrow#m
 \varbarwedge#m
 \varcarriagereturn#m
 \varclubsuit#m

--- a/completion/tdclock.cwl
+++ b/completion/tdclock.cwl
@@ -1,0 +1,61 @@
+# tdclock package
+# Matthew Bertucci 2022/07/25 for v2.3
+
+#include:hyperref
+#include:xcolor
+#include:xkeyval
+
+#keyvals:\usepackage/tdclock#c
+font=#Helv,HelvB,HelvI,HelvBI,Times,TimesB,TimesI,TimesBI,Cour,CourB,CourI,CourBI
+timeinterval=%<integer%>
+timeduration=%<minutes%>
+timewarningfirst=%<integer 0-100%>
+timewarningsecond=%<integer 0-100%>
+timedeath=%<0|1%>
+colorwarningfirst=#%color
+colorwarningsecond=#%color
+fillcolorwarningfirst=#%color
+fillcolorwarningsecond=#%color
+resetatpages=#none,all,%<integer%>,{%<list of integers%>}
+pageresetcontrol=#pdfpagelabels,pdfpagenumbers
+#endkeyvals
+
+\initclock
+\tdclock
+\tdtime
+\tddate
+\tdday
+\tdmonth
+\tdyear
+\tdhours
+\tdminutes
+\tdseconds
+\crono
+\cronohours
+\cronominutes
+\cronoseconds
+\resetcrono{button text}
+\toggleclock{button text}
+\factorclockfont{factor}
+\hhmmss
+\hhmm
+\timeseparator#*
+\ddmmyyyy
+\mmddyyyy
+\dateseparator#*
+\pdfslash#*
+\pdfcolon#*
+
+# not documented
+\colorninety#S
+\colorninetyfive#S
+\fillcolorninety#S
+\fillcolorninetyfive#S
+\auxiliar#S
+\resetclock#S
+\tdwarningbox{arg}#S
+\mm#S
+\sizebox#S
+\clockfield{field}#S
+\initfields#S
+\startclock#S

--- a/completion/texdraw.cwl
+++ b/completion/texdraw.cwl
@@ -1,0 +1,69 @@
+# texdraw package
+# Matthew Bertucci 2022/07/27 for v2019-04-18
+
+#include:graphics
+
+\begin{texdraw}#\pictureHighlight
+\end{texdraw}
+
+\centertexdraw{TeXdraw commands}
+\everytexdraw{TeXdraw commands}
+
+\drawdim %<dim%>
+\move (x y)
+\lvec (x y)
+\avec (x y)
+\rmove (dx dy)
+\rlvec (dx dy)
+\ravec (dx dy)
+\linewd %<width%>
+\lpatt (pattern)
+\setgray %<level%>
+\arrowheadtype t:%<type%>
+\arrowheadsize l:%<length%> w:%<width%>
+\htext (x y){text}
+\htext{text}
+\vtext (x y){text}
+\vtext{text}
+\rtext td:%<angle%> (x y){text}
+\rtext td:%<angle%> {text}
+\textref h:%<h-ref%> v:%<v-ref%>
+\lcir r:%<radius%>
+\fcir f:%<level%> r:%<radius%>
+\lellip rx:%<x-radius%> ry:%<y-radius%>
+\fellip f:%<level%> rx:%<x-radius%> ry:%<y-radius%>
+\larc r:%<radius%> sd:%<start-angle%> ed:%<end-angle%>
+\clvec (x1 y1)(x2 y2)(x3 y3)
+\lfill f:%<level%>
+\ifill f:%<level%>
+\bsegment
+\esegment
+\savecurrpos (*%<px%> *%<py%>)
+\savepos (%<x y%>)(*%<px%> *%<py%>)
+\setunitscale %<scale%>
+\relunitscale %<value%>
+\setsegscale %<scale%>
+\relsegscale %<value%>
+\drawbb
+\writeps{ps-commands}
+\getpos (%<x y%>)%<\mx\my%>
+\realmult {%<value1%>}{%<value2%>}%<\prod%>
+\realmult{value1}{value2}{cmd}#Sd
+
+# for plaintex
+\btexdraw#S
+\etexdraw#S
+
+# not documented
+\TeXdrawId#S
+\coordtopix {dimen}{pixels}#*
+\getsympos (%<x y%>)%<\mx\my%>#*
+\intdiv{numerator}{denominator}{macro%cmd}#*d
+\listtopix (list){macro%cmd}#*d
+\pixtobp{pixels}{macro%cmd}#*d
+\pixtocoord{pixels}{macro%cmd}#*d
+\pixtodim{pixels}{dimen}#*
+\rottxt{arg1}{arg2}
+\setRevDate#S
+\sppix %<num%>/%<unit%>
+\writetx{ps-commands}#*

--- a/completion/xeCJK.cwl
+++ b/completion/xeCJK.cwl
@@ -1,11 +1,10 @@
 # xeCJK package
 # Darcy Hu <hot123tea123@gmail.com> 2016
 #modified zepinglee 30 Jan 2021
-# updated 02 May 2022 for v3.8.8
+# updated 7 June 2022 for v3.9.0
 
 #include:xetex
 #include:expl3
-#include:l3keys2e
 #include:xtemplate
 #include:xparse
 #include:fontspec

--- a/completion/xpinyin.cwl
+++ b/completion/xpinyin.cwl
@@ -1,8 +1,7 @@
 # xpinyin package
-# Matthew Bertucci 12/30/2021 for v2.9
+# Matthew Bertucci 2022/07/26 for v3.1
 
 #include:xparse
-#include:l3keys2e
 #include:CJKutf8
 
 \begin{pinyinscope}

--- a/completion/zhnumber.cwl
+++ b/completion/zhnumber.cwl
@@ -1,10 +1,10 @@
 # zhnumber package
 # Darcy Hu <hot123tea123@gmail.com> 2016
 #modified zepinglee 30 Jan 2021
+# edited for v3.0
 
 #include:expl3
 #include:xparse
-#include:l3keys2e
 
 \zhnumber{number}
 \zhnumber[options%keyvals]{number}
@@ -122,6 +122,8 @@ sun=
 #endkeyvals
 
 # not documented
+\zhnumClearWrapper#*
+\zhnumResetWrapper#*
 \zhnumberwithoptions{options}{number}#S
 \zhdigitswithoptions{options}{number}#S
 \zhnumwithoptions{options}{counter}#S


### PR DESCRIPTION
New cwls for `analogclock`, `bxeepic`, `jlreq-deluxe`, `robustglossary`, `robustindex`, `texdraw`, and `tdclock`.

Updated cwl for `babel` and other small fixes.