### PR TITLE
narrow PDF viewer config

### DIFF
--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -4506,7 +4506,7 @@ Note: Changing this setting will only affect documents that are opened afterward
                     </property>
                    </widget>
                   </item>
-                  <item row="18" column="0">
+                  <item row="18" column="0" colspan="2">
                    <widget class="QCheckBox" name="autoHideToolbars">
                     <property name="text">
                      <string>Auto-hide Toolbars in Embedded Mode</string>


### PR DESCRIPTION
This PR is a cut down of PR #2747 where you can find full details. Change affects page Internal PDF Viewer of Config Dialog:

![14_PdfViewer](https://user-images.githubusercontent.com/102688820/206705535-537a415c-051f-4ae3-9305-4dc1925931f1.gif)

No need to align with checkboxes.