### PR TITLE
use position of edit context menu for preview actions

### DIFF
--- a/src/latexeditorview.cpp
+++ b/src/latexeditorview.cpp
@@ -541,40 +541,38 @@ bool DefaultInputBinding::contextMenuEvent(QContextMenuEvent *event, QEditor *ed
 		}
 		{
 			//	copy managed action "previewLatex" from texstudio.cpp
-//			QAction *act = new QAction(LatexEditorView::tr("Pre&view Selection/Parentheses"));
-			QAction *act = new QAction();
-			act->setData(QPoint(cursor.anchorLineNumber(), cursor.anchorColumnNumber()));
-			edView->connect(act, SIGNAL(triggered()), edView, SLOT(triggeredPreviewLatex()));
-			int i = -1;
+			int i = 0;
 			foreach (QAction *baseAct, baseActions) {
-				i++;
-				if (baseAct->objectName().endsWith("previewLatex")) {
+				if (baseAct->objectName().endsWith("/previewLatex")) {
+					QAction *act = new QAction();
 					act->setObjectName(baseAct->objectName());
 					act->setText(baseAct->text());
 					act->setShortcut(baseAct->shortcut());
+					act->setData(QPoint(cursor.anchorLineNumber(), cursor.anchorColumnNumber()));
+					edView->connect(act, SIGNAL(triggered()), edView, SLOT(triggeredPreviewLatex()));
 					baseActions[i] = act;
 					break;
 				}
+				i++;
 			}
 		}
 		
 		{
 			//	copy managed action "removePreviewLatex" from texstudio.cpp
-//			QAction *act = new QAction(LatexEditorView::tr("C&lear Inline Preview"));
-			QAction *act = new QAction();
 			isPicMenu = false;
-			act->setData( QVariantList() << QVariant(QPoint(cursor.anchorLineNumber(), cursor.anchorColumnNumber())) << QVariant(isPicMenu) );
-			edView->connect(act, SIGNAL(triggered()), edView, SLOT(triggeredClearPreview()));
-			int i = -1;
+			int i = 0;
 			foreach (QAction *baseAct, baseActions) {
-				i++;
-				if (baseAct->objectName().endsWith("removePreviewLatex")) {
+				if (baseAct->objectName().endsWith("/removePreviewLatex")) {
+					QAction *act = new QAction();
 					act->setObjectName(baseAct->objectName());
 					act->setText(baseAct->text());
 					act->setShortcut(baseAct->shortcut());
+					act->setData( QVariantList() << QVariant(QPoint(cursor.anchorLineNumber(), cursor.anchorColumnNumber())) << QVariant(isPicMenu) );
+					edView->connect(act, SIGNAL(triggered()), edView, SLOT(triggeredClearPreview()));
 					baseActions[i] = act;
 					break;
 				}
+				i++;
 			}
 		}
 

--- a/src/latexeditorview.h
+++ b/src/latexeditorview.h
@@ -336,7 +336,7 @@ signals:
 	void openCompleter();
 	void thesaurus(int line, int col);
 	void previewlatex(int line, int col);
-	void clearpreview(int line, int col, bool isPicMenu);
+	void clearpreview(int startLine, int endLine);
 	void changeDiff(QPoint pt);
 	void spellerChanged(const QString &name);
 	void gotoDefinition(QDocumentCursor c);

--- a/src/latexeditorview.h
+++ b/src/latexeditorview.h
@@ -236,6 +236,8 @@ private slots:
 	void lineMarkClicked(int line);
 	void lineMarkToolTip(int line, int mark);
 	void triggeredThesaurus();
+	void triggeredPreviewLatex();
+	void triggeredClearPreview();
 	void reloadSpeller();
 	void changeSpellingDict(const QString &name);
 	void copyImageFromAction();
@@ -333,6 +335,8 @@ signals:
 	void openFile(const QString &baseName, const QString &defaultExtension);
 	void openCompleter();
 	void thesaurus(int line, int col);
+	void previewlatex(int line, int col);
+	void clearpreview(int line, int col, bool isPicMenu);
 	void changeDiff(QPoint pt);
 	void spellerChanged(const QString &name);
 	void gotoDefinition(QDocumentCursor c);

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -2005,7 +2005,7 @@ void Texstudio::configureNewEditorViewEnd(LatexEditorView *edit, bool reloadFrom
     connect(edit->document, SIGNAL(encodingChanged()), this, SLOT(updateStatusBarEncoding()));
     connect(edit, SIGNAL(thesaurus(int,int)), this, SLOT(editThesaurus(int,int)));
     connect(edit, SIGNAL(previewlatex(int,int)), this, SLOT(previewLatex(int,int)));
-    connect(edit, SIGNAL(clearpreview(int,int, bool)), this, SLOT(clearPreview(int,int,bool)));
+    connect(edit, SIGNAL(clearpreview(int,int)), this, SLOT(clearPreview(int,int)));
     connect(edit, SIGNAL(changeDiff(QPoint)), this, SLOT(editChangeDiff(QPoint)));
     connect(edit, SIGNAL(saveCurrentCursorToHistoryRequested()), this, SLOT(saveCurrentCursorToHistory()));
     connect(edit->document,SIGNAL(structureUpdated(LatexDocument*)),this,SLOT(updateTOCs()));
@@ -8460,30 +8460,19 @@ void Texstudio::previewAvailable(const QString &imageFile, const PreviewSource &
 	}
 }
 
-void Texstudio::clearPreview(int line, int col, bool isPicMenu)
+void Texstudio::clearPreview(int startLine, int endLine)
 {
 	QEditor *edit = currentEditor();
 	if (!edit) return;
 
-	int startLine = 0;
-	int endLine = 0;
-
-	if (isPicMenu) {
-		// inline preview context menu supplies the calling point in doc coordinates as data
-		startLine = edit->document()->indexOf(edit->lineAtPosition(QPoint(line, col)));
-		// slight performance penalty for use of lineNumber(), which is not stictly necessary because
-		// we convert it back to a QDocumentLine, but easier to handle together with the other cases
-		endLine = startLine;
-	} else if (edit->cursor().hasSelection()) {
+	if (edit->cursor().hasSelection()) {
 		startLine = edit->cursor().selectionStart().lineNumber();
 		endLine = edit->cursor().selectionEnd().lineNumber();
 	} else {
-		if (line > -1 && col > -1) {
-			startLine = line;
-		} else {
+		if (startLine == -1 && endLine == -1) {
 			startLine = edit->cursor().lineNumber();
+			endLine = startLine;
 		}
-		endLine = startLine;
 	}
 
         for (int i = startLine; i <= endLine; i++) {

--- a/src/texstudio.h
+++ b/src/texstudio.h
@@ -581,7 +581,7 @@ protected slots:
 
 	void previewLatex(int line=-1, int col=-1);
 	void previewAvailable(const QString &imageFile, const PreviewSource &source);
-	void clearPreview(int line=-1, int col=-1, bool isPicMenu=false);
+	void clearPreview(int startLine=-1, int endLine=-1);
 	void showPreview(const QString &text);
 	void showPreview(const QDocumentCursor &c);
 	void showPreview(const QDocumentCursor &c, bool addToList);

--- a/src/texstudio.h
+++ b/src/texstudio.h
@@ -579,9 +579,9 @@ protected slots:
 	void saveCurrentCursorToHistory();
 	void saveEditorCursorToHistory(LatexEditorView *edView);
 
-	void previewLatex();
+	void previewLatex(int line=-1, int col=-1);
 	void previewAvailable(const QString &imageFile, const PreviewSource &source);
-	void clearPreview();
+	void clearPreview(int line=-1, int col=-1, bool isPicMenu=false);
 	void showPreview(const QString &text);
 	void showPreview(const QDocumentCursor &c);
 	void showPreview(const QDocumentCursor &c, bool addToList);


### PR DESCRIPTION
This PR resolves #2794. This is done by replacing in the context menu the original main menu entries with entries which use new slots. These slots pass the coordinates of the context menu to the preview/remove preview functions. The latter also needs information what type the coordinates are, because different coordinate systems are used for the editor and the inline preview.
 
BTW it seems that no one ever noticed that two entries of the preview context menu are not translatable. This should be possible now either:

![grafik](https://user-images.githubusercontent.com/102688820/209571168-de9ce3e6-bd7a-4426-97b8-f52f1c58fcbc.png)

Key accelerators for these are also added.
