### PR TITLE
fix alignement of option in insert graphic wizard

### DIFF
--- a/src/insertgraphics.ui
+++ b/src/insertgraphics.ui
@@ -190,22 +190,6 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>8</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
       <widget class="QCheckBox" name="cbCentering">
        <property name="text">
         <string>Center Horizontally</string>


### PR DESCRIPTION
This PR fixes #2538.

Change: Removed spacer in front of the checkbox of option "Center Horizontally":

before:
![image](https://user-images.githubusercontent.com/102688820/192119350-acea12e3-2c47-4da1-93d4-4e8e535a5a30.png)

after:
![image](https://user-images.githubusercontent.com/102688820/192119355-c741ed62-466e-4d1e-9007-a4c876721d7b.png)

Note:
A center env is used when only option Center Horizontally is set.
Are both options set (default) then \centering is used within a figure env.