### PR TITLE
Stop re-calculating text width after rebuilds

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -705,7 +705,6 @@ void PDFWidget::setDocument(const QSharedPointer<Poppler::Document> &doc)
 	document = doc;
 	maxPageSize.setHeight(-1.0);
 	maxPageSize.setWidth(-1.0);
-    horizontalTextRange.setWidth(-1.0);
 
 	if (!document.isNull()) {
 		docPages = document->numPages();


### PR DESCRIPTION
Revert e9cfcec7a8a73045882b6551d71deeb679401989, unfix #1935. See: https://github.com/texstudio-org/texstudio/issues/1935#issuecomment-1199282889 for the explanations.