### PR TITLE
completer shows macro name

### DIFF
--- a/src/latexcompleter.cpp
+++ b/src/latexcompleter.cpp
@@ -1686,7 +1686,10 @@ void LatexCompleter::updateAbbreviations()
 		// <!compatibility>
 		cw.word = macro.abbrev;
 		cw.sortWord = makeSortWord(cw.word);
-		cw.setName(macro.abbrev + tr(" (Usertag)"));
+		if (macro.name == "")
+			cw.setName(macro.abbrev + tr(" (Usertag)"));
+		else 
+			cw.setName(macro.abbrev + " (" + macro.name + ")");
 		wordsAbbrev << cw;
 	}
 	listModel->setAbbrevWords(wordsAbbrev);


### PR DESCRIPTION
This PR resolves #2679. @sunderme I would please you to update manual [here](https://texstudio-org.github.io/editing.html#user-tags-completion) (text and images).

As examples the completer will show
1. abbrev. a for macro named alpha:
![image](https://user-images.githubusercontent.com/102688820/202778105-6ee7d764-ee92-4979-a7ed-02de2ad47412.png)
2. abbrev. b for unnamed macro:
![image](https://user-images.githubusercontent.com/102688820/202778373-77c51f46-1c93-414b-9d09-f27bb3b625b4.png)

This also works for abbreviations starting with a backslash.