### PR TITLE
Update usermanual_en.html

### DIFF
--- a/utilities/manual/usermanual_en.html
+++ b/utilities/manual/usermanual_en.html
@@ -328,7 +328,7 @@ A shortcut can be assigned a multiple keystroke combinations, for example <code>
 If a shortcut should be set to default value or removed completely, the items "&lt;default&gt;" or "&lt;none&gt;" at the top of the list can be selected respectively.
 </p>
 <p>
-A rough overview of the available (default) keyboard shortcuts can be found in <a href="#SHORTCUTS">Section 4.12</a>.
+A rough overview of the available (default) keyboard shortcuts can be found in <a href="#SHORTCUTS">Section 4.13</a>.
 </p>
 <p><IMG src="configure_shortcuts.png" border="1" alt="Configure Shortcuts"></p>
 <h2 id="SECTION06">1.7 Configuring the Latex/Math-Menu (Advanced option)</h2>

--- a/utilities/manual/usermanual_en.html
+++ b/utilities/manual/usermanual_en.html
@@ -82,7 +82,7 @@
   <li><a href="#MISC-FEATURES">4.16 Miscellaneous Features</a></li>
 	</ul>
 </li>
-<li><a href="#TENTATIVE-FEATURES">5. Experimental Features</a>
+<li><a href="#EXPERIMENTAL-FEATURES">5. Experimental Features</a>
 	<ul>
 	<li><a href="#ADVANCED-SCRIPTING">5.1 Advanced Scripting</a></li>
 	<li><a href="#STYLESHEETS">5.2 Style Sheets</a></li>
@@ -1879,7 +1879,7 @@ println("\\end{"+env+"}")
   Normally every structure command marks a start of foldable range, and every environment or TeX group constructs a foldable range. You can mark an extra foldable range by inserting special comments <code>%BEGIN_FOLD</code> and <code>%END_FOLD</code>.
 </ul>
 
-<h1 id="TENTATIVE-FEATURES">5. Tentative Features</h1>
+<h1 id="EXPERIMENTAL-FEATURES">5. Experimental Features</h1>
 <p>These features allow you to modify core aspects of TeXstudio and thus provide a great flexibility of adapting TeXstudio to your needs. Since these features are either complex or are tightly bound to the internals, we cannot guarantee functionality in all cases and forever. For once, we do not have enough resources to provide full support. Additionally, the dependence on internals conflicts with our need to freely change internals without restriction for future development.</p>
 <p>Nevertheless, we decided that these features may be of interest for experiended users. As a compromise, we provide these features tentatively.</p>
 <p><strong>We do not guarantee any of this will still be working in future versions. Functionality may change or be removed without notice.</strong></p>


### PR DESCRIPTION
Label #SHORTCUTS refers to section _4.13 Keyboard shortcuts_, not _4.12 Synopsis of the TeXstudio command_.
The wrong text appeared in _1.6 Configuring shortcuts_.
Two other places where text 4.12 is used are correct.

This PR also removes a mismatch among the title of the 5<sup>th</sup> chapter _Tentative Features_ and its name _Experimental Features_ in the index and the label (TENTATIVE-FEATURES).