### PR TITLE
show Advanced Options notifications only one time

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -868,7 +868,7 @@ void ConfigDialog::advancedOptionsToggled(bool on)
 
 void ConfigDialog::advancedOptionsClicked(bool on)
 {
-	if (on) {
+	if (on & !riddled) {
 		if (!askRiddle()) ui.checkBoxShowAdvancedOptions->setChecked(false);
 		else riddled = true;
 	}


### PR DESCRIPTION
This PR closes #2684. The first time a user checks "Show Advanced Options" (in General options) he will be presented a notification about advanced options. Txs already remembers this (s. Config%20Riddled below). But due to this PR txs will never popup this notification again when Config%20Riddles is true.

see ini-file:
```
Interface\Config%20Show%20Advanced%20Options=false
Interface\Config%20Riddled=true
```