### PR TITLE
add menu LaTeX/Horizontal Spacing

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -1206,7 +1206,7 @@ void Texstudio::setupMenus()
 	newManagedAction(submenu, "remHLine", tr("Remove \\hline", "table"), SLOT(remHLineCB()));
 	newManagedAction(submenu, "insertTableTemplate", tr("Remodel Table Using Template", "table"), SLOT(insertTableTemplate()));
 	newManagedAction(submenu, "alignColumns", tr("Align Columns"), SLOT(alignTableCols()), QKeySequence(), "alignCols");
-	submenu = newManagedMenu(menu, "magicComments", tr("Add magic comments ..."));
+	submenu = newManagedMenu(menu, "magicComments", tr("Add magic comments"));
 	newManagedAction(submenu, "addMagicRoot", tr("Insert root document name as TeX comment"), SLOT(addMagicRoot()));
 	newManagedAction(submenu, "addMagicLang", tr("Insert language as TeX comment"), SLOT(insertSpellcheckMagicComment()));
 	newManagedAction(submenu, "addMagicCoding", tr("Insert document coding as TeX comment"), SLOT(addMagicCoding()));

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -1206,7 +1206,7 @@ void Texstudio::setupMenus()
 	newManagedAction(submenu, "remHLine", tr("Remove \\hline", "table"), SLOT(remHLineCB()));
 	newManagedAction(submenu, "insertTableTemplate", tr("Remodel Table Using Template", "table"), SLOT(insertTableTemplate()));
 	newManagedAction(submenu, "alignColumns", tr("Align Columns"), SLOT(alignTableCols()), QKeySequence(), "alignCols");
-	submenu = newManagedMenu(menu, "magicComments", tr("Add magic comments"));
+	submenu = newManagedMenu(menu, "magicComments", tr("Add magic comments ..."));
 	newManagedAction(submenu, "addMagicRoot", tr("Insert root document name as TeX comment"), SLOT(addMagicRoot()));
 	newManagedAction(submenu, "addMagicLang", tr("Insert language as TeX comment"), SLOT(insertSpellcheckMagicComment()));
 	newManagedAction(submenu, "addMagicCoding", tr("Insert document coding as TeX comment"), SLOT(addMagicCoding()));

--- a/uiconfig.xml
+++ b/uiconfig.xml
@@ -12,21 +12,21 @@
   
   
   <menu id="sectioning" text="&amp;Sectioning">
-    <insert id="part" text="\part" insert="\part{%&lt;title%>}" icon="part"/>
-    <insert id="chapter" text="\chapter" insert="\chapter{%&lt;title%>}" icon="chapter"/>
-    <insert id="section" text="\section" insert="\section{%&lt;title%>}" icon="section"/>
-    <insert id="subsection" text="\subsection" insert="\subsection{%&lt;title%>}" icon="subsection"/>
-    <insert id="subsubsection" text="\subsubsection" insert="\subsubsection{%&lt;title%>}" icon="subsubsection"/>
-    <insert id="paragraph" text="\paragraph" insert="\paragraph{%&lt;title%>}"/>
-    <insert id="subparagraph" text="\subparagraph" insert="\subparagraph{%&lt;title%>}"/>
+    <insert id="part" text="part" insert="\part{%&lt;title%>}" icon="part"/>
+    <insert id="chapter" text="chapter" insert="\chapter{%&lt;title%>}" icon="chapter"/>
+    <insert id="section" text="section" insert="\section{%&lt;title%>}" icon="section"/>
+    <insert id="subsection" text="subsection" insert="\subsection{%&lt;title%>}" icon="subsection"/>
+    <insert id="subsubsection" text="subsubsection" insert="\subsubsection{%&lt;title%>}" icon="subsubsection"/>
+    <insert id="paragraph" text="paragraph" insert="\paragraph{%&lt;title%>}"/>
+    <insert id="subparagraph" text="subparagraph" insert="\subparagraph{%&lt;title%>}"/>
 
-    <insert id="part*" text="\part*" insert="\part*{%&lt;title%>}"/>
-    <insert id="chapter*" text="\chapter*" insert="\chapter*{%&lt;title%>}"/>
-    <insert id="section*" text="\section*" insert="\section*{%&lt;title%>}"/>
-    <insert id="subsection*" text="\subsection*" insert="\subsection*{%&lt;title%>}"/>
-    <insert id="subsubsection*" text="\subsubsection*" insert="\subsubsection*{%&lt;title%>}"/>
-    <insert id="paragraph*" text="\paragraph*" insert="\paragraph*{%&lt;title%>}"/>
-    <insert id="subparagraph*" text="\subparagraph*" insert="\subparagraph*{%&lt;title%>}"/>
+    <insert id="part*" text="part*" insert="\part*{%&lt;title%>}"/>
+    <insert id="chapter*" text="chapter*" insert="\chapter*{%&lt;title%>}"/>
+    <insert id="section*" text="section*" insert="\section*{%&lt;title%>}"/>
+    <insert id="subsection*" text="subsection*" insert="\subsection*{%&lt;title%>}"/>
+    <insert id="subsubsection*" text="subsubsection*" insert="\subsubsection*{%&lt;title%>}"/>
+    <insert id="paragraph*" text="paragraph*" insert="\paragraph*{%&lt;title%>}"/>
+    <insert id="subparagraph*" text="subparagraph*" insert="\subparagraph*{%&lt;title%>}"/>
   </menu>
 
   <menu id="environment" text="&amp;Environments">
@@ -92,18 +92,18 @@
   
   
   <menu id="boxes" text="Boxes">
-     <insert id="mbox" text="\mbox" insert="\mbox{%&lt;content%>}"/>
-     <insert id="makebox" text="\makebox" insert="\makebox[][]{%&lt;content%>}"/>
-     <insert id="fbox" text="\fbox" insert="\fbox{%&lt;content%>}"/>
-     <insert id="framebox" text="\framebox" insert="\framebox[][]{%&lt;content%>}"/>
-     <insert id="newsavebox" text="\newsavebox" insert="\newsavebox{%&lt;name%>}"/>
-     <insert id="sbox" text="\sbox" insert="\sbox{%&lt;name%>}{%&lt;content%>}"/>
-     <insert id="savebox" text="\savebox" insert="\savebox{%&lt;name%>}[][]{%&lt;content%>}"/>
-     <insert id="usebox" text="\usebox" insert="\usebox{%&lt;name%>}"/>
-     <insert id="raisebox" text="\raisebox" insert="\raisebox{%&lt;voffset%>}[][]{%&lt;content%>}"/>
-     <insert id="parbox" text="\parbox" insert="\parbox[]{%&lt;width%>}{%&lt;content%>}"/>
+     <insert id="mbox" text="mbox" insert="\mbox{%&lt;content%>}"/>
+     <insert id="makebox" text="makebox" insert="\makebox[][]{%&lt;content%>}"/>
+     <insert id="fbox" text="fbox" insert="\fbox{%&lt;content%>}"/>
+     <insert id="framebox" text="framebox" insert="\framebox[][]{%&lt;content%>}"/>
+     <insert id="newsavebox" text="newsavebox" insert="\newsavebox{%&lt;name%>}"/>
+     <insert id="sbox" text="sbox" insert="\sbox{%&lt;name%>}{%&lt;content%>}"/>
+     <insert id="savebox" text="savebox" insert="\savebox{%&lt;name%>}[][]{%&lt;content%>}"/>
+     <insert id="usebox" text="usebox" insert="\usebox{%&lt;name%>}"/>
+     <insert id="raisebox" text="raisebox" insert="\raisebox{%&lt;voffset%>}[][]{%&lt;content%>}"/>
+     <insert id="parbox" text="parbox" insert="\parbox[]{%&lt;width%>}{%&lt;content%>}"/>
      <insert id="minipage" text="\begin{minipage}" insert="\begin{minipage}[][][]{%&lt;width%>}%\%|%\\end{minipage}"/>
-     <insert id="rule" text="\rule" insert="\rule[]{%&lt;width%>}{%&lt;height%>}"/>
+     <insert id="rule" text="rule" insert="\rule[]{%&lt;width%>}{%&lt;height%>}"/>
   </menu>
   
   
@@ -119,16 +119,16 @@
   </menu>
 
   <menu id="fontsizes" text="Font Sizes">
-    <insert id="tiny" text="\tiny" insert="{\tiny %|}"/>
-    <insert id="scriptsize" text="\scriptsize" insert="{\scriptsize %|}"/>
-    <insert id="footnotesize" text="\footnotesize" insert="{\footnotesize %|}"/>
-    <insert id="small" text="\small" insert="{\small %|}"/>
-    <insert id="normalsize" text="\normalsize" insert="{\normalsize %|}"/>
-    <insert id="large" text="\large" insert="{\large %|}"/>
-    <insert id="Large" text="\Large" insert="{\Large %|}"/>
-    <insert id="LARGE" text="\LARGE" insert="{\LARGE %|}"/>
-    <insert id="huge" text="\huge" insert="{\huge %|}"/>
-    <insert id="Huge" text="\Huge" insert="{\Huge %|}"/>
+    <insert id="tiny" text="tiny" insert="{\tiny %|}"/>
+    <insert id="scriptsize" text="scriptsize" insert="{\scriptsize %|}"/>
+    <insert id="footnotesize" text="footnotesize" insert="{\footnotesize %|}"/>
+    <insert id="small" text="small" insert="{\small %|}"/>
+    <insert id="normalsize" text="normalsize" insert="{\normalsize %|}"/>
+    <insert id="large" text="large" insert="{\large %|}"/>
+    <insert id="Large" text="Large" insert="{\Large %|}"/>
+    <insert id="LARGE" text="LARGE" insert="{\LARGE %|}"/>
+    <insert id="huge" text="huge" insert="{\huge %|}"/>
+    <insert id="Huge" text="Huge" insert="{\Huge %|}"/>
   </menu>
 
   
@@ -223,13 +223,13 @@
   </menu>
 
   <menu id="references" text="Cross References">
-    <insert id="label" text="\label" insert="\label{%&lt;key%>}" info="\label{key}"/>
-    <action id="ref" text="\ref" slot="1insertRef()"/> 
-    <action id="eqref" text="\eqref" slot="1insertEqRef()"/> 
-    <action id="pageref" text="\pageref" slot="1insertPageRef()"/> 
-    <insert id="index" text="\index" insert="\index{%&lt;key%>}"/>
-    <insert id="cite" text="\cite" insert="\cite{%&lt;key%>}"  info="This command generates an in-text citation to the reference associated with the ref entry in the bib file"/>
-    <insert id="footnote" text="\footnote" insert="\footnote{%&lt;text%|%>}" info="\footnote[number]{text}%nThe \footnote command places the numbered footnote text at the bottom of the current page."/>
+    <insert id="label" text="label" insert="\label{%&lt;key%>}" info="\label{key}"/>
+    <action id="ref" text="ref" slot="1insertRef()"/> 
+    <action id="eqref" text="eqref" slot="1insertEqRef()"/> 
+    <action id="pageref" text="pageref" slot="1insertPageRef()"/> 
+    <insert id="index" text="index" insert="\index{%&lt;key%>}"/>
+    <insert id="cite" text="cite" insert="\cite{%&lt;key%>}"  info="This command generates an in-text citation to the reference associated with the ref entry in the bib file"/>
+    <insert id="footnote" text="footnote" insert="\footnote{%&lt;text%|%>}" info="\footnote[number]{text}%nThe \footnote command places the numbered footnote text at the bottom of the current page."/>
   </menu>
   
   <menu id="bibliographyMenu" text="Bibliography">

--- a/uiconfig.xml
+++ b/uiconfig.xml
@@ -12,21 +12,21 @@
   
   
   <menu id="sectioning" text="&amp;Sectioning">
-    <insert id="part" text="part" insert="\part{%&lt;title%>}" icon="part"/>
-    <insert id="chapter" text="chapter" insert="\chapter{%&lt;title%>}" icon="chapter"/>
-    <insert id="section" text="section" insert="\section{%&lt;title%>}" icon="section"/>
-    <insert id="subsection" text="subsection" insert="\subsection{%&lt;title%>}" icon="subsection"/>
-    <insert id="subsubsection" text="subsubsection" insert="\subsubsection{%&lt;title%>}" icon="subsubsection"/>
-    <insert id="paragraph" text="paragraph" insert="\paragraph{%&lt;title%>}"/>
-    <insert id="subparagraph" text="subparagraph" insert="\subparagraph{%&lt;title%>}"/>
+    <insert id="part" text="\part" insert="\part{%&lt;title%>}" icon="part"/>
+    <insert id="chapter" text="\chapter" insert="\chapter{%&lt;title%>}" icon="chapter"/>
+    <insert id="section" text="\section" insert="\section{%&lt;title%>}" icon="section"/>
+    <insert id="subsection" text="\subsection" insert="\subsection{%&lt;title%>}" icon="subsection"/>
+    <insert id="subsubsection" text="\subsubsection" insert="\subsubsection{%&lt;title%>}" icon="subsubsection"/>
+    <insert id="paragraph" text="\paragraph" insert="\paragraph{%&lt;title%>}"/>
+    <insert id="subparagraph" text="\subparagraph" insert="\subparagraph{%&lt;title%>}"/>
 
-    <insert id="part*" text="part*" insert="\part*{%&lt;title%>}"/>
-    <insert id="chapter*" text="chapter*" insert="\chapter*{%&lt;title%>}"/>
-    <insert id="section*" text="section*" insert="\section*{%&lt;title%>}"/>
-    <insert id="subsection*" text="subsection*" insert="\subsection*{%&lt;title%>}"/>
-    <insert id="subsubsection*" text="subsubsection*" insert="\subsubsection*{%&lt;title%>}"/>
-    <insert id="paragraph*" text="paragraph*" insert="\paragraph*{%&lt;title%>}"/>
-    <insert id="subparagraph*" text="subparagraph*" insert="\subparagraph*{%&lt;title%>}"/>
+    <insert id="part*" text="\part*" insert="\part*{%&lt;title%>}"/>
+    <insert id="chapter*" text="\chapter*" insert="\chapter*{%&lt;title%>}"/>
+    <insert id="section*" text="\section*" insert="\section*{%&lt;title%>}"/>
+    <insert id="subsection*" text="\subsection*" insert="\subsection*{%&lt;title%>}"/>
+    <insert id="subsubsection*" text="\subsubsection*" insert="\subsubsection*{%&lt;title%>}"/>
+    <insert id="paragraph*" text="\paragraph*" insert="\paragraph*{%&lt;title%>}"/>
+    <insert id="subparagraph*" text="\subparagraph*" insert="\subparagraph*{%&lt;title%>}"/>
   </menu>
 
   <menu id="environment" text="&amp;Environments">
@@ -92,18 +92,18 @@
   
   
   <menu id="boxes" text="Boxes">
-     <insert id="mbox" text="mbox" insert="\mbox{%&lt;content%>}"/>
-     <insert id="makebox" text="makebox" insert="\makebox[][]{%&lt;content%>}"/>
-     <insert id="fbox" text="fbox" insert="\fbox{%&lt;content%>}"/>
-     <insert id="framebox" text="framebox" insert="\framebox[][]{%&lt;content%>}"/>
-     <insert id="newsavebox" text="newsavebox" insert="\newsavebox{%&lt;name%>}"/>
-     <insert id="sbox" text="sbox" insert="\sbox{%&lt;name%>}{%&lt;content%>}"/>
-     <insert id="savebox" text="savebox" insert="\savebox{%&lt;name%>}[][]{%&lt;content%>}"/>
-     <insert id="usebox" text="usebox" insert="\usebox{%&lt;name%>}"/>
-     <insert id="raisebox" text="raisebox" insert="\raisebox{%&lt;voffset%>}[][]{%&lt;content%>}"/>
-     <insert id="parbox" text="parbox" insert="\parbox[]{%&lt;width%>}{%&lt;content%>}"/>
+     <insert id="mbox" text="\mbox" insert="\mbox{%&lt;content%>}"/>
+     <insert id="makebox" text="\makebox" insert="\makebox[][]{%&lt;content%>}"/>
+     <insert id="fbox" text="\fbox" insert="\fbox{%&lt;content%>}"/>
+     <insert id="framebox" text="\framebox" insert="\framebox[][]{%&lt;content%>}"/>
+     <insert id="newsavebox" text="\newsavebox" insert="\newsavebox{%&lt;name%>}"/>
+     <insert id="sbox" text="\sbox" insert="\sbox{%&lt;name%>}{%&lt;content%>}"/>
+     <insert id="savebox" text="\savebox" insert="\savebox{%&lt;name%>}[][]{%&lt;content%>}"/>
+     <insert id="usebox" text="\usebox" insert="\usebox{%&lt;name%>}"/>
+     <insert id="raisebox" text="\raisebox" insert="\raisebox{%&lt;voffset%>}[][]{%&lt;content%>}"/>
+     <insert id="parbox" text="\parbox" insert="\parbox[]{%&lt;width%>}{%&lt;content%>}"/>
      <insert id="minipage" text="\begin{minipage}" insert="\begin{minipage}[][][]{%&lt;width%>}%\%|%\\end{minipage}"/>
-     <insert id="rule" text="rule" insert="\rule[]{%&lt;width%>}{%&lt;height%>}"/>
+     <insert id="rule" text="\rule" insert="\rule[]{%&lt;width%>}{%&lt;height%>}"/>
   </menu>
   
   
@@ -119,16 +119,16 @@
   </menu>
 
   <menu id="fontsizes" text="Font Sizes">
-    <insert id="tiny" text="tiny" insert="{\tiny %|}"/>
-    <insert id="scriptsize" text="scriptsize" insert="{\scriptsize %|}"/>
-    <insert id="footnotesize" text="footnotesize" insert="{\footnotesize %|}"/>
-    <insert id="small" text="small" insert="{\small %|}"/>
-    <insert id="normalsize" text="normalsize" insert="{\normalsize %|}"/>
-    <insert id="large" text="large" insert="{\large %|}"/>
-    <insert id="Large" text="Large" insert="{\Large %|}"/>
-    <insert id="LARGE" text="LARGE" insert="{\LARGE %|}"/>
-    <insert id="huge" text="huge" insert="{\huge %|}"/>
-    <insert id="Huge" text="Huge" insert="{\Huge %|}"/>
+    <insert id="tiny" text="\tiny" insert="{\tiny %|}"/>
+    <insert id="scriptsize" text="\scriptsize" insert="{\scriptsize %|}"/>
+    <insert id="footnotesize" text="\footnotesize" insert="{\footnotesize %|}"/>
+    <insert id="small" text="\small" insert="{\small %|}"/>
+    <insert id="normalsize" text="\normalsize" insert="{\normalsize %|}"/>
+    <insert id="large" text="\large" insert="{\large %|}"/>
+    <insert id="Large" text="\Large" insert="{\Large %|}"/>
+    <insert id="LARGE" text="\LARGE" insert="{\LARGE %|}"/>
+    <insert id="huge" text="\huge" insert="{\huge %|}"/>
+    <insert id="Huge" text="\Huge" insert="{\Huge %|}"/>
   </menu>
 
   
@@ -142,14 +142,29 @@
     <insert id="cline" text="\cline" insert="\cline{%&lt;from%|%>-%&lt;to%>}" info=""/>
   </menu>
 
-  <menu id="spacing" text="&amp;Vertical Spacing">
+  <menu id="horizontalSpacing" text="&amp;Horizontal Spacing">
+    <insert id="spaceCharacter" text="\space" insert="\space" info="The command \space gives you a space where you can't enter a space character."/>
+    <insert id="enspace" text="\enspace" insert="\enspace" info="The \enspace command inserts a horizontal space of 1/2em."/>
+    <insert id="quad" text="\quad" insert="\quad" info="The \quad command inserts a horizontal space of 1em (1em being the width of M)."/>
+    <insert id="qquad" text="\qquad" insert="\qquad" info="The \qquad command inserts a horizontal space of 2em."/>
+    <insert id="thinspace" text="\thinspace" insert="\thinspace" info="The command \thinsapce produces unbreakable and unstretchable space of 1/6em (same as \, in math mode)."/>
+    <insert id="negthinspace" text="\negthinspace" insert="\negthinspace" info="The command \thinspace produces unbreakable and unstretchable space of -1/6em (same as \, in math mode)."/>
+    <insert id="hspace" text="\hspace" insert="\hspace{%&lt;skip%>}" info="The \hspace command inserts an amount of skip of horizontal space."/>
+    <insert id="hfill" text="\hfill" insert="\hfill" info="The \hfill command inserts a rubber length which has no natural space but that can stretch horizontally as far as needed."/>
+    <insert id="hrulefill" text="\hrulefill" insert="\hrulefill" info="The \hrulefill command produces an infinite horizontal rubber length hat LaTeX fills with a rule (that is, a line), instead of white space."/>
+    <insert id="dotfill" text="\dotfill" insert="\dotfill" info="The \dotfill command produces an infinite horizontal rubber length that LaTeX fills with with dots, instead of white space."/>
+  </menu>
+
+  <menu id="verticalSpacing" text="&amp;Vertical Spacing">
     <insert id="newpage" text="\newpage" insert="\newpage" info="The \newpage command ends the current page"/>
     <insert id="linebreak" text="\linebreak" insert="\linebreak" info="The \linebreak command tells LaTeX to break the current line at the point of the command."/>
     <insert id="pagebreak" text="\pagebreak" insert="\pagebreak" info="The \pagebreak command tells LaTeX to break the current page at the point of the command."/>
     <insert id="bigskip" text="\bigskip" insert="\bigskip" info="The \bigskip command adds a 'big' vertical space."/>
     <insert id="medskip" text="\medskip" insert="\medskip" info="The \medskip command adds a 'medium' vertical space."/>
     <insert id="smallskip" text="\smallskip" insert="\smallskip" info="The \smallskip command adds a 'small' vertical space."/>
-    <insert id="vspace" text="\vspace" insert="\vspace{%&lt;skip%>}"/>
+    <insert id="baselineskip" text="\baselineskip" insert="\baselineskip" info="The \baselineskip command adds the normal distance between lines in a paragraph."/>
+    <insert id="vspace" text="\vspace" insert="\vspace{%&lt;skip%>}" info="The \vspace command inserts an amount of skip (positiv, zero or negativ) of vertical space."/>
+    <insert id="vfill" text="\vfill" insert="\vfill" info="The \vfill command inserts a rubber length which has no natural space but that can stretch vertictally as far as needed."/>
     <insert id="newline" text="New line - \\" insert="\\%\" info="The \newline command breaks the line right where it is." icon="newline" shortcut="Ctrl+Return"/>
   </menu>
   
@@ -208,13 +223,13 @@
   </menu>
 
   <menu id="references" text="Cross References">
-    <insert id="label" text="label" insert="\label{%&lt;key%>}" info="\label{key}"/>
-    <action id="ref" text="ref" slot="1insertRef()"/> 
-    <action id="eqref" text="eqref" slot="1insertEqRef()"/> 
-    <action id="pageref" text="pageref" slot="1insertPageRef()"/> 
-    <insert id="index" text="index" insert="\index{%&lt;key%>}"/>
-    <insert id="cite" text="cite" insert="\cite{%&lt;key%>}"  info="This command generates an in-text citation to the reference associated with the ref entry in the bib file"/>
-    <insert id="footnote" text="footnote" insert="\footnote{%&lt;text%|%>}" info="\footnote[number]{text}%nThe \footnote command places the numbered footnote text at the bottom of the current page."/>
+    <insert id="label" text="\label" insert="\label{%&lt;key%>}" info="\label{key}"/>
+    <action id="ref" text="\ref" slot="1insertRef()"/> 
+    <action id="eqref" text="\eqref" slot="1insertEqRef()"/> 
+    <action id="pageref" text="\pageref" slot="1insertPageRef()"/> 
+    <insert id="index" text="\index" insert="\index{%&lt;key%>}"/>
+    <insert id="cite" text="\cite" insert="\cite{%&lt;key%>}"  info="This command generates an in-text citation to the reference associated with the ref entry in the bib file"/>
+    <insert id="footnote" text="\footnote" insert="\footnote{%&lt;text%|%>}" info="\footnote[number]{text}%nThe \footnote command places the numbered footnote text at the bottom of the current page."/>
   </menu>
   
   <menu id="bibliographyMenu" text="Bibliography">

--- a/uiconfig.xml
+++ b/uiconfig.xml
@@ -163,8 +163,8 @@
     <insert id="medskip" text="\medskip" insert="\medskip" info="The \medskip command adds a 'medium' vertical space."/>
     <insert id="smallskip" text="\smallskip" insert="\smallskip" info="The \smallskip command adds a 'small' vertical space."/>
     <insert id="baselineskip" text="\baselineskip" insert="\baselineskip" info="The \baselineskip command adds the normal distance between lines in a paragraph."/>
-    <insert id="vspace" text="\vspace" insert="\vspace{%&lt;skip%>}" info="The \vspace command inserts an amount of skip (positiv, zero or negativ) of vertical space."/>
-    <insert id="vfill" text="\vfill" insert="\vfill" info="The \vfill command inserts a rubber length which has no natural space but that can stretch vertictally as far as needed."/>
+    <insert id="vspace" text="\vspace" insert="\vspace{%&lt;skip%>}" info="The \vspace command inserts an amount of skip (positive, zero or negative) of vertical space."/>
+    <insert id="vfill" text="\vfill" insert="\vfill" info="The \vfill command inserts a rubber length which has no natural space but that can stretch vertically as far as needed."/>
     <insert id="newline" text="New line - \\" insert="\\%\" info="The \newline command breaks the line right where it is." icon="newline" shortcut="Ctrl+Return"/>
   </menu>
   

--- a/uiconfig.xml
+++ b/uiconfig.xml
@@ -147,12 +147,12 @@
     <insert id="enspace" text="\enspace" insert="\enspace" info="The \enspace command inserts a horizontal space of 1/2em."/>
     <insert id="quad" text="\quad" insert="\quad" info="The \quad command inserts a horizontal space of 1em (1em being the width of M)."/>
     <insert id="qquad" text="\qquad" insert="\qquad" info="The \qquad command inserts a horizontal space of 2em."/>
-    <insert id="thinspace" text="\thinspace" insert="\thinspace" info="The command \thinsapce produces unbreakable and unstretchable space of 1/6em (same as \, in math mode)."/>
-    <insert id="negthinspace" text="\negthinspace" insert="\negthinspace" info="The command \thinspace produces unbreakable and unstretchable space of -1/6em (same as \, in math mode)."/>
+    <insert id="thinspace" text="\thinspace" insert="\thinspace" info="The command \thinspace produces unbreakable and unstretchable space of 1/6em (same as \, in math mode)."/>
+    <insert id="negthinspace" text="\negthinspace" insert="\negthinspace" info="The command \negthinspace produces unbreakable and unstretchable space of -1/6em (same as \, in math mode)."/>
     <insert id="hspace" text="\hspace" insert="\hspace{%&lt;skip%>}" info="The \hspace command inserts an amount of skip of horizontal space."/>
     <insert id="hfill" text="\hfill" insert="\hfill" info="The \hfill command inserts a rubber length which has no natural space but that can stretch horizontally as far as needed."/>
-    <insert id="hrulefill" text="\hrulefill" insert="\hrulefill" info="The \hrulefill command produces an infinite horizontal rubber length hat LaTeX fills with a rule (that is, a line), instead of white space."/>
-    <insert id="dotfill" text="\dotfill" insert="\dotfill" info="The \dotfill command produces an infinite horizontal rubber length that LaTeX fills with with dots, instead of white space."/>
+    <insert id="hrulefill" text="\hrulefill" insert="\hrulefill" info="The \hrulefill command produces an infinite horizontal rubber length that LaTeX fills with a rule (that is, a line), instead of white space."/>
+    <insert id="dotfill" text="\dotfill" insert="\dotfill" info="The \dotfill command produces an infinite horizontal rubber length that LaTeX fills with dots, instead of white space."/>
   </menu>
 
   <menu id="verticalSpacing" text="&amp;Vertical Spacing">

--- a/uiconfig.xml
+++ b/uiconfig.xml
@@ -162,7 +162,6 @@
     <insert id="bigskip" text="\bigskip" insert="\bigskip" info="The \bigskip command adds a 'big' vertical space."/>
     <insert id="medskip" text="\medskip" insert="\medskip" info="The \medskip command adds a 'medium' vertical space."/>
     <insert id="smallskip" text="\smallskip" insert="\smallskip" info="The \smallskip command adds a 'small' vertical space."/>
-    <insert id="baselineskip" text="\baselineskip" insert="\baselineskip" info="The \baselineskip command adds the normal distance between lines in a paragraph."/>
     <insert id="vspace" text="\vspace" insert="\vspace{%&lt;skip%>}" info="The \vspace command inserts an amount of skip (positive, zero or negative) of vertical space."/>
     <insert id="vfill" text="\vfill" insert="\vfill" info="The \vfill command inserts a rubber length which has no natural space but that can stretch vertically as far as needed."/>
     <insert id="newline" text="New line - \\" insert="\\%\" info="The \newline command breaks the line right where it is." icon="newline" shortcut="Ctrl+Return"/>


### PR DESCRIPTION
This PR closes #2687.

Additionally:
- added \vfill to menu Vertical Spacing

Question: Where are the info texts displayed or are they only documentation? Hoped they would be tooltips.