### PR TITLE
new cwls

### DIFF
--- a/completion/sa-tikz.cwl
+++ b/completion/sa-tikz.cwl
@@ -1,0 +1,5 @@
+# sa-tikz package
+# Matthew Bertucci 2022/12/08 for v0.7a
+
+#include:tikz
+#include:tikzlibraryswitching-architectures

--- a/completion/simpleicons.cwl
+++ b/completion/simpleicons.cwl
@@ -1,5 +1,5 @@
 # simpleicons package
-# Matthew Bertucci 2022/12/02 for v7.21.0
+# Matthew Bertucci 2022/12/09 for v8.0.0
 
 #include:ifxetex
 #include:ifluatex
@@ -170,7 +170,6 @@ apachetomcat
 aparat
 apollographql
 apostrophe
-appannie
 appian
 apple
 applearcade
@@ -342,6 +341,7 @@ burgerking
 burton
 buymeacoffee
 buzzfeed
+bvg
 byjus
 byte
 bytedance
@@ -503,6 +503,7 @@ csharp
 css3
 cssmodules
 csswizardry
+cts
 cucumber
 curl
 curseforge
@@ -532,7 +533,6 @@ datagrip
 dataiku
 datastax
 dataverse
-dataversioncontrol
 datocms
 datto
 dazn
@@ -1921,6 +1921,7 @@ smrt
 smugmug
 snapchat
 snapcraft
+sncf
 snowflake
 snowpack
 snyk

--- a/completion/struktex.cwl
+++ b/completion/struktex.cwl
@@ -1,0 +1,111 @@
+# struktex package
+# Matthew Bertucci 2022/12/08 for v2.3c-0-g7d3fc5b
+
+#include:ifthen
+#include:struktxf
+#include:struktxp
+#include:pict2e
+
+#keyvals:\usepackage/struktex#c
+english
+german
+ngerman
+curves
+emlines
+pict2e
+verification
+nofiller
+draft
+final
+debug
+outer
+#endkeyvals
+
+#ifOption:curves
+#include:curves
+#endif
+
+#ifOption:emlines
+#include:emlines2
+#endif
+
+#ifOption:verification
+\assert{assertion%text}
+\assert[height]{assertion%text}
+#endif
+
+\StrukTeX
+
+\begin{struktogramm}(width,height)#\pictureHighlight
+\begin{struktogramm}(width,height)[title%text]
+\end{struktogramm}
+
+\sProofOn
+\sProofOff
+\PositionNSS{position}
+\assign{content%text}
+\assign[height]{content%text}
+
+\begin{declaration}
+\begin{declaration}[title%text]
+\end{declaration}
+
+\declarationtitle
+\description{variable name}{description%text}
+\descriptionindent
+\descriptionwidth
+\descriptionsep
+
+\sub{text}
+\sub[height]{text}
+\return{text}
+\return[height]{text}
+
+\while{text}
+\while[width]{text}
+\whileend
+\until{text}
+\until[width]{text}
+\untilend
+\forallin{text}
+\forallin[width]{text}
+\forallinend
+\forever
+\forever[width]
+\foreverend
+\exit{text}
+\exit[height]{text}
+
+\ifthenelse{left angle}{right angle}{condition%text}{left text%text}{right text%text}
+\ifthenelse[height]{left angle}{right angle}{condition%text}{left text%text}{right text%text}
+\change
+\ifend
+
+\case{angle}{num cases}{condition%text}{case1 text%text}
+\case[height]{angle}{num cases}{condition%text}{case1 text%text}
+\switch{case-n text%text}
+\switch[position]{case-n text%text}
+\caseend
+
+\inparallel{num tasks}{task1 description%text}
+\inparallel[height]{num tasks}{task1 description%text}
+\task{task-n description%text}
+\task[position]{task-n description%text}
+\inparallelend
+
+\begin{centernss}
+\end{centernss}
+
+\CenterNssFile{file}#i
+\centernssfile{file}#*i
+
+# not documented
+\dimtomm{arg}#S
+\getnum[arg]#S
+\getoption[arg]#S
+
+# deprecated
+\openstrukt{width}{height}#S
+\closestrukt#S
+\dfr#S
+\dfrend#S

--- a/completion/struktxf.cwl
+++ b/completion/struktxf.cwl
@@ -1,0 +1,14 @@
+# struktxf package
+# Matthew Bertucci 2022/12/08 for v2.3c-0-g7d3fc5b
+
+\mathbb{text%plain}#m
+\nat#m
+\integer#m
+\real#m
+\complex#m
+
+\MathItalics
+\MathNormal
+
+# not documented
+\btt#S

--- a/completion/struktxp.cwl
+++ b/completion/struktxp.cwl
@@ -1,0 +1,24 @@
+# struktxp package
+# Matthew Bertucci 2022/12/08 for v2.3c-0-g7d3fc5b
+
+#include:url
+
+\pVariable{name%definition}
+\pVar{name%definition}
+\pKeyword{keyword%definition}
+\pKey{keyword%definition}
+\pExpression{expression%definition}
+\pExp{expression%definition}
+\pComment{text}
+
+\pTrue
+\pFalse
+\pFonts{variable font}{keyword font}{comment font}
+\pBoolValue{true}{false}
+
+# deprecated
+\sVar{name%definition}#S
+\sKey{keyword%definition}#S
+\sTrue#S
+\sFalse#S
+\sBoolValue{true}{false}#S

--- a/completion/tikzlibrarybayesnet.cwl
+++ b/completion/tikzlibrarybayesnet.cwl
@@ -1,0 +1,31 @@
+# bayesnet tikzlibrary
+# 2022/12/09 for v0.1
+
+#include:tikzlibraryshapes
+#include:tikzlibraryfit
+#include:tikzlibrarychains
+
+#keyvals:\node#c
+latent
+obs
+det
+const
+factor
+plate
+gate
+#endkeyvals
+
+\factor{name}{caption%text}{inputs}{outputs}
+\factor[TikZ keys]{name}{caption%text}{inputs}{outputs}
+\plate{name}{fitlist}{caption%text}
+\plate[TikZ keys]{name}{fitlist}{caption%text}
+\gate{name}{fitlist}{inputs}
+\gate[TikZ keys]{name}{fitlist}{inputs}
+\vgate{name}{fitlist-left}{caption-left%text}{fitlist-right}{caption-right%text}{inputs}
+\vgate[TikZ keys]{name}{fitlist-left}{caption-left%text}{fitlist-right}{caption-right%text}{inputs}
+\hgate{name}{fitlist-top}{caption-top%text}{fitlist-bottom}{caption-bottom%text}{inputs}
+\hgate[TikZ keys]{name}{fitlist-top}{caption-top%text}{fitlist-bottom}{caption-bottom%text}{inputs}
+\edge{inputs}{outputs}
+\edge[TikZ keys]{inputs}{outputs}
+\factoredge{inputs}{factors}{outputs}
+\factoredge[TikZ keys]{inputs}{factors}{outputs}

--- a/completion/tikzlibrarycircuits.ee.IEC.relay.cwl
+++ b/completion/tikzlibrarycircuits.ee.IEC.relay.cwl
@@ -1,0 +1,12 @@
+# circuits.ee.IEC.relay tikzlibrary
+# 2022/12/06 for v1.3
+
+#include:tikzlibrarycircuits.ee.IEC
+#include:tikzlibraryshapes.geometric
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\tikzset#c,\scoped#c
+circuit ee IEC relay
+every term/.style={%<TikZ keys%>}
+every term'/.style={%<TikZ keys%>}
+every term''/.style={%<TikZ keys%>}
+#endkeyvals

--- a/completion/tikzlibrarycircuits.plc.ladder.cwl
+++ b/completion/tikzlibrarycircuits.plc.ladder.cwl
@@ -1,0 +1,23 @@
+# circuits.plc.ladder tikzlibrary
+# 2022/12/09 for v1.3
+
+#include:tikzlibrarycircuits
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\tikzset#c,\scoped#c
+circuit plc ladder
+ladderrungsep=%<number%>
+#endkeyvals
+
+\ladderskip#L
+\ladderrungend{number}
+\ladderpowerrails
+
+#keyvals:\node#c
+symbol=%<symbol%>
+symbol color=#%color
+clksize=##L
+input sep=##L
+output sep=##L
+inputs={%<input1,input2,...%>}
+outputs={%<output1,output2,...%>}
+#endkeyvals

--- a/completion/tikzlibrarycircuits.plc.sfc.cwl
+++ b/completion/tikzlibrarycircuits.plc.sfc.cwl
@@ -1,0 +1,30 @@
+# circuits.plc.sfc tikzlibrary
+# 2022/12/09 for v1.0.1
+
+#include:tikzlibrarycircuits
+#include:tikzlibraryshapes.gates.ee
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\tikzset#c,\scoped#c
+circuit plc sfc
+sfcaqw=##L
+sfcanw=##L
+sfcah=##L
+time=%<time%>
+qualifier=#N,R,S,L,D,P,SD,DS,SL,P1,P0
+every sfcstep/.style={%<TikZ keys%>}
+every sfcstepi/.style={%<TikZ keys%>}
+every info/.style={%<TikZ keys%>}
+every info'/.style={%<TikZ keys%>}
+every sfctransition/.style={%<TikZ keys%>}
+every sfcaction/.style={%<TikZ keys%>}
+every sfcqualifier/.style={%<TikZ keys%>}
+every sfctime/.style={%<TikZ keys%>}
+every sfcactionname/.style={%<TikZ keys%>}
+#endkeyvals
+
+#keyvals:\node#c
+sfcstep={%<options%>}
+sfcstepi={%<options%>}
+sfctransition={%<options%>}
+sfcstar={%<options%>}
+#endkeyvals

--- a/completion/tikzlibraryext.calendar-plus.cwl
+++ b/completion/tikzlibraryext.calendar-plus.cwl
@@ -1,0 +1,19 @@
+# ext.calendar-plus tikzlibrary
+# 2022/12/09 for v0.4.2
+
+#include:tikzlibrarycalendar
+#include:pgfcalendar-ext
+
+\pgfmathweeksinmonthofyear{first weekday}{month}{year}#*
+\pgfmathlastdayinmonthofyear{month}{year}#*
+
+#keyvals:\calendar#c
+week code=%<code%>
+week text=%<text%>
+every week/.append style={%<TikZ keys%>}
+week label left
+#endkeyvals
+
+# not documented
+\tikzweekcode#*
+\tikzweektext#*

--- a/completion/tikzlibraryext.misc.cwl
+++ b/completion/tikzlibraryext.misc.cwl
@@ -1,0 +1,20 @@
+# ext.misc tikzlibrary
+# 2022/12/09 for v0.4.2
+
+# loads ext.pgfkeys-plus pgfkeyslibrary
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\tikzset#c,\scoped#c
+full arc
+full arc=%<number%>
+#endkeyvals
+
+\pgfmathstrrepeat{"text"}{number}#*
+\pgfmathisInString{"string"}{"text"}#*
+\pgfmathstrcat{"textA"}{"textB"}#*
+\pgfmathisEmpty{"text"}#*
+\pgfmathatanXY{x}{y}#*
+\pgfmathatanYX{y}{x}#*
+\pgfmathanglebetween{"p1"}{"p2"}#*
+\pgfmathqanglebetween{"p"}#*
+\pgfmathdistancebetween{"p1"}{"p2"}#*
+\pgfmathqdistancebetween{"p"}#*

--- a/completion/tikzlibraryext.node-families.shapes.geometric.cwl
+++ b/completion/tikzlibraryext.node-families.shapes.geometric.cwl
@@ -1,0 +1,5 @@
+# ext.node-families.shapes.geometric tikzlibrary
+# 2022/12/09 for v0.4.2
+
+#include:tikzlibraryext.node-families
+#include:tikzlibraryshapes.geometric

--- a/completion/tikzlibraryext.paths.arcto.cwl
+++ b/completion/tikzlibraryext.paths.arcto.cwl
@@ -1,0 +1,6 @@
+# ext.paths.arcto tikzlibrary
+# 2022/12/09 for v0.4.2
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\tikzset#c,\scoped#c
+every arc to/.style={%<TikZ keys%>}
+#endkeyvals

--- a/completion/tikzlibraryext.patterns.images.cwl
+++ b/completion/tikzlibraryext.patterns.images.cwl
@@ -1,0 +1,17 @@
+# ext.patterns.images tikzlibrary
+# 2022/12/09 for v0.4.2
+
+\pgfsetupimageaspattern{name}{imagefile}#g
+\pgfsetupimageaspattern[options%keyvals]{name}{imagefile}#g
+
+#keyvals:\pgfsetupimageaspattern
+height=##L
+width=##L
+page=%<page number%>
+interpolate#true,false
+mask=%<mask name%>
+#endkeyvals
+
+#keyvals:\node#c
+image as pattern={%<options%>}
+#endkeyvals

--- a/completion/tikzlibraryext.positioning-plus.cwl
+++ b/completion/tikzlibraryext.positioning-plus.cwl
@@ -1,0 +1,52 @@
+# ext.positioning-plus tikzlibrary
+# 2022/12/09 for v0.4.2
+
+#include:tikzlibrarypositioning
+#include:tikzlibraryfit
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\tikzset#c,\scoped#c,\path#c,\draw#c,\fill#c,\filldraw#c,\pattern#c,\shade#c,\shadedraw#c,\clip#c,\node#c,\coordinate#c,\nodepart#c,\pic#c,\matrix#c,\calendar#c,\chainin#c,\arrow#c,\arrowreversed#c
+corner above left
+corner above left=%<specification%>
+corner below left
+corner below left=%<specification%>
+corner above right
+corner above right=%<specification%>
+corner below right
+corner below right=%<specification%>
+north left
+north left=%<specification%>
+north right
+north right=%<specification%>
+south left
+south left=%<specification%>
+south right
+south right=%<specification%>
+west above
+west above=%<specification%>
+west below
+west below=%<specification%>
+east above
+east above=%<specification%>
+east below
+east below=%<specification%>
+corner north left
+corner north left=%<specification%>
+corner north right
+corner north right=%<specification%>
+corner south left
+corner south left=%<specification%>
+corner south right
+corner south right=%<specification%>
+corner west above
+corner west above=%<specification%>
+corner west below
+corner west below=%<specification%>
+corner east above
+corner east above=%<specification%>
+corner east below
+corner east below=%<specification%>
+fit bounding box=%<list of coords%>
+span vertical=%<list of coords%>
+span horizontal=%<list of coords%>
+span=%<list of coords%>
+#endkeyvals

--- a/completion/tikzlibraryext.scalepicture.cwl
+++ b/completion/tikzlibraryext.scalepicture.cwl
@@ -1,0 +1,24 @@
+# ext.scalepicture tikzlibrary
+# 2022/12/09 for v0.4.2
+
+\tikzextpicturewidth#L
+\tikzextpictureheight#L
+
+#keyvals:\begin{tikzpicture}#c
+save picture size
+picture width=##L
+minimum picture width=##L
+maximum picture width=##L
+picture height=##L
+minimum picture height=##L
+maximum picture height=##L
+minimum picture size={%<width%>}{%<height%>}
+maximum picture size={%<width%>}{%<height%>}
+picture width*=##L
+minimum picture width*=##L
+maximum picture width*=##L
+picture height*=##L
+minimum picture height*=##L
+maximum picture height*=##L
+picture size*={%<width%>}{%<height%>}
+#endkeyvals

--- a/completion/tikzlibraryext.shapes.circlearrow.cwl
+++ b/completion/tikzlibraryext.shapes.circlearrow.cwl
@@ -1,0 +1,21 @@
+# ext.shapes.circlearrow tikzlibrary
+# 2022/12/09 for v0.4.2
+
+#keyvals:\node#c,\coordinate#c,\nodepart#c,\pic#c
+circle arrow
+#endkeyvals
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\tikzset#c,\scoped#c,\node#c,\coordinate#c,\nodepart#c,\pic#c
+circle arrow start angle=%<degrees%>
+circle arrow end angle=%<degrees%>
+circle arrow delta angle=%<degrees%>
+circle arrow arrows=%<⟨start tip spec⟩-⟨end tip spec⟩%>
+circle arrow turn left north
+circle arrow turn left east
+circle arrow turn left west
+circle arrow turn left south
+circle arrow turn right north
+circle arrow turn right east
+circle arrow turn right west
+circle arrow turn right south
+#endkeyvals

--- a/completion/tikzlibraryext.shapes.circlecrosssplit.cwl
+++ b/completion/tikzlibraryext.shapes.circlecrosssplit.cwl
@@ -1,0 +1,11 @@
+# ext.shapes.circlecrosssplit tikzlibrary
+# 2022/12/09 for v0.4.2
+
+#keyvals:\node#c,\coordinate#c,\nodepart#c,\pic#c
+circle cross split
+#endkeyvals
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\tikzset#c,\scoped#c,\node#c,\coordinate#c,\nodepart#c,\pic#c
+circle cross split part fill={%<color1,color2,...%>}
+circle cross split uses custom fill#true,false
+#endkeyvals

--- a/completion/tikzlibraryext.shapes.heatmark.cwl
+++ b/completion/tikzlibraryext.shapes.heatmark.cwl
@@ -1,0 +1,16 @@
+# ext.shapes.heatmark tikzlibrary
+# 2022/12/09 for v0.4.2
+
+#keyvals:\node#c,\coordinate#c,\nodepart#c,\pic#c
+heatmark
+#endkeyvals
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\tikzset#c,\scoped#c,\node#c,\coordinate#c,\nodepart#c,\pic#c
+heatmark arcs=%<integer%>
+heatmark arc width=##L
+heatmark arc sep=##L
+heatmark arc rings=%<integer%>
+heatmark arc sep angle=%<degrees%>
+heatmark inner opacity=%<factor%>
+heatmark outer opacity=%<factor%>
+#endkeyvals

--- a/completion/tikzlibraryext.shapes.rectangleroundedcorners.cwl
+++ b/completion/tikzlibraryext.shapes.rectangleroundedcorners.cwl
@@ -1,0 +1,14 @@
+# ext.shapes.rectangleroundedcorners tikzlibrary
+# 2022/12/09 for v0.4.2
+
+#keyvals:\node#c,\coordinate#c,\nodepart#c,\pic#c
+rectangle with rounded corners
+#endkeyvals
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\tikzset#c,\scoped#c,\node#c,\coordinate#c,\nodepart#c,\pic#c
+rectangle with rounded corners north west radius=##L
+rectangle with rounded corners north east radius=##L
+rectangle with rounded corners south west radius=##L
+rectangle with rounded corners south east radius=##L
+rectangle with rounded corners radius=##L
+#endkeyvals

--- a/completion/tikzlibraryext.shapes.superellipse.cwl
+++ b/completion/tikzlibraryext.shapes.superellipse.cwl
@@ -1,0 +1,20 @@
+# ext.shapes.superellipse tikzlibrary
+# 2022/12/09 for v0.4.2
+
+#include:tikzlibraryshapes.geometric
+#include:tikzlibraryintersections
+
+#keyvals:\node#c,\coordinate#c,\nodepart#c,\pic#c
+superellipse
+#endkeyvals
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\tikzset#c,\scoped#c,\node#c,\coordinate#c,\nodepart#c,\pic#c
+superellipse x exponent=%<exponent%>
+superellipse y exponent=%<exponent%>
+superellipse step=%<integer%>
+superellipse exponent=%<exponent%>
+#endkeyvals
+
+\pgfmathsuperellipsex{t}{2/m}{r_x}#*
+\pgfmathsuperellipsey{t}{2/n}{r_y}#*
+\pgfmathsuperellipseXY{t}{2/m}{2/n}{a}{b}#*

--- a/completion/tikzlibraryext.shapes.uncenteredrectangle.cwl
+++ b/completion/tikzlibraryext.shapes.uncenteredrectangle.cwl
@@ -1,0 +1,11 @@
+# ext.shapes.uncenteredrectangle tikzlibrary
+# 2022/12/09 for v0.4.2
+
+#keyvals:\node#c,\coordinate#c,\nodepart#c,\pic#c
+uncentered rectangle
+#endkeyvals
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\tikzset#c,\scoped#c,\node#c,\coordinate#c,\nodepart#c,\pic#c
+uncentered rectangle center=#left,text,right,real
+uncentered rectangle center yshift=##L
+#endkeyvals

--- a/completion/tikzlibraryext.transformations.mirror.cwl
+++ b/completion/tikzlibraryext.transformations.mirror.cwl
@@ -1,0 +1,35 @@
+# ext.transformations.mirror tikzlibrary
+# 2022/12/09 for v0.4.2
+
+# loads ext.transformations.mirror pgflibrary
+
+#keyvals:\path#c,\draw#c,\fill#c,\filldraw#c,\pattern#c,\shade#c,\shadedraw#c,\clip#c,\node#c,\coordinate#c,\nodepart#c,\pic#c,\matrix#c,\calendar#c,\chainin#c,\arrow#c,\arrowreversed#c
+xmirror
+xmirror=%<val or coord%>
+ymirror
+ymirror=%<val or coord%>
+mirror x
+mirror x=%<coord%>
+mirror y
+mirror y=%<coord%>
+mirror=%<⟨pointA⟩%>--%<⟨pointB⟩%> 
+xMirror
+xMirror=%<val or coord%>
+yMirror
+yMirror=%<val or coord%>
+Mirror x
+Mirror x=%<coord%>
+Mirror y
+Mirror y=%<coord%>
+Mirror=%<⟨pointA⟩%>--%<⟨pointB⟩%> 
+#endkeyvals
+
+# from ext.transformations.mirror pgflibrary
+\pgftransformxmirror{value}#*
+\pgftransformymirror{value}#*
+\pgftransformmirror{pointA}{pointB}#*
+\pgfqtransformmirror{point}#*
+\pgftransformxMirror{value}#*
+\pgftransformyMirror{value}#*
+\pgftransformMirror{pointA}{pointB}#*
+\pgfqtransformMirror{point}#*

--- a/completion/tikzlibrarynef.cwl
+++ b/completion/tikzlibrarynef.cwl
@@ -1,0 +1,21 @@
+# nef tikzlibrary
+# 2022/12/09 for v0.1
+
+#include:tikzlibraryshadows
+#include:tikzlibraryshapes.geometric
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\tikzset#c,\scoped#c,\path#c,\draw#c,\fill#c,\filldraw#c,\pattern#c,\shade#c,\shadedraw#c,\clip#c,\node#c,\coordinate#c,\nodepart#c,\pic#c
+nef
+#endkeyvals
+
+#keyvals:\node#c,\coordinate#c,\nodepart#c,\pic#c
+ea
+ens
+ext
+net
+pnode
+rect
+#endkeyvals
+
+\fileversion#S
+\filedate#S

--- a/completion/tikzlibraryoptics.cwl
+++ b/completion/tikzlibraryoptics.cwl
@@ -1,0 +1,86 @@
+# optics tikzlibrary
+# 2022/12/09 for v0.2.3
+
+#include:tikzlibrarydecorations
+#include:tikzlibrarydecorations.markings
+#include:tikzlibrarydecorations.pathreplacing
+#include:etoolbox
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\scoped#c
+use optics
+#endkeyvals
+
+#keyvals:\node#c,\coordinate#c
+object height=##L
+object aspect ratio=%<number%>
+lens
+draw focal points
+draw focal points={%<TikZ keys%>}
+focal length=##L
+lens height=%<number%>
+lens type=#converging,diverging
+slit
+slit height=%<number%>
+double slit
+slit separation=%<number%>
+mirror
+mirror decoration separation=%<number%>
+mirror decoration amplitude=%<number%>
+spherical mirror
+spherical mirror angle=%<degrees%>
+spherical mirror type=#concave,convex
+concave mirror
+convex mirror
+spherical mirror orientation=#ltr,rtl
+draw mirror center
+draw mirror center={%<TikZ keys%>}
+draw mirror focus
+draw mirror focus={%<TikZ keys%>}
+polarizer
+beam splitter
+double amici prism
+prism height=##L
+prism apex angle=%<degrees%>
+thin optics element
+thick optics element
+heat filter
+screen
+diffraction grating
+grid
+semi-transparent mirror
+diaphragm
+generic optics io
+io body height=##L
+io body aspect ratio=%<number%>
+io aperture width=%<number%>
+io aperture height=%<number%>
+io aperture shift=%<number%>
+io orientation=#ltr,rtl
+sensor line
+sensor line height=##L
+sensor line aspect ratio=%<number%>
+sensor line pixel number=%<number%>
+sensor line pixel width=%<number%>
+sensor line inner ysep=%<number%>
+generic sensor
+generic lamp
+halogen lamp
+spectral lamp
+laser
+laser'
+#endkeyvals
+
+#keyvals:\draw#c
+->-
+-<-
+->>-
+-<<-
+->n={n=%<〈num〉,〈specs〉%>}
+-<n={n=%<〈num〉,〈specs〉%>}
+put arrow
+put arrow={%<options%>}
+put coordinate=%<coord%> at %<position%>
+#endkeyvals
+
+\tikzopticsversiondate#S
+\tikzopticsversion#S

--- a/completion/tikzlibrarypenrose.cwl
+++ b/completion/tikzlibrarypenrose.cwl
@@ -1,0 +1,84 @@
+# penrose tikzlibrary
+# 2022/12/09 for v1.4
+
+#include:tikzlibraryspath3
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\tikzset#c,\scoped#c
+every Penrose tile/.style={%<TikZ keys%>}
+Penrose tile %<<n>%>/.style={%<TikZ keys%>}
+every Penrose pic/.style={%<TikZ keys%>}
+every kite/.style={%<TikZ keys%>}
+every dart/.style={%<TikZ keys%>}
+every thin rhombus/.style={%<TikZ keys%>}
+every thick rhombus/.style={%<TikZ keys%>}
+every pentagon 5/.style={%<TikZ keys%>}
+every pentagon 3/.style={%<TikZ keys%>}
+every pentagon 2/.style={%<TikZ keys%>}
+every pentagram/.style={%<TikZ keys%>}
+every boat/.style={%<TikZ keys%>}
+every diamond/.style={%<TikZ keys%>}
+every golden triangle/.style={%<TikZ keys%>}
+every reverse golden triangle/.style={%<TikZ keys%>}
+every golden gnomon/.style={%<TikZ keys%>}
+every reverse golden gnomon/.style={%<TikZ keys%>}
+every circle arc/.style={%<TikZ keys%>}
+every long arc/.style={%<TikZ keys%>}
+Penrose step=##L
+#endkeyvals
+
+\BakePenroseTile{name%keyvals}
+
+#keyvals:\BakePenroseTile#c,\pic#c
+kite
+dart
+thin rhombus
+thick rhombus
+pentagon 5
+pentagon 3
+pentagon 2
+pentagram
+boat
+diamond
+golden triangle
+reverse golden triangle
+golden gnomon
+reverse golden gnomon
+%penrosetilename
+#endkeyvals
+
+#keyvals:\pic#c
+align with=%<tile%> along %<edge%>
+align with=%<tile%> along %<edge%> using %<number%>
+#endkeyvals
+
+\PenroseDecomposition{type%keyvals}{level}{seed}
+\PenroseDecomposition[TikZ keys]{type%keyvals}{level}{seed}
+
+#keyvals:\PenroseDecomposition#c
+kite
+rhombus
+pentagon
+ktriangle
+rtriangle
+#endkeyvals
+
+#keyvals:\path#c
+save Penrose path=%<edge%>
+#endkeyvals
+
+#keyvals:\tikzset#c
+clone Penrose side path={%<target%>}{%<source%>}
+clone Penrose tile path={%<target%>}{%<source%>}
+#endkeyvals
+
+\DefineTile{name}{sides}{coordinates}#s#%penrosetilename
+
+# not documented
+\SetPenrosePath{arg}#S
+\UsePenroseTile{arg}#S
+\UsePenroseTile[opt]{arg}#S
+\TransformAlongSide{arg1}{arg2}#S
+\CoordinatesAtVertices{arg}#S
+
+# deprecated
+\MakePenroseTile{name}#S

--- a/completion/tikzlibraryswigs.cwl
+++ b/completion/tikzlibraryswigs.cwl
@@ -1,0 +1,41 @@
+# swigs tikzlibrary
+# 2022/12/06 for v2021-07-09
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\tikzset#c,\scoped#c,\node#c
+swig hsplit={%<options%>}
+swig vsplit={%<options%>}
+#endkeyvals
+
+\pgfnodepartlowerbox#S
+\pgfnodepartupperbox#S
+\upper#S
+\uppercolor#S
+\lowercolor#S
+\upperfillcolor#S
+\lowerfillcolor#S
+\linewidthupper#S
+\linewidthlower#S
+\uppercenterpoint#S
+\greaterlinewidth#S
+\gapcenter#S
+\basepointlower#S
+\midpointlower#S
+\defaultpgflinewidth#S
+\pgfnodepartleftbox#S
+\pgfnodepartrightbox#S
+\leftcolor#S
+\rightcolor#S
+\leftfillcolor#S
+\rightfillcolor#S
+\gap#S
+\linewidthleft#S
+\linewidthright#S
+\vsplitangle#S
+\centerleftgapside#S
+\globalcenterpoint#S
+\linewidthatwidestcenter#S
+\leftcenter#S
+\rightcenter#S
+\basepointright#S
+\midpointleft#S
+\midpointright#S

--- a/completion/tikzlibraryswitching-architectures.cwl
+++ b/completion/tikzlibraryswitching-architectures.cwl
@@ -1,0 +1,63 @@
+# switching-architectures tikzlibrary
+# 2022/12/08 for v0.7a
+
+#include:tikzlibrarybackgrounds
+#include:tikzlibrarycalc
+#include:tikzlibrarypositioning
+#include:tikzlibrarydecorations.pathreplacing
+
+#keyvals:\node#c
+clos snb
+clos rear
+benes
+benes complete
+banyan omega
+banyan flip
+clos snb example
+clos rear example
+clos example with labels
+#endkeyvals
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\tikzset#c,\scoped#c,\node#c
+N=%<num input ports%>
+M=%<num output ports%>
+r1=%<num modules%>
+r3=%<num modules%>
+P=%<num ports%>
+module size=##L
+module ysep=%<number%>
+module xsep=%<number%>
+module label opacity=%<factor%>
+pin length factor=%<factor%>
+module font=%<font commands%>
+connections disabled#true,false
+N label=%<text%>
+r1 label=%<text%>
+m1 label=%<text%>
+r2 label=%<text%>
+M label=%<text%>
+r3 label=%<text%>
+m3 label=%<text%>
+set math mode labels#true,false
+#endkeyvals
+
+\pgfmathomegarotation{degrees}{bits}{macro}#S
+\rone#S
+\ronelabel#S
+\monelabel#S
+\rtwolabel#S
+\M#S
+\Mlabel#S
+\rthree#S
+\rthreelabel#S
+\mthreelabel#S
+\P#S
+\modulesize#S
+\moduleysep#S
+\modulexsep#S
+\modulefont#S
+\modulelabelopacity#S
+\pinlength#S
+\ifconnectiondisabled#S
+\connectiondisabledtrue#S
+\connectiondisabledfalse#S

--- a/completion/tikzlibrarytqft.cwl
+++ b/completion/tikzlibrarytqft.cwl
@@ -1,0 +1,65 @@
+# tqft tikzlibrary
+# 2022/12/09 for v2.1
+
+#include:tikzlibraryshapes.geometric
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\tikzset#c,\scoped#c
+every tqft/.style={%<TikZ keys%>}
+tqft/every boundary component/.style={%<TikZ keys%>}
+tqft/every incoming boundary component/.style={%<TikZ keys%>}
+tqft/every outgoing boundary component/.style={%<TikZ keys%>}
+tqft/every lower boundary component/.style={%<TikZ keys%>}
+tqft/every incoming lower boundary component/.style={%<TikZ keys%>}
+tqft/every outgoing lower boundary component/.style={%<TikZ keys%>}
+tqft/every upper boundary component/.style={%<TikZ keys%>}
+tqft/every incoming upper boundary component/.style={%<TikZ keys%>}
+tqft/every outgoing upper boundary component/.style={%<TikZ keys%>}
+#endkeyvals
+
+#keyvals:\node#c,\coordinate#c,\pic#c
+tqft/pair of pants
+tqft/reverse pair of pants
+tqft/cylinder to prior
+tqft/cylinder to next
+tqft/cylinder
+tqft/cap
+tqft/cup
+#endkeyvals
+
+#keyvals:\begin{tikzpicture}#c,\tikz#c,\begin{scope}#c,\tikzset#c,\scoped#c,\node#c,\coordinate#c,\pic#c
+tqft/view from=#incoming,outgoing
+tqft/cobordism height=##L
+tqft/boundary separation=##L
+tqft/circle x radius=##L
+tqft/circle y radius=##L
+tqft/incoming boundary components=%<integer%>
+tqft/skip incoming boundary components=%<integer%>
+tqft/outgoing boundary components=%<integer%>
+tqft/skip outgoing boundary components=%<integer%>
+tqft/offset=%<number%>
+tqft/genus=%<integer%>
+tqft/incoming boundary component %<<n>%>/.style={%<TikZ keys%>}
+tqft/outgoing boundary component %<<n>%>/.style={%<TikZ keys%>}
+tqft/incoming lower boundary component %<<n>%>/.style={%<TikZ keys%>}
+tqft/outgoing lower boundary component %<<n>%>/.style={%<TikZ keys%>}
+tqft/cobordism/.style={%<TikZ keys%>}
+tqft/genus upper/.style={%<TikZ keys%>}
+tqft/genus lower/.style={%<TikZ keys%>}
+tqft/hole %<<n>%>/.style={%<TikZ keys%>}
+tqft/hole %<<n>%> upper/.style={%<TikZ keys%>}
+tqft/hole %<<n>%> lower/.style={%<TikZ keys%>}
+tqft/cobordism edge/.style={%<TikZ keys%>}
+tqft/cobordism outer edge/.style={%<TikZ keys%>}
+tqft/between incoming/.style={%<TikZ keys%>}
+tqft/between outgoing/.style={%<TikZ keys%>}
+tqft/between incoming and outgoing/.style={%<TikZ keys%>}
+tqft/between incoming %<<n>%> and %<<n+1>%>/.style={%<TikZ keys%>}
+tqft/between outgoing %<<n>%> and %<<n+1>%>/.style={%<TikZ keys%>}
+tqft/between first incoming and first outgoing/.style={%<TikZ keys%>}
+tqft/between first incoming and first outgoing/.style={%<TikZ keys%>}
+tqft/between last incoming and last outgoing/.style={%<TikZ keys%>}
+tqft/between first and last incoming/.style={%<TikZ keys%>}
+tqft/between first and last outgoing/.style={%<TikZ keys%>}
+tqft/incoming upper boundary component %<<n>%>/.style={%<TikZ keys%>}
+tqft/outgoing upper boundary component %<<n>%>/.style={%<TikZ keys%>}
+#endkeyvals


### PR DESCRIPTION
New cwls for package `sa-tikz`, `struktex`, `struktxf`, and `struktxp`, and tikzlibraries `bayesnet`, `circuits.ee.IEC.relay`, `circuits.plc.ladder`, `circuits.plc.sfc`, the `tikz-ext` bundle, `nef`, `optics`, `penrose`, `swigs`, `switching-architectures`, and `tqft`.