### PR TITLE
Reduced precision in file time change filter

### DIFF
--- a/src/qcodeedit/lib/qreliablefilewatch.cpp
+++ b/src/qcodeedit/lib/qreliablefilewatch.cpp
@@ -197,7 +197,9 @@ void QReliableFileWatch::sourceChanged(const QString& filepath)
 
 	qDebug("%s modified.", qPrintable(filepath));
 	QFileInfo info(filepath);
-	if(it->lastModified==info.lastModified() && it->size==info.size()){
+	// (issue #2805) when using e.g. cloud storage, clashes between mtime precision of different file-systems can occur.
+    // assume no more than 1 second precision. If new time is older than cached time, ignore.
+    if(it->lastModified.secsTo(info.lastModified()) < 1 && it->size == info.size()) {
 		qDebug("filtered");
 		return;
 	}

--- a/src/qcodeedit/lib/qreliablefilewatch.cpp
+++ b/src/qcodeedit/lib/qreliablefilewatch.cpp
@@ -198,8 +198,8 @@ void QReliableFileWatch::sourceChanged(const QString& filepath)
 	qDebug("%s modified.", qPrintable(filepath));
 	QFileInfo info(filepath);
 	// (issue #2805) when using e.g. cloud storage, clashes between mtime precision of different file-systems can occur.
-    // assume no more than 1 second precision. If new time is older than cached time, ignore.
-    if(it->lastModified.secsTo(info.lastModified()) < 1 && it->size == info.size()) {
+	// assume no more than 1 second precision. If new time is older than cached time, ignore.
+	if(it->lastModified.secsTo(info.lastModified()) < 1 && it->size == info.size()) {
 		qDebug("filtered");
 		return;
 	}


### PR DESCRIPTION
Changes condition

https://github.com/texstudio-org/texstudio/blob/78ef1555f5bf9aaf0784f66cd82ef983fde898b1/src/qcodeedit/lib/qreliablefilewatch.cpp#L200

to require a file time change greater than 1 (positive) second. This way, issues with cloud storage that may be backed by file systems with lower/higher mtime precision than the local file system are avoided. Fixes #2805. If the new time is older than the cached time, ignore the change, as we are by definition "newer".