### PR TITLE
use position of selection instead of context menu

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -8475,14 +8475,14 @@ void Texstudio::clearPreview()
 
     LatexEditorView *edView=currentEditorView();
     int row=edView->getLineRowforContexMenu();
-    if (row>=0) {
+    if (edit->cursor().hasSelection()) {
+		startLine = edit->cursor().selectionStart().lineNumber();
+		endLine = edit->cursor().selectionEnd().lineNumber();
+	} else if (row>=0) {
         // inline preview context menu supplies the calling point as row/col in LatexEditorView member variable
         // That variable is only >-1 when context menu is active
         startLine = row;
 		endLine = startLine;
-	} else if (edit->cursor().hasSelection()) {
-		startLine = edit->cursor().selectionStart().lineNumber();
-		endLine = edit->cursor().selectionEnd().lineNumber();
 	} else {
 		startLine = edit->cursor().lineNumber();
 		endLine = startLine;

--- a/utilities/manual/CHANGELOG.txt
+++ b/utilities/manual/CHANGELOG.txt
@@ -11,6 +11,7 @@ TeXstudio 4.5.1
 - show macro name in completer list (#2679)
 - show macro trigger and shortcut in configuration window (#2635)
 - fix wrong side panel title when changing grid size in config (#2743)
+- preview/clear preview now use position of context menu as reference (#2794)
 
 TeXstudio 4.4.1
 -----------------


### PR DESCRIPTION
This adopts the behavior of starting preview via context menu when deleting the preview. Now in both cases if there is a selection then the position of the selection is used, not that of the context menu. Thus you can make a selection, preview it (even if the context menu is opened with the cursor over a begin{xyz} not contained in the selection) and then remove the preview without having to move the pointer over the selected text (or the preview image). This had already been implemented in PR #2803 which had been changed.
This finally closes #2794.