### PR TITLE
fix min. height for config dialog

### DIFF
--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>1116</width>
-    <height>674</height>
+    <height>300</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Configure TeXstudio</string>
   </property>
- <layout class="QGridLayout">
+  <layout class="QGridLayout">
    <property name="leftMargin">
     <number>9</number>
    </property>
@@ -32,121 +32,91 @@
    <property name="verticalSpacing">
     <number>6</number>
    </property>
-<item row="0" column="0">
-<widget class="QSplitter" name="mainSplitter">
- <property name="childrenCollapsible">
-  <bool>
-   true
-  </bool>
- </property>
- <property name="handleWidth">
-  <number>9</number>
- </property>
- <widget class="QWidget" name="leftPart">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
-       <horstretch>2</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="0" column="0">
+    <widget class="QSplitter" name="mainSplitter">
+     <property name="childrenCollapsible">
+      <bool>
+       true
+      </bool>
      </property>
-  <layout class="QVBoxLayout">
-   <item>
-    <widget class="QListWidget" name="contentsWidget">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-       <horstretch>1</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+     <property name="handleWidth">
+      <number>9</number>
      </property>
-     <property name="minimumSize">
-      <size>
-       <width>40</width>
-       <height>410</height>
-      </size>
-     </property>
-     <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
-     </property>
-     <property name="currentRow">
-      <number>-1</number>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLineEdit" name="lineEditMetaFilter">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-  </layout>
- </widget>
- <widget class="QWidget" name="rightPart">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
-       <horstretch>4</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-  <layout class="QGridLayout">
-   <item row="0" column="0" rowspan="2">
-    <widget class="QStackedWidget" name="pagesWidget">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>400</width>
-       <height>390</height>
-      </size>
-     </property>
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="pageGeneral">
+     <widget class="QWidget" name="leftPart">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+        <horstretch>2</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
       <layout class="QVBoxLayout">
-       <property name="spacing">
-        <number>6</number>
-       </property>
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
        <item>
-        <widget class="QScrollArea" name="scrollAreaGeneral">
-         <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
+        <widget class="QListWidget" name="contentsWidget">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>1</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-         <property name="widgetResizable">
-          <bool>true</bool>
+         <property name="minimumSize">
+          <size>
+           <width>40</width>
+           <height>300</height>
+          </size>
          </property>
-         <widget class="QWidget" name="scrollAreaWidgetContents">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>662</width>
-            <height>617</height>
-           </rect>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout">
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="currentRow">
+          <number>-1</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="lineEditMetaFilter">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="rightPart">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+        <horstretch>4</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <layout class="QGridLayout">
+       <item row="0" column="0" rowspan="2">
+        <widget class="QStackedWidget" name="pagesWidget">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>400</width>
+           <height>300</height>
+          </size>
+         </property>
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="pageGeneral">
+          <layout class="QVBoxLayout">
+           <property name="spacing">
+            <number>6</number>
+           </property>
            <property name="leftMargin">
             <number>0</number>
            </property>
@@ -160,432 +130,1383 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QGroupBox" name="groupBox_Appearance">
-             <property name="title">
-              <string>Appearance</string>
+            <widget class="QScrollArea" name="scrollAreaGeneral">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
              </property>
-             <layout class="QGridLayout">
-              <item row="4" column="1">
-               <widget class="QCheckBox" name="checkBoxUseTexmakerPalette">
-                <property name="text">
-                 <string>Ignore Most System Colors</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1" colspan="3">
-               <widget class="QComboBox" name="comboBoxInterfaceStyle">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_14">
-                <property name="text">
-                 <string>Color Scheme:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="1" colspan="3">
-               <widget class="QFontComboBox" name="comboBoxInterfaceFont">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-               </widget>
-              </item>
-              <item row="10" column="1" colspan="3">
-               <widget class="QComboBox" name="comboBoxLanguage">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_3">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Style:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="1" colspan="3">
-               <widget class="QSpinBox" name="spinBoxInterfaceFontSize">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-               </widget>
-              </item>
-              <item row="10" column="0">
-               <widget class="QLabel" name="label_9">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Language:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="0">
-               <widget class="QLabel" name="label_5">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Font:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1" colspan="3">
-               <widget class="QComboBox" name="comboBoxInterfaceModernStyle">
-                <item>
-                 <property name="text">
-                  <string>Classic</string>
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>662</width>
+                <height>300</height>
+               </rect>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QGroupBox" name="groupBox_Appearance">
+                 <property name="title">
+                  <string>Appearance</string>
                  </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Modern</string>
+                 <layout class="QGridLayout">
+                  <item row="4" column="1">
+                   <widget class="QCheckBox" name="checkBoxUseTexmakerPalette">
+                    <property name="text">
+                     <string>Ignore Most System Colors</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1" colspan="3">
+                   <widget class="QComboBox" name="comboBoxInterfaceStyle">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_14">
+                    <property name="text">
+                     <string>Color Scheme:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="1" colspan="3">
+                   <widget class="QFontComboBox" name="comboBoxInterfaceFont">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="10" column="1" colspan="3">
+                   <widget class="QComboBox" name="comboBoxLanguage">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_3">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Style:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="1" colspan="3">
+                   <widget class="QSpinBox" name="spinBoxInterfaceFontSize">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="10" column="0">
+                   <widget class="QLabel" name="label_9">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Language:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="0">
+                   <widget class="QLabel" name="label_5">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Font:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1" colspan="3">
+                   <widget class="QComboBox" name="comboBoxInterfaceModernStyle">
+                    <item>
+                     <property name="text">
+                      <string>Classic</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Modern</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Modern - dark</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="6" column="0">
+                   <widget class="QLabel" name="label_7">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Font Size:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="2">
+                   <widget class="QCheckBox" name="checkBoxUseSystemTheme">
+                    <property name="text">
+                     <string>Use System Theme Icons</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="label_27">
+                    <property name="text">
+                     <string>Icon Theme:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1" colspan="3">
+                   <widget class="QComboBox" name="comboBoxInterfaceIconTheme">
+                    <item>
+                     <property name="text">
+                      <string>Colibre</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Oxygen Modern</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Oxygen Classic</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox_Files">
+                 <property name="title">
+                  <string>Files</string>
                  </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Modern - dark</string>
+                 <property name="advancedOption" stdset="0">
+                  <bool>true</bool>
                  </property>
-                </item>
-               </widget>
-              </item>
-              <item row="6" column="0">
-               <widget class="QLabel" name="label_7">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
+                 <layout class="QGridLayout" columnstretch="0,0,1">
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="label_10">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Max. Recent Root Documents:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="1">
+                   <widget class="QCheckBox" name="checkBoxRememberFileFilter">
+                    <property name="text">
+                     <string>Remember selected file filter in open/save dialog </string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1" colspan="2">
+                   <widget class="QSpinBox" name="spinBoxMaxRecentProjects">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="maximum">
+                     <number>10000</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_8">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Max. Recent Documents:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1" colspan="2">
+                   <widget class="QSpinBox" name="spinBoxMaxRecentFiles">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="maximum">
+                     <number>10000</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="1">
+                   <widget class="QCheckBox" name="checkBoxUseNativeFileDialog">
+                    <property name="text">
+                     <string>Use system file dialogs</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="2">
+                   <widget class="QCheckBox" name="checkBoxParseRootDoc">
+                    <property name="text">
+                     <string>Always Show Structure of Root Document</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="2">
+                   <widget class="QCheckBox" name="checkBoxMRUDocumentChooser">
+                    <property name="text">
+                     <string>MRU Document Chooser</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox_Session">
+                 <property name="title">
+                  <string>Session</string>
+                 </property>
+                 <property name="advancedOption" stdset="0">
+                  <bool>true</bool>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_10">
+                  <item>
+                   <widget class="QCheckBox" name="checkBoxRestoreSession">
+                    <property name="text">
+                     <string>Restore Previous Session at Startup</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="checkBoxSessionStoreRelativePaths">
+                    <property name="text">
+                     <string>Store relative paths</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox_Startup">
+                 <property name="title">
+                  <string>Startup</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_14">
+                  <item>
+                   <widget class="QCheckBox" name="checkBoxCheckLatexConfiguration">
+                    <property name="text">
+                     <string>Check LaTeX Configuration</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox_Update">
+                 <property name="title">
+                  <string>Update</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout03">
+                  <item row="0" column="6">
+                   <widget class="QComboBox" name="comboBoxUpdateLevel">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="toolTip">
+                     <string>Defines the kinds of update notifications you will receive:
+- Stable Releases: Choose this if stability is most important to you.
+- Release Candidates: Are close to a future release in terms of features and stability. Choose this to get previews of future releases and help us by testing the version before it's been published as an official release. (Stable releases are notifed as well)
+- Development Versions: Contain the latest features, but might be unstable. (Stable releases and release candidates are notified as well).</string>
+                    </property>
+                    <item>
+                     <property name="text">
+                      <string>Stable Releases</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Release Candidates</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Development Versions</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="1" column="4">
+                   <spacer name="horizontalSpacer_7">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item row="1" column="3">
+                   <widget class="QPushButton" name="pushButtonUpdateCheckNow">
+                    <property name="text">
+                     <string>Check Now</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="3" colspan="2">
+                   <spacer name="horizontalSpacer_4">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QLabel" name="labelUpdateCheckDate">
+                    <property name="text">
+                     <string notr="true">&lt;checkDate&gt;</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_56">
+                    <property name="text">
+                     <string>Last Checked:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QSpinBox" name="spinBoxAutoUpdateCheckIntervalDays">
+                    <property name="suffix">
+                     <string> days</string>
+                    </property>
+                    <property name="minimum">
+                     <number>0</number>
+                    </property>
+                    <property name="value">
+                     <number>7</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QCheckBox" name="checkBoxAutoUpdateCheck">
+                    <property name="text">
+                     <string>Automatically check every</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="5">
+                   <widget class="QLabel" name="label_74">
+                    <property name="text">
+                     <string>Update Level:</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer>
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::MinimumExpanding</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="pageCommands">
+          <layout class="QVBoxLayout">
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QGroupBox" name="groupBoxCommands">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="title">
+              <string>Commands (%: filename without extension - @: line number - ?: extended filename options)</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_15">
+             <property name="text">
+              <string>&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Special chars&lt;/span&gt;</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_4">
+             <property name="text">
+              <string>&lt;b&gt;%&lt;/b&gt;: filename without extension; &lt;b&gt;@&lt;/b&gt;: line number; &lt;b&gt;?[selector][pathname parts][terminating char]&lt;/b&gt;: formated filename</string>
+             </property>
+             <property name="indent">
+              <number>15</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_17">
+             <property name="text">
+              <string>&lt;i&gt;File selector (Optional. If present include the terminating colon):&lt;/i&gt; If no selector then select root file. &lt;b&gt;c:&lt;/b&gt; select current file, &lt;b&gt;p{ext}:&lt;/b&gt; Find a file with same basename as root file and extension &lt;b&gt;ext&lt;/b&gt;. Search is done in root file directory and additional PDF directories.&lt;br /&gt;&lt;i&gt;Pathname parts:&lt;/i&gt; a combination of &lt;b&gt;a&lt;/b&gt;: absolute path, &lt;b&gt;m&lt;/b&gt;: basefile name without extension,&lt;b&gt;e&lt;/b&gt;: extension, &lt;b&gt;r&lt;/b&gt;: path relative to root, &lt;b&gt;*&lt;/b&gt;: all files matching the following pattern&lt;br/&gt;&lt;i&gt;Terminating chars:&lt;/i&gt;&lt;b&gt;)&lt;/b&gt;: ends selector. The following chars end the selector and have additional meaning&lt;br/&gt;&lt;b&gt;&amp;quot;&lt;/b&gt;: enclose in double-quotes, &lt;b&gt;.&lt;/b&gt; (dot) add a point at the end, (space): add a space at the end&lt;br/&gt;&lt;i&gt;Examples:&lt;/i&gt;&lt;b&gt;?ame&amp;quot;&lt;/b&gt;: complete absolute filename enclosed in double-quotes, &lt;b&gt;?e)&lt;/b&gt; just the extension without leading dot (e.g. tex), &lt;br/&gt;&lt;b&gt;?m&amp;quot;&lt;/b&gt; double-quoted filename without extension (identical to &lt;b&gt;%&lt;/b&gt;), &lt;b&gt;?me&lt;/b&gt; filename with extension (e.g. example.tex), &lt;b&gt;?*.aux&lt;/b&gt;: all .aux files in the current directory</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+             <property name="indent">
+              <number>30</number>
+             </property>
+             <property name="advancedOption" stdset="0">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_16">
+             <property name="text">
+              <string>&lt;b&gt;%%&lt;/b&gt;, &lt;b&gt;@@&lt;/b&gt; and &lt;b&gt;?? &lt;/b&gt; become: %, @ or ?
+</string>
+             </property>
+             <property name="margin">
+              <number>0</number>
+             </property>
+             <property name="indent">
+              <number>15</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="pageBuild">
+          <layout class="QVBoxLayout" stretch="0">
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QScrollArea" name="scrollAreaBuild">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaBuildContents">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>662</width>
+                <height>300</height>
+               </rect>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_17">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QGroupBox" name="groupBoxMetaCommands">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>200</height>
+                  </size>
+                 </property>
+                 <property name="baseSize">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="title">
+                  <string>Meta Commands</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBoxUserCommands">
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>95</height>
+                  </size>
+                 </property>
+                 <property name="title">
+                  <string>User Commands</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBoxBuildOptions">
+                 <property name="title">
+                  <string>Build Options</string>
+                 </property>
+                 <property name="advancedOption" stdset="0">
+                  <bool>true</bool>
+                 </property>
+                 <layout class="QFormLayout" name="formLayout">
+                  <property name="fieldGrowthPolicy">
+                   <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                  </property>
+                  <item row="0" column="0">
+                   <widget class="QCheckBox" name="checkBoxRunAfterBibTeXChange">
+                    <property name="toolTip">
+                     <string>Runs txs:///recompile-bibliography, if bib-files were changed.</string>
+                    </property>
+                    <property name="text">
+                     <string>Check and update bibliography before compiling</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QCheckBox" name="checkBoxShowMessagesOnCompile">
+                    <property name="text">
+                     <string>Show messages when starting compiling</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QCheckBox" name="checkBoxSingleInstanceViewer">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="minimumSize">
+                     <size>
+                      <width>0</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                    <property name="baseSize">
+                     <size>
+                      <width>600</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                    <property name="text">
+                     <string>Don't launch a new instance of the viewer if the dvi/ps/pdf file is already opened</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="label_37">
+                    <property name="text">
+                     <string>Show stdout:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="1">
+                   <widget class="QComboBox" name="comboBoxShowStdout">
+                    <item>
+                     <property name="text">
+                      <string>Never</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Only For User Commands</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Always (If not redirected &gt; /dev/null)</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="4" column="0">
+                   <widget class="QLabel" name="label_38">
+                    <property name="toolTip">
+                     <string>Some LaTeX constructs (e.g. references) need multiple compilation cycles until they are displayed correctly.</string>
+                    </property>
+                    <property name="text">
+                     <string>Maximum Compile Repetitions:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="7" column="0" colspan="2">
+                   <layout class="QGridLayout" name="gridLayout_1">
+                    <property name="leftMargin">
+                     <number>9</number>
+                    </property>
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="rightMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="verticalSpacing">
+                     <number>2</number>
+                    </property>
+                    <item row="1" column="1">
+                     <widget class="QLineEdit" name="lineEditPathPDF"/>
+                    </item>
+                    <item row="2" column="1">
+                     <widget class="QLineEdit" name="lineEditPathCommands"/>
+                    </item>
+                    <item row="1" column="2">
+                     <widget class="QPushButton" name="pushButtonPathPdf">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="text">
+                       <string/>
+                      </property>
+                      <property name="icon">
+                       <iconset resource="../images.qrc">
+                        <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="0">
+                     <widget class="QLabel" name="label_59">
+                      <property name="text">
+                       <string>Commands ($PATH)</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="0">
+                     <widget class="QLabel" name="label_58">
+                      <property name="text">
+                       <string>PDF File</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="1">
+                     <widget class="QLineEdit" name="lineEditPathLog"/>
+                    </item>
+                    <item row="0" column="2">
+                     <widget class="QPushButton" name="pushButtonPathLog">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="text">
+                       <string/>
+                      </property>
+                      <property name="icon">
+                       <iconset resource="../images.qrc">
+                        <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="2">
+                     <widget class="QPushButton" name="pushButtonPathCommands">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="text">
+                       <string/>
+                      </property>
+                      <property name="icon">
+                       <iconset resource="../images.qrc">
+                        <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="0">
+                     <widget class="QLabel" name="label_57">
+                      <property name="text">
+                       <string>Log File</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item row="6" column="0" colspan="2">
+                   <widget class="QLabel" name="label_68">
+                    <property name="text">
+                     <string>Additional Search Paths:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QCheckBox" name="checkBoxReplaceEnvironmentVariables">
+                    <property name="toolTip">
+                     <string>Replaces environment variables in commands.The behavior is OS-specific.
+
+Windows:
+Variables are written as: %MYVAR%. They are case-insensitive.
+
+Linux, OS X:
+Variables are written as: $MYVAR. They are case-sensitive.
+</string>
+                    </property>
+                    <property name="text">
+                     <string>Replace Environment Variables</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QCheckBox" name="checkBoxShowLogInCaseOfCompileError">
+                    <property name="text">
+                     <string>Show log in case of compile error</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1">
+                   <widget class="QCheckBox" name="checkBoxInterpetCommandDefinitionInMagicComment">
+                    <property name="toolTip">
+                     <string>This allows to redefine commands using comment of style &lt;code&gt;%&amp;nbsp;!TeX&amp;nbsp;program&lt;/code&gt;, &lt;code&gt;%&amp;nbsp;!TeX&amp;nbsp;TS-program&lt;/code&gt; and &lt;code&gt;%&amp;nbsp;!TeX&amp;nbsp;TXS-program&lt;/code&gt;. For details see the manual.</string>
+                    </property>
+                    <property name="text">
+                     <string>Interpret command definition in magic comments</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="1">
+                   <widget class="QSpinBox" name="spinBoxRerunLatex">
+                    <property name="value">
+                     <number>5</number>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="pageShortcuts">
+          <layout class="QVBoxLayout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_6">
+             <property name="text">
+              <string>Shortcuts</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QTreeWidget" name="shortcutTree">
+             <property name="toolTip">
+              <string>For editing, double-click on the entries in 'Current Shortcut' or 'Additional Shortcut'.
+Then you can select a new shortcut by one of the following ways:
+(1) select from the dropdown list
+(2) hit the shortcut combination
+(3) type the string of the shortcut</string>
+             </property>
+             <property name="animated">
+              <bool>true</bool>
+             </property>
+             <property name="columnCount">
+              <number>4</number>
+             </property>
+             <attribute name="headerDefaultSectionSize">
+              <number>150</number>
+             </attribute>
+             <column>
+              <property name="text">
+               <string>1</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>2</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>3</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>4</string>
+              </property>
+             </column>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="groupBox">
+             <property name="toolTip">
+              <string>Close Element applies to a fixed list of GUI elements (not all shown here). The first visible element will be closed. With this setting you can exclude some elements from being closed.</string>
+             </property>
+             <property name="title">
+              <string>Close Element (Esc)</string>
+             </property>
+             <layout class="QHBoxLayout" name="horizontalLayout_5">
+              <item>
+               <widget class="QCheckBox" name="checkBoxCloseLogByEsc">
                 <property name="text">
-                 <string>Font Size:</string>
+                 <string>Close Log-View</string>
                 </property>
                </widget>
               </item>
-              <item row="4" column="2">
-               <widget class="QCheckBox" name="checkBoxUseSystemTheme">
+              <item>
+               <widget class="QCheckBox" name="checkBoxCloseEmbeddedViewerByEsc">
                 <property name="text">
-                 <string>Use System Theme Icons</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
+                 <string>Close Embedded Viewer</string>
                 </property>
                </widget>
               </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="label_27">
+              <item>
+               <widget class="QCheckBox" name="checkBoxCloseFullscreenByEsc">
                 <property name="text">
-                 <string>Icon Theme:</string>
+                 <string>Close Full Screen Mode</string>
                 </property>
-               </widget>
-              </item>
-              <item row="2" column="1" colspan="3">
-               <widget class="QComboBox" name="comboBoxInterfaceIconTheme">
-                <item>
-                 <property name="text">
-                  <string>Colibre</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Oxygen Modern</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Oxygen Classic</string>
-                 </property>
-                </item>
                </widget>
               </item>
              </layout>
             </widget>
            </item>
            <item>
-            <widget class="QGroupBox" name="groupBox_Files">
-             <property name="title">
-              <string>Files</string>
+            <widget class="QCheckBox" name="checkBoxShowShortcutsInTooltips">
+             <property name="text">
+              <string>Show Shortcuts in Tooltips</string>
              </property>
-             <property name="advancedOption" stdset="0">
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="pageLatexMenus">
+          <layout class="QVBoxLayout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_19">
+             <property name="text">
+              <string>Menus</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QTreeWidget" name="menuTree">
+             <property name="toolTip">
+              <string>Here the menu items are listed and can be hidden or edited.</string>
+             </property>
+             <property name="animated">
               <bool>true</bool>
              </property>
-             <layout class="QGridLayout" columnstretch="0,0,1">
-              <item row="2" column="0">
-               <widget class="QLabel" name="label_10">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
+             <property name="columnCount">
+              <number>3</number>
+             </property>
+             <attribute name="headerDefaultSectionSize">
+              <number>250</number>
+             </attribute>
+             <column>
+              <property name="text">
+               <string>Name</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Command</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Slot</string>
+              </property>
+             </column>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="checkBoxShowAllMenus">
+             <property name="toolTip">
+              <string>This controls if the list above shows all menu items or only commonly changed ones.</string>
+             </property>
+             <property name="text">
+              <string>Show All</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="pageToolbars">
+          <layout class="QVBoxLayout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_20">
+             <property name="text">
+              <string>Toolbar Customization</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <layout class="QGridLayout" name="_2">
+             <item row="1" column="1">
+              <widget class="QListWidget" name="listCustomToolBar">
+               <property name="toolTip">
+                <string>This shows all actions on the currently edited toolbar.</string>
+               </property>
+               <property name="movement">
+                <enum>QListView::Free</enum>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="2">
+              <layout class="QVBoxLayout" name="_3">
+               <item>
+                <spacer name="verticalSpacer_3">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QPushButton" name="pbToToolbar">
+                 <property name="toolTip">
+                  <string>This adds an action to the toolbar.</string>
+                 </property>
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="icon">
+                  <iconset resource="../images.qrc">
+                   <normaloff>:/images-ng/left.svgz</normaloff>:/images-ng/left.svgz</iconset>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="pbFromToolbar">
+                 <property name="toolTip">
+                  <string>This removes an action from the toolbar.</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                 <property name="icon">
+                  <iconset resource="../images.qrc">
+                   <normaloff>:/images-ng/right.svgz</normaloff>:/images-ng/right.svgz</iconset>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="spacer">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+             <item row="0" column="1">
+              <widget class="QComboBox" name="comboBoxToolbars">
+               <property name="toolTip">
+                <string>Here you can choose a toolbar to modify.</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="3">
+              <widget class="QComboBox" name="comboBoxActions">
+               <property name="toolTip">
+                <string>Here you can choose a list of commands that can be mapped to the toolbar.</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="3">
+              <widget class="QTreeWidget" name="treePossibleToolbarActions">
+               <property name="toolTip">
+                <string>This shows available actions to map on a toolbar.</string>
+               </property>
+               <property name="rootIsDecorated">
+                <bool>false</bool>
+               </property>
+               <property name="animated">
+                <bool>true</bool>
+               </property>
+               <property name="allColumnsShowFocus">
+                <bool>true</bool>
+               </property>
+               <column>
                 <property name="text">
-                 <string>Max. Recent Root Documents:</string>
+                 <string>1</string>
                 </property>
-               </widget>
-              </item>
-              <item row="4" column="1">
-               <widget class="QCheckBox" name="checkBoxRememberFileFilter">
-                <property name="text">
-                 <string>Remember selected file filter in open/save dialog </string>
+               </column>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="pageScaling">
+          <layout class="QVBoxLayout" name="layoutScaling">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QGroupBox" name="groupBox_17">
+             <property name="title">
+              <string>GUI Scaling</string>
+             </property>
+             <layout class="QGridLayout">
+              <property name="horizontalSpacing">
+               <number>60</number>
+              </property>
+              <item row="4" column="1" colspan="2">
+               <widget class="QSlider" name="horizontalSliderSymbol">
+                <property name="toolTip">
+                 <string>This changes the scaling of the symbol grid (for high resolution displays).</string>
                 </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1" colspan="2">
-               <widget class="QSpinBox" name="spinBoxMaxRecentProjects">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
+                <property name="minimum">
+                 <number>16</number>
                 </property>
                 <property name="maximum">
-                 <number>10000</number>
+                 <number>128</number>
+                </property>
+                <property name="tracking">
+                 <bool>true</bool>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="invertedAppearance">
+                 <bool>false</bool>
+                </property>
+                <property name="invertedControls">
+                 <bool>false</bool>
+                </property>
+                <property name="tickPosition">
+                 <enum>QSlider::TicksBelow</enum>
+                </property>
+                <property name="tickInterval">
+                 <number>8</number>
                 </property>
                </widget>
               </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_8">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_11">
                 <property name="text">
-                 <string>Max. Recent Documents:</string>
+                 <string>Main Toolbar</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="3">
+               <widget class="QToolButton" name="tbRevertIcon">
+                <property name="text">
+                 <string>Reset</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="3">
+               <widget class="QToolButton" name="tbRevertCentralIcon">
+                <property name="text">
+                 <string>Reset</string>
                 </property>
                </widget>
               </item>
               <item row="1" column="1" colspan="2">
-               <widget class="QSpinBox" name="spinBoxMaxRecentFiles">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
+               <widget class="QSlider" name="horizontalSliderCentraIcon">
+                <property name="toolTip">
+                 <string>This changes the scaling of the vertical toolbars (for high resolution displays).</string>
+                </property>
+                <property name="minimum">
+                 <number>8</number>
                 </property>
                 <property name="maximum">
-                 <number>10000</number>
+                 <number>64</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="tickPosition">
+                 <enum>QSlider::TicksBelow</enum>
+                </property>
+                <property name="tickInterval">
+                 <number>8</number>
                 </property>
                </widget>
               </item>
-              <item row="6" column="1">
-               <widget class="QCheckBox" name="checkBoxUseNativeFileDialog">
-                <property name="text">
-                 <string>Use system file dialogs</string>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="2">
-               <widget class="QCheckBox" name="checkBoxParseRootDoc">
-                <property name="text">
-                 <string>Always Show Structure of Root Document</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="2">
-               <widget class="QCheckBox" name="checkBoxMRUDocumentChooser">
-                <property name="text">
-                 <string>MRU Document Chooser</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="groupBox_Session">
-             <property name="title">
-              <string>Session</string>
-             </property>
-             <property name="advancedOption" stdset="0">
-              <bool>true</bool>
-             </property>
-             <layout class="QVBoxLayout" name="verticalLayout_10">
-              <item>
-               <widget class="QCheckBox" name="checkBoxRestoreSession">
-                <property name="text">
-                 <string>Restore Previous Session at Startup</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="checkBoxSessionStoreRelativePaths">
-                <property name="text">
-                 <string>Store relative paths</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="groupBox_Startup">
-             <property name="title">
-              <string>Startup</string>
-             </property>
-             <layout class="QVBoxLayout" name="verticalLayout_14">
-              <item>
-               <widget class="QCheckBox" name="checkBoxCheckLatexConfiguration">
-                <property name="text">
-                 <string>Check LaTeX Configuration</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="groupBox_Update">
-             <property name="title">
-              <string>Update</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout03">
-              <item row="0" column="6">
-               <widget class="QComboBox" name="comboBoxUpdateLevel">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
+              <item row="0" column="1" colspan="2">
+               <widget class="QSlider" name="horizontalSliderIcon">
                 <property name="toolTip">
-                 <string>Defines the kinds of update notifications you will receive:
-- Stable Releases: Choose this if stability is most important to you.
-- Release Candidates: Are close to a future release in terms of features and stability. Choose this to get previews of future releases and help us by testing the version before it's been published as an official release. (Stable releases are notifed as well)
-- Development Versions: Contain the latest features, but might be unstable. (Stable releases and release candidates are notified as well).</string>
+                 <string>This changes the scaling of the horizontal toolbars (for high resolution displays).</string>
                 </property>
-                <item>
-                 <property name="text">
-                  <string>Stable Releases</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Release Candidates</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Development Versions</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="1" column="4">
-               <spacer name="horizontalSpacer_7">
+                <property name="minimum">
+                 <number>16</number>
+                </property>
+                <property name="maximum">
+                 <number>128</number>
+                </property>
+                <property name="value">
+                 <number>24</number>
+                </property>
+                <property name="sliderPosition">
+                 <number>24</number>
+                </property>
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
                 </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
+                <property name="tickPosition">
+                 <enum>QSlider::TicksBelow</enum>
                 </property>
-               </spacer>
-              </item>
-              <item row="1" column="3">
-               <widget class="QPushButton" name="pushButtonUpdateCheckNow">
-                <property name="text">
-                 <string>Check Now</string>
+                <property name="tickInterval">
+                 <number>8</number>
                 </property>
                </widget>
               </item>
-              <item row="0" column="3" colspan="2">
-               <spacer name="horizontalSpacer_4">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="1" column="1">
-               <widget class="QLabel" name="labelUpdateCheckDate">
+              <item row="4" column="3">
+               <widget class="QToolButton" name="tbRevertSymbol">
                 <property name="text">
-                 <string notr="true">&lt;checkDate&gt;</string>
+                 <string>Reset</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="label_72">
+                <property name="text">
+                 <string>Symbol Grid</string>
                 </property>
                </widget>
               </item>
               <item row="1" column="0">
-               <widget class="QLabel" name="label_56">
+               <widget class="QLabel" name="label_71">
                 <property name="text">
-                 <string>Last Checked:</string>
+                 <string>Secondary Toolbars</string>
                 </property>
                </widget>
               </item>
-              <item row="0" column="1">
-               <widget class="QSpinBox" name="spinBoxAutoUpdateCheckIntervalDays">
-                <property name="suffix">
-                 <string> days</string>
+              <item row="5" column="1" colspan="2">
+               <widget class="QSlider" name="horizontalSliderPDF">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the scaling of the toolbar of the embeded pdf viewer (for high resolution displays).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="minimum">
-                 <number>0</number>
+                 <number>8</number>
                 </property>
-                <property name="value">
-                 <number>7</number>
+                <property name="maximum">
+                 <number>128</number>
+                </property>
+                <property name="tracking">
+                 <bool>true</bool>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="tickPosition">
+                 <enum>QSlider::TicksBelow</enum>
+                </property>
+                <property name="tickInterval">
+                 <number>8</number>
                 </property>
                </widget>
               </item>
-              <item row="0" column="0">
-               <widget class="QCheckBox" name="checkBoxAutoUpdateCheck">
+              <item row="5" column="0">
+               <widget class="QLabel" name="label_87">
                 <property name="text">
-                 <string>Automatically check every</string>
+                 <string>Embedded PDF Toolbar</string>
                 </property>
                </widget>
               </item>
-              <item row="0" column="5">
-               <widget class="QLabel" name="label_74">
+              <item row="5" column="3">
+               <widget class="QToolButton" name="tbRevertPDF">
                 <property name="text">
-                 <string>Update Level:</string>
+                 <string>Reset</string>
                 </property>
                </widget>
               </item>
@@ -593,12 +1514,12 @@
             </widget>
            </item>
            <item>
-            <spacer>
+            <spacer name="verticalSpacer_6">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
              </property>
              <property name="sizeType">
-              <enum>QSizePolicy::MinimumExpanding</enum>
+              <enum>QSizePolicy::Expanding</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -610,124 +1531,8 @@
            </item>
           </layout>
          </widget>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="pageCommands">
-      <layout class="QVBoxLayout">
-       <property name="spacing">
-        <number>6</number>
-       </property>
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QGroupBox" name="groupBoxCommands">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="title">
-          <string>Commands (%: filename without extension - @: line number - ?: extended filename options)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_15">
-         <property name="text">
-          <string>&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Special chars&lt;/span&gt;</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_4">
-         <property name="text">
-          <string>&lt;b&gt;%&lt;/b&gt;: filename without extension; &lt;b&gt;@&lt;/b&gt;: line number; &lt;b&gt;?[selector][pathname parts][terminating char]&lt;/b&gt;: formated filename</string>
-         </property>
-         <property name="indent">
-          <number>15</number>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_17">
-         <property name="text">
-          <string>&lt;i&gt;File selector (Optional. If present include the terminating colon):&lt;/i&gt; If no selector then select root file. &lt;b&gt;c:&lt;/b&gt; select current file, &lt;b&gt;p{ext}:&lt;/b&gt; Find a file with same basename as root file and extension &lt;b&gt;ext&lt;/b&gt;. Search is done in root file directory and additional PDF directories.&lt;br /&gt;&lt;i&gt;Pathname parts:&lt;/i&gt; a combination of &lt;b&gt;a&lt;/b&gt;: absolute path, &lt;b&gt;m&lt;/b&gt;: basefile name without extension,&lt;b&gt;e&lt;/b&gt;: extension, &lt;b&gt;r&lt;/b&gt;: path relative to root, &lt;b&gt;*&lt;/b&gt;: all files matching the following pattern&lt;br/&gt;&lt;i&gt;Terminating chars:&lt;/i&gt;&lt;b&gt;)&lt;/b&gt;: ends selector. The following chars end the selector and have additional meaning&lt;br/&gt;&lt;b&gt;&amp;quot;&lt;/b&gt;: enclose in double-quotes, &lt;b&gt;.&lt;/b&gt; (dot) add a point at the end, (space): add a space at the end&lt;br/&gt;&lt;i&gt;Examples:&lt;/i&gt;&lt;b&gt;?ame&amp;quot;&lt;/b&gt;: complete absolute filename enclosed in double-quotes, &lt;b&gt;?e)&lt;/b&gt; just the extension without leading dot (e.g. tex), &lt;br/&gt;&lt;b&gt;?m&amp;quot;&lt;/b&gt; double-quoted filename without extension (identical to &lt;b&gt;%&lt;/b&gt;), &lt;b&gt;?me&lt;/b&gt; filename with extension (e.g. example.tex), &lt;b&gt;?*.aux&lt;/b&gt;: all .aux files in the current directory</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-         <property name="indent">
-          <number>30</number>
-         </property>
-         <property name="advancedOption" stdset="0">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_16">
-         <property name="text">
-          <string>&lt;b&gt;%%&lt;/b&gt;, &lt;b&gt;@@&lt;/b&gt; and &lt;b&gt;?? &lt;/b&gt; become: %, @ or ?
-</string>
-         </property>
-         <property name="margin">
-          <number>0</number>
-         </property>
-         <property name="indent">
-          <number>15</number>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="pageBuild">
-      <layout class="QVBoxLayout" stretch="0">
-       <property name="spacing">
-        <number>6</number>
-       </property>
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QScrollArea" name="scrollAreaBuild">
-         <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
-         </property>
-         <property name="widgetResizable">
-          <bool>true</bool>
-         </property>
-         <widget class="QWidget" name="scrollAreaBuildContents">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>662</width>
-            <height>617</height>
-           </rect>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_17">
+         <widget class="QWidget" name="pageEditor">
+          <layout class="QVBoxLayout" name="verticalLayout_1">
            <property name="leftMargin">
             <number>0</number>
            </property>
@@ -741,9 +1546,1384 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QGroupBox" name="groupBoxMetaCommands">
+            <widget class="QScrollArea" name="scrollAreaEditor">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents_1">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>528</width>
+                <height>300</height>
+               </rect>
+              </property>
+              <layout class="QGridLayout">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <property name="spacing">
+                <number>6</number>
+               </property>
+               <item row="3" column="0">
+                <spacer name="verticalSpacer_5">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="1" column="0">
+                <widget class="QGroupBox" name="groupBox_3">
+                 <property name="title">
+                  <string>Editor</string>
+                 </property>
+                 <layout class="QGridLayout">
+                  <item row="13" column="0">
+                   <widget class="QCheckBox" name="checkBoxRealTimeCheck">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Inline Checking:</string>
+                    </property>
+                    <property name="checked">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="11" column="0">
+                   <widget class="QLabel" name="label_33">
+                    <property name="text">
+                     <string>Show Line Numbers:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="11" column="1">
+                   <widget class="QComboBox" name="comboboxLineNumbers">
+                    <property name="" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                    <item>
+                     <property name="text">
+                      <string>No Line Numbers</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>All Line Numbers</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Only Important Line Numbers</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="15" column="0" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxInlineCheckNonTeXFiles">
+                    <property name="text">
+                     <string>Check non tex files</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="17" column="0" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxScanInstalledLatexPackages">
+                    <property name="text">
+                     <string>Scan LaTeX distribution for installed packages</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="12" column="0" colspan="4">
+                   <widget class="QCheckBox" name="checkBoxFolding">
+                    <property name="text">
+                     <string>Folding</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="7" column="3" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxReplaceIndentTabByWhitespace">
+                    <property name="text">
+                     <string>Replace Indentation Tab by Spaces</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="labelFamily">
+                    <property name="text">
+                     <string>Font Family:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="10" column="0">
+                   <widget class="QLabel" name="label_39">
+                    <property name="text">
+                     <string>Replace Double Quotes:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="labelEncoding">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Default Font Encoding:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="7" column="0">
+                   <widget class="QLabel" name="label_30">
+                    <property name="text">
+                     <string>Indentation Mode:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="0">
+                   <widget class="QLabel" name="label_65">
+                    <property name="text">
+                     <string>Automatic Encoding Detection:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="1" colspan="2">
+                   <widget class="QComboBox" name="comboBoxEncoding"/>
+                  </item>
+                  <item row="5" column="1" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxAutoDetectEncodingFromLatex">
+                    <property name="text">
+                     <string>Analyze LaTeX (% !TeX encoding, inputenc, inputenx)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="3" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxAutoDetectEncodingFromChars">
+                    <property name="toolTip">
+                     <string>can only decide between utf16/utf-8 and ISO 8859-1 !</string>
+                    </property>
+                    <property name="text">
+                     <string>Analyze Characters</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1" colspan="2">
+                   <widget class="QComboBox" name="comboBoxFont">
+                    <property name="editable">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1" colspan="4">
+                   <widget class="QSpinBox" name="spinBoxSize">
+                    <property name="minimum">
+                     <number>1</number>
+                    </property>
+                    <property name="value">
+                     <number>12</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1" colspan="4">
+                   <widget class="QSpinBox" name="spinBoxLineSpacingPercent">
+                    <property name="suffix">
+                     <string>%</string>
+                    </property>
+                    <property name="minimum">
+                     <number>100</number>
+                    </property>
+                    <property name="maximum">
+                     <number>500</number>
+                    </property>
+                    <property name="singleStep">
+                     <number>10</number>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="labelSize">
+                    <property name="text">
+                     <string>Font Size:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="label_2">
+                    <property name="text">
+                     <string>Line Spacing:</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="10" column="1" colspan="4">
+                   <widget class="QComboBox" name="comboBoxReplaceQuotes">
+                    <item>
+                     <property name="text">
+                      <string>No Replacement</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>English Quotes:  `` ''</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>French Quotes:  &quot;&lt; &quot;&gt;</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>German Quotes:  &quot;` &quot;'</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>French Quotes (babel): \og{} \fg{}</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Reverse French Quotes: &quot;&gt; &quot;&lt;</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Package csquotes: \enquote{  }</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>English Quotes (unicode): “ ”</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Polish Quotes: ,, ''</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Polish Quotes (unicode): „ ”</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="0" column="3" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxShowOnlyMonospacedFonts">
+                    <property name="text">
+                     <string>Show Only Monospaced Fonts</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="7" column="1" colspan="2">
+                   <widget class="QComboBox" name="comboBoxAutoIndent">
+                    <property name="advancedOption" stdset="0">
+                     <bool>false</bool>
+                    </property>
+                    <item>
+                     <property name="text">
+                      <string>Ignore Indentation</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Keep Indentation</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Indent and Unindent Automatically</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="13" column="1" colspan="4">
+                   <widget class="QGroupBox" name="groupBoxInlineChecking">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="title">
+                     <string/>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_4">
+                     <item>
+                      <widget class="QCheckBox" name="checkBoxInlineSpellCheck">
+                       <property name="text">
+                        <string>Spelling</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QCheckBox" name="checkBoxInlineGrammarCheck">
+                       <property name="text">
+                        <string>Grammar</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QCheckBox" name="checkBoxInlineCitationCheck">
+                       <property name="text">
+                        <string>Citations</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QCheckBox" name="checkBoxInlineReferenceCheck">
+                       <property name="text">
+                        <string>References</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QCheckBox" name="checkBoxInlineSyntaxCheck">
+                       <property name="text">
+                        <string>Syntax</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QCheckBox" name="checkBoxInlinePackageCheck">
+                       <property name="text">
+                        <string>Package</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item row="8" column="3" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxReplaceTextTabByWhitespace">
+                    <property name="text">
+                     <string>Replace Tab in Text by Spaces</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="16" column="0" colspan="3">
+                   <widget class="QCheckBox" name="checkBoxAutoLoad">
+                    <property name="text">
+                     <string>Automatically load included files</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="14" column="2" colspan="3">
+                   <widget class="QCheckBox" name="checkBoxHideGrammarErrorsInNonText">
+                    <property name="text">
+                     <string>Hide grammar errors in non-text environments</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="14" column="0" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxHideSpellingErrorsInNonText">
+                    <property name="text">
+                     <string>Hide spelling errors in non-text environments</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="9" column="3" colspan="2">
+                   <widget class="QCheckBox" name="checkboxRemoveTrailingWsOnSave">
+                    <property name="text">
+                     <string>Remove Trailing Whitespace on Save</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="pageAdvEditor">
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QScrollArea" name="scrollAreaAdvancedEditor">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents_2">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>528</width>
+                <height>300</height>
+               </rect>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_8">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QGroupBox" name="groupBox_9">
+                 <property name="title">
+                  <string>Appearance</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_6">
+                  <item row="2" column="0">
+                   <layout class="QHBoxLayout" name="horizontalLayout_6">
+                    <item>
+                     <spacer name="horizontalSpacer_6">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>40</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                   </layout>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QCheckBox" name="checkBoxState">
+                    <property name="text">
+                     <string>Show State Panel</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <layout class="QHBoxLayout" name="horizontalLayout_7">
+                    <item>
+                     <widget class="QLabel" name="label_22">
+                      <property name="text">
+                       <string>Tab Width:</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QSpinBox" name="sbTabSpace">
+                      <property name="minimum">
+                       <number>1</number>
+                      </property>
+                      <property name="maximum">
+                       <number>32</number>
+                      </property>
+                      <property name="value">
+                       <number>4</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="horizontalSpacer_5">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>0</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                   </layout>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QCheckBox" name="checkBoxShowWhitespace">
+                    <property name="text">
+                     <string>Show Whitespace</string>
+                    </property>
+                    <property name="checked">
+                     <bool>true</bool>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QCheckBox" name="checkBoxLineState">
+                    <property name="text">
+                     <string>Show Line Change State</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1">
+                   <widget class="QCheckBox" name="checkBoxBoldCursor">
+                    <property name="toolTip">
+                     <string>Draw cursor as a thick line</string>
+                    </property>
+                    <property name="text">
+                     <string>Bold Cursor</string>
+                    </property>
+                    <property name="checked">
+                     <bool>true</bool>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox_10">
+                 <property name="title">
+                  <string>Search Panel</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_5">
+                  <item>
+                   <widget class="QCheckBox" name="checkBoxCloseSearchReplaceTogether">
+                    <property name="text">
+                     <string>Close search and replace panel together</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="checkBoxUseLineForSearch">
+                    <property name="text">
+                     <string>Use single line selection as Search Word</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="checkBoxSearchOnlyInSelection">
+                    <property name="text">
+                     <string>Restrict search scope to an existing selection</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox_11">
+                 <property name="title">
+                  <string>Special options</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>false</bool>
+                 </property>
+                 <layout class="QGridLayout" columnstretch="0,1,1,1">
+                  <item row="16" column="0" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxUseQSaveWrite">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This uses QSaveFile to prevent losing existing data if the writing operation fails. As a drawback, the current user becomes the owner of the file and extended file attributes are lost. Also, there appear to be problems of this method with dropbox folders.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="text">
+                     <string>Safe writing of files</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="2" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxImageToolTip">
+                    <property name="text">
+                     <string>Show image tooltip on image files</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="7" column="0" colspan="2">
+                   <widget class="QCheckBox" name="checkOverwriteOpeningBracketFollowedByPlaceholder">
+                    <property name="text">
+                     <string>Overwrite Opening Bracket Followed by a Placeholder</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="21" column="0">
+                   <widget class="QCheckBox" name="checkBoxShowLogMarkersWhenClickingLogEntry">
+                    <property name="text">
+                     <string>Show log markers when clicking log entry</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="0">
+                   <widget class="QCheckBox" name="checkBoxMouseWheelZoom">
+                    <property name="text">
+                     <string>Mouse Wheel Zoom</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="18" column="0" colspan="3">
+                   <layout class="QVBoxLayout" name="verticalLayout_12">
+                    <property name="leftMargin">
+                     <number>16</number>
+                    </property>
+                    <item>
+                     <widget class="QCheckBox" name="checkBoxSilentReload">
+                      <property name="text">
+                       <string>Silently reload saved files on external changes (discards undo/redo stack)</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item row="17" column="0" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxMonitorFilesForExternalChanges">
+                    <property name="text">
+                     <string>Monitor open files for external changes</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="25" column="0">
+                   <widget class="QLabel" name="label_85">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;External programs (such as Zotero) can push citations into texstudio by calling: &lt;span style=&quot; font-family:'monospace';&quot;&gt;texstudio --insert-cite &amp;quot;citation&amp;quot;&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;If the cursor is not already within an citation command, the &amp;quot;command&amp;quot; given here is used as \cite-command.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="text">
+                     <string>Latex Command for pushed citations:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="24" column="1" colspan="2">
+                   <widget class="QComboBox" name="comboBoxContextMenuSpellcheckingEntryLocation">
+                    <item>
+                     <property name="text">
+                      <string>Add Entries Directly To Context  Menu</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Create Dedicated Submenu</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="15" column="1">
+                   <widget class="QComboBox" name="comboBoxAutoSave">
+                    <item>
+                     <property name="text">
+                      <string>Never</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>1 minute</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>2 minutes</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>5 minutes</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>10 minutes</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>20 minutes</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>60 minutes</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="20" column="0">
+                   <widget class="QCheckBox" name="checkBoxInsertSymbolAsUCS">
+                    <property name="toolTip">
+                     <string>When using unicode characters in the source code, LaTeX still has
+to render the characters. Since unicode is not natively supported by LaTeX, you have to include appropriate packages for unicode characters in your document.</string>
+                    </property>
+                    <property name="text">
+                     <string>Insert Symbol as Unicode</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="12" column="0">
+                   <widget class="QLabel" name="label_41">
+                    <property name="text">
+                     <string>Line Wrapping:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="8" column="0" colspan="2">
+                   <widget class="QCheckBox" name="checkOverwriteClosingBracketFollowingPlaceholder">
+                    <property name="text">
+                     <string>Overwrite Closing Bracket Following a Placeholder</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="13" column="2">
+                   <widget class="QCheckBox" name="checkBoxCenterDocumentInEditor">
+                    <property name="toolTip">
+                     <string>This does only have an effect if the width of the document is limited by soft or hard line wrapping.</string>
+                    </property>
+                    <property name="text">
+                     <string>Center Document in Editor</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="25" column="1" colspan="2">
+                   <widget class="QLineEdit" name="lineEditCiteCommand"/>
+                  </item>
+                  <item row="11" column="0">
+                   <widget class="QLabel" name="label_82">
+                    <property name="text">
+                     <string>Triple-Click Selection:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="23" column="1" colspan="2">
+                   <widget class="QComboBox" name="comboBoxLogFileEncoding"/>
+                  </item>
+                  <item row="5" column="2" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxTexDocInternal">
+                    <property name="text">
+                     <string>Show help on commands in internal pdf viewer (texdoc)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="0" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxAllowDragAndDrop">
+                    <property name="text">
+                     <string>Allow Drag and Drop</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="11" column="1" colspan="2">
+                   <widget class="QComboBox" name="comboBoxTripleClickSelection">
+                    <item>
+                     <property name="text">
+                      <string>Select Word</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Select Word or Command</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Select Parentheses Content</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Select Parentheses</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Select Line</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="13" column="0">
+                   <widget class="QLabel" name="label_23">
+                    <property name="text">
+                     <string>Maximal Characters:</string>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="0">
+                   <widget class="QCheckBox" name="checkBoxSmoothScrolling">
+                    <property name="text">
+                     <string>Smooth Scrolling</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="23" column="0">
+                   <widget class="QLabel" name="label_80">
+                    <property name="text">
+                     <string>Default Log Encoding</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="15" column="0">
+                   <widget class="QLabel" name="label_24">
+                    <property name="text">
+                     <string>Auto Save All Files:</string>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="13" column="1">
+                   <widget class="QSpinBox" name="spinBoxWrapLineWidth">
+                    <property name="minimum">
+                     <number>20</number>
+                    </property>
+                    <property name="maximum">
+                     <number>999</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="12" column="1" colspan="2">
+                   <widget class="QComboBox" name="comboBoxLineWrap">
+                    <item>
+                     <property name="text">
+                      <string>No Line Wrap</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Soft Line Wrap at Window Edge</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Soft Line Wrap after max. Characters</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Hard Line Wrap after max. Characters</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="4" column="2" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxToolTipHelp2">
+                    <property name="text">
+                     <string>Show help as tooltip on text in editor</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="21" column="2">
+                   <widget class="QCheckBox" name="checkBoxGoToErrorWhenDisplayingLog">
+                    <property name="text">
+                     <string>Go to error when displaying log</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="24" column="0">
+                   <widget class="QLabel" name="label_70">
+                    <property name="text">
+                     <string>Spellchecking via context menu:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QCheckBox" name="checkBoxAutoCompleteParens">
+                    <property name="text">
+                     <string>Auto Complete Parentheses</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="9" column="0" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxDoubleClickSelectionIncludeLeadingBackslash">
+                    <property name="text">
+                     <string>Double-Click Selection: Include Leading Backslash</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="10" column="0" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxVerticalOverScroll">
+                    <property name="text">
+                     <string>Vertical Overscroll (Scroll below end of file)</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox_16">
+                 <property name="title">
+                  <string>Structure Panel</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_2">
+                  <item row="10" column="2">
+                   <widget class="QComboBox" name="comboBoxTOCBackgroundColor">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The global TOC uses different shades of background color to distinguish different files. The color scheme can be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <item>
+                     <property name="text">
+                      <string>No Color Background</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Green Background</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Blue Background</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="9" column="0">
+                   <widget class="QCheckBox" name="checkBoxMarkStructureElementsBeyondEnd">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Elements like &amp;quot;\section&amp;quot; are highlighted with a different background color to show that they will &lt;span style=&quot; font-weight:600;&quot;&gt;not&lt;/span&gt; appear in the document.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="text">
+                     <string>Mark structure elements beyond \end{document}</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="0">
+                   <widget class="QLabel" name="label_64">
+                    <property name="text">
+                     <string>Reference commands in context menu:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="2">
+                   <widget class="QLineEdit" name="leReferenceCommandsInContextMenu"/>
+                  </item>
+                  <item row="7" column="2">
+                   <widget class="QLineEdit" name="leRegExpTODO"/>
+                  </item>
+                  <item row="7" column="0">
+                   <widget class="QLabel" name="label_83">
+                    <property name="text">
+                     <string>Regular expression for TODO comment: </string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxIndentIncludesInStructureTree">
+                    <property name="text">
+                     <string>Keep indentation of includes in structure tree</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="2">
+                   <widget class="QCheckBox" name="checkBoxScrollToCurrentPosition">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The current cursor position is highlighted in the structure view.&lt;/p&gt;&lt;p&gt;If this option is active, the entry is expanded and scrolled to be visible.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="text">
+                     <string>Scroll to current cursor position</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="9" column="2">
+                   <widget class="QCheckBox" name="checkBoxMarkStructureElementsInAppendix">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Elements like &amp;quot;\section&amp;quot; are highlighted with a different background color to show that they will appear as appendix.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="text">
+                     <string>Mark structure elements in appendix</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="10" column="0">
+                   <widget class="QLabel" name="label_90">
+                    <property name="text">
+                     <string>Use color in global TOC:</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                 <zorder>checkBoxIndentIncludesInStructureTree</zorder>
+                 <zorder>label_64</zorder>
+                 <zorder>leReferenceCommandsInContextMenu</zorder>
+                 <zorder>checkBoxMarkStructureElementsBeyondEnd</zorder>
+                 <zorder>label_83</zorder>
+                 <zorder>leRegExpTODO</zorder>
+                 <zorder>comboBoxTOCBackgroundColor</zorder>
+                 <zorder>checkBoxScrollToCurrentPosition</zorder>
+                 <zorder>checkBoxMarkStructureElementsInAppendix</zorder>
+                 <zorder>label_90</zorder>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBoxBibliography">
+                 <property name="title">
+                  <string>Bibliography</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_7">
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_73">
+                    <property name="text">
+                     <string>bib File Encoding:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QCheckBox" name="checkBoxParseBibTeX">
+                    <property name="text">
+                     <string>Parse BibTeX</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QComboBox" name="comboBoxBibFileEncoding"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gbTableAutoformat">
+                 <property name="title">
+                  <string>Table Autoformating</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayoutTableAutoFormat">
+                  <item row="2" column="0" colspan="2">
+                   <widget class="QCheckBox" name="cbTableFormatingOneLinePerCell">
+                    <property name="text">
+                     <string>One Line Per Cell</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QComboBox" name="cbTableFormatingSpecialCommandPos">
+                    <item>
+                     <property name="text">
+                      <string>Behind Line Break</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Separate Line (No Indent)</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Separate Line (Indented to First Column)</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_61">
+                    <property name="text">
+                     <string>Special Commands Position:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QLineEdit" name="leTableFormatingSpecialCommands"/>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_60">
+                    <property name="text">
+                     <string>Special Commands:</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gbAdditionalSearchPaths">
+                 <property name="title">
+                  <string>Additional Search Paths</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout71">
+                  <property name="verticalSpacing">
+                   <number>2</number>
+                  </property>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_62">
+                    <property name="text">
+                     <string>Bib Files:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QLineEdit" name="lineEditPathBib"/>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QLineEdit" name="lineEditPathImages"/>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_63">
+                    <property name="text">
+                     <string>Image Files:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="2">
+                   <widget class="QPushButton" name="pushButtonPathBib">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../images.qrc">
+                      <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="2">
+                   <widget class="QPushButton" name="pushButtonPathImages">
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../images.qrc">
+                      <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox_15">
+                 <property name="title">
+                  <string>Bi-Di</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout8">
+                  <item row="0" column="0" colspan="3">
+                   <widget class="QCheckBox" name="checkBoxAutoLRM">
+                    <property name="text">
+                     <string>Automatically insert LRM characters</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0" colspan="3">
+                   <widget class="QCheckBox" name="checkBoxVisualColumnMode">
+                    <property name="text">
+                     <string>Visual column cursor mode (i.e. move cursor in direction of arrow keys in rtl-text)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="labelSwitchKeyboardLayout">
+                    <property name="text">
+                     <string>Automatically switch keyboard layout: </string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1">
+                   <widget class="QCheckBox" name="checkBoxSwitchLanguagesDirection">
+                    <property name="text">
+                     <string>depending on character direction</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="2">
+                   <widget class="QCheckBox" name="checkBoxSwitchLanguagesMath">
+                    <property name="text">
+                     <string>depending on text/math mode</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox_12">
+                 <property name="title">
+                  <string>Hacks/Workarounds</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_11">
+                  <item>
+                   <widget class="QCheckBox" name="checkBoxHackDisableAccentWorkaround">
+                    <property name="text">
+                     <string>Disable work-around on accent typing (Mac OS X only)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="checkBoxHackAutoRendering">
+                    <property name="text">
+                     <string>Try to automatically choose best display options</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QGridLayout" name="gridLayout_3">
+                    <property name="leftMargin">
+                     <number>16</number>
+                    </property>
+                    <item row="4" column="0">
+                     <widget class="QLabel" name="labelRenderMode">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="text">
+                       <string>Render Mode:</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="4" column="1">
+                     <widget class="QComboBox" name="comboBoxHackRenderMode">
+                      <item>
+                       <property name="text">
+                        <string>QCE (recommended)</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string>Qt</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string>Single Letter</string>
+                       </property>
+                      </item>
+                     </widget>
+                    </item>
+                    <item row="2" column="0" colspan="2">
+                     <widget class="QCheckBox" name="checkBoxHackDisableLineCache">
+                      <property name="toolTip">
+                       <string>If the cache of rendered lines is enabled, rendered lines are stored in a cache, so they do not have to be rendered again. Leading to a speed improvement (especially on Mac), at the cost of a higher memory usage.</string>
+                      </property>
+                      <property name="text">
+                       <string>Disable cache of rendered lines</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="0" colspan="2">
+                     <widget class="QCheckBox" name="checkBoxHackDisableFixedPitch">
+                      <property name="text">
+                       <string>Disable fixed pitch mode</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="0" colspan="2">
+                     <widget class="QCheckBox" name="checkBoxHackDisableWidthCache">
+                      <property name="text">
+                       <string>Disable cache of character width</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="3" column="0">
+                     <widget class="QCheckBox" name="checkBoxHackQImageCache">
+                      <property name="text">
+                       <string>Use QImage as cache type</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>2</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="pageSyntaxHighlighting">
+          <layout class="QVBoxLayout" name="verticalLayout_7">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QGroupBox" name="formatConfigBox">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
@@ -751,7 +2931,7 @@
              <property name="minimumSize">
               <size>
                <width>0</width>
-               <height>200</height>
+               <height>0</height>
               </size>
              </property>
              <property name="baseSize">
@@ -761,1245 +2941,144 @@
               </size>
              </property>
              <property name="title">
-              <string>Meta Commands</string>
+              <string>Formats</string>
              </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="groupBoxUserCommands">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>95</height>
-              </size>
-             </property>
-             <property name="title">
-              <string>User Commands</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="groupBoxBuildOptions">
-             <property name="title">
-              <string>Build Options</string>
-             </property>
-             <property name="advancedOption" stdset="0">
-              <bool>true</bool>
-             </property>
-             <layout class="QFormLayout" name="formLayout">
-              <property name="fieldGrowthPolicy">
-               <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-              </property>
-              <item row="0" column="0">
-               <widget class="QCheckBox" name="checkBoxRunAfterBibTeXChange">
-                <property name="toolTip">
-                 <string>Runs txs:///recompile-bibliography, if bib-files were changed.</string>
-                </property>
-                <property name="text">
-                 <string>Check and update bibliography before compiling</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QCheckBox" name="checkBoxShowMessagesOnCompile">
-                <property name="text">
-                 <string>Show messages when starting compiling</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QCheckBox" name="checkBoxSingleInstanceViewer">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>0</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="baseSize">
-                 <size>
-                  <width>600</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="text">
-                 <string>Don't launch a new instance of the viewer if the dvi/ps/pdf file is already opened</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="label_37">
-                <property name="text">
-                 <string>Show stdout:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QComboBox" name="comboBoxShowStdout">
-                <item>
-                 <property name="text">
-                  <string>Never</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Only For User Commands</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Always (If not redirected &gt; /dev/null)</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="4" column="0">
-               <widget class="QLabel" name="label_38">
-                <property name="toolTip">
-                 <string>Some LaTeX constructs (e.g. references) need multiple compilation cycles until they are displayed correctly.</string>
-                </property>
-                <property name="text">
-                 <string>Maximum Compile Repetitions:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="7" column="0" colspan="2">
-               <layout class="QGridLayout" name="gridLayout_1">
-                <property name="leftMargin">
-                 <number>9</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <property name="verticalSpacing">
-                 <number>2</number>
-                </property>
-                <item row="1" column="1">
-                 <widget class="QLineEdit" name="lineEditPathPDF"/>
-                </item>
-                <item row="2" column="1">
-                 <widget class="QLineEdit" name="lineEditPathCommands"/>
-                </item>
-                <item row="1" column="2">
-                 <widget class="QPushButton" name="pushButtonPathPdf">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                  <property name="icon">
-                   <iconset resource="../images.qrc">
-                    <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
-                  </property>
-                 </widget>
-                </item>
-                <item row="2" column="0">
-                 <widget class="QLabel" name="label_59">
-                  <property name="text">
-                   <string>Commands ($PATH)</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="1" column="0">
-                 <widget class="QLabel" name="label_58">
-                  <property name="text">
-                   <string>PDF File</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="1">
-                 <widget class="QLineEdit" name="lineEditPathLog"/>
-                </item>
-                <item row="0" column="2">
-                 <widget class="QPushButton" name="pushButtonPathLog">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                  <property name="icon">
-                   <iconset resource="../images.qrc">
-                    <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
-                  </property>
-                 </widget>
-                </item>
-                <item row="2" column="2">
-                 <widget class="QPushButton" name="pushButtonPathCommands">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                  <property name="icon">
-                   <iconset resource="../images.qrc">
-                    <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="0">
-                 <widget class="QLabel" name="label_57">
-                  <property name="text">
-                   <string>Log File</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item row="6" column="0" colspan="2">
-               <widget class="QLabel" name="label_68">
-                <property name="text">
-                 <string>Additional Search Paths:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QCheckBox" name="checkBoxReplaceEnvironmentVariables">
-                <property name="toolTip">
-                 <string>Replaces environment variables in commands.The behavior is OS-specific.
-
-Windows:
-Variables are written as: %MYVAR%. They are case-insensitive.
-
-Linux, OS X:
-Variables are written as: $MYVAR. They are case-sensitive.
-</string>
-                </property>
-                <property name="text">
-                 <string>Replace Environment Variables</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QCheckBox" name="checkBoxShowLogInCaseOfCompileError">
-                <property name="text">
-                 <string>Show log in case of compile error</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QCheckBox" name="checkBoxInterpetCommandDefinitionInMagicComment">
-                <property name="toolTip">
-                 <string>This allows to redefine commands using comment of style &lt;code&gt;%&amp;nbsp;!TeX&amp;nbsp;program&lt;/code&gt;, &lt;code&gt;%&amp;nbsp;!TeX&amp;nbsp;TS-program&lt;/code&gt; and &lt;code&gt;%&amp;nbsp;!TeX&amp;nbsp;TXS-program&lt;/code&gt;. For details see the manual.</string>
-                </property>
-                <property name="text">
-                 <string>Interpret command definition in magic comments</string>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="1">
-               <widget class="QSpinBox" name="spinBoxRerunLatex">
-                <property name="value">
-                 <number>5</number>
-                </property>
-               </widget>
-              </item>
-             </layout>
             </widget>
            </item>
           </layout>
          </widget>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="pageShortcuts">
-      <layout class="QVBoxLayout">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QLabel" name="label_6">
-         <property name="text">
-          <string>Shortcuts</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QTreeWidget" name="shortcutTree">
-         <property name="toolTip">
-          <string>For editing, double-click on the entries in 'Current Shortcut' or 'Additional Shortcut'.
-Then you can select a new shortcut by one of the following ways:
-(1) select from the dropdown list
-(2) hit the shortcut combination
-(3) type the string of the shortcut</string>
-         </property>
-         <property name="animated">
-          <bool>true</bool>
-         </property>
-         <property name="columnCount">
-          <number>4</number>
-         </property>
-         <attribute name="headerDefaultSectionSize">
-          <number>150</number>
-         </attribute>
-         <column>
-          <property name="text">
-           <string>1</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>2</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>3</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>4</string>
-          </property>
-         </column>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupBox">
-         <property name="toolTip">
-          <string>Close Element applies to a fixed list of GUI elements (not all shown here). The first visible element will be closed. With this setting you can exclude some elements from being closed.</string>
-         </property>
-         <property name="title">
-          <string>Close Element (Esc)</string>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_5">
-          <item>
-           <widget class="QCheckBox" name="checkBoxCloseLogByEsc">
-            <property name="text">
-             <string>Close Log-View</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="checkBoxCloseEmbeddedViewerByEsc">
-            <property name="text">
-             <string>Close Embedded Viewer</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="checkBoxCloseFullscreenByEsc">
-            <property name="text">
-             <string>Close Full Screen Mode</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBoxShowShortcutsInTooltips">
-         <property name="text">
-          <string>Show Shortcuts in Tooltips</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="pageLatexMenus">
-      <layout class="QVBoxLayout">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QLabel" name="label_19">
-         <property name="text">
-          <string>Menus</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QTreeWidget" name="menuTree">
-         <property name="toolTip">
-          <string>Here the menu items are listed and can be hidden or edited.</string>
-         </property>
-         <property name="animated">
-          <bool>true</bool>
-         </property>
-         <property name="columnCount">
-          <number>3</number>
-         </property>
-         <attribute name="headerDefaultSectionSize">
-          <number>250</number>
-         </attribute>
-         <column>
-          <property name="text">
-           <string>Name</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Command</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Slot</string>
-          </property>
-         </column>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBoxShowAllMenus">
-         <property name="toolTip">
-          <string>This controls if the list above shows all menu items or only commonly changed ones.</string>
-         </property>
-         <property name="text">
-          <string>Show All</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="pageToolbars">
-      <layout class="QVBoxLayout">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QLabel" name="label_20">
-         <property name="text">
-          <string>Toolbar Customization</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="_2">
-         <item row="1" column="1">
-          <widget class="QListWidget" name="listCustomToolBar">
-           <property name="toolTip">
-            <string>This shows all actions on the currently edited toolbar.</string>
-           </property>
-           <property name="movement">
-            <enum>QListView::Free</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2">
-          <layout class="QVBoxLayout" name="_3">
-           <item>
-            <spacer name="verticalSpacer_3">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>40</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QPushButton" name="pbToToolbar">
-             <property name="toolTip">
-              <string>This adds an action to the toolbar.</string>
-             </property>
-             <property name="text">
-              <string/>
-             </property>
-             <property name="icon">
-              <iconset resource="../images.qrc">
-               <normaloff>:/images-ng/left.svgz</normaloff>:/images-ng/left.svgz</iconset>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="pbFromToolbar">
-             <property name="toolTip">
-              <string>This removes an action from the toolbar.</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="../images.qrc">
-               <normaloff>:/images-ng/right.svgz</normaloff>:/images-ng/right.svgz</iconset>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="spacer">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>40</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="comboBoxToolbars">
-           <property name="toolTip">
-            <string>Here you can choose a toolbar to modify.</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="3">
-          <widget class="QComboBox" name="comboBoxActions">
-           <property name="toolTip">
-            <string>Here you can choose a list of commands that can be mapped to the toolbar.</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="3">
-          <widget class="QTreeWidget" name="treePossibleToolbarActions">
-           <property name="toolTip">
-            <string>This shows available actions to map on a toolbar.</string>
-           </property>
-           <property name="rootIsDecorated">
-            <bool>false</bool>
-           </property>
-           <property name="animated">
-            <bool>true</bool>
-           </property>
-           <property name="allColumnsShowFocus">
-            <bool>true</bool>
-           </property>
-           <column>
-            <property name="text">
-             <string>1</string>
-            </property>
-           </column>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="pageScaling">
-      <layout class="QVBoxLayout" name="layoutScaling">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QGroupBox" name="groupBox_17">
-         <property name="title">
-          <string>GUI Scaling</string>
-         </property>
-         <layout class="QGridLayout">
-          <property name="horizontalSpacing">
-           <number>60</number>
-          </property>
-          <item row="4" column="1" colspan="2">
-           <widget class="QSlider" name="horizontalSliderSymbol">
-            <property name="toolTip">
-             <string>This changes the scaling of the symbol grid (for high resolution displays).</string>
-            </property>
-            <property name="minimum">
-             <number>16</number>
-            </property>
-            <property name="maximum">
-             <number>128</number>
-            </property>
-            <property name="tracking">
-             <bool>true</bool>
-            </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="invertedAppearance">
-             <bool>false</bool>
-            </property>
-            <property name="invertedControls">
-             <bool>false</bool>
-            </property>
-            <property name="tickPosition">
-             <enum>QSlider::TicksBelow</enum>
-            </property>
-            <property name="tickInterval">
-             <number>8</number>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_11">
-            <property name="text">
-             <string>Main Toolbar</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QToolButton" name="tbRevertIcon">
-            <property name="text">
-             <string>Reset</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="3">
-           <widget class="QToolButton" name="tbRevertCentralIcon">
-            <property name="text">
-             <string>Reset</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1" colspan="2">
-           <widget class="QSlider" name="horizontalSliderCentraIcon">
-            <property name="toolTip">
-             <string>This changes the scaling of the vertical toolbars (for high resolution displays).</string>
-            </property>
-            <property name="minimum">
-             <number>8</number>
-            </property>
-            <property name="maximum">
-             <number>64</number>
-            </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="tickPosition">
-             <enum>QSlider::TicksBelow</enum>
-            </property>
-            <property name="tickInterval">
-             <number>8</number>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1" colspan="2">
-           <widget class="QSlider" name="horizontalSliderIcon">
-            <property name="toolTip">
-             <string>This changes the scaling of the horizontal toolbars (for high resolution displays).</string>
-            </property>
-            <property name="minimum">
-             <number>16</number>
-            </property>
-            <property name="maximum">
-             <number>128</number>
-            </property>
-            <property name="value">
-             <number>24</number>
-            </property>
-            <property name="sliderPosition">
-             <number>24</number>
-            </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="tickPosition">
-             <enum>QSlider::TicksBelow</enum>
-            </property>
-            <property name="tickInterval">
-             <number>8</number>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="3">
-           <widget class="QToolButton" name="tbRevertSymbol">
-            <property name="text">
-             <string>Reset</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_72">
-            <property name="text">
-             <string>Symbol Grid</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_71">
-            <property name="text">
-             <string>Secondary Toolbars</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1" colspan="2">
-           <widget class="QSlider" name="horizontalSliderPDF">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the scaling of the toolbar of the embeded pdf viewer (for high resolution displays).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="minimum">
-             <number>8</number>
-            </property>
-            <property name="maximum">
-             <number>128</number>
-            </property>
-            <property name="tracking">
-             <bool>true</bool>
-            </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="tickPosition">
-             <enum>QSlider::TicksBelow</enum>
-            </property>
-            <property name="tickInterval">
-             <number>8</number>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label_87">
-            <property name="text">
-             <string>Embedded PDF Toolbar</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="3">
-           <widget class="QToolButton" name="tbRevertPDF">
-            <property name="text">
-             <string>Reset</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_6">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Expanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>0</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="pageEditor">
-      <layout class="QGridLayout">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <property name="spacing">
-        <number>6</number>
-       </property>
-       <item row="3" column="0">
-        <spacer name="verticalSpacer_5">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="1" column="0">
-        <widget class="QGroupBox" name="groupBox_3">
-         <property name="title">
-          <string>Editor</string>
-         </property>
-         <layout class="QGridLayout">
-          <item row="13" column="0">
-           <widget class="QCheckBox" name="checkBoxRealTimeCheck">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Inline Checking:</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="11" column="0">
-           <widget class="QLabel" name="label_33">
-            <property name="text">
-             <string>Show Line Numbers:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="11" column="1">
-           <widget class="QComboBox" name="comboboxLineNumbers">
-            <property name="" stdset="0">
-             <bool>true</bool>
-            </property>
-            <item>
-             <property name="text">
-              <string>No Line Numbers</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>All Line Numbers</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Only Important Line Numbers</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="15" column="0" colspan="2">
-           <widget class="QCheckBox" name="checkBoxInlineCheckNonTeXFiles">
-            <property name="text">
-             <string>Check non tex files</string>
-            </property>
-            <property name="advancedOption" stdset="0">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="17" column="0" colspan="2">
-           <widget class="QCheckBox" name="checkBoxScanInstalledLatexPackages">
-            <property name="text">
-             <string>Scan LaTeX distribution for installed packages</string>
-            </property>
-            <property name="advancedOption" stdset="0">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="12" column="0" colspan="4">
-           <widget class="QCheckBox" name="checkBoxFolding">
-            <property name="text">
-             <string>Folding</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="3" colspan="2">
-           <widget class="QCheckBox" name="checkBoxReplaceIndentTabByWhitespace">
-            <property name="text">
-             <string>Replace Indentation Tab by Spaces</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="labelFamily">
-            <property name="text">
-             <string>Font Family:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="10" column="0">
-           <widget class="QLabel" name="label_39">
-            <property name="text">
-             <string>Replace Double Quotes:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="labelEncoding">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Default Font Encoding:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0">
-           <widget class="QLabel" name="label_30">
-            <property name="text">
-             <string>Indentation Mode:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label_65">
-            <property name="text">
-             <string>Automatic Encoding Detection:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1" colspan="2">
-           <widget class="QComboBox" name="comboBoxEncoding"/>
-          </item>
-          <item row="5" column="1" colspan="2">
-           <widget class="QCheckBox" name="checkBoxAutoDetectEncodingFromLatex">
-            <property name="text">
-             <string>Analyze LaTeX (% !TeX encoding, inputenc, inputenx)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="3" colspan="2">
-           <widget class="QCheckBox" name="checkBoxAutoDetectEncodingFromChars">
-            <property name="toolTip">
-             <string>can only decide between utf16/utf-8 and ISO 8859-1 !</string>
-            </property>
-            <property name="text">
-             <string>Analyze Characters</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1" colspan="2">
-           <widget class="QComboBox" name="comboBoxFont">
-            <property name="editable">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1" colspan="4">
-           <widget class="QSpinBox" name="spinBoxSize">
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="value">
-             <number>12</number>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1" colspan="4">
-           <widget class="QSpinBox" name="spinBoxLineSpacingPercent">
-            <property name="suffix">
-             <string>%</string>
-            </property>
-            <property name="minimum">
-             <number>100</number>
-            </property>
-            <property name="maximum">
-             <number>500</number>
-            </property>
-            <property name="singleStep">
-             <number>10</number>
-            </property>
-            <property name="advancedOption" stdset="0">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="labelSize">
-            <property name="text">
-             <string>Font Size:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>Line Spacing:</string>
-            </property>
-            <property name="advancedOption" stdset="0">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="10" column="1" colspan="4">
-           <widget class="QComboBox" name="comboBoxReplaceQuotes">
-            <item>
-             <property name="text">
-              <string>No Replacement</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>English Quotes:  `` ''</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>French Quotes:  &quot;&lt; &quot;&gt;</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>German Quotes:  &quot;` &quot;'</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>French Quotes (babel): \og{} \fg{}</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Reverse French Quotes: &quot;&gt; &quot;&lt;</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Package csquotes: \enquote{  }</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>English Quotes (unicode): “ ”</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Polish Quotes: ,, ''</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Polish Quotes (unicode): „ ”</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="0" column="3" colspan="2">
-           <widget class="QCheckBox" name="checkBoxShowOnlyMonospacedFonts">
-            <property name="text">
-             <string>Show Only Monospaced Fonts</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="1" colspan="2">
-           <widget class="QComboBox" name="comboBoxAutoIndent">
-            <property name="advancedOption" stdset="0">
-             <bool>false</bool>
-            </property>
-            <item>
-             <property name="text">
-              <string>Ignore Indentation</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Keep Indentation</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Indent and Unindent Automatically</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="13" column="1" colspan="4">
-           <widget class="QGroupBox" name="groupBoxInlineChecking">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="title">
-             <string/>
-            </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_4">
-             <item>
-              <widget class="QCheckBox" name="checkBoxInlineSpellCheck">
-               <property name="text">
-                <string>Spelling</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="checkBoxInlineGrammarCheck">
-               <property name="text">
-                <string>Grammar</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="checkBoxInlineCitationCheck">
-               <property name="text">
-                <string>Citations</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="checkBoxInlineReferenceCheck">
-               <property name="text">
-                <string>References</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="checkBoxInlineSyntaxCheck">
-               <property name="text">
-                <string>Syntax</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="checkBoxInlinePackageCheck">
-               <property name="text">
-                <string>Package</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="8" column="3" colspan="2">
-           <widget class="QCheckBox" name="checkBoxReplaceTextTabByWhitespace">
-            <property name="text">
-             <string>Replace Tab in Text by Spaces</string>
-            </property>
-           </widget>
-          </item>
-          <item row="16" column="0" colspan="3">
-           <widget class="QCheckBox" name="checkBoxAutoLoad">
-            <property name="text">
-             <string>Automatically load included files</string>
-            </property>
-            <property name="advancedOption" stdset="0">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="14" column="2" colspan="3">
-           <widget class="QCheckBox" name="checkBoxHideGrammarErrorsInNonText">
-            <property name="text">
-             <string>Hide grammar errors in non-text environments</string>
-            </property>
-            <property name="advancedOption" stdset="0">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="14" column="0" colspan="2">
-           <widget class="QCheckBox" name="checkBoxHideSpellingErrorsInNonText">
-            <property name="text">
-             <string>Hide spelling errors in non-text environments</string>
-            </property>
-            <property name="advancedOption" stdset="0">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="3" colspan="2">
-           <widget class="QCheckBox" name="checkboxRemoveTrailingWsOnSave">
-            <property name="text">
-             <string>Remove Trailing Whitespace on Save</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="pageAdvEditor">
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QScrollArea" name="scrollAreaAdvancedEditor">
-         <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
-         </property>
-         <property name="widgetResizable">
-          <bool>true</bool>
-         </property>
-         <widget class="QWidget" name="scrollAreaWidgetContents_2">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>528</width>
-            <height>1379</height>
-           </rect>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_8">
+         <widget class="QWidget" name="pageCompletion">
+          <layout class="QVBoxLayout" name="verticalLayout_4">
            <property name="leftMargin">
             <number>0</number>
            </property>
            <property name="topMargin">
             <number>0</number>
            </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
            <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
-            <widget class="QGroupBox" name="groupBox_9">
-             <property name="title">
-              <string>Appearance</string>
+            <widget class="QGroupBox" name="groupBox_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
              </property>
-             <layout class="QGridLayout" name="gridLayout_6">
-              <item row="2" column="0">
-               <layout class="QHBoxLayout" name="horizontalLayout_6">
+             <property name="title">
+              <string>Completion</string>
+             </property>
+             <layout class="QGridLayout" rowstretch="0,0,0,0,0,0" columnstretch="1,1">
+              <item row="1" column="0">
+               <widget class="QCheckBox" name="checkBoxAutoReplaceCommands">
+                <property name="toolTip">
+                 <string>Allows in-place substitution of commands. Example:&lt;br&gt;
+&lt;code&gt;\textbf{foo}&lt;/code&gt;
+&lt;ul&gt;
+&lt;li&gt;Put cursor behind &quot;text&quot;&lt;/li&gt;
+&lt;li&gt;Start completer by Ctrl+Space&lt;/li&gt;
+&lt;li&gt;Select &lt;code&gt;\textrm&lt;/code&gt;&lt;li&gt;
+&lt;li&gt;The result is &lt;code&gt;\textrm{foo}&lt;/code&gt;&lt;li&gt;
+&lt;/ul&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Auto Replace Latex-Commands</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QCheckBox" name="checkBoxUsePlaceholders">
+                <property name="text">
+                 <string>Insert Arguments</string>
+                </property>
+                <property name="advancedOption" stdset="0">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QCheckBox" name="checkBoxToolTipCompletePreview">
+                <property name="toolTip">
+                 <string>Shows a tooltip with target text for labels/bibitem, previews colors or images</string>
+                </property>
+                <property name="text">
+                 <string>ToolTip-Preview</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QCheckBox" name="checkBoxShowPlaceholders">
+                <property name="text">
+                 <string>Arguments as Placeholders</string>
+                </property>
+                <property name="advancedOption" stdset="0">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QCheckBox" name="checkBoxToolTipHelp">
+                <property name="toolTip">
+                 <string>Shows a tooltip with a description of the selected completer command</string>
+                </property>
+                <property name="text">
+                 <string>ToolTip-Help</string>
+                </property>
+                <property name="advancedOption" stdset="0">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QCheckBox" name="checkBoxCompletion">
+                <property name="toolTip">
+                 <string>Starts the completer as soon as '\' is typed. Alternatively the completer can always be started manually by Ctrl+Space.</string>
+                </property>
+                <property name="text">
+                 <string>Automatically start completer when typing LaTeX-Commands</string>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="1">
+               <layout class="QHBoxLayout" name="horizontalLayout_2">
                 <item>
-                 <spacer name="horizontalSpacer_6">
+                 <widget class="QLabel" name="label_40">
+                  <property name="toolTip">
+                   <string>Size of the tab bar at the bottom or top of the completer</string>
+                  </property>
+                  <property name="text">
+                   <string>Tab Bar Size</string>
+                  </property>
+                  <property name="advancedOption" stdset="0">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QSpinBox" name="spinBoxTabRelFontSize">
+                  <property name="toolTip">
+                   <string>Size of the command set tabs at the bottom or top of the completer</string>
+                  </property>
+                  <property name="suffix">
+                   <string notr="true"> %</string>
+                  </property>
+                  <property name="maximum">
+                   <number>10000</number>
+                  </property>
+                  <property name="value">
+                   <number>75</number>
+                  </property>
+                  <property name="advancedOption" stdset="0">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_2">
                   <property name="orientation">
                    <enum>Qt::Horizontal</enum>
                   </property>
@@ -2013,46 +3092,70 @@ Then you can select a new shortcut by one of the following ways:
                 </item>
                </layout>
               </item>
-              <item row="1" column="0">
-               <widget class="QCheckBox" name="checkBoxState">
+              <item row="2" column="0">
+               <widget class="QCheckBox" name="checkBoxEOWCompletes">
                 <property name="text">
-                 <string>Show State Panel</string>
+                 <string>Complete selected text when non-word character is pressed</string>
                 </property>
                 <property name="advancedOption" stdset="0">
                  <bool>true</bool>
                 </property>
                </widget>
               </item>
-              <item row="1" column="1">
-               <layout class="QHBoxLayout" name="horizontalLayout_7">
+              <item row="3" column="0">
+               <widget class="QCheckBox" name="checkBoxCompletePrefix">
+                <property name="toolTip">
+                 <string>If all completer suggestions have the next characters in common, you can use &lt;Tab&gt; to automatically insert them.</string>
+                </property>
+                <property name="text">
+                 <string>Auto Complete Common Prefix</string>
+                </property>
+                <property name="advancedOption" stdset="0">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="0">
+               <layout class="QHBoxLayout" name="horizontalLayout">
                 <item>
-                 <widget class="QLabel" name="label_22">
+                 <widget class="QLabel" name="label">
                   <property name="text">
-                   <string>Tab Width:</string>
+                   <string>Preferred Commands Set:</string>
                   </property>
                  </widget>
                 </item>
                 <item>
-                 <widget class="QSpinBox" name="sbTabSpace">
-                  <property name="minimum">
-                   <number>1</number>
-                  </property>
-                  <property name="maximum">
-                   <number>32</number>
-                  </property>
-                  <property name="value">
-                   <number>4</number>
-                  </property>
+                 <widget class="QComboBox" name="comboBoxPreferedTab">
+                  <item>
+                   <property name="text">
+                    <string>Typical</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string>Most Used</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string>Fuzzy</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string>All</string>
+                   </property>
+                  </item>
                  </widget>
                 </item>
                 <item>
-                 <spacer name="horizontalSpacer_5">
+                 <spacer name="horizontalSpacer_3">
                   <property name="orientation">
                    <enum>Qt::Horizontal</enum>
                   </property>
                   <property name="sizeHint" stdset="0">
                    <size>
-                    <width>0</width>
+                    <width>40</width>
                     <height>20</height>
                    </size>
                   </property>
@@ -2060,413 +3163,13 @@ Then you can select a new shortcut by one of the following ways:
                 </item>
                </layout>
               </item>
-              <item row="0" column="1">
-               <widget class="QCheckBox" name="checkBoxShowWhitespace">
-                <property name="text">
-                 <string>Show Whitespace</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QCheckBox" name="checkBoxLineState">
-                <property name="text">
-                 <string>Show Line Change State</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QCheckBox" name="checkBoxBoldCursor">
-                <property name="toolTip">
-                 <string>Draw cursor as a thick line</string>
-                </property>
-                <property name="text">
-                 <string>Bold Cursor</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="groupBox_10">
-             <property name="title">
-              <string>Search Panel</string>
-             </property>
-             <layout class="QVBoxLayout" name="verticalLayout_5">
-              <item>
-               <widget class="QCheckBox" name="checkBoxCloseSearchReplaceTogether">
-                <property name="text">
-                 <string>Close search and replace panel together</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="checkBoxUseLineForSearch">
-                <property name="text">
-                 <string>Use single line selection as Search Word</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="checkBoxSearchOnlyInSelection">
-                <property name="text">
-                 <string>Restrict search scope to an existing selection</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="groupBox_11">
-             <property name="title">
-              <string>Special options</string>
-             </property>
-             <property name="checkable">
-              <bool>false</bool>
-             </property>
-             <layout class="QGridLayout" columnstretch="0,1,1,1">
-              <item row="16" column="0" colspan="2">
-               <widget class="QCheckBox" name="checkBoxUseQSaveWrite">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This uses QSaveFile to prevent losing existing data if the writing operation fails. As a drawback, the current user becomes the owner of the file and extended file attributes are lost. Also, there appear to be problems of this method with dropbox folders.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>Safe writing of files</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="2" colspan="2">
-               <widget class="QCheckBox" name="checkBoxImageToolTip">
-                <property name="text">
-                 <string>Show image tooltip on image files</string>
-                </property>
-               </widget>
-              </item>
-              <item row="7" column="0" colspan="2">
-               <widget class="QCheckBox" name="checkOverwriteOpeningBracketFollowedByPlaceholder">
-                <property name="text">
-                 <string>Overwrite Opening Bracket Followed by a Placeholder</string>
-                </property>
-               </widget>
-              </item>
-              <item row="21" column="0">
-               <widget class="QCheckBox" name="checkBoxShowLogMarkersWhenClickingLogEntry">
-                <property name="text">
-                 <string>Show log markers when clicking log entry</string>
-                </property>
-               </widget>
-              </item>
               <item row="4" column="0">
-               <widget class="QCheckBox" name="checkBoxMouseWheelZoom">
-                <property name="text">
-                 <string>Mouse Wheel Zoom</string>
-                </property>
-               </widget>
-              </item>
-              <item row="18" column="0" colspan="3">
-               <layout class="QVBoxLayout" name="verticalLayout_12">
-                <property name="leftMargin">
-                 <number>16</number>
-                </property>
-                <item>
-                 <widget class="QCheckBox" name="checkBoxSilentReload">
-                  <property name="text">
-                   <string>Silently reload saved files on external changes (discards undo/redo stack)</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item row="17" column="0" colspan="2">
-               <widget class="QCheckBox" name="checkBoxMonitorFilesForExternalChanges">
-                <property name="text">
-                 <string>Monitor open files for external changes</string>
-                </property>
-               </widget>
-              </item>
-              <item row="25" column="0">
-               <widget class="QLabel" name="label_85">
+               <widget class="QCheckBox" name="checkBoxAutoInsertMathDelimiters">
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;External programs (such as Zotero) can push citations into texstudio by calling: &lt;span style=&quot; font-family:'monospace';&quot;&gt;texstudio --insert-cite &amp;quot;citation&amp;quot;&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;If the cursor is not already within an citation command, the &amp;quot;command&amp;quot; given here is used as \cite-command.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>If a math command is inserted via completion outside any math environment, $$ is inserted automatically.</string>
                 </property>
                 <property name="text">
-                 <string>Latex Command for pushed citations:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="24" column="1" colspan="2">
-               <widget class="QComboBox" name="comboBoxContextMenuSpellcheckingEntryLocation">
-                <item>
-                 <property name="text">
-                  <string>Add Entries Directly To Context  Menu</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Create Dedicated Submenu</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="15" column="1">
-               <widget class="QComboBox" name="comboBoxAutoSave">
-                <item>
-                 <property name="text">
-                  <string>Never</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>1 minute</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>2 minutes</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>5 minutes</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>10 minutes</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>20 minutes</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>60 minutes</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="20" column="0">
-               <widget class="QCheckBox" name="checkBoxInsertSymbolAsUCS">
-                <property name="toolTip">
-                 <string>When using unicode characters in the source code, LaTeX still has
-to render the characters. Since unicode is not natively supported by LaTeX, you have to include appropriate packages for unicode characters in your document.</string>
-                </property>
-                <property name="text">
-                 <string>Insert Symbol as Unicode</string>
-                </property>
-               </widget>
-              </item>
-              <item row="12" column="0">
-               <widget class="QLabel" name="label_41">
-                <property name="text">
-                 <string>Line Wrapping:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="8" column="0" colspan="2">
-               <widget class="QCheckBox" name="checkOverwriteClosingBracketFollowingPlaceholder">
-                <property name="text">
-                 <string>Overwrite Closing Bracket Following a Placeholder</string>
-                </property>
-               </widget>
-              </item>
-              <item row="13" column="2">
-               <widget class="QCheckBox" name="checkBoxCenterDocumentInEditor">
-                <property name="toolTip">
-                 <string>This does only have an effect if the width of the document is limited by soft or hard line wrapping.</string>
-                </property>
-                <property name="text">
-                 <string>Center Document in Editor</string>
-                </property>
-               </widget>
-              </item>
-              <item row="25" column="1" colspan="2">
-               <widget class="QLineEdit" name="lineEditCiteCommand"/>
-              </item>
-              <item row="11" column="0">
-               <widget class="QLabel" name="label_82">
-                <property name="text">
-                 <string>Triple-Click Selection:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="23" column="1" colspan="2">
-               <widget class="QComboBox" name="comboBoxLogFileEncoding"/>
-              </item>
-              <item row="5" column="2" colspan="2">
-               <widget class="QCheckBox" name="checkBoxTexDocInternal">
-                <property name="text">
-                 <string>Show help on commands in internal pdf viewer (texdoc)</string>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="0" colspan="2">
-               <widget class="QCheckBox" name="checkBoxAllowDragAndDrop">
-                <property name="text">
-                 <string>Allow Drag and Drop</string>
-                </property>
-               </widget>
-              </item>
-              <item row="11" column="1" colspan="2">
-               <widget class="QComboBox" name="comboBoxTripleClickSelection">
-                <item>
-                 <property name="text">
-                  <string>Select Word</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Select Word or Command</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Select Parentheses Content</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Select Parentheses</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Select Line</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="13" column="0">
-               <widget class="QLabel" name="label_23">
-                <property name="text">
-                 <string>Maximal Characters:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="0">
-               <widget class="QCheckBox" name="checkBoxSmoothScrolling">
-                <property name="text">
-                 <string>Smooth Scrolling</string>
-                </property>
-               </widget>
-              </item>
-              <item row="23" column="0">
-               <widget class="QLabel" name="label_80">
-                <property name="text">
-                 <string>Default Log Encoding</string>
-                </property>
-               </widget>
-              </item>
-              <item row="15" column="0">
-               <widget class="QLabel" name="label_24">
-                <property name="text">
-                 <string>Auto Save All Files:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="13" column="1">
-               <widget class="QSpinBox" name="spinBoxWrapLineWidth">
-                <property name="minimum">
-                 <number>20</number>
-                </property>
-                <property name="maximum">
-                 <number>999</number>
-                </property>
-               </widget>
-              </item>
-              <item row="12" column="1" colspan="2">
-               <widget class="QComboBox" name="comboBoxLineWrap">
-                <item>
-                 <property name="text">
-                  <string>No Line Wrap</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Soft Line Wrap at Window Edge</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Soft Line Wrap after max. Characters</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Hard Line Wrap after max. Characters</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="4" column="2" colspan="2">
-               <widget class="QCheckBox" name="checkBoxToolTipHelp2">
-                <property name="text">
-                 <string>Show help as tooltip on text in editor</string>
-                </property>
-               </widget>
-              </item>
-              <item row="21" column="2">
-               <widget class="QCheckBox" name="checkBoxGoToErrorWhenDisplayingLog">
-                <property name="text">
-                 <string>Go to error when displaying log</string>
-                </property>
-               </widget>
-              </item>
-              <item row="24" column="0">
-               <widget class="QLabel" name="label_70">
-                <property name="text">
-                 <string>Spellchecking via context menu:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QCheckBox" name="checkBoxAutoCompleteParens">
-                <property name="text">
-                 <string>Auto Complete Parentheses</string>
-                </property>
-               </widget>
-              </item>
-              <item row="9" column="0" colspan="2">
-               <widget class="QCheckBox" name="checkBoxDoubleClickSelectionIncludeLeadingBackslash">
-                <property name="text">
-                 <string>Double-Click Selection: Include Leading Backslash</string>
-                </property>
-               </widget>
-              </item>
-              <item row="10" column="0" colspan="2">
-               <widget class="QCheckBox" name="checkBoxVerticalOverScroll">
-                <property name="text">
-                 <string>Vertical Overscroll (Scroll below end of file)</string>
+                 <string>Auto Insert Math Delimiters where needed</string>
                 </property>
                </widget>
               </item>
@@ -2474,793 +3177,94 @@ to render the characters. Since unicode is not natively supported by LaTeX, you 
             </widget>
            </item>
            <item>
-            <widget class="QGroupBox" name="groupBox_16">
-             <property name="title">
-              <string>Structure Panel</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_2">
-              <item row="10" column="2">
-               <widget class="QComboBox" name="comboBoxTOCBackgroundColor">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The global TOC uses different shades of background color to distinguish different files. The color scheme can be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <item>
-                 <property name="text">
-                  <string>No Color Background</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Green Background</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Blue Background</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="9" column="0">
-               <widget class="QCheckBox" name="checkBoxMarkStructureElementsBeyondEnd">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Elements like &amp;quot;\section&amp;quot; are highlighted with a different background color to show that they will &lt;span style=&quot; font-weight:600;&quot;&gt;not&lt;/span&gt; appear in the document.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>Mark structure elements beyond \end{document}</string>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="0">
-               <widget class="QLabel" name="label_64">
-                <property name="text">
-                 <string>Reference commands in context menu:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="2">
-               <widget class="QLineEdit" name="leReferenceCommandsInContextMenu"/>
-              </item>
-              <item row="7" column="2">
-               <widget class="QLineEdit" name="leRegExpTODO"/>
-              </item>
-              <item row="7" column="0">
-               <widget class="QLabel" name="label_83">
-                <property name="text">
-                 <string>Regular expression for TODO comment: </string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0" colspan="2">
-               <widget class="QCheckBox" name="checkBoxIndentIncludesInStructureTree">
-                <property name="text">
-                 <string>Keep indentation of includes in structure tree</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="QCheckBox" name="checkBoxScrollToCurrentPosition">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The current cursor position is highlighted in the structure view.&lt;/p&gt;&lt;p&gt;If this option is active, the entry is expanded and scrolled to be visible.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>Scroll to current cursor position</string>
-                </property>
-               </widget>
-              </item>
-              <item row="9" column="2">
-               <widget class="QCheckBox" name="checkBoxMarkStructureElementsInAppendix">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Elements like &amp;quot;\section&amp;quot; are highlighted with a different background color to show that they will appear as appendix.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>Mark structure elements in appendix</string>
-                </property>
-               </widget>
-              </item>
-              <item row="10" column="0">
-               <widget class="QLabel" name="label_90">
-                <property name="text">
-                 <string>Use color in global TOC:</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-             <zorder>checkBoxIndentIncludesInStructureTree</zorder>
-             <zorder>label_64</zorder>
-             <zorder>leReferenceCommandsInContextMenu</zorder>
-             <zorder>checkBoxMarkStructureElementsBeyondEnd</zorder>
-             <zorder>label_83</zorder>
-             <zorder>leRegExpTODO</zorder>
-             <zorder>comboBoxTOCBackgroundColor</zorder>
-             <zorder>checkBoxScrollToCurrentPosition</zorder>
-             <zorder>checkBoxMarkStructureElementsInAppendix</zorder>
-             <zorder>label_90</zorder>
-            </widget>
+            <layout class="QHBoxLayout" name="horizontalLayout_3">
+             <item>
+              <widget class="QLabel" name="label_12">
+               <property name="toolTip">
+                <string>TXS tries to automatically load completion files for packages if a
+\usepackage{} command is found. These automatically included files
+are not shown here. Checking additional packages here is usually not
+necessary. However if automatic detection fails or you want to include
+specfic user completion files, you can enforce their usage by activating
+them here.</string>
+               </property>
+               <property name="text">
+                <string>Permanently active completion files:</string>
+               </property>
+               <property name="advancedOption" stdset="0">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLineEdit" name="leCompletionFilter">
+               <property name="toolTip">
+                <string>Filter list below</string>
+               </property>
+               <property name="advancedOption" stdset="0">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
            <item>
-            <widget class="QGroupBox" name="groupBoxBibliography">
-             <property name="title">
-              <string>Bibliography</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_7">
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_73">
-                <property name="text">
-                 <string>bib File Encoding:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QCheckBox" name="checkBoxParseBibTeX">
-                <property name="text">
-                 <string>Parse BibTeX</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QComboBox" name="comboBoxBibFileEncoding"/>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="gbTableAutoformat">
-             <property name="title">
-              <string>Table Autoformating</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayoutTableAutoFormat">
-              <item row="2" column="0" colspan="2">
-               <widget class="QCheckBox" name="cbTableFormatingOneLinePerCell">
-                <property name="text">
-                 <string>One Line Per Cell</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QComboBox" name="cbTableFormatingSpecialCommandPos">
-                <item>
-                 <property name="text">
-                  <string>Behind Line Break</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Separate Line (No Indent)</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Separate Line (Indented to First Column)</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_61">
-                <property name="text">
-                 <string>Special Commands Position:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QLineEdit" name="leTableFormatingSpecialCommands"/>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_60">
-                <property name="text">
-                 <string>Special Commands:</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="gbAdditionalSearchPaths">
-             <property name="title">
-              <string>Additional Search Paths</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout71">
-              <property name="verticalSpacing">
-               <number>2</number>
-              </property>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_62">
-                <property name="text">
-                 <string>Bib Files:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QLineEdit" name="lineEditPathBib"/>
-              </item>
-              <item row="1" column="1">
-               <widget class="QLineEdit" name="lineEditPathImages"/>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_63">
-                <property name="text">
-                 <string>Image Files:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="QPushButton" name="pushButtonPathBib">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="icon">
-                 <iconset resource="../images.qrc">
-                  <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="2">
-               <widget class="QPushButton" name="pushButtonPathImages">
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="icon">
-                 <iconset resource="../images.qrc">
-                  <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="groupBox_15">
-             <property name="title">
-              <string>Bi-Di</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout8">
-              <item row="0" column="0" colspan="3">
-               <widget class="QCheckBox" name="checkBoxAutoLRM">
-                <property name="text">
-                 <string>Automatically insert LRM characters</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0" colspan="3">
-               <widget class="QCheckBox" name="checkBoxVisualColumnMode">
-                <property name="text">
-                 <string>Visual column cursor mode (i.e. move cursor in direction of arrow keys in rtl-text)</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="labelSwitchKeyboardLayout">
-                <property name="text">
-                 <string>Automatically switch keyboard layout: </string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QCheckBox" name="checkBoxSwitchLanguagesDirection">
-                <property name="text">
-                 <string>depending on character direction</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="2">
-               <widget class="QCheckBox" name="checkBoxSwitchLanguagesMath">
-                <property name="text">
-                 <string>depending on text/math mode</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="groupBox_12">
-             <property name="title">
-              <string>Hacks/Workarounds</string>
-             </property>
-             <layout class="QVBoxLayout" name="verticalLayout_11">
-              <item>
-               <widget class="QCheckBox" name="checkBoxHackDisableAccentWorkaround">
-                <property name="text">
-                 <string>Disable work-around on accent typing (Mac OS X only)</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="checkBoxHackAutoRendering">
-                <property name="text">
-                 <string>Try to automatically choose best display options</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <layout class="QGridLayout" name="gridLayout_3">
-                <property name="leftMargin">
-                 <number>16</number>
-                </property>
-                <item row="4" column="0">
-                 <widget class="QLabel" name="labelRenderMode">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="text">
-                   <string>Render Mode:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="4" column="1">
-                 <widget class="QComboBox" name="comboBoxHackRenderMode">
-                  <item>
-                   <property name="text">
-                    <string>QCE (recommended)</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string>Qt</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string>Single Letter</string>
-                   </property>
-                  </item>
-                 </widget>
-                </item>
-                <item row="2" column="0" colspan="2">
-                 <widget class="QCheckBox" name="checkBoxHackDisableLineCache">
-                  <property name="toolTip">
-                   <string>If the cache of rendered lines is enabled, rendered lines are stored in a cache, so they do not have to be rendered again. Leading to a speed improvement (especially on Mac), at the cost of a higher memory usage.</string>
-                  </property>
-                  <property name="text">
-                   <string>Disable cache of rendered lines</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="1" column="0" colspan="2">
-                 <widget class="QCheckBox" name="checkBoxHackDisableFixedPitch">
-                  <property name="text">
-                   <string>Disable fixed pitch mode</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="0" colspan="2">
-                 <widget class="QCheckBox" name="checkBoxHackDisableWidthCache">
-                  <property name="text">
-                   <string>Disable cache of character width</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="3" column="0">
-                 <widget class="QCheckBox" name="checkBoxHackQImageCache">
-                  <property name="text">
-                   <string>Use QImage as cache type</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <spacer name="verticalSpacer">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>2</height>
-              </size>
-             </property>
-            </spacer>
+            <layout class="QHBoxLayout" name="horizontalLayout_8">
+             <item>
+              <widget class="QListWidget" name="completeListWidget">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>TXS tries to automatically load completion files for packages if a
+\usepackage{} command is found. These automatically included files
+are not shown here. Checking additional packages here is usually not
+necessary. However if automatic detection fails or you want to include
+specfic user completion files, you can enforce their usage by activating
+them here.</string>
+               </property>
+               <property name="flow">
+                <enum>QListView::TopToBottom</enum>
+               </property>
+               <property name="isWrapping" stdset="0">
+                <bool>true</bool>
+               </property>
+               <property name="resizeMode">
+                <enum>QListView::Adjust</enum>
+               </property>
+               <property name="uniformItemSizes">
+                <bool>false</bool>
+               </property>
+               <property name="sortingEnabled">
+                <bool>true</bool>
+               </property>
+               <property name="advancedOption" stdset="0">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="verticalSpacer_9">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>0</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
            </item>
           </layout>
          </widget>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="pageSyntaxHighlighting">
-      <layout class="QVBoxLayout" name="verticalLayout_7">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QGroupBox" name="formatConfigBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="baseSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="title">
-          <string>Formats</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="pageCompletion">
-      <layout class="QVBoxLayout" name="verticalLayout_4">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QGroupBox" name="groupBox_2">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="title">
-          <string>Completion</string>
-         </property>
-         <layout class="QGridLayout" rowstretch="0,0,0,0,0,0" columnstretch="1,1">
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="checkBoxAutoReplaceCommands">
-            <property name="toolTip">
-             <string>Allows in-place substitution of commands. Example:&lt;br&gt;
-&lt;code&gt;\textbf{foo}&lt;/code&gt;
-&lt;ul&gt;
-&lt;li&gt;Put cursor behind &quot;text&quot;&lt;/li&gt;
-&lt;li&gt;Start completer by Ctrl+Space&lt;/li&gt;
-&lt;li&gt;Select &lt;code&gt;\textrm&lt;/code&gt;&lt;li&gt;
-&lt;li&gt;The result is &lt;code&gt;\textrm{foo}&lt;/code&gt;&lt;li&gt;
-&lt;/ul&gt;</string>
-            </property>
-            <property name="text">
-             <string>Auto Replace Latex-Commands</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QCheckBox" name="checkBoxUsePlaceholders">
-            <property name="text">
-             <string>Insert Arguments</string>
-            </property>
-            <property name="advancedOption" stdset="0">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QCheckBox" name="checkBoxToolTipCompletePreview">
-            <property name="toolTip">
-             <string>Shows a tooltip with target text for labels/bibitem, previews colors or images</string>
-            </property>
-            <property name="text">
-             <string>ToolTip-Preview</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QCheckBox" name="checkBoxShowPlaceholders">
-            <property name="text">
-             <string>Arguments as Placeholders</string>
-            </property>
-            <property name="advancedOption" stdset="0">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QCheckBox" name="checkBoxToolTipHelp">
-            <property name="toolTip">
-             <string>Shows a tooltip with a description of the selected completer command</string>
-            </property>
-            <property name="text">
-             <string>ToolTip-Help</string>
-            </property>
-            <property name="advancedOption" stdset="0">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QCheckBox" name="checkBoxCompletion">
-            <property name="toolTip">
-             <string>Starts the completer as soon as '\' is typed. Alternatively the completer can always be started manually by Ctrl+Space.</string>
-            </property>
-            <property name="text">
-             <string>Automatically start completer when typing LaTeX-Commands</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
-            <item>
-             <widget class="QLabel" name="label_40">
-              <property name="toolTip">
-               <string>Size of the tab bar at the bottom or top of the completer</string>
-              </property>
-              <property name="text">
-               <string>Tab Bar Size</string>
-              </property>
-              <property name="advancedOption" stdset="0">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QSpinBox" name="spinBoxTabRelFontSize">
-              <property name="toolTip">
-               <string>Size of the command set tabs at the bottom or top of the completer</string>
-              </property>
-              <property name="suffix">
-               <string notr="true"> %</string>
-              </property>
-              <property name="maximum">
-               <number>10000</number>
-              </property>
-              <property name="value">
-               <number>75</number>
-              </property>
-              <property name="advancedOption" stdset="0">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item row="2" column="0">
-           <widget class="QCheckBox" name="checkBoxEOWCompletes">
-            <property name="text">
-             <string>Complete selected text when non-word character is pressed</string>
-            </property>
-            <property name="advancedOption" stdset="0">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QCheckBox" name="checkBoxCompletePrefix">
-            <property name="toolTip">
-             <string>If all completer suggestions have the next characters in common, you can use &lt;Tab&gt; to automatically insert them.</string>
-            </property>
-            <property name="text">
-             <string>Auto Complete Common Prefix</string>
-            </property>
-            <property name="advancedOption" stdset="0">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-             <widget class="QLabel" name="label">
-              <property name="text">
-               <string>Preferred Commands Set:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QComboBox" name="comboBoxPreferedTab">
-              <item>
-               <property name="text">
-                <string>Typical</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Most Used</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Fuzzy</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>All</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_3">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item row="4" column="0">
-           <widget class="QCheckBox" name="checkBoxAutoInsertMathDelimiters">
-            <property name="toolTip">
-             <string>If a math command is inserted via completion outside any math environment, $$ is inserted automatically.</string>
-            </property>
-            <property name="text">
-             <string>Auto Insert Math Delimiters where needed</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <item>
-          <widget class="QLabel" name="label_12">
-           <property name="toolTip">
-            <string>TXS tries to automatically load completion files for packages if a
-\usepackage{} command is found. These automatically included files
-are not shown here. Checking additional packages here is usually not
-necessary. However if automatic detection fails or you want to include
-specfic user completion files, you can enforce their usage by activating
-them here.</string>
-           </property>
-           <property name="text">
-            <string>Permanently active completion files:</string>
-           </property>
-           <property name="advancedOption" stdset="0">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="leCompletionFilter">
-           <property name="toolTip">
-            <string>Filter list below</string>
-           </property>
-           <property name="advancedOption" stdset="0">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_8">
-         <item>
-          <widget class="QListWidget" name="completeListWidget">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>TXS tries to automatically load completion files for packages if a
-\usepackage{} command is found. These automatically included files
-are not shown here. Checking additional packages here is usually not
-necessary. However if automatic detection fails or you want to include
-specfic user completion files, you can enforce their usage by activating
-them here.</string>
-           </property>
-           <property name="flow">
-            <enum>QListView::TopToBottom</enum>
-           </property>
-           <property name="isWrapping" stdset="0">
-            <bool>true</bool>
-           </property>
-           <property name="resizeMode">
-            <enum>QListView::Adjust</enum>
-           </property>
-           <property name="uniformItemSizes">
-            <bool>false</bool>
-           </property>
-           <property name="sortingEnabled">
-            <bool>true</bool>
-           </property>
-           <property name="advancedOption" stdset="0">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer_9">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>0</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="pageGrammar">
-      <layout class="QVBoxLayout" name="verticalLayout_6">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QScrollArea" name="scrollAreaGrammar">
-         <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
-         </property>
-         <property name="widgetResizable">
-          <bool>true</bool>
-         </property>
-         <widget class="QWidget" name="scrollAreaWidgetContents_3">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>405</width>
-            <height>617</height>
-           </rect>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_9">
+         <widget class="QWidget" name="pageGrammar">
+          <layout class="QVBoxLayout" name="verticalLayout_6">
            <property name="leftMargin">
             <number>0</number>
            </property>
@@ -3274,1229 +3278,1505 @@ them here.</string>
             <number>0</number>
            </property>
            <item>
-            <widget class="QGroupBox" name="groupBox_Dictionaries">
-             <property name="title">
-              <string>Spell Check</string>
+            <widget class="QScrollArea" name="scrollAreaGrammar">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
              </property>
-             <layout class="QGridLayout" name="_4">
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_43">
-                <property name="text">
-                 <string>Default Language:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="5">
-               <widget class="QPushButton" name="pushButtonDictDir">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="icon">
-                 <iconset resource="../images.qrc">
-                  <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1" colspan="5">
-               <widget class="QComboBox" name="comboBoxSpellcheckLang"/>
-              </item>
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents_3">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>405</width>
+                <height>300</height>
+               </rect>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_9">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QGroupBox" name="groupBox_Dictionaries">
+                 <property name="title">
+                  <string>Spell Check</string>
+                 </property>
+                 <layout class="QGridLayout" name="_4">
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_43">
+                    <property name="text">
+                     <string>Default Language:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="5">
+                   <widget class="QPushButton" name="pushButtonDictDir">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../images.qrc">
+                      <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1" colspan="5">
+                   <widget class="QComboBox" name="comboBoxSpellcheckLang"/>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_42">
+                    <property name="text">
+                     <string>Spelling Dictionary Directories:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1" colspan="4">
+                   <widget class="QLineEdit" name="leDictDir">
+                    <property name="toolTip">
+                     <string>Folders with Hunspell dictionaries separated by semicolon. The special keywords [txs-settings-dir] and [txs-app-dir] will be resolved to the respective directories.</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="1" colspan="4">
+                   <widget class="QComboBox" name="comboBoxThesaurusFileName">
+                    <property name="editable">
+                     <bool>true</bool>
+                    </property>
+                    <property name="dirFilter" stdset="0">
+                     <string>*.dat</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="label_13">
+                    <property name="text">
+                     <string>Thesaurus Database:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="5">
+                   <widget class="QPushButton" name="btSelectThesaurusFileName">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../images.qrc">
+                      <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="2" colspan="4">
+                   <widget class="QLabel" name="labelGetDic">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>TextLabel</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1">
+                   <widget class="QPushButton" name="pushButtonImportDictionary">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Import Dictionary...</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox_13">
+                 <property name="title">
+                  <string>Internal Grammar Check</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_8">
+                  <item row="0" column="0" colspan="3">
+                   <widget class="QCheckBox" name="checkBoxGrammarRepetitionCheck">
+                    <property name="toolTip">
+                     <string>Words repeated within a paragraph will be highlighted.</string>
+                    </property>
+                    <property name="text">
+                     <string>Check for Word Repetitions</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_47">
+                    <property name="text">
+                     <string>Words Between Repetitions:</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1" colspan="2">
+                   <widget class="QSpinBox" name="spinBoxGrammarRepetitionDistance">
+                    <property name="toolTip">
+                     <string>Equal words are marked as repetition if there are no more than this number of words between them.</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1" colspan="2">
+                   <widget class="QSpinBox" name="spinBoxGrammarLongRangeRepetition">
+                    <property name="toolTip">
+                     <string>Equal, longer words are marked as long range repetition if there are no more than this number of words between them.</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="1" colspan="2">
+                   <widget class="QSpinBox" name="spinBoxGrammarLongRangeRepetitionMinLength">
+                    <property name="toolTip">
+                     <string>Only words with have this length are checked for long range repetitions.</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="label_54">
+                    <property name="text">
+                     <string>Long Range Repetitions:</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="label_55">
+                    <property name="text">
+                     <string>Min Length of Words with Long Repetition:</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="0">
+                   <widget class="QLabel" name="label_48">
+                    <property name="text">
+                     <string>Wordlist Directory:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="0">
+                   <widget class="QCheckBox" name="checkBoxGrammarBadWordCheck">
+                    <property name="toolTip">
+                     <string>Certain informal or weak words will be highlighted.</string>
+                    </property>
+                    <property name="text">
+                     <string>Check for Bad Words</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="1">
+                   <widget class="QLineEdit" name="lineEditGrammarWordlists">
+                    <property name="toolTip">
+                     <string>Directory containing the lists which words are &quot;bad&quot; or may be repeated.</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="2">
+                   <widget class="QPushButton" name="pushButtonGrammarWordlists">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../images.qrc">
+                      <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox_14">
+                 <property name="title">
+                  <string>LanguageTool</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_9">
+                  <item row="7" column="1">
+                   <widget class="QLineEdit" name="lineEditGrammarLTPath">
+                    <property name="toolTip">
+                     <string>Path containing the LanguageTool java archive.</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="7" column="0">
+                   <widget class="QLabel" name="label_45">
+                    <property name="text">
+                     <string>LT Path:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="0" colspan="4">
+                   <widget class="QCheckBox" name="checkBoxGrammarLTAutorun">
+                    <property name="text">
+                     <string>Start LanguageTool if not running</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_44">
+                    <property name="text">
+                     <string>Server URL: </string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="1" colspan="3">
+                   <widget class="QLineEdit" name="lineEditGrammarLTIgnoredRules">
+                    <property name="toolTip">
+                     <string>Comma separated list of LanguageTool rules which will not be highlighted as errors.</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="7" column="3">
+                   <widget class="QPushButton" name="pushButtonGrammarLTPath">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../images.qrc">
+                      <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="label_46">
+                    <property name="text">
+                     <string>Ignored Rules:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="9" column="1" colspan="3">
+                   <widget class="QLineEdit" name="lineEditGrammarSpecialRules1">
+                    <property name="toolTip">
+                     <string>Comma separated list of LanguageTool rules which will highlighted in a special format.</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="10" column="1" colspan="3">
+                   <widget class="QLineEdit" name="lineEditGrammarSpecialRules2">
+                    <property name="toolTip">
+                     <string>Comma separated list of LanguageTool rules which will highlighted in a special format.</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="12" column="1" colspan="3">
+                   <widget class="QLineEdit" name="lineEditGrammarSpecialRules4">
+                    <property name="toolTip">
+                     <string>Comma separated list of LanguageTool rules which will highlighted in a special format.</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="11" column="0">
+                   <widget class="QLabel" name="label_52">
+                    <property name="text">
+                     <string>Special Rules 3:</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="10" column="0">
+                   <widget class="QLabel" name="label_50">
+                    <property name="text">
+                     <string>Special Rules 2:</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="11" column="1" colspan="3">
+                   <widget class="QLineEdit" name="lineEditGrammarSpecialRules3">
+                    <property name="toolTip">
+                     <string>Comma separated list of LanguageTool rules which will highlighted in a special format.</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="9" column="0">
+                   <widget class="QLabel" name="label_51">
+                    <property name="text">
+                     <string>Special Rules 1:</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_78">
+                    <property name="text">
+                     <string>Language:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="12" column="0">
+                   <widget class="QLabel" name="label_53">
+                    <property name="text">
+                     <string>Special Rules 4:</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1" colspan="3">
+                   <widget class="QLabel" name="label_79">
+                    <property name="text">
+                     <string>Will be inferred from the language of the spell checker used in the document.</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="1">
+                   <widget class="QLineEdit" name="lineEditGrammarLTJava">
+                    <property name="toolTip">
+                     <string>Java executable, used to start LanguageTool, if it is not running.</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="0">
+                   <widget class="QLabel" name="label_49">
+                    <property name="text">
+                     <string>Java:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="8" column="0">
+                   <widget class="QLabel" name="label_81">
+                    <property name="toolTip">
+                     <string>Arguments passed when starting LanguageTool. This option does only have an effect if LanguageTool is started from TeXstudio (i.e. not for an already running server).</string>
+                    </property>
+                    <property name="text">
+                     <string>LT Arguments:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="3">
+                   <widget class="QPushButton" name="pushButtonGrammarLTJava">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../images.qrc">
+                      <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="3">
+                   <widget class="QPushButton" name="pushButtonResetLTURL">
+                    <property name="toolTip">
+                     <string>Restore Default</string>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../images.qrc">
+                      <normaloff>:/images-ng/edit-undo.svg</normaloff>:/images-ng/edit-undo.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QLineEdit" name="lineEditGrammarLTUrl">
+                    <property name="toolTip">
+                     <string>Url to connect to LanguageTool. </string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="8" column="1">
+                   <widget class="QLineEdit" name="lineEditGrammarLTArguments">
+                    <property name="toolTip">
+                     <string>Arguments passed when starting LanguageTool. This option does only have an effect if LanguageTool is started from TeXstudio (i.e. not for an already running server).</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="8" column="3">
+                   <widget class="QPushButton" name="pushButtonResetLTArgs">
+                    <property name="toolTip">
+                     <string>Restore Default</string>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../images.qrc">
+                      <normaloff>:/images-ng/edit-undo.svg</normaloff>:/images-ng/edit-undo.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_4">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="pagePreview">
+          <layout class="QVBoxLayout" name="verticalLayout_3">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QScrollArea" name="scrollAreaPreview">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaPreviewLayout">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>292</width>
+                <height>228</height>
+               </rect>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_13">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QGroupBox" name="groupBox_5">
+                 <property name="title">
+                  <string>Preview</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_5">
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_31">
+                    <property name="text">
+                     <string>Command:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QComboBox" name="comboBoxDvi2PngMode">
+                    <property name="advancedOption" stdset="0">
+                     <bool>false</bool>
+                    </property>
+                    <item>
+                     <property name="text">
+                      <string>Preview with dvipng</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Preview with dvipng --follow (parallel)</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Preview with dvips/ghostscript</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Preview with pdflatex</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Preview with lualatex</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_32">
+                    <property name="text">
+                     <string>Display Mode:</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>false</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QComboBox" name="comboBoxPreviewMode">
+                    <property name="advancedOption" stdset="0">
+                     <bool>false</bool>
+                    </property>
+                    <item>
+                     <property name="text">
+                      <string>Show preview as tooltip if panel is hidden</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Always show preview in preview panel</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Always show preview as tool tip</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Always show both</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Inline</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string extracomment="Only available if pdflatex is used for compilation">Show in embedded viewer</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="label_35">
+                    <property name="toolTip">
+                     <string>Update the preview on text change</string>
+                    </property>
+                    <property name="text">
+                     <string>Auto Update:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="1">
+                   <widget class="QComboBox" name="comboBoxAutoPreview">
+                    <item>
+                     <property name="text">
+                      <string>Never</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Previously previewed text</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="4" column="0">
+                   <widget class="QLabel" name="label_36">
+                    <property name="text">
+                     <string>Auto Update Delay:</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="1">
+                   <widget class="QSpinBox" name="spinBoxAutoPreviewDelay">
+                    <property name="minimum">
+                     <number>40</number>
+                    </property>
+                    <property name="maximum">
+                     <number>3000</number>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="0">
+                   <widget class="QCheckBox" name="checkBoxReplaceBeamer">
+                    <property name="text">
+                     <string>Replace beamer class by article</string>
+                    </property>
+                    <property name="checked">
+                     <bool>true</bool>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="0">
+                   <widget class="QCheckBox" name="checkBoxPrecompilePreamble">
+                    <property name="text">
+                     <string>Precompile Preamble</string>
+                    </property>
+                    <property name="checked">
+                     <bool>true</bool>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="7" column="0" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxToolTipPreview">
+                    <property name="text">
+                     <string>Show preview as tooltip on formulas in editor</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="label_75">
+                    <property name="toolTip">
+                     <string/>
+                    </property>
+                    <property name="text">
+                     <string>Scaling:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1">
+                   <widget class="QSpinBox" name="spinBoxSegmentPreviewScalePercent">
+                    <property name="toolTip">
+                     <string/>
+                    </property>
+                    <property name="specialValueText">
+                     <string notr="true"/>
+                    </property>
+                    <property name="suffix">
+                     <string>%</string>
+                    </property>
+                    <property name="minimum">
+                     <number>20</number>
+                    </property>
+                    <property name="maximum">
+                     <number>10000</number>
+                    </property>
+                    <property name="singleStep">
+                     <number>10</number>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_2">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>1</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="pagePDFviewer">
+          <layout class="QVBoxLayout" name="verticalLayout_15">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QScrollArea" name="scrollAreaPDFviewer">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaPDFviewerLayout">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>409</width>
+                <height>300</height>
+               </rect>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_16">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QGroupBox" name="groupBox_8">
+                 <property name="title">
+                  <string>Internal PDF Viewer</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_4">
+                  <item row="3" column="1">
+                   <widget class="QSpinBox" name="spinBoxPreviewScale">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="specialValueText">
+                     <string notr="true"/>
+                    </property>
+                    <property name="suffix">
+                     <string>%</string>
+                    </property>
+                    <property name="minimum">
+                     <number>1</number>
+                    </property>
+                    <property name="maximum">
+                     <number>10000</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="label_29">
+                    <property name="text">
+                     <string>Scaling:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="16" column="0">
+                   <widget class="QLabel" name="label_69">
+                    <property name="text">
+                     <string>Load Strategy:</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="19" column="0" colspan="2">
+                   <widget class="QCheckBox" name="autoRecompileFullDocument">
+                    <property name="text">
+                     <string>Auto-recompile document on changes</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="15" column="0">
+                   <widget class="QLabel" name="label_18">
+                    <property name="text">
+                     <string>Cache Size:</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="1">
+                   <widget class="QSpinBox" name="spinBoxPreviewMagnifierSize">
+                    <property name="suffix">
+                     <string> px</string>
+                    </property>
+                    <property name="prefix">
+                     <string/>
+                    </property>
+                    <property name="minimum">
+                     <number>50</number>
+                    </property>
+                    <property name="maximum">
+                     <number>10000</number>
+                    </property>
+                    <property name="singleStep">
+                     <number>50</number>
+                    </property>
+                    <property name="value">
+                     <number>300</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="12" column="1">
+                   <widget class="QSpinBox" name="spinBoxHighlightDuration">
+                    <property name="specialValueText">
+                     <string>Infinite</string>
+                    </property>
+                    <property name="suffix">
+                     <string notr="true"> ms</string>
+                    </property>
+                    <property name="maximum">
+                     <number>86400000</number>
+                    </property>
+                    <property name="value">
+                     <number>2000</number>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="1">
+                   <widget class="QSpinBox" name="spinBoxPreviewDPI">
+                    <property name="suffix">
+                     <string> dpi</string>
+                    </property>
+                    <property name="maximum">
+                     <number>600</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="16" column="1">
+                   <widget class="QComboBox" name="comboBoxPDFLoadStrategy">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Defines how a PDF is loaded:&lt;/p&gt;&lt;p&gt;&lt;b&gt;Buffered:&lt;/b&gt; Load the file into a buffer and check for completeness. Then pass the data on to poppler. This was primarily introduced as a speedup for old poppler versions (&amp;lt;0.24) which were not thread-safe. It has been reported that poppler may crash when loading large buffers. Therefore this option is deprecated.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Direct:&lt;/b&gt; Use native poppler file loading. This is fastest, but does not allow checking for incomplete files.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Hybrid (recommended):&lt;/b&gt; First load file into buffer and check for completeness. Use that buffer for small documents (&amp;lt; 50MB). Large files are loaded using native poppler file loading. This combines file-checking while preventing problems with large PDF files.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="currentIndex">
+                     <number>2</number>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                    <item>
+                     <property name="text">
+                      <string>Buffered</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Direct</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Hybrid</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="12" column="0">
+                   <widget class="QLabel" name="label_66">
+                    <property name="text">
+                     <string>Highlight Duration</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="11" column="1">
+                   <widget class="QLineEdit" name="lineEditHighlightColor">
+                    <property name="toolTip">
+                     <string>Specify as hexadecimal RGBA value. Note: The transparency is required because the highlighting is drawn on top of the text due to technical limitations.</string>
+                    </property>
+                    <property name="inputMask">
+                     <string>\#HHHHHHHH;_</string>
+                    </property>
+                    <property name="text">
+                     <string notr="true">#</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="1">
+                   <widget class="QComboBox" name="comboBoxPreviewMagnifierShape">
+                    <item>
+                     <property name="text">
+                      <string>Square</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Circle</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Circle without shadow</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="14" column="1">
+                   <widget class="QLineEdit" name="lineEditPreviewSyncFileMask">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="11" column="0">
+                   <widget class="QLabel" name="label_67">
+                    <property name="text">
+                     <string>Highlight Color</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="10" column="1">
+                   <widget class="QLineEdit" name="lineEditPaperColor">
+                    <property name="toolTip">
+                     <string>Default background color. Specify as hexadecimal RGB value. Note: This will only affect PDFs loaded after the change of the option. The paper color of already open PDFs is not modified.</string>
+                    </property>
+                    <property name="inputMask">
+                     <string notr="true">\#HHHHHH;_</string>
+                    </property>
+                    <property name="text">
+                     <string notr="true">#</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="0">
+                   <widget class="QLabel" name="labelScreenResolution">
+                    <property name="text">
+                     <string notr="true">&lt;ScreenResolution&gt;</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="7" column="1">
+                   <widget class="QCheckBox" name="checkBoxPreviewMagnifierBorder">
+                    <property name="text">
+                     <string>Border</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QComboBox" name="comboBoxPreviewScale">
+                    <item>
+                     <property name="text">
+                      <string>Original Size</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Fit to Window Width</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Fit to Window Size</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Scaled Size</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Fit to Text Width</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="15" column="1">
+                   <widget class="QSpinBox" name="spinBoxCacheSizeMB">
+                    <property name="suffix">
+                     <string> MB</string>
+                    </property>
+                    <property name="minimum">
+                     <number>100</number>
+                    </property>
+                    <property name="maximum">
+                     <number>1024</number>
+                    </property>
+                    <property name="singleStep">
+                     <number>100</number>
+                    </property>
+                    <property name="value">
+                     <number>512</number>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="14" column="0">
+                   <widget class="QLabel" name="label_34">
+                    <property name="text">
+                     <string>Synchronized Files Types:</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="10" column="0">
+                   <widget class="QLabel" name="label_84">
+                    <property name="text">
+                     <string>Paper Color</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="17" column="0">
+                   <widget class="QLabel" name="label_76">
+                    <property name="toolTip">
+                     <string>The Render Backend used by the PDF library poppler.
+'Splash' is the default and suitable for most situations.
+If there are rendering issues, you may try the alternative 'Arthur' backend.
+Note: Changing this setting will only affect documents that are opened afterwards.</string>
+                    </property>
+                    <property name="text">
+                     <string>Render Backend:</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="8" column="0">
+                   <widget class="QLabel" name="label_88">
+                    <property name="text">
+                     <string>Presentation Laser Pointer Size:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0" colspan="2">
+                   <widget class="QLabel" name="label_77">
+                    <property name="text">
+                     <string>Note: Windowed/embedded mode is configured at Build -&gt; PDF Viewer</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1">
+                   <widget class="QCheckBox" name="checkBoxDisableHorizontalScrollingForFitToTextWidth">
+                    <property name="text">
+                     <string>Disable horizontal scrolling for &quot;Fit to Text Width&quot;</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_28">
+                    <property name="text">
+                     <string>Scale Option:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="0">
+                   <widget class="QLabel" name="label_26">
+                    <property name="text">
+                     <string>Magnifier Shape:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="17" column="1">
+                   <widget class="QComboBox" name="comboBoxPDFRenderBackend">
+                    <property name="toolTip">
+                     <string>The Render Backend used by the PDF library poppler.
+'Splash' is the default and suitable for most situations.
+If there are rendering issues, you may try the alternative 'Arthur' backend.
+Note: Changing this setting will only affect documents that are opened afterwards.</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                    <item>
+                     <property name="text">
+                      <string notr="true">Splash</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string notr="true">Arthur</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="6" column="0">
+                   <widget class="QLabel" name="label_25">
+                    <property name="text">
+                     <string>Magnifier Size:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="18" column="0">
+                   <widget class="QCheckBox" name="autoHideToolbars">
+                    <property name="text">
+                     <string>Auto-hide Toolbars in Embedded Mode</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="9" column="0">
+                   <widget class="QLabel" name="label_89">
+                    <property name="text">
+                     <string>Presentation Laser Pointer Color:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="8" column="1">
+                   <widget class="QSpinBox" name="spinBoxPreviewLaserPointerSize"/>
+                  </item>
+                  <item row="9" column="1">
+                   <widget class="QLineEdit" name="lineEditLaserPointerColor"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_7">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="pageSVN">
+          <layout class="QVBoxLayout" name="verticalLayout_18">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QScrollArea" name="scrollAreaSVN">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents_4">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>528</width>
+                <height>300</height>
+               </rect>
+              </property>
+              <layout class="QGridLayout">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item row="0" column="0">
+                <widget class="QGroupBox" name="groupBox_18">
+                 <property name="title">
+                  <string>SVN/GIT</string>
+                 </property>
+                 <layout class="QVBoxLayout">
+                  <item>
+                   <widget class="QComboBox" name="comboBoxUseVCS">
+                    <item>
+                     <property name="text">
+                      <string>Use SVN</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Use GIT</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="comboBoxAutoCheckinLevel">
+                    <property name="toolTip">
+                     <string>Select how txs checks in saved files</string>
+                    </property>
+                    <item>
+                     <property name="text">
+                      <string>No automatic check-in after save</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Check-in after File/Save only</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Check-in after all save operations, i.e. also before compiles.</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="cbSVNUndo">
+                    <property name="text">
+                     <string>Use SVN/GIT revisions to undo before last saved version</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="cbKeywordSubstitution">
+                    <property name="toolTip">
+                     <string>on svn add executes svn propset svn:keywords &quot;Date Author Revision HeadURL&quot;</string>
+                    </property>
+                    <property name="text">
+                     <string>Substitute Keywords with Properties (on svn add)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout">
+                    <item>
+                     <widget class="QLabel" name="label_21">
+                      <property name="text">
+                       <string>SVN Directory Search Depth: </string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QSpinBox" name="sbDirSearchDepth">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <spacer>
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="pageInternalTerminal">
+          <layout class="QGridLayout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <item row="0" column="0">
+            <widget class="QGroupBox" name="groupBox_4">
+             <property name="title">
+              <string>Internal Terminal</string>
+             </property>
+             <layout class="QGridLayout">
               <item row="0" column="0">
-               <widget class="QLabel" name="label_42">
+               <widget class="QLabel" name="label_86">
                 <property name="text">
-                 <string>Spelling Dictionary Directories:</string>
+                 <string>Color Scheme:</string>
                 </property>
                </widget>
               </item>
-              <item row="0" column="1" colspan="4">
-               <widget class="QLineEdit" name="leDictDir">
-                <property name="toolTip">
-                 <string>Folders with Hunspell dictionaries separated by semicolon. The special keywords [txs-settings-dir] and [txs-app-dir] will be resolved to the respective directories.</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1" colspan="4">
-               <widget class="QComboBox" name="comboBoxThesaurusFileName">
+              <item row="0" column="1" colspan="2">
+               <widget class="QComboBox" name="comboBoxTerminalColorScheme">
                 <property name="editable">
                  <bool>true</bool>
                 </property>
-                <property name="dirFilter" stdset="0">
-                 <string>*.dat</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="label_13">
-                <property name="text">
-                 <string>Thesaurus Database:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="5">
-               <widget class="QPushButton" name="btSelectThesaurusFileName">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="icon">
-                 <iconset resource="../images.qrc">
-                  <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="2" colspan="4">
-               <widget class="QLabel" name="labelGetDic">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>TextLabel</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QPushButton" name="pushButtonImportDictionary">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Import Dictionary...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="groupBox_13">
-             <property name="title">
-              <string>Internal Grammar Check</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_8">
-              <item row="0" column="0" colspan="3">
-               <widget class="QCheckBox" name="checkBoxGrammarRepetitionCheck">
-                <property name="toolTip">
-                 <string>Words repeated within a paragraph will be highlighted.</string>
-                </property>
-                <property name="text">
-                 <string>Check for Word Repetitions</string>
-                </property>
                </widget>
               </item>
               <item row="1" column="0">
-               <widget class="QLabel" name="label_47">
+               <widget class="QLabel" name="labelFamily_2">
                 <property name="text">
-                 <string>Words Between Repetitions:</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
+                 <string>Font Family:</string>
                 </property>
                </widget>
               </item>
               <item row="1" column="1" colspan="2">
-               <widget class="QSpinBox" name="spinBoxGrammarRepetitionDistance">
-                <property name="toolTip">
-                 <string>Equal words are marked as repetition if there are no more than this number of words between them.</string>
-                </property>
-                <property name="advancedOption" stdset="0">
+               <widget class="QComboBox" name="comboBoxTerminalFont">
+                <property name="editable">
                  <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="labelSize_2">
+                <property name="text">
+                 <string>Font Size:</string>
                 </property>
                </widget>
               </item>
               <item row="2" column="1" colspan="2">
-               <widget class="QSpinBox" name="spinBoxGrammarLongRangeRepetition">
-                <property name="toolTip">
-                 <string>Equal, longer words are marked as long range repetition if there are no more than this number of words between them.</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1" colspan="2">
-               <widget class="QSpinBox" name="spinBoxGrammarLongRangeRepetitionMinLength">
-                <property name="toolTip">
-                 <string>Only words with have this length are checked for long range repetitions.</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="label_54">
-                <property name="text">
-                 <string>Long Range Repetitions:</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="label_55">
-                <property name="text">
-                 <string>Min Length of Words with Long Repetition:</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="0">
-               <widget class="QLabel" name="label_48">
-                <property name="text">
-                 <string>Wordlist Directory:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="0">
-               <widget class="QCheckBox" name="checkBoxGrammarBadWordCheck">
-                <property name="toolTip">
-                 <string>Certain informal or weak words will be highlighted.</string>
-                </property>
-                <property name="text">
-                 <string>Check for Bad Words</string>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="1">
-               <widget class="QLineEdit" name="lineEditGrammarWordlists">
-                <property name="toolTip">
-                 <string>Directory containing the lists which words are &quot;bad&quot; or may be repeated.</string>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="2">
-               <widget class="QPushButton" name="pushButtonGrammarWordlists">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="icon">
-                 <iconset resource="../images.qrc">
-                  <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="groupBox_14">
-             <property name="title">
-              <string>LanguageTool</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_9">
-              <item row="7" column="1">
-               <widget class="QLineEdit" name="lineEditGrammarLTPath">
-                <property name="toolTip">
-                 <string>Path containing the LanguageTool java archive.</string>
-                </property>
-               </widget>
-              </item>
-              <item row="7" column="0">
-               <widget class="QLabel" name="label_45">
-                <property name="text">
-                 <string>LT Path:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="0" colspan="4">
-               <widget class="QCheckBox" name="checkBoxGrammarLTAutorun">
-                <property name="text">
-                 <string>Start LanguageTool if not running</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_44">
-                <property name="text">
-                 <string>Server URL: </string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1" colspan="3">
-               <widget class="QLineEdit" name="lineEditGrammarLTIgnoredRules">
-                <property name="toolTip">
-                 <string>Comma separated list of LanguageTool rules which will not be highlighted as errors.</string>
-                </property>
-               </widget>
-              </item>
-              <item row="7" column="3">
-               <widget class="QPushButton" name="pushButtonGrammarLTPath">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="icon">
-                 <iconset resource="../images.qrc">
-                  <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="label_46">
-                <property name="text">
-                 <string>Ignored Rules:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="9" column="1" colspan="3">
-               <widget class="QLineEdit" name="lineEditGrammarSpecialRules1">
-                <property name="toolTip">
-                 <string>Comma separated list of LanguageTool rules which will highlighted in a special format.</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="10" column="1" colspan="3">
-               <widget class="QLineEdit" name="lineEditGrammarSpecialRules2">
-                <property name="toolTip">
-                 <string>Comma separated list of LanguageTool rules which will highlighted in a special format.</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="12" column="1" colspan="3">
-               <widget class="QLineEdit" name="lineEditGrammarSpecialRules4">
-                <property name="toolTip">
-                 <string>Comma separated list of LanguageTool rules which will highlighted in a special format.</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="11" column="0">
-               <widget class="QLabel" name="label_52">
-                <property name="text">
-                 <string>Special Rules 3:</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="10" column="0">
-               <widget class="QLabel" name="label_50">
-                <property name="text">
-                 <string>Special Rules 2:</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="11" column="1" colspan="3">
-               <widget class="QLineEdit" name="lineEditGrammarSpecialRules3">
-                <property name="toolTip">
-                 <string>Comma separated list of LanguageTool rules which will highlighted in a special format.</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="9" column="0">
-               <widget class="QLabel" name="label_51">
-                <property name="text">
-                 <string>Special Rules 1:</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_78">
-                <property name="text">
-                 <string>Language:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="12" column="0">
-               <widget class="QLabel" name="label_53">
-                <property name="text">
-                 <string>Special Rules 4:</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1" colspan="3">
-               <widget class="QLabel" name="label_79">
-                <property name="text">
-                 <string>Will be inferred from the language of the spell checker used in the document.</string>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="1">
-               <widget class="QLineEdit" name="lineEditGrammarLTJava">
-                <property name="toolTip">
-                 <string>Java executable, used to start LanguageTool, if it is not running.</string>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="0">
-               <widget class="QLabel" name="label_49">
-                <property name="text">
-                 <string>Java:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="8" column="0">
-               <widget class="QLabel" name="label_81">
-                <property name="toolTip">
-                 <string>Arguments passed when starting LanguageTool. This option does only have an effect if LanguageTool is started from TeXstudio (i.e. not for an already running server).</string>
-                </property>
-                <property name="text">
-                 <string>LT Arguments:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="3">
-               <widget class="QPushButton" name="pushButtonGrammarLTJava">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="icon">
-                 <iconset resource="../images.qrc">
-                  <normaloff>:/images-ng/document-open.svgz</normaloff>:/images-ng/document-open.svgz</iconset>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="3">
-               <widget class="QPushButton" name="pushButtonResetLTURL">
-                <property name="toolTip">
-                 <string>Restore Default</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="icon">
-                 <iconset resource="../images.qrc">
-                  <normaloff>:/images-ng/edit-undo.svg</normaloff>:/images-ng/edit-undo.svg</iconset>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QLineEdit" name="lineEditGrammarLTUrl">
-                <property name="toolTip">
-                 <string>Url to connect to LanguageTool. </string>
-                </property>
-               </widget>
-              </item>
-              <item row="8" column="1">
-               <widget class="QLineEdit" name="lineEditGrammarLTArguments">
-                <property name="toolTip">
-                 <string>Arguments passed when starting LanguageTool. This option does only have an effect if LanguageTool is started from TeXstudio (i.e. not for an already running server).</string>
-                </property>
-               </widget>
-              </item>
-              <item row="8" column="3">
-               <widget class="QPushButton" name="pushButtonResetLTArgs">
-                <property name="toolTip">
-                 <string>Restore Default</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="icon">
-                 <iconset resource="../images.qrc">
-                  <normaloff>:/images-ng/edit-undo.svg</normaloff>:/images-ng/edit-undo.svg</iconset>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <spacer name="verticalSpacer_4">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>40</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </widget>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="pagePreview">
-      <layout class="QVBoxLayout" name="verticalLayout_3">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QScrollArea" name="scrollAreaPreview">
-         <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
-         </property>
-         <property name="widgetResizable">
-          <bool>true</bool>
-         </property>
-         <widget class="QWidget" name="scrollAreaPreviewLayout">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>292</width>
-            <height>228</height>
-           </rect>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_13">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QGroupBox" name="groupBox_5">
-             <property name="title">
-              <string>Preview</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_5">
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_31">
-                <property name="text">
-                 <string>Command:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QComboBox" name="comboBoxDvi2PngMode">
-                <property name="advancedOption" stdset="0">
-                 <bool>false</bool>
-                </property>
-                <item>
-                 <property name="text">
-                  <string>Preview with dvipng</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Preview with dvipng --follow (parallel)</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Preview with dvips/ghostscript</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Preview with pdflatex</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Preview with lualatex</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_32">
-                <property name="text">
-                 <string>Display Mode:</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>false</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QComboBox" name="comboBoxPreviewMode">
-                <property name="advancedOption" stdset="0">
-                 <bool>false</bool>
-                </property>
-                <item>
-                 <property name="text">
-                  <string>Show preview as tooltip if panel is hidden</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Always show preview in preview panel</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Always show preview as tool tip</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Always show both</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Inline</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string extracomment="Only available if pdflatex is used for compilation">Show in embedded viewer</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="label_35">
-                <property name="toolTip">
-                 <string>Update the preview on text change</string>
-                </property>
-                <property name="text">
-                 <string>Auto Update:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QComboBox" name="comboBoxAutoPreview">
-                <item>
-                 <property name="text">
-                  <string>Never</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Previously previewed text</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="4" column="0">
-               <widget class="QLabel" name="label_36">
-                <property name="text">
-                 <string>Auto Update Delay:</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="1">
-               <widget class="QSpinBox" name="spinBoxAutoPreviewDelay">
-                <property name="minimum">
-                 <number>40</number>
-                </property>
-                <property name="maximum">
-                 <number>3000</number>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="0">
-               <widget class="QCheckBox" name="checkBoxReplaceBeamer">
-                <property name="text">
-                 <string>Replace beamer class by article</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="0">
-               <widget class="QCheckBox" name="checkBoxPrecompilePreamble">
-                <property name="text">
-                 <string>Precompile Preamble</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="7" column="0" colspan="2">
-               <widget class="QCheckBox" name="checkBoxToolTipPreview">
-                <property name="text">
-                 <string>Show preview as tooltip on formulas in editor</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="label_75">
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="text">
-                 <string>Scaling:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QSpinBox" name="spinBoxSegmentPreviewScalePercent">
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="specialValueText">
-                 <string notr="true"/>
-                </property>
-                <property name="suffix">
-                 <string>%</string>
-                </property>
-                <property name="minimum">
-                 <number>20</number>
-                </property>
-                <property name="maximum">
-                 <number>10000</number>
-                </property>
-                <property name="singleStep">
-                 <number>10</number>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <spacer name="verticalSpacer_2">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>1</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </widget>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="pagePDFviewer">
-      <layout class="QVBoxLayout" name="verticalLayout_15">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QScrollArea" name="scrollAreaPDFviewer">
-         <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
-         </property>
-         <property name="widgetResizable">
-          <bool>true</bool>
-         </property>
-         <widget class="QWidget" name="scrollAreaPDFviewerLayout">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>409</width>
-            <height>488</height>
-           </rect>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_16">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QGroupBox" name="groupBox_8">
-             <property name="title">
-              <string>Internal PDF Viewer</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_4">
-              <item row="3" column="1">
-               <widget class="QSpinBox" name="spinBoxPreviewScale">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="specialValueText">
-                 <string notr="true"/>
-                </property>
-                <property name="suffix">
-                 <string>%</string>
-                </property>
+               <widget class="QSpinBox" name="spinBoxTerminalFontSize">
                 <property name="minimum">
                  <number>1</number>
                 </property>
-                <property name="maximum">
-                 <number>10000</number>
+                <property name="value">
+                 <number>12</number>
                 </property>
                </widget>
               </item>
               <item row="3" column="0">
-               <widget class="QLabel" name="label_29">
+               <widget class="QLabel" name="labelShell">
                 <property name="text">
-                 <string>Scaling:</string>
+                 <string>Shell:</string>
                 </property>
                </widget>
               </item>
-              <item row="16" column="0">
-               <widget class="QLabel" name="label_69">
-                <property name="text">
-                 <string>Load Strategy:</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="19" column="0" colspan="2">
-               <widget class="QCheckBox" name="autoRecompileFullDocument">
-                <property name="text">
-                 <string>Auto-recompile document on changes</string>
-                </property>
-               </widget>
-              </item>
-              <item row="15" column="0">
-               <widget class="QLabel" name="label_18">
-                <property name="text">
-                 <string>Cache Size:</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="1">
-               <widget class="QSpinBox" name="spinBoxPreviewMagnifierSize">
-                <property name="suffix">
-                 <string> px</string>
-                </property>
-                <property name="prefix">
-                 <string/>
-                </property>
-                <property name="minimum">
-                 <number>50</number>
-                </property>
-                <property name="maximum">
-                 <number>10000</number>
-                </property>
-                <property name="singleStep">
-                 <number>50</number>
-                </property>
-                <property name="value">
-                 <number>300</number>
-                </property>
-               </widget>
-              </item>
-              <item row="12" column="1">
-               <widget class="QSpinBox" name="spinBoxHighlightDuration">
-                <property name="specialValueText">
-                 <string>Infinite</string>
-                </property>
-                <property name="suffix">
-                 <string notr="true"> ms</string>
-                </property>
-                <property name="maximum">
-                 <number>86400000</number>
-                </property>
-                <property name="value">
-                 <number>2000</number>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="1">
-               <widget class="QSpinBox" name="spinBoxPreviewDPI">
-                <property name="suffix">
-                 <string> dpi</string>
-                </property>
-                <property name="maximum">
-                 <number>600</number>
-                </property>
-               </widget>
-              </item>
-              <item row="16" column="1">
-               <widget class="QComboBox" name="comboBoxPDFLoadStrategy">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Defines how a PDF is loaded:&lt;/p&gt;&lt;p&gt;&lt;b&gt;Buffered:&lt;/b&gt; Load the file into a buffer and check for completeness. Then pass the data on to poppler. This was primarily introduced as a speedup for old poppler versions (&amp;lt;0.24) which were not thread-safe. It has been reported that poppler may crash when loading large buffers. Therefore this option is deprecated.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Direct:&lt;/b&gt; Use native poppler file loading. This is fastest, but does not allow checking for incomplete files.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Hybrid (recommended):&lt;/b&gt; First load file into buffer and check for completeness. Use that buffer for small documents (&amp;lt; 50MB). Large files are loaded using native poppler file loading. This combines file-checking while preventing problems with large PDF files.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="currentIndex">
-                 <number>2</number>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-                <item>
-                 <property name="text">
-                  <string>Buffered</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Direct</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Hybrid</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="12" column="0">
-               <widget class="QLabel" name="label_66">
-                <property name="text">
-                 <string>Highlight Duration</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="11" column="1">
-               <widget class="QLineEdit" name="lineEditHighlightColor">
-                <property name="toolTip">
-                 <string>Specify as hexadecimal RGBA value. Note: The transparency is required because the highlighting is drawn on top of the text due to technical limitations.</string>
-                </property>
-                <property name="inputMask">
-                 <string>\#HHHHHHHH;_</string>
-                </property>
-                <property name="text">
-                 <string notr="true">#</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="1">
-               <widget class="QComboBox" name="comboBoxPreviewMagnifierShape">
-                <item>
-                 <property name="text">
-                  <string>Square</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Circle</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Circle without shadow</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="14" column="1">
-               <widget class="QLineEdit" name="lineEditPreviewSyncFileMask">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="11" column="0">
-               <widget class="QLabel" name="label_67">
-                <property name="text">
-                 <string>Highlight Color</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="10" column="1">
-               <widget class="QLineEdit" name="lineEditPaperColor">
-                <property name="toolTip">
-                 <string>Default background color. Specify as hexadecimal RGB value. Note: This will only affect PDFs loaded after the change of the option. The paper color of already open PDFs is not modified.</string>
-                </property>
-                <property name="inputMask">
-                 <string notr="true">\#HHHHHH;_</string>
-                </property>
-                <property name="text">
-                 <string notr="true">#</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="0">
-               <widget class="QLabel" name="labelScreenResolution">
-                <property name="text">
-                 <string notr="true">&lt;ScreenResolution&gt;</string>
-                </property>
-               </widget>
-              </item>
-              <item row="7" column="1">
-               <widget class="QCheckBox" name="checkBoxPreviewMagnifierBorder">
-                <property name="text">
-                 <string>Border</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QComboBox" name="comboBoxPreviewScale">
-                <item>
-                 <property name="text">
-                  <string>Original Size</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Fit to Window Width</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Fit to Window Size</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Scaled Size</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Fit to Text Width</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="15" column="1">
-               <widget class="QSpinBox" name="spinBoxCacheSizeMB">
-                <property name="suffix">
-                 <string> MB</string>
-                </property>
-                <property name="minimum">
-                 <number>100</number>
-                </property>
-                <property name="maximum">
-                 <number>1024</number>
-                </property>
-                <property name="singleStep">
-                 <number>100</number>
-                </property>
-                <property name="value">
-                 <number>512</number>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="14" column="0">
-               <widget class="QLabel" name="label_34">
-                <property name="text">
-                 <string>Synchronized Files Types:</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="10" column="0">
-               <widget class="QLabel" name="label_84">
-                <property name="text">
-                 <string>Paper Color</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="17" column="0">
-               <widget class="QLabel" name="label_76">
-                <property name="toolTip">
-                 <string>The Render Backend used by the PDF library poppler.
-'Splash' is the default and suitable for most situations.
-If there are rendering issues, you may try the alternative 'Arthur' backend.
-Note: Changing this setting will only affect documents that are opened afterwards.</string>
-                </property>
-                <property name="text">
-                 <string>Render Backend:</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="8" column="0">
-               <widget class="QLabel" name="label_88">
-                <property name="text">
-                 <string>Presentation Laser Pointer Size:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0" colspan="2">
-               <widget class="QLabel" name="label_77">
-                <property name="text">
-                 <string>Note: Windowed/embedded mode is configured at Build -&gt; PDF Viewer</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QCheckBox" name="checkBoxDisableHorizontalScrollingForFitToTextWidth">
-                <property name="text">
-                 <string>Disable horizontal scrolling for &quot;Fit to Text Width&quot;</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_28">
-                <property name="text">
-                 <string>Scale Option:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="0">
-               <widget class="QLabel" name="label_26">
-                <property name="text">
-                 <string>Magnifier Shape:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="17" column="1">
-               <widget class="QComboBox" name="comboBoxPDFRenderBackend">
-                <property name="toolTip">
-                 <string>The Render Backend used by the PDF library poppler.
-'Splash' is the default and suitable for most situations.
-If there are rendering issues, you may try the alternative 'Arthur' backend.
-Note: Changing this setting will only affect documents that are opened afterwards.</string>
-                </property>
-                <property name="advancedOption" stdset="0">
-                 <bool>true</bool>
-                </property>
-                <item>
-                 <property name="text">
-                  <string notr="true">Splash</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string notr="true">Arthur</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="6" column="0">
-               <widget class="QLabel" name="label_25">
-                <property name="text">
-                 <string>Magnifier Size:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="18" column="0">
-               <widget class="QCheckBox" name="autoHideToolbars">
-                <property name="text">
-                 <string>Auto-hide Toolbars in Embedded Mode</string>
-                </property>
-               </widget>
-              </item>
-              <item row="9" column="0">
-               <widget class="QLabel" name="label_89">
-                <property name="text">
-                 <string>Presentation Laser Pointer Color:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="8" column="1">
-               <widget class="QSpinBox" name="spinBoxPreviewLaserPointerSize"/>
-              </item>
-              <item row="9" column="1">
-               <widget class="QLineEdit" name="lineEditLaserPointerColor"/>
+              <item row="3" column="1">
+               <widget class="QLineEdit" name="lineEditTerminalShell"/>
               </item>
              </layout>
             </widget>
            </item>
-           <item>
-            <spacer name="verticalSpacer_7">
+           <item row="1" column="0">
+            <spacer name="verticalSpacer_8">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
              </property>
@@ -4511,296 +4791,81 @@ Note: Changing this setting will only affect documents that are opened afterward
           </layout>
          </widget>
         </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="pageSVN">
-      <layout class="QGridLayout">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item row="0" column="0">
-        <widget class="QGroupBox" name="groupBox_18">
-         <property name="title">
-          <string>SVN/GIT</string>
-         </property>
-         <layout class="QVBoxLayout">
-          <item>
-           <widget class="QComboBox" name="comboBoxUseVCS">
-            <item>
-             <property name="text">
-              <string>Use SVN</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Use GIT</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="comboBoxAutoCheckinLevel">
-            <property name="toolTip">
-             <string>Select how txs checks in saved files</string>
-            </property>
-            <item>
-             <property name="text">
-              <string>No automatic check-in after save</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Check-in after File/Save only</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Check-in after all save operations, i.e. also before compiles.</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="cbSVNUndo">
-            <property name="text">
-             <string>Use SVN/GIT revisions to undo before last saved version</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="cbKeywordSubstitution">
-            <property name="toolTip">
-             <string>on svn add executes svn propset svn:keywords &quot;Date Author Revision HeadURL&quot;</string>
-            </property>
-            <property name="text">
-             <string>Substitute Keywords with Properties (on svn add)</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout">
-            <item>
-             <widget class="QLabel" name="label_21">
-              <property name="text">
-               <string>SVN Directory Search Depth: </string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QSpinBox" name="sbDirSearchDepth">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::MinimumExpanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>554</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="pageInternalTerminal">
-      <layout class="QGridLayout">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <property name="spacing">
-        <number>6</number>
-       </property>
-       <item row="0" column="0">
-        <widget class="QGroupBox" name="groupBox_4">
-         <property name="title">
-          <string>Internal Terminal</string>
-         </property>
-         <layout class="QGridLayout">
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_86">
-            <property name="text">
-             <string>Color Scheme:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1" colspan="2">
-           <widget class="QComboBox" name="comboBoxTerminalColorScheme">
-            <property name="editable">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="labelFamily_2">
-            <property name="text">
-             <string>Font Family:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1" colspan="2">
-           <widget class="QComboBox" name="comboBoxTerminalFont">
-            <property name="editable">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="labelSize_2">
-            <property name="text">
-             <string>Font Size:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1" colspan="2">
-           <widget class="QSpinBox" name="spinBoxTerminalFontSize">
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="value">
-             <number>12</number>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="labelShell">
-            <property name="text">
-             <string>Shell:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QLineEdit" name="lineEditTerminalShell"/>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <spacer name="verticalSpacer_8">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
        </item>
       </layout>
      </widget>
     </widget>
    </item>
-  </layout>
- </widget>
-</widget>
-</item>
- <item row="1" column="0">
-  <layout class="QGridLayout">
-   <item row="2" column="0" colspan="2">
-    <layout class="QHBoxLayout">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <property name="sizeConstraint">
-      <enum>QLayout::SetMinimumSize</enum>
-     </property>
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QCheckBox" name="checkBoxShowAdvancedOptions">
-       <property name="text">
-        <string>Show Advanced Options</string>
+   <item row="1" column="0">
+    <layout class="QGridLayout">
+     <item row="2" column="0" colspan="2">
+      <layout class="QHBoxLayout">
+       <property name="spacing">
+        <number>6</number>
        </property>
-       <property name="checked">
-        <bool>true</bool>
+       <property name="sizeConstraint">
+        <enum>QLayout::SetMinimumSize</enum>
        </property>
-      </widget>
-     </item>
-     <item>
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Expanding</enum>
+       <property name="topMargin">
+        <number>0</number>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>407</width>
-         <height>31</height>
-        </size>
+       <property name="rightMargin">
+        <number>0</number>
        </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="okButton">
-       <property name="text">
-        <string>OK</string>
+       <property name="bottomMargin">
+        <number>0</number>
        </property>
-       <property name="default">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="cancelButton">
-       <property name="text">
-        <string>Cancel</string>
-       </property>
-      </widget>
+       <item>
+        <widget class="QCheckBox" name="checkBoxShowAdvancedOptions">
+         <property name="text">
+          <string>Show Advanced Options</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Expanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>407</width>
+           <height>31</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="okButton">
+         <property name="text">
+          <string>OK</string>
+         </property>
+         <property name="default">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="cancelButton">
+         <property name="text">
+          <string>Cancel</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>
   </layout>
- </item>
- </layout>
  </widget>
  <tabstops>
   <tabstop>scrollAreaGeneral</tabstop>


### PR DESCRIPTION
This PR addresses some new and old issues regarding the minimum height achievable for the config dialog.
I observed that for the current dev version the height of the config dialog is almost fixed:

![smallShrinkAmount](https://user-images.githubusercontent.com/102688820/206285607-db7caf03-b6bf-434a-8480-d8e950c49eef.gif)

While investigating I found that current version 4.2.1 shows some strange behaviors. First is that all pages have the same minimum height except Commands page having a larger one. But you will only notice if you try to increase the height of the window because then heigth makes a step up:

![CommandsNeedMoreHeight](https://user-images.githubusercontent.com/102688820/206287022-e506d1b6-517d-451f-bb1c-b2c19499d82c.gif)

Second the Editor page schrinks the height of some widgets when height is minimal, but this is less obvious:

![EditorShrinksWidgets](https://user-images.githubusercontent.com/102688820/206288189-d61f5ea2-061d-494a-9395-9f0d6a40e758.gif)

Now Editor page has a scrollbar so this no longer happens. And now all pages have the same minimum height. Both can be seen in the following images:

![EditorScrollbar](https://user-images.githubusercontent.com/102688820/206289398-0ae2bc7f-dd71-4c99-ab92-9fc05a26dc45.gif)

![BuildHeightFixed](https://user-images.githubusercontent.com/102688820/206289450-ca3f2c74-19dd-498f-a287-b5b6dcb32cbd.gif)
