### PR TITLE
usermanual manipulating tables w. multicursors

### DIFF
--- a/utilities/manual/build/html/editing.html
+++ b/utilities/manual/build/html/editing.html
@@ -458,7 +458,7 @@ current row. If already a command <code class="docutils literal notranslate"><sp
 command is placed.</p></li>
 <li><p>Remodel the table after a template,see <a class="reference internal" href="#using-table-templates"><span class="std std-doc">below</span></a>.</p></li>
 </ul>
-<p>TeXstudio also allows block cursors. Press <code class="docutils literal notranslate"><span class="pre">Ctrl+Alt</span></code>
+<p>TeXstudio also allows block cursors. Press <code class="docutils literal notranslate"><span class="pre">Ctrl+Shift</span></code>
 and drag the cursor with the mouse. The <a class="reference internal" href="#block-cursor"><span class="std std-doc">block cursor</span></a> works like a set of
 normal cursors. You can copy and paste text as usual. Also you can type
 in new text, which will be added in every row.

--- a/utilities/manual/source/editing.md
+++ b/utilities/manual/source/editing.md
@@ -256,7 +256,7 @@ The following functions are only accessible via the "Latex/Table Manipulation" m
     command is placed.
 -   Remodel the table after a template,see [below](#using-table-templates). 
 
-TeXstudio also allows block cursors. Press `Ctrl+Alt`
+TeXstudio also allows block cursors. Press `Ctrl+Shift`
 and drag the cursor with the mouse. The [block cursor](#block-cursor) works like a set of
 normal cursors. You can copy and paste text as usual. Also you can type
 in new text, which will be added in every row.


### PR DESCRIPTION
Ctrl+Shift instead of Ctrl+Alt, s. [#2608 comment](https://github.com/texstudio-org/texstudio/issues/2608#issuecomment-1263527690) and [block cursors](https://texstudio-org.github.io/editing.html#block-cursor)