### PR TITLE
add completion localization for `tabularray` libraries

### DIFF
--- a/completion/tabularray.cwl
+++ b/completion/tabularray.cwl
@@ -406,10 +406,7 @@ hang=##L
 \MapTblrRemarks{code}#*
 
 \NewTblrLibrary{name}{code}#*
-\UseTblrLibrary{library%keyvals}
-# note \UseTblrLibrary is not a package loading command, however each tblrlibrary
-# except "counter" loads the package of the same name, so the #u designation is convenient
-\UseTblrLibrary{package}#Su
+\UseTblrLibrary{library%keyvals}#u
 
 #keyvals:\UseTblrLibrary#c
 amsmath

--- a/src/latexdocument.cpp
+++ b/src/latexdocument.cpp
@@ -997,6 +997,10 @@ bool LatexDocument::patchStructure(int linenr, int count, bool recheck)
                     QString preambel = "tcolorboxlibrary";
                     packagesHelper.replaceInStrings(QRegularExpression("^"), preambel);
                 }
+		if (cmd=="\\UseTblrLibrary") { // special treatment for \UseTblrLibrary
+                    QString preambel = "tabularraylibrary";
+                    packagesHelper.replaceInStrings(QRegularExpression("^"), preambel);
+                }
 
 				QString firstOptArg = Parsing::getArg(args, dlh, 0, ArgumentList::Optional);
 				if (cmd == "\\documentclass") {


### PR DESCRIPTION
In line with recently added support for `\usetikzlibrary` and so on, makes `\UseTblrLibrary{amsmath}` load `tabularraylibraryamsmath.cwl`.