### PR TITLE
fix update check if current version type is stable

### DIFF
--- a/src/tests/utilsversion_t.h
+++ b/src/tests/utilsversion_t.h
@@ -210,6 +210,7 @@ private slots:
 		QTest::newRow("valid2.6") << "3.0.1" << "alpha" << 0 << 0 << true;
 		QTest::newRow("valid2.7") << "3.0.1" << "alpha" << -1 << 0 << false;
 		QTest::newRow("valid2.8") << "3.0.1" << "alpha" << 1 << -2 << false;
+		QTest::newRow("valid2.9") << "2.3.1" << "" << 1 << 0 << false;
 	}
 
 	void isValid2() {

--- a/src/updatechecker.cpp
+++ b/src/updatechecker.cpp
@@ -148,6 +148,8 @@ void UpdateChecker::checkForNewVersion()
 	bool checkReleaseCandidate = updateLevel >= 1;
 	bool checkDevVersions = updateLevel >= 2;
 	Version currentVersion = Version::current();
+	if (!currentVersion.isValid())
+		UtilsUi::txsWarning(tr("Current version number:%1 type:%2 revision:%3 not valid.").arg(currentVersion.versionNumber,currentVersion.type).arg(currentVersion.revision));
 	QString downloadAddress = "https://texstudio.org";
 	QString downloadAddressGit = "https://github.com/texstudio-org/texstudio/releases";
 

--- a/src/utilsVersion.cpp
+++ b/src/utilsVersion.cpp
@@ -100,7 +100,6 @@ Version::VersionCompareResult Version::compareIntVersion(const QList<int> &v1, c
 Version Version::current(const QString &versionString)
 {
 	QStringList vp = stringVersion2Parts(versionString);
-//	qDebug() << "Version::current:" << versionString;
 	if (!vp.isEmpty()) {
 		QString ver = vp[0];
 		QString type = vp[1];
@@ -139,8 +138,6 @@ QString Version::versionToString(const Version &v)
 
 bool Version::operator >(const Version &other) const
 {
-//	qDebug() << "Version::operator left :" << versionToString(*this);
-//	qDebug() << "Version::operator right:" << versionToString(other);
 	VersionCompareResult res = compareStringVersion(versionNumber, other.versionNumber);
     if (res != Same)
         return (res == Higher);

--- a/src/utilsVersion.cpp
+++ b/src/utilsVersion.cpp
@@ -102,11 +102,12 @@ Version Version::current(const QString &versionString)
 	QStringList vp = stringVersion2Parts(versionString);
 	qDebug() << "Version::current:" << versionString;
 	if (!vp.isEmpty()) {
+		QString ver = vp[0];
 		QString type = vp[1];
 		if (type == "") type = "stable";
 		int revision = vp[2].toInt();
 		int commitsAfter = vp[3].toInt();
-		Version v( TXSVERSION, type, revision, commitsAfter);
+		Version v( ver, type, revision, commitsAfter);
 #if defined(Q_OS_WIN)
 		v.platform =  "win";
 #elif defined(Q_OS_MAC)

--- a/src/utilsVersion.cpp
+++ b/src/utilsVersion.cpp
@@ -100,8 +100,10 @@ Version::VersionCompareResult Version::compareIntVersion(const QList<int> &v1, c
 Version Version::current(const QString &versionString)
 {
 	QStringList vp = stringVersion2Parts(versionString);
+	qDebug() << "Version::current:" << versionString;
 	if (!vp.isEmpty()) {
 		QString type = vp[1];
+		if (type == "") type = "stable";
 		int revision = vp[2].toInt();
 		int commitsAfter = vp[3].toInt();
 		Version v( TXSVERSION, type, revision, commitsAfter);
@@ -136,6 +138,8 @@ QString Version::versionToString(const Version &v)
 
 bool Version::operator >(const Version &other) const
 {
+	qDebug() << "Version::operator left :" << versionToString(*this);
+	qDebug() << "Version::operator right:" << versionToString(other);
 	VersionCompareResult res = compareStringVersion(versionNumber, other.versionNumber);
     if (res != Same)
         return (res == Higher);

--- a/src/utilsVersion.cpp
+++ b/src/utilsVersion.cpp
@@ -100,7 +100,7 @@ Version::VersionCompareResult Version::compareIntVersion(const QList<int> &v1, c
 Version Version::current(const QString &versionString)
 {
 	QStringList vp = stringVersion2Parts(versionString);
-	qDebug() << "Version::current:" << versionString;
+//	qDebug() << "Version::current:" << versionString;
 	if (!vp.isEmpty()) {
 		QString ver = vp[0];
 		QString type = vp[1];
@@ -139,8 +139,8 @@ QString Version::versionToString(const Version &v)
 
 bool Version::operator >(const Version &other) const
 {
-	qDebug() << "Version::operator left :" << versionToString(*this);
-	qDebug() << "Version::operator right:" << versionToString(other);
+//	qDebug() << "Version::operator left :" << versionToString(*this);
+//	qDebug() << "Version::operator right:" << versionToString(other);
 	VersionCompareResult res = compareStringVersion(versionNumber, other.versionNumber);
     if (res != Same)
         return (res == Higher);


### PR DESCRIPTION
This PR will fix a problem with current stable version 4.3.0. When updates are checked result is:

![image](https://user-images.githubusercontent.com/102688820/184181674-ec25b656-132a-463e-a011-e874f06c4d23.png)
The second 0 is the revision that is printed after the version type (which should be "stable", s. next section).

Reason: Conversion of string "4.3.0" into a version object leaves type as null string instead of assigning "stable". This was intended to remember that the string was not the equivalent one "4.3.0stable0" (which would be accepted but is never used). But printing the version always suppresses stable0, so a null string for type is obsolete.

This is fixed and I added printing some debug information. Further I added a message for the case that the current version object isn't valid (note that type is emtpy in the message):

![image](https://user-images.githubusercontent.com/102688820/184184223-edea145d-f860-4fbe-8895-cb16ec7c442f.png)
This is accompanied by a new auto test for this case.

Final test running txs now shows the message expected:

![image](https://user-images.githubusercontent.com/102688820/184184371-83be39d0-7e84-4cfe-b173-62c6cadf2866.png)
