### PR TITLE
usermanual typos: changed "an" to "a"

### DIFF
--- a/utilities/manual/build/html/advanced.html
+++ b/utilities/manual/build/html/advanced.html
@@ -250,7 +250,7 @@ on it.</p>
 <p><img alt="Menu SVN/GIT" src="_images/menu_svn.png" /></p>
 <dl class="simple myst">
 <dt>“File/Checkin”</dt><dd><p>Performs an explicit save and check in, with a input
-dialog which asks for an checkin in message which is stored in the SVN/GIT
+dialog which asks for a checkin in message which is stored in the SVN/GIT
 history.</p>
 </dd>
 <dt>“File/Show old Revisions”</dt><dd><p>Pops up a dialog, which shows all available
@@ -770,7 +770,7 @@ menus</p></li>
 <td><p>Converts a relative filename to an absolute one</p></td>
 </tr>
 <tr class="row-even"><td><p>app.load(file)</p></td>
-<td><p>Loads an file</p></td>
+<td><p>Loads a file</p></td>
 </tr>
 <tr class="row-odd"><td><p>app.fileOpen/Save/Close/…/editUndo/…/QuickBuild/…</p></td>
 <td><p>All menu commands (i.e. all slots in the texmaker.h file). You can view a list of all currently existing slots on the “menu” page of the config dialog.</p></td>
@@ -788,7 +788,7 @@ menus</p></li>
 <td><p>Creates a new action and returns it<br><br>-   menu: Parent menu<br>-   id: Id of the new action (the final, unique id will be <em>menu id/action id</em>)<br>-   caption: Visible text<br><br>You can use action.triggered.connect(function(){ … }); to link a function to the returned action (for details see the <a class="reference external" href="https://doc.qt.io/qt-6/signalsandslots.html">qt signal/slot</a> documentation).</p></td>
 </tr>
 <tr class="row-even"><td><p>app.getManagedAction([id])</p></td>
-<td><p>Returns an <a class="reference external" href="https://doc.qt.io/qt-6/qaction.html">QAction</a> with a certain id (all ids have the form main/menu1/menu2/…/menuN/action, with usually one menu, e.g. “main/edit/undo”, see texmaker.cpp)</p></td>
+<td><p>Returns a <a class="reference external" href="https://doc.qt.io/qt-6/qaction.html">QAction</a> with a certain id (all ids have the form main/menu1/menu2/…/menuN/action, with usually one menu, e.g. “main/edit/undo”, see texmaker.cpp)</p></td>
 </tr>
 <tr class="row-odd"><td><p>app.createUI(file, [parent])</p></td>
 <td><p>Loads a certain ui file and creates a QWidget* from it</p></td>

--- a/utilities/manual/build/html/configuration.html
+++ b/utilities/manual/build/html/configuration.html
@@ -1058,7 +1058,7 @@ custom toolbar list in the configure dialog.</p>
 <div class="section" id="configuring-svn-git-support">
 <h2>Configuring SVN/GIT support<a class="headerlink" href="#configuring-svn-git-support" title="Permalink to this heading">#</a></h2>
 <p>TexStudio supports some simple actions for subversion/git. Here svn or git can be selected.</p>
-<p>“Automatically check in after save” allows TeXstudio to perform an SVN
+<p>“Automatically check in after save” allows TeXstudio to perform a SVN
 check in after every save of a document, thus providing a very complete
 history of the creation of a document. Since text documents are rather
 small compared to disk spaces, size of the SVN/GIT database should not be a

--- a/utilities/manual/build/html/editing.html
+++ b/utilities/manual/build/html/editing.html
@@ -547,7 +547,7 @@ settings.</p>
 <p>This toolbox in the toolbar allows you to insert quickly the label,
 cite, ref, footnote… code.</p>
 <p><img alt="Structure View Labels" src="_images/tb_reference.png" /></p>
-<p>Selecting “reference” open a dialog which let’s you select an reference and inserts the complete code.
+<p>Selecting “reference” open a dialog which let’s you select a reference and inserts the complete code.
 All other commands will be inserted with empty arguments.</p>
 <p><img alt="Inserting reference" src="_images/insert_ref.png" /></p>
 <p>The labels used in your documents are displayed in the “Structure View”.

--- a/utilities/manual/build/html/getting_started.html
+++ b/utilities/manual/build/html/getting_started.html
@@ -228,7 +228,7 @@ The central toolbar offers access to some common latex commands as we will see.<
 </div>
 <div class="section" id="create-a-first-document">
 <h2>Create a first document<a class="headerlink" href="#create-a-first-document" title="Permalink to this heading">#</a></h2>
-<p>LaTeX needs some configuartion code in the document. The <a class="reference internal" href="editing.html#setting-the-preamble-of-a-tex-document"><span class="std std-doc">Quick Start Wizard</span></a> offers an easy way to set up an typical document.</p>
+<p>LaTeX needs some configuartion code in the document. The <a class="reference internal" href="editing.html#setting-the-preamble-of-a-tex-document"><span class="std std-doc">Quick Start Wizard</span></a> offers an easy way to set up a typical document.</p>
 <p><img alt="Quick start wizard" src="_images/txs_wizard.png" /></p>
 <p>Select <code class="docutils literal notranslate"><span class="pre">Wizards/Quick</span> <span class="pre">Start...</span></code> and confirm the dialog with <code class="docutils literal notranslate"><span class="pre">OK</span></code>.
 This will lead to this basic document:</p>
@@ -261,7 +261,7 @@ So next we click the save button (or use <code class="docutils literal notransla
 </div>
 <div class="section" id="insert-symbols">
 <h3>Insert symbols<a class="headerlink" href="#insert-symbols" title="Permalink to this heading">#</a></h3>
-<p>LaTeX offers a huge number of mathematical and other symbols. An convenient way of selecting the right one is using the symbol pane on the left side. Symbols can be declared as favourites and the most used symbols are collected as well to allow faster navigation.</p>
+<p>LaTeX offers a huge number of mathematical and other symbols. A convenient way of selecting the right one is using the symbol pane on the left side. Symbols can be declared as favourites and the most used symbols are collected as well to allow faster navigation.</p>
 <p><img alt="symbol pane" src="_images/txs_symbol.png" /></p>
 </div>
 </div>

--- a/utilities/manual/source/advanced.md
+++ b/utilities/manual/source/advanced.md
@@ -48,7 +48,7 @@ on it.
 
 \"File/Checkin\" 
 :   Performs an explicit save and check in, with a input
-    dialog which asks for an checkin in message which is stored in the SVN/GIT
+    dialog which asks for a checkin in message which is stored in the SVN/GIT
     history.
 
 \"File/Show old Revisions\"
@@ -355,13 +355,13 @@ The following table gives an overview on the provided commands.
 | app.clipboard | Property to read/write to the clipboard |
 | app.getCurrentFileName() | File name of currently edited file |
 | app.getAbsoluteFilePath(rel, ext = \"\") | Converts a relative filename to an absolute one |
-| app.load(file) | Loads an file |
+| app.load(file) | Loads a file |
 | app.fileOpen/Save/Close/\.../editUndo/\.../QuickBuild/\... | All menu commands (i.e. all slots in the texmaker.h file). You can view a list of all currently existing slots on the \"menu\" page of the config dialog. |
 | app.completerIsVisible() | check if completer is visible. |
 | app.newManagedMenu(\[parent menu,\] id, caption) | Creates a new menu and returns it |
 | app.getManagedMenu(id) | Returns a [QMenu](https://doc.qt.io/qt-6/qmenu.html) with a certain id |
 | app.newManagedAction(menu, id, caption) | Creates a new action and returns it<br><br>-   menu: Parent menu<br>-   id: Id of the new action (the final, unique id will be *menu id/action id*)<br>-   caption: Visible text<br><br>You can use action.triggered.connect(function(){ \... }); to link a function to the returned action (for details see the [qt signal/slot](https://doc.qt.io/qt-6/signalsandslots.html) documentation). |
-| app.getManagedAction(\[id\]) | Returns an [QAction](https://doc.qt.io/qt-6/qaction.html) with a certain id (all ids have the form main/menu1/menu2/\.../menuN/action, with usually one menu, e.g. \"main/edit/undo\", see texmaker.cpp) |
+| app.getManagedAction(\[id\]) | Returns a [QAction](https://doc.qt.io/qt-6/qaction.html) with a certain id (all ids have the form main/menu1/menu2/\.../menuN/action, with usually one menu, e.g. \"main/edit/undo\", see texmaker.cpp) |
 | app.createUI(file, \[parent\]) | Loads a certain ui file and creates a QWidget\* from it |
 | app.createUIFromString(string, \[parent\]) | Creates a QWidget\* described in the string |
 | app.slowOperationStarted()/slowOperationEnded() | Notify txs about the start/end of a slow operation to temporary disable the endless loop detection. |

--- a/utilities/manual/source/configuration.md
+++ b/utilities/manual/source/configuration.md
@@ -803,7 +803,7 @@ custom toolbar list in the configure dialog.
 
 TexStudio supports some simple actions for subversion/git. Here svn or git can be selected.
 
-\"Automatically check in after save\" allows TeXstudio to perform an SVN
+\"Automatically check in after save\" allows TeXstudio to perform a SVN
 check in after every save of a document, thus providing a very complete
 history of the creation of a document. Since text documents are rather
 small compared to disk spaces, size of the SVN/GIT database should not be a

--- a/utilities/manual/source/editing.md
+++ b/utilities/manual/source/editing.md
@@ -358,7 +358,7 @@ cite, ref, footnote\... code.
 
 ![Structure View Labels](images/tb_reference.png)
 
-Selecting "reference" open a dialog which let's you select an reference and inserts the complete code.
+Selecting "reference" open a dialog which let's you select a reference and inserts the complete code.
 All other commands will be inserted with empty arguments.
 
 ![Inserting reference](images/insert_ref.png)

--- a/utilities/manual/source/getting_started.md
+++ b/utilities/manual/source/getting_started.md
@@ -18,7 +18,7 @@ On the lower right you see the *messages panel* which can be switched to the [*l
 The central toolbar offers access to some common latex commands as we will see.
 
 ## Create a first document
-LaTeX needs some configuartion code in the document. The [Quick Start Wizard](editing.md#setting-the-preamble-of-a-tex-document) offers an easy way to set up an typical document.
+LaTeX needs some configuartion code in the document. The [Quick Start Wizard](editing.md#setting-the-preamble-of-a-tex-document) offers an easy way to set up a typical document.
 
 ![Quick start wizard](images/txs_wizard.png)
 
@@ -53,7 +53,7 @@ We can insert an equation environment via the menu `Math/Math equations/env equa
 ![Insert equation](images/txs_equation.png)
 
 ### Insert symbols
-LaTeX offers a huge number of mathematical and other symbols. An convenient way of selecting the right one is using the symbol pane on the left side. Symbols can be declared as favourites and the most used symbols are collected as well to allow faster navigation.
+LaTeX offers a huge number of mathematical and other symbols. A convenient way of selecting the right one is using the symbol pane on the left side. Symbols can be declared as favourites and the most used symbols are collected as well to allow faster navigation.
 
 ![symbol pane](images/txs_symbol.png)
 


### PR DESCRIPTION
Several cases where a word starting with a consonant follows the word "an".