### PR TITLE
narrow Spell check config

### DIFF
--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -3312,7 +3312,7 @@ them here.</string>
                  <property name="title">
                   <string>Spell Check</string>
                  </property>
-                 <layout class="QGridLayout" name="_4">
+                 <layout class="QGridLayout" columnstretch="0,1,1,1,1,1" name="_4">
                   <item row="1" column="0">
                    <widget class="QLabel" name="label_43">
                     <property name="text">


### PR DESCRIPTION
This PR is a cut down of PR #2747 where you can find full details. Change affects page Language Checking of Config Dialog:

![12_SpellCheck](https://user-images.githubusercontent.com/102688820/206722237-6b5efd3f-89fb-4608-a4f3-e7c0f2438ce7.gif)

Loss of vertical alignment of widgets where it seems that the widgets of the first group box are left aligned with those of the second group box. But they are no longer when you change the width. So moving left to the labels as all others are.