### PR TITLE
fix side panel title when changing grid size in config

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -11059,7 +11059,11 @@ void Texstudio::changeSymbolGridIconSize(int value, bool changePanel)
 	int iconWidth=qRound(value*scale);
 
 	if (changePanel) {
-		leftPanel->setCurrentWidget(leftPanel->widget("symbols"));
+		QWidget *sympanel = leftPanel->widget("symbols");
+		if ( !leftPanel->hiddenWidgets().split("|").contains(sympanel->property("id").toString()) ) {
+			leftPanel->setCurrentWidget(sympanel);
+			emit leftPanel->titleChanged(sympanel->property("Name").toString());
+		}
 	}
 	symbolWidget->setSymbolSize(iconWidth);
 }


### PR DESCRIPTION
This PR fixes #2743. When changing the grid size in the config we first have to check if the symbols view is not hidden in the left panel. If not we can switch to that view and update the side panel title appropriate.