### PR TITLE
narrow Preview config

### DIFF
--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -3847,7 +3847,7 @@ them here.</string>
                  <property name="title">
                   <string>Preview</string>
                  </property>
-                 <layout class="QGridLayout" name="gridLayout_5">
+                 <layout class="QGridLayout" columnstretch="0,1" name="gridLayout_5">
                   <item row="0" column="0">
                    <widget class="QLabel" name="label_31">
                     <property name="text">
@@ -3981,7 +3981,7 @@ them here.</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="5" column="0">
+                  <item row="5" column="0" colspan="2">
                    <widget class="QCheckBox" name="checkBoxReplaceBeamer">
                     <property name="text">
                      <string>Replace beamer class by article</string>
@@ -3994,7 +3994,7 @@ them here.</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="6" column="0">
+                  <item row="6" column="0" colspan="2">
                    <widget class="QCheckBox" name="checkBoxPrecompilePreamble">
                     <property name="text">
                      <string>Precompile Preamble</string>


### PR DESCRIPTION
This PR is a cut down of PR #2747 where you can find full details. Change affects page Preview of Config Dialog:

![13_Preview](https://user-images.githubusercontent.com/102688820/206705532-537ff99e-3e24-4fcd-951d-5bbda85e0056.gif)

Why using a grid that splits the pane in two halfs?