### PR TITLE
usermanual typos: changed "a" to "an"

### DIFF
--- a/utilities/manual/build/html/advanced.html
+++ b/utilities/manual/build/html/advanced.html
@@ -249,7 +249,7 @@ on it.</p>
 </div>
 <p><img alt="Menu SVN/GIT" src="_images/menu_svn.png" /></p>
 <dl class="simple myst">
-<dt>“File/Checkin”</dt><dd><p>Performs an explicit save and check in, with a input
+<dt>“File/Checkin”</dt><dd><p>Performs an explicit save and check in, with an input
 dialog which asks for an checkin in message which is stored in the SVN/GIT
 history.</p>
 </dd>

--- a/utilities/manual/build/html/configuration.html
+++ b/utilities/manual/build/html/configuration.html
@@ -938,7 +938,7 @@ it there.</p>
 <p>In the advanced config mode, you can also mark certain LT rules as
 “special” whose matches will then be highlighted in a
 different/customizable way. This can be useful to do a stylistic
-analysis, e.g. by creating a own rule in LT highlighting all verbs or
+analysis, e.g. by creating an own rule in LT highlighting all verbs or
 all adverbs.</p>
 <p><img alt="advanced LT rules" src="_images/conf_LT_adv.png" /></p>
 <p>Independent from LanguageTool, TeXstudio also checks for repeated and
@@ -1051,7 +1051,7 @@ can be be directly edited by doubleclicking on them.</p>
 <p>One Custom Toolbar is present in TMX. This toolbar can be filled with
 actions from the Latex-, Math- and User-Menu. Since many of those item
 don’t have icons, user icons can be loaded as well. This is achieved by
-applying “load other icon” from the context menu on a item in the
+applying “load other icon” from the context menu on an item in the
 custom toolbar list in the configure dialog.</p>
 <p><img alt="Customize Toolbars" src="_images/configure_customToolbar.png" /></p>
 </div>

--- a/utilities/manual/build/html/editing.html
+++ b/utilities/manual/build/html/editing.html
@@ -236,7 +236,7 @@ from template”. A dialogue gives a selection of templates.</p>
 it as file(s) on disk and open these in the editor. The former option is
 not available for multi-file templates.</p>
 <p>New templates can be created by using the command “File/Make Template”
-on a opened document which you like to have has a template. Note that
+on an opened document which you like to have has a template. Note that
 this dialog currently does not support the full capabilities of the
 template system. In particular you cannot supply a preview image or
 create a multi-file template with it. You’ll have to do this manually
@@ -605,7 +605,7 @@ commands.</p></li>
 <li><p>Most used: list only commands which have already been used in the
 completer by the user. This Is empty if txs has not been used before.</p></li>
 <li><p>Fuzzy: search the command in a fuzzy way. The command needs to
-contain all given letters in the same order though with a arbitrary
+contain all given letters in the same order though with an arbitrary
 of letters between them. E.g. <code class="docutils literal notranslate"><span class="pre">\bf</span></code> lists, among others,
 \<strong>b</strong>egin{<strong>f</strong>igure}</p></li>
 <li><p>All: list all known commands.</p></li>

--- a/utilities/manual/source/advanced.md
+++ b/utilities/manual/source/advanced.md
@@ -47,7 +47,7 @@ on it.
 ![Menu SVN/GIT](images/menu_svn.png)
 
 \"File/Checkin\" 
-:   Performs an explicit save and check in, with a input
+:   Performs an explicit save and check in, with an input
     dialog which asks for an checkin in message which is stored in the SVN/GIT
     history.
 

--- a/utilities/manual/source/configuration.md
+++ b/utilities/manual/source/configuration.md
@@ -669,7 +669,7 @@ it there.
 In the advanced config mode, you can also mark certain LT rules as
 \"special\" whose matches will then be highlighted in a
 different/customizable way. This can be useful to do a stylistic
-analysis, e.g. by creating a own rule in LT highlighting all verbs or
+analysis, e.g. by creating an own rule in LT highlighting all verbs or
 all adverbs.
 
 ![advanced LT rules](images/conf_LT_adv.png)
@@ -794,7 +794,7 @@ can be be directly edited by doubleclicking on them.
 One Custom Toolbar is present in TMX. This toolbar can be filled with
 actions from the Latex-, Math- and User-Menu. Since many of those item
 don\'t have icons, user icons can be loaded as well. This is achieved by
-applying \"load other icon\" from the context menu on a item in the
+applying \"load other icon\" from the context menu on an item in the
 custom toolbar list in the configure dialog.
 
 ![Customize Toolbars](images/configure_customToolbar.png)

--- a/utilities/manual/source/editing.md
+++ b/utilities/manual/source/editing.md
@@ -33,7 +33,7 @@ it as file(s) on disk and open these in the editor. The former option is
 not available for multi-file templates.
 
 New templates can be created by using the command \"File/Make Template\"
-on a opened document which you like to have has a template. Note that
+on an opened document which you like to have has a template. Note that
 this dialog currently does not support the full capabilities of the
 template system. In particular you cannot supply a preview image or
 create a multi-file template with it. You\'ll have to do this manually
@@ -432,7 +432,7 @@ below the command list. You can switch to the next mode by pressing `Shift+Space
 -   Most used: list only commands which have already been used in the
     completer by the user. This Is empty if txs has not been used before.
 -   Fuzzy: search the command in a fuzzy way. The command needs to
-    contain all given letters in the same order though with a arbitrary
+    contain all given letters in the same order though with an arbitrary
     of letters between them. E.g. `\bf` lists, among others,
     \\**b**egin{**f**igure}
 -   All: list all known commands.


### PR DESCRIPTION
Some cases where a word starting with a vowel follows the word "a".