### PR TITLE
add completion support for pgfplots and tcolorbox libraries

### DIFF
--- a/completion/pgfplots.cwl
+++ b/completion/pgfplots.cwl
@@ -789,7 +789,7 @@ enable tick line clipping#true,false
 # no new user commands
 
 ## pgfplotslibrary.code.tex
-\usepgfplotslibrary{library list%keyvals}
+\usepgfplotslibrary{library list%keyvals}#u
 \pgfplotsiflibraryloaded{library%keyvals}{true}{false}#*
 #keyvals:\usepgfplotslibrary#c,\pgfplotsiflibraryloaded#c
 clickable

--- a/completion/tcolorbox.cwl
+++ b/completion/tcolorbox.cwl
@@ -310,7 +310,7 @@
 #endif
 
 # << Libraries >>
-\tcbuselibrary{%<library%>%keys}
+\tcbuselibrary{%<library%>%keys}#u
 #keyvals:\tcbuselibrary,\usepackage/tcolorbox#c
 skins
 vignette

--- a/src/latexdocument.cpp
+++ b/src/latexdocument.cpp
@@ -979,14 +979,22 @@ bool LatexDocument::patchStructure(int linenr, int count, bool recheck)
 				completerNeedsUpdate = true;
 				QStringList packagesHelper = firstArg.split(",");
 
-				if (cmd.endsWith("theme")) { // special treatment for  \usetheme
+				if (cmd.endsWith("theme")) { // special treatment for \usetheme
 					QString preambel = cmd;
 					preambel.remove(0, 4);
 					preambel.prepend("beamer");
                     packagesHelper.replaceInStrings(QRegularExpression("^"), preambel);
 				}
-                if (cmd=="\\usetikzlibrary") { // special treatment for  \usetheme
+                if (cmd=="\\usetikzlibrary") { // special treatment for \usetikzlibrary
                     QString preambel = "tikzlibrary";
+                    packagesHelper.replaceInStrings(QRegularExpression("^"), preambel);
+                }
+		if (cmd=="\\usepgfplotslibrary") { // special treatment for \usepgfplotslibrary
+                    QString preambel = "pgfplotslibrary";
+                    packagesHelper.replaceInStrings(QRegularExpression("^"), preambel);
+                }
+		if (cmd=="\\tcbuselibrary") { // special treatment for \tcbuselibrary
+                    QString preambel = "tcolorboxlibrary";
                     packagesHelper.replaceInStrings(QRegularExpression("^"), preambel);
                 }
 


### PR DESCRIPTION
Makes completion possible for pgfplots and tcolorbox libraries, so `\usepgfplotslibrary{clickable}` will load `pgfplotslibraryclickable.cwl` and `\tcbuselibrary{minted}` will load `tcolorboxlibraryminted.cwl`.

I had trouble building (perhaps the [Ubuntu instructions](https://github.com/texstudio-org/texstudio/wiki/Compiling#ubuntu) could be updated) so wasn't able to test, but based on the analogous [commit](https://github.com/texstudio-org/texstudio/commit/74b4042daef8e2df5614354748a15a16b1671baf) for tikzlibraries I think it should be okay.