### PR TITLE
Improvements to config dialog pages layout

### DIFF
--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Configure TeXstudio</string>
   </property>
-  <layout class="QGridLayout">
+ <layout class="QGridLayout">
    <property name="leftMargin">
     <number>9</number>
    </property>
@@ -32,7 +32,25 @@
    <property name="verticalSpacing">
     <number>6</number>
    </property>
-   <item row="0" column="0">
+<item row="0" column="0">
+<widget class="QSplitter" name="mainSplitter">
+ <property name="childrenCollapsible">
+  <bool>
+   true
+  </bool>
+ </property>
+ <property name="handleWidth">
+  <number>9</number>
+ </property>
+ <widget class="QWidget" name="leftPart">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+       <horstretch>2</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+  <layout class="QVBoxLayout">
+   <item>
     <widget class="QListWidget" name="contentsWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
@@ -42,14 +60,8 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>200</width>
+       <width>40</width>
        <height>410</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>400</width>
-       <height>32000</height>
       </size>
      </property>
      <property name="horizontalScrollBarPolicy">
@@ -60,72 +72,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="2">
-    <layout class="QHBoxLayout">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <property name="sizeConstraint">
-      <enum>QLayout::SetMinimumSize</enum>
-     </property>
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QCheckBox" name="checkBoxShowAdvancedOptions">
-       <property name="text">
-        <string>Show Advanced Options</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Expanding</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>407</width>
-         <height>31</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="okButton">
-       <property name="text">
-        <string>OK</string>
-       </property>
-       <property name="default">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="cancelButton">
-       <property name="text">
-        <string>Cancel</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="1" column="0">
+   <item>
     <widget class="QLineEdit" name="lineEditMetaFilter">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -138,7 +85,17 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1" rowspan="2">
+  </layout>
+ </widget>
+ <widget class="QWidget" name="rightPart">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+       <horstretch>4</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+  <layout class="QGridLayout">
+   <item row="0" column="0" rowspan="2">
     <widget class="QStackedWidget" name="pagesWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
@@ -526,7 +483,7 @@
              <property name="title">
               <string>Update</string>
              </property>
-             <layout class="QGridLayout" name="gridLayout3">
+             <layout class="QGridLayout" name="gridLayout03">
               <item row="0" column="6">
                <widget class="QComboBox" name="comboBoxUpdateLevel">
                 <property name="sizePolicy">
@@ -4771,6 +4728,79 @@ Note: Changing this setting will only affect documents that are opened afterward
     </widget>
    </item>
   </layout>
+ </widget>
+</widget>
+</item>
+ <item row="1" column="0">
+  <layout class="QGridLayout">
+   <item row="2" column="0" colspan="2">
+    <layout class="QHBoxLayout">
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <property name="sizeConstraint">
+      <enum>QLayout::SetMinimumSize</enum>
+     </property>
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QCheckBox" name="checkBoxShowAdvancedOptions">
+       <property name="text">
+        <string>Show Advanced Options</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Expanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>407</width>
+         <height>31</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="okButton">
+       <property name="text">
+        <string>OK</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="cancelButton">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </item>
+ </layout>
  </widget>
  <tabstops>
   <tabstop>scrollAreaGeneral</tabstop>

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -27,7 +27,7 @@
     <number>9</number>
    </property>
    <property name="horizontalSpacing">
-    <number>18</number>
+    <number>12</number>
    </property>
    <property name="verticalSpacing">
     <number>6</number>
@@ -60,7 +60,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="3">
+   <item row="2" column="0" colspan="2">
     <layout class="QHBoxLayout">
      <property name="spacing">
       <number>6</number>
@@ -138,7 +138,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="2" rowspan="2">
+   <item row="0" column="1" rowspan="2">
     <widget class="QStackedWidget" name="pagesWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
@@ -197,7 +197,7 @@
             <number>0</number>
            </property>
            <property name="rightMargin">
-            <number>9</number>
+            <number>0</number>
            </property>
            <property name="bottomMargin">
             <number>0</number>
@@ -777,6 +777,9 @@
            <property name="topMargin">
             <number>0</number>
            </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
            <property name="bottomMargin">
             <number>0</number>
            </property>
@@ -912,122 +915,104 @@
                </widget>
               </item>
               <item row="7" column="0" colspan="2">
-               <widget class="QScrollArea" name="scrollAreaPaths">
-                <property name="frameShape">
-                 <enum>QFrame::NoFrame</enum>
+               <layout class="QGridLayout" name="gridLayout_1">
+                <property name="leftMargin">
+                 <number>9</number>
                 </property>
-                <property name="widgetResizable">
-                 <bool>true</bool>
+                <property name="topMargin">
+                 <number>0</number>
                 </property>
-                <widget class="QWidget" name="scrollAreaWidgetContents_4">
-                 <property name="geometry">
-                  <rect>
-                   <x>0</x>
-                   <y>0</y>
-                   <width>638</width>
-                   <height>70</height>
-                  </rect>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_1">
-                  <property name="leftMargin">
-                   <number>9</number>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <property name="verticalSpacing">
+                 <number>2</number>
+                </property>
+                <item row="1" column="1">
+                 <widget class="QLineEdit" name="lineEditPathPDF"/>
+                </item>
+                <item row="2" column="1">
+                 <widget class="QLineEdit" name="lineEditPathCommands"/>
+                </item>
+                <item row="1" column="2">
+                 <widget class="QPushButton" name="pushButtonPathPdf">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
                   </property>
-                  <property name="topMargin">
-                   <number>0</number>
+                  <property name="text">
+                   <string/>
                   </property>
-                  <property name="rightMargin">
-                   <number>0</number>
+                  <property name="icon">
+                   <iconset resource="../images.qrc">
+                    <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
                   </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
+                 </widget>
+                </item>
+                <item row="2" column="0">
+                 <widget class="QLabel" name="label_59">
+                  <property name="text">
+                   <string>Commands ($PATH)</string>
                   </property>
-                  <property name="verticalSpacing">
-                   <number>2</number>
+                 </widget>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QLabel" name="label_58">
+                  <property name="text">
+                   <string>PDF File</string>
                   </property>
-                  <item row="1" column="1">
-                   <widget class="QLineEdit" name="lineEditPathPDF"/>
-                  </item>
-                  <item row="2" column="1">
-                   <widget class="QLineEdit" name="lineEditPathCommands"/>
-                  </item>
-                  <item row="1" column="2">
-                   <widget class="QPushButton" name="pushButtonPathPdf">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../images.qrc">
-                      <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="label_59">
-                    <property name="text">
-                     <string>Commands ($PATH)</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="label_58">
-                    <property name="text">
-                     <string>PDF File</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
-                   <widget class="QLineEdit" name="lineEditPathLog"/>
-                  </item>
-                  <item row="0" column="2">
-                   <widget class="QPushButton" name="pushButtonPathLog">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../images.qrc">
-                      <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="2">
-                   <widget class="QPushButton" name="pushButtonPathCommands">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../images.qrc">
-                      <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="label_57">
-                    <property name="text">
-                     <string>Log File</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </widget>
+                 </widget>
+                </item>
+                <item row="0" column="1">
+                 <widget class="QLineEdit" name="lineEditPathLog"/>
+                </item>
+                <item row="0" column="2">
+                 <widget class="QPushButton" name="pushButtonPathLog">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="icon">
+                   <iconset resource="../images.qrc">
+                    <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="2">
+                 <widget class="QPushButton" name="pushButtonPathCommands">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="icon">
+                   <iconset resource="../images.qrc">
+                    <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="0">
+                 <widget class="QLabel" name="label_57">
+                  <property name="text">
+                   <string>Log File</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
               </item>
               <item row="6" column="0" colspan="2">
                <widget class="QLabel" name="label_68">
@@ -1400,7 +1385,7 @@ Then you can select a new shortcut by one of the following ways:
        <item>
         <widget class="QGroupBox" name="groupBox_17">
          <property name="title">
-          <string>Scaling</string>
+          <string>GUI Scaling</string>
          </property>
          <layout class="QGridLayout">
           <property name="horizontalSpacing">
@@ -1522,19 +1507,6 @@ Then you can select a new shortcut by one of the following ways:
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
-           <spacer name="verticalSpacer_6">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>470</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
           <item row="1" column="0">
            <widget class="QLabel" name="label_71">
             <property name="text">
@@ -1583,6 +1555,22 @@ Then you can select a new shortcut by one of the following ways:
           </item>
          </layout>
         </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_6">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Expanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>
@@ -1638,14 +1626,14 @@ Then you can select a new shortcut by one of the following ways:
             </property>
            </widget>
           </item>
-          <item row="12" column="0">
+          <item row="11" column="0">
            <widget class="QLabel" name="label_33">
             <property name="text">
              <string>Show Line Numbers:</string>
             </property>
            </widget>
           </item>
-          <item row="12" column="1">
+          <item row="11" column="1">
            <widget class="QComboBox" name="comboboxLineNumbers">
             <property name="" stdset="0">
              <bool>true</bool>
@@ -1687,14 +1675,14 @@ Then you can select a new shortcut by one of the following ways:
             </property>
            </widget>
           </item>
-          <item row="6" column="1" colspan="4">
+          <item row="12" column="0" colspan="4">
            <widget class="QCheckBox" name="checkBoxFolding">
             <property name="text">
              <string>Folding</string>
             </property>
            </widget>
           </item>
-          <item row="8" column="3" colspan="2">
+          <item row="7" column="3" colspan="2">
            <widget class="QCheckBox" name="checkBoxReplaceIndentTabByWhitespace">
             <property name="text">
              <string>Replace Indentation Tab by Spaces</string>
@@ -1708,7 +1696,7 @@ Then you can select a new shortcut by one of the following ways:
             </property>
            </widget>
           </item>
-          <item row="11" column="0">
+          <item row="10" column="0">
            <widget class="QLabel" name="label_39">
             <property name="text">
              <string>Replace Double Quotes:</string>
@@ -1728,7 +1716,7 @@ Then you can select a new shortcut by one of the following ways:
             </property>
            </widget>
           </item>
-          <item row="8" column="0">
+          <item row="7" column="0">
            <widget class="QLabel" name="label_30">
             <property name="text">
              <string>Indentation Mode:</string>
@@ -1815,7 +1803,7 @@ Then you can select a new shortcut by one of the following ways:
             </property>
            </widget>
           </item>
-          <item row="11" column="1" colspan="4">
+          <item row="10" column="1" colspan="4">
            <widget class="QComboBox" name="comboBoxReplaceQuotes">
             <item>
              <property name="text">
@@ -1876,7 +1864,7 @@ Then you can select a new shortcut by one of the following ways:
             </property>
            </widget>
           </item>
-          <item row="8" column="1" colspan="2">
+          <item row="7" column="1" colspan="2">
            <widget class="QComboBox" name="comboBoxAutoIndent">
             <property name="advancedOption" stdset="0">
              <bool>false</bool>
@@ -1955,7 +1943,7 @@ Then you can select a new shortcut by one of the following ways:
             </layout>
            </widget>
           </item>
-          <item row="9" column="3" colspan="2">
+          <item row="8" column="3" colspan="2">
            <widget class="QCheckBox" name="checkBoxReplaceTextTabByWhitespace">
             <property name="text">
              <string>Replace Tab in Text by Spaces</string>
@@ -1992,7 +1980,7 @@ Then you can select a new shortcut by one of the following ways:
             </property>
            </widget>
           </item>
-          <item row="10" column="3" colspan="2">
+          <item row="9" column="3" colspan="2">
            <widget class="QCheckBox" name="checkboxRemoveTrailingWsOnSave">
             <property name="text">
              <string>Remove Trailing Whitespace on Save</string>
@@ -3316,6 +3304,18 @@ them here.</string>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_9">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
            <item>
             <widget class="QGroupBox" name="groupBox_Dictionaries">
              <property name="title">
@@ -3854,7 +3854,7 @@ them here.</string>
            <item>
             <widget class="QGroupBox" name="groupBox_5">
              <property name="title">
-              <string>Segment Preview</string>
+              <string>Preview</string>
              </property>
              <layout class="QGridLayout" name="gridLayout_5">
               <item row="0" column="0">
@@ -3990,7 +3990,7 @@ them here.</string>
                 </property>
                </widget>
               </item>
-              <item row="5" column="1">
+              <item row="5" column="0">
                <widget class="QCheckBox" name="checkBoxReplaceBeamer">
                 <property name="text">
                  <string>Replace beamer class by article</string>
@@ -4003,7 +4003,7 @@ them here.</string>
                 </property>
                </widget>
               </item>
-              <item row="6" column="1">
+              <item row="6" column="0">
                <widget class="QCheckBox" name="checkBoxPrecompilePreamble">
                 <property name="text">
                  <string>Precompile Preamble</string>
@@ -4558,7 +4558,7 @@ Note: Changing this setting will only affect documents that are opened afterward
       </layout>
      </widget>
      <widget class="QWidget" name="pageSVN">
-      <layout class="QVBoxLayout">
+      <layout class="QGridLayout">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -4571,84 +4571,96 @@ Note: Changing this setting will only affect documents that are opened afterward
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <item>
-        <widget class="QComboBox" name="comboBoxUseVCS">
-         <item>
-          <property name="text">
-           <string>Use SVN</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Use GIT</string>
-          </property>
-         </item>
+       <item row="0" column="0">
+        <widget class="QGroupBox" name="groupBox_18">
+         <property name="title">
+          <string>SVN/GIT</string>
+         </property>
+         <layout class="QVBoxLayout">
+          <item>
+           <widget class="QComboBox" name="comboBoxUseVCS">
+            <item>
+             <property name="text">
+              <string>Use SVN</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Use GIT</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="comboBoxAutoCheckinLevel">
+            <property name="toolTip">
+             <string>Select how txs checks in saved files</string>
+            </property>
+            <item>
+             <property name="text">
+              <string>No automatic check-in after save</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Check-in after File/Save only</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Check-in after all save operations, i.e. also before compiles.</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbSVNUndo">
+            <property name="text">
+             <string>Use SVN/GIT revisions to undo before last saved version</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbKeywordSubstitution">
+            <property name="toolTip">
+             <string>on svn add executes svn propset svn:keywords &quot;Date Author Revision HeadURL&quot;</string>
+            </property>
+            <property name="text">
+             <string>Substitute Keywords with Properties (on svn add)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout">
+            <item>
+             <widget class="QLabel" name="label_21">
+              <property name="text">
+               <string>SVN Directory Search Depth: </string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="sbDirSearchDepth">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
         </widget>
        </item>
-       <item>
-        <widget class="QComboBox" name="comboBoxAutoCheckinLevel">
-         <property name="toolTip">
-          <string>Select how txs checks in saved files</string>
-         </property>
-         <item>
-          <property name="text">
-           <string>No automatic check-in after save</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Check-in after File/Save only</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Check-in after all save operations, i.e. also before compiles.</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbSVNUndo">
-         <property name="text">
-          <string>Use SVN/GIT revisions to undo before last saved version</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbKeywordSubstitution">
-         <property name="toolTip">
-          <string>on svn add executes svn propset svn:keywords &quot;Date Author Revision HeadURL&quot;</string>
-         </property>
-         <property name="text">
-          <string>Substitute Keywords with Properties (on svn add)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout">
-         <item>
-          <widget class="QLabel" name="label_21">
-           <property name="text">
-            <string>SVN Directory Search Depth: </string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="sbDirSearchDepth">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
+       <item row="1" column="0">
         <spacer>
          <property name="orientation">
           <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::MinimumExpanding</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -4757,22 +4769,6 @@ Note: Changing this setting will only affect documents that are opened afterward
       </layout>
      </widget>
     </widget>
-   </item>
-   <item row="0" column="1">
-    <spacer name="vsCompletionList">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Expanding</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
This PR mainly addresses following items:

- Implementing a splitter (this solves #2707, where you can find a small animation). For a more pleasing look space in the middle (between page list and page area) is decreased from 36px to 9px, so the splitter handle here can be located easily.
- Resolving that some of the pages use a different right margin as the majority does, and that the language checking page is in addition moved a little bit downwards (s. images).

The list below states changes done in the pages (reducing left margin for all pages is not listed).

Note: The splitter is set such that the list of pages has the same width as it is in the reference image to reduce jitter. The first image (with the arrow) in #2707 shows the initial width when opening the config dialog.

1. General: right margin of page (s. animation)
![General](https://user-images.githubusercontent.com/102688820/205199573-f9adf2b9-6ced-43e0-a313-ec5a8610632b.gif)
2. Commands:
3. Build: right margin of page, no scroll area for three lines at bottom ("Additional Search Paths") (s. animation)
![Build](https://user-images.githubusercontent.com/102688820/205199586-b26c7bee-7ded-45b3-9fd1-c5c6e17b5445.gif)
4. Shortcuts:
5. Menus:
6. Toolbars:
7. GUI Scaling: fit group box, changed group box title (s. animation)
![GUI-Scaling](https://user-images.githubusercontent.com/102688820/205199613-74c69e19-85da-4513-8ac0-a7ac927af82e.gif)
8. Editor: moved checkbox "folding" below "Show Line Numbers" (s. animation)
![Editor](https://user-images.githubusercontent.com/102688820/205199636-5fba7a5c-0757-408d-ab3b-3e91e2009386.gif)
9. Adv. Editor:
10. Syntax Highlighting:
11. Completion:
12. Language Checking: upper, and right margin of page (s. animation)
![SpellCheck](https://user-images.githubusercontent.com/102688820/205199660-b16ddb26-82bf-4921-8766-48a2cb5b840e.gif)
13. Preview: moved two checkboxes to the left, changed group box title (s. animation)
![Preview](https://user-images.githubusercontent.com/102688820/205199685-e751832f-ea96-4b36-bfad-a3e064d8c893.gif)
14. Internal PDF Viewer:
15. SVN/GIT: new group box (s. animation)
![SVN-GIT](https://user-images.githubusercontent.com/102688820/205199708-2426ae19-4163-4ad3-a9ef-80420a86a97b.gif)

