### PR TITLE
new cwls

### DIFF
--- a/completion/ProfLycee.cwl
+++ b/completion/ProfLycee.cwl
@@ -1,5 +1,5 @@
 # ProfLycee package
-# Matthew Bertucci 2022/12/19 for v2.1.0
+# Matthew Bertucci 2023/01/01 for v2.1.3
 
 #include:mathtools
 #include:xcolor
@@ -233,6 +233,7 @@ HautRes=%<hauteur%>
 
 #keyvals:\begin{CodePiton}
 Lignes#true,false
+Gobble#true,false
 Largeur=##L
 TaillePolice=%<font commands%>
 Alignement=#justify,left,flush left,right,flush right,center,flush center
@@ -399,6 +400,8 @@ Affs#true,false
 #keyvals:\AxesTikz
 Epaisseur=##L
 Police=%<font commands%>
+ElargirOx=%<num%>
+ElargirOy=%<num%>
 Labelx=%<text%>
 Labely=%<text%>
 AffLabel=#x,y,xy
@@ -424,10 +427,10 @@ Annee#true,false
 #endkeyvals
 
 \FenetreTikz
-\FenetreSimpleTikz{liste abscisses}{liste ordonnées}
-\FenetreSimpleTikz{liste abscisses}<options axe Oy>{liste ordonnées}
-\FenetreSimpleTikz<options axe Ox>{liste abscisses}{liste ordonnées}
-\FenetreSimpleTikz<options axe Ox>{liste abscisses}<options axe Oy>{liste ordonnées}
+\FenetreSimpleTikz{liste valx}{liste valy}
+\FenetreSimpleTikz<opt axe Ox>{liste valx}<opt axe Oy>{liste valy}
+\FenetreSimpleTikz(opt axes)<opt axe Ox>{liste valx}<opt axe Oy>{liste valy}
+\FenetreSimpleTikz[opt](opt axes)<opt axe Ox>{liste valx}<opt axe Oy>{liste valy}
 
 \OrigineTikz#*
 \OrigineTikz[options%keyvals]#*
@@ -724,6 +727,15 @@ Anegatif#true,false
 ## Simplification de racines ##
 \SimplificationRacine{expression ou calcul}
 
+## Mesure principale d’un angle ##
+\MesurePrincipale{angle}
+\MesurePrincipale[options%keyvals]{angle}
+
+#keyvals:\MesurePrincipale
+d#true,false
+Crochets#true,false
+#endkeyvals
+
 ## PixelART via un fichier csv, en TikZ ##
 \PixelArtTikz{file}#i
 \PixelArtTikz[options%keyvals]{file}#i
@@ -935,6 +947,12 @@ vertcapyt#B
 \algomathttPL{text%plain}#S
 \axesafflabel#S
 \axesechellefleche#S
+\axeselargx#S
+\axeselargy#S
+\axesenlargxD#S
+\axesenlargxG#S
+\axesenlargyD#S
+\axesenlargyG#S
 \axesfont#S
 \axeslabelx#S
 \axeslabely#S

--- a/completion/beamerthemeBerlinFU.cwl
+++ b/completion/beamerthemeBerlinFU.cwl
@@ -7,13 +7,6 @@ compress
 
 # passes table option to xcolor
 #include:colortbl
-\rowcolors[commands]{row}{even-row-color}{odd-row-color}
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*[commands]{row}{even-row-color}{odd-row-color}
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum
 
 # from BerlinFU colortheme
 FUblue#B

--- a/completion/bfhlayout.cwl
+++ b/completion/bfhlayout.cwl
@@ -48,17 +48,6 @@ BFH-Title#B
 
 # from table option of xcolor
 #include:colortbl
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum
 
 # from tabular bfhmodule
 BFH-table#B

--- a/completion/byzantinemusic.cwl
+++ b/completion/byzantinemusic.cwl
@@ -3472,14 +3472,3 @@ Teal#B
 
 # from table option of xcolor
 #include:colortbl
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum

--- a/completion/calctab.cwl
+++ b/completion/calctab.cwl
@@ -48,14 +48,3 @@ until=%<row id%>
 
 # from table option of xcolor
 #include:colortbl
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum

--- a/completion/class-FUbeamer.cwl
+++ b/completion/class-FUbeamer.cwl
@@ -144,13 +144,6 @@ decodearray={%<color array%>}
 
 # passes table option to xcolor
 #include:colortbl
-\rowcolors[commands]{row}{even-row-color}{odd-row-color}
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*[commands]{row}{even-row-color}{odd-row-color}
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum
 
 # from T1 option of fontenc
 \DH#n

--- a/completion/class-FUpowerdot.cwl
+++ b/completion/class-FUpowerdot.cwl
@@ -115,17 +115,6 @@ decodearray={%<color array%>}
 
 # from table option of xcolor
 #include:colortbl
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum
 
 # from T1 option of fontenc
 \DH#n

--- a/completion/class-bewerbung.cwl
+++ b/completion/class-bewerbung.cwl
@@ -364,17 +364,6 @@ Purple0#B
 # other xcolor options loaded via lebenslaufXcolor=...
 #ifOption:lebenslaufXcolor=table
 #include:colortbl
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum
 #endif
 
 #ifOption:lebenslaufXcolor=fixpdftex

--- a/completion/class-bfhbeamer.cwl
+++ b/completion/class-bfhbeamer.cwl
@@ -91,14 +91,3 @@ BFH-tablehead#B
 
 # from table option of xcolor
 #include:colortbl
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum

--- a/completion/class-elpres.cwl
+++ b/completion/class-elpres.cwl
@@ -135,13 +135,6 @@ eptitlecolor#B
 # from xcolor options
 #ifOption:table
 #include:colortbl
-\rowcolors[commands]{row}{even-row-color}{odd-row-color}
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*[commands]{row}{even-row-color}{odd-row-color}
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum
 #endif
 #ifOption:fixpdftex
 #include:pdfcolmk

--- a/completion/class-emisa.cwl
+++ b/completion/class-emisa.cwl
@@ -512,17 +512,6 @@ boxbgcolor#B
 
 # from table option of xcolor
 #include:colortbl
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum
 
 # from style=emisa option of biblatex
 \bibitemlabel{text}#*

--- a/completion/class-komacv.cwl
+++ b/completion/class-komacv.cwl
@@ -186,13 +186,6 @@ emaillinkfont
 
 #ifOption:xcolor=table
 #include:colortbl
-\rowcolors[commands]{row}{even-row-color}{odd-row-color}
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*[commands]{row}{even-row-color}{odd-row-color}
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum
 #endif
 
 #ifOption:xcolor=fixpdftex

--- a/completion/class-ryersonSGSThesis.cwl
+++ b/completion/class-ryersonSGSThesis.cwl
@@ -307,17 +307,6 @@ Teal#B
 
 # from table option of xcolor
 #include:colortbl
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum
 
 # from x11names option of xcolor
 AntiqueWhite1#B

--- a/completion/class-tlc-article.cwl
+++ b/completion/class-tlc-article.cwl
@@ -102,14 +102,3 @@ backcolour#B
 
 # from table option of xcolor
 #include:colortbl
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum

--- a/completion/class-xdupgthesis.cwl
+++ b/completion/class-xdupgthesis.cwl
@@ -18,6 +18,7 @@
 #include:biblatex
 # loads style=gb7714-2015 option of biblatex
 #include:tabularray
+#include:tabularraylibraryfunctional
 #include:enumitem
 
 \xdusetup{options%keyvals}

--- a/completion/class-xebaposter.cwl
+++ b/completion/class-xebaposter.cwl
@@ -64,14 +64,6 @@ latin
 
 #ifOption:table
 #include:colortbl
-## double command as workaround for color args to be recognized properly as colors
-\rowcolors[commands]{row}{even-row-color}{odd-row-color}
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*[commands]{row}{even-row-color}{odd-row-color}
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum
 #endif
 
 \begin{poster}{settings%keyvals}{eyecatcher}{title%text}{author}{logo}

--- a/completion/easybase.cwl
+++ b/completion/easybase.cwl
@@ -21,7 +21,7 @@
 #include:titletoc
 #include:caption
 #include:tabularray
-# loads booktabs tblrlibrary
+#include:tabularraylibrarybooktabs
 #include:listings
 #include:amsthm
 #include:thmtools
@@ -532,30 +532,6 @@ i
 \begin{description*}
 \begin{description*}[options%keyvals]
 \end{description*}
-
-# from booktabs tblrlibrary
-#include:booktabs
-\toprule
-\toprule[options]
-\midrule
-\midrule[options]
-\cmidrule{i-j}
-\cmidrule[options]{i-j}
-\bottomrule
-\bottomrule[options]
-\cmidrulemore{i-j}
-\morecmidrules
-\begin{booktabs}{preamble%keyvals}#\tabular
-\end{booktabs}
-\begin{longtabs}{preamble%keyvals}#\tabular
-\end{longtabs}
-\begin{talltabs}{preamble%keyvals}#\tabular
-\end{talltabs}
-\specialrule{width}{sep1}{sep2}
-\addrowspace
-\addrowspace[space%l]
-\addlinespace
-\addlinespace[space%l]
 
 # from svgnames option of xcolor
 AliceBlue#B

--- a/completion/eqexam.cwl
+++ b/completion/eqexam.cwl
@@ -1007,17 +1007,6 @@ topline#true,false
 # from options passed to xcolor
 #ifOption:table
 #include:colortbl
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum
 #endif
 
 #ifOption:fixpdftex

--- a/completion/exerquiz.cwl
+++ b/completion/exerquiz.cwl
@@ -608,17 +608,6 @@ webgreen#B
 # from options passed to xcolor
 #ifOption:table
 #include:colortbl
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum
 #endif
 
 #ifOption:fixpdftex

--- a/completion/fortextbook.cwl
+++ b/completion/fortextbook.cwl
@@ -335,17 +335,6 @@ MRGPARTcolor#B
 # from options passed to xcolor
 #ifOption:table
 #include:colortbl
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum
 #endif
 
 #ifOption:fixpdftex

--- a/completion/gfdl.cwl
+++ b/completion/gfdl.cwl
@@ -1,0 +1,19 @@
+# gfdl package
+# Matthew Bertucci 2023/01/01 for v0.1
+
+#include:float
+#include:expkv-def
+#include:expkv-opt
+#include:csquotes
+#include:hyperref
+#include:hyperxmp
+
+#keyvals:\usepackage/gfdl#c
+manual
+#endkeyvals
+
+\gfdlcopyrightdescription{project-description%text}
+\gfdlcopyrightableyears{copyrightable-years}
+\gfdlcopyrightholders{copyright-holders}
+\printgfdlnotice
+\printgfdltext

--- a/completion/invoice2.cwl
+++ b/completion/invoice2.cwl
@@ -37,14 +37,3 @@ total-color=#%color
 
 # from table option of xcolor
 #include:colortbl
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum

--- a/completion/keyvaltable.cwl
+++ b/completion/keyvaltable.cwl
@@ -1,12 +1,16 @@
 # keyvaltable package
-# Matthew Bertucci 10/1/2021 for v2.2
+# Matthew Bertucci 2023/01/01 for v2.3
 
 #include:etoolbox
 #include:xkeyval
 #include:trimspaces
+#include:colortbl
 #include:xcolor
-# loads table option of xcolor
 #include:booktabs
+
+#keyvals:\usepackage/keyvaltable#c
+compat=%<version%>
+#endkeyvals
 
 \NewKeyValTable{table name}{colspecs}
 \NewKeyValTable[options%keyvals]{table name}{colspecs}
@@ -56,6 +60,30 @@
 \kvtNewRowStyle{name}{options%keyvals}
 \kvtRenewRowStyle{name}{options%keyvals}
 
+\MidRule
+\MidRule[width]
+\CMidRule{columns}
+\CMidRule[width]{columns}
+
+\kvtRuleTop{color}
+\kvtRuleTop[width]{color}
+\kvtRuleBottom{color}
+\kvtRuleBottom[width]{color}
+\kvtRuleMid{color1}{color2}
+\kvtRuleMid[width]{color1}{color2}
+\kvtRuleMid{color}{color}#S
+\kvtRuleMid[width]{color}{color}#S
+\kvtRuleCMid{a-b}{color1}{color2}
+\kvtRuleCMid(trim){a-b}{color1}{color2}
+\kvtRuleCMid[width](trim){a-b}{color1}{color2}
+\kvtRuleCMid{a-b}{color}{color}#S
+\kvtRuleCMid(trim){a-b}{color}{color}#S
+\kvtRuleCMid[width](trim){a-b}{color}{color}#S
+\kvtRulesCMid{rlist}{color1}{color2}
+\kvtRulesCMid[width]{rlist}{color1}{color2}
+\kvtRulesCMid{rlist}{color}{color}#S
+\kvtRulesCMid[width]{rlist}{color}{color}#S
+
 \kvtTableOpt{option}#*
 
 \kvtSet{options%keyvals}
@@ -102,6 +130,7 @@ Row/expandonce#true,false
 Row/expand#true,false
 HeadCell/align=%<coltype%>
 HeadCell/head=%<text%>
+HeadCell/underline#true,false
 ColGroup/span=%<+ separated columns%>
 ColGroup/align=%<coltype%>
 ColGroup/format=%<single-arg macro%>
@@ -147,18 +176,3 @@ captionpos=#t,b
 \metatblUsePackage{envnames}#*
 \metatblRequire{envnames}#*
 \metatblAtEnd{envname}{code}#*
-
-# from table option of xcolor
-#include:colortbl
-## double command as workaround for color args to be recognized properly as colors
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum

--- a/completion/latex-dev.cwl
+++ b/completion/latex-dev.cwl
@@ -440,7 +440,7 @@ debug={%<options%>}
 \stockheight#*L
 \stockwidth#*L
 
-# pdftex specials
+# pdftex v3.141592653-2.6-1.40.25
 \efcode#*
 \expanded#*
 \ifincsname#*
@@ -532,6 +532,7 @@ debug={%<options%>}
 \pdfobjcompresslevel#*
 \pdfomitcharset#*
 \pdfomitinfodict#*
+\pdfomitprocset#*
 \pdfoutline#*
 \pdfoutput#*
 \pdfpageattr{attributes}#*

--- a/completion/luacomplex.cwl
+++ b/completion/luacomplex.cwl
@@ -1,0 +1,20 @@
+# luacomplex package
+# Matthew Bertucci 2022/12/28 for v1.0
+
+#include:xkeyval
+#include:amsmath
+#include:luacode
+#include:luamaths
+
+\cpxNew{name}{x,y}
+\cpxPrint{name}
+\cpxAdd{name}{name1}{name2}
+\cpxSub{name}{name1}{name2}
+\cpxMul{name}{name1}{name2}
+\cpxDiv{name}{name1}{name2}
+\cpxInv{name}{orig-name}
+\cpxRe{name}{orig-name}
+\cpxIm{name}{orig-name}
+\cpxMod{name}{orig-name}
+\cpxPrinArg{name}{orig-name}
+\cpxOp{name}{expression%definition}

--- a/completion/luagcd.cwl
+++ b/completion/luagcd.cwl
@@ -1,0 +1,9 @@
+# luagcd package
+# Matthew Bertucci 2023/01/01 for v1.0
+
+#include:luacode
+
+\luagcd{int1,int2,...}
+\luagcdwithsteps{int1}{int2}
+\luagcdlincomb{int1}{int2}
+\luagcdlincombwithsteps{int1}{int2}

--- a/completion/luamaths.cwl
+++ b/completion/luamaths.cwl
@@ -1,0 +1,27 @@
+# luamaths package
+# Matthew Bertucci 2022/12/28 for v1.0
+
+#include:xkeyval
+#include:amsmath
+#include:luacode
+
+\mathOp{expression%definition}
+\mathAbs{number}
+\mathAcos{number}
+\mathAsin{number}
+\mathAtan{number}
+\mathCeil{number}
+\mathCos{number}
+\mathExp{number}
+\mathFloor{number}
+\mathHuge#*
+\mathLog{number}
+\mathMax{num1,num2,...}
+\mathMin{num1,num2,...}
+\mathPi
+\mathRandom{arg}
+\mathSin{number}
+\mathSqrt{number}
+\mathTan{number}
+\mathRad{degrees}
+\mathRound{number}{digits}

--- a/completion/luaset.cwl
+++ b/completion/luaset.cwl
@@ -1,0 +1,18 @@
+# luaset package
+# Matthew Bertucci 2022/12/28 for v1.0
+
+#include:xkeyval
+#include:amsmath
+#include:luacode
+#include:luamaths
+
+\luaSetNew{name}{set}
+\luaSetPrint{name}
+\luaSetUnion{name}{name1}{name2}
+\luaSetIntersection{name}{name1}{name2}
+\luaSetDifference{name}{name1}{name2}
+\luaSetCardinal{name}
+\luaSetBelongsto{element}{set}
+\luaSetSubseteq{name1}{name2}
+\luaSetSubset{name1}{name2}
+\luaSetEqual{name1}{name2}

--- a/completion/maze.cwl
+++ b/completion/maze.cwl
@@ -1,0 +1,5 @@
+# maze package
+# Matthew Bertucci 2022/12/28 for v1.1
+
+\maze{size}
+\maze{size}[seed]

--- a/completion/piton.cwl
+++ b/completion/piton.cwl
@@ -1,5 +1,5 @@
 # piton package
-# Matthew Bertucci 2022/11/30 for v0.99
+# Matthew Bertucci 2023/01/01 for v1.0
 
 #include:l3keys2e
 #include:luatexbase
@@ -44,6 +44,7 @@ last-line=%<integer%>
 #keyvals:\PitonOptions
 gobble=%<integer%>
 auto-gobble
+tabs-auto-gobble
 line-numbers
 all-line-numbers
 resume

--- a/completion/postnotes.cwl
+++ b/completion/postnotes.cwl
@@ -1,11 +1,12 @@
 # postnotes package
-# Matthew Bertucci 2022/04/29 for v0.1.2
+# Matthew Bertucci 2022/12/28 for v0.2.0
 
 \postnote{text}
 \postnote[options%keyvals]{text}
 
 #keyvals:\postnote
-mark=%<mark%>
+mark=%<number%>
+markstr=%<string%>
 sortnum=%<number%>
 nomark
 label=##l
@@ -14,11 +15,10 @@ zlabel=##l
 
 \postnotesection{text}
 \postnotesection[options%keyvals]{text}
-\postnotesectionx{text}
-\postnotesectionx[options%keyvals]{text}
 
 #keyvals:\postnotesection,\postnotesectionx
 name=%<name%>
+exp#true,false
 #endkeyvals
 
 \printpostnotes
@@ -67,3 +67,7 @@ sort#true,false
 \thepostnote#*
 \thepostnotesection#*
 \thepostnotetext#*
+
+# deprecated
+\postnotesectionx{text}#S
+\postnotesectionx[options]{text}#S

--- a/completion/resmes.cwl
+++ b/completion/resmes.cwl
@@ -1,0 +1,6 @@
+# resmes package
+# Matthew Bertucci 2022/12/28 for v1.0
+
+#include:tikz
+
+\resmes#m

--- a/completion/simpleicons.cwl
+++ b/completion/simpleicons.cwl
@@ -1,5 +1,5 @@
 # simpleicons package
-# Matthew Bertucci 2022/12/09 for v8.1.0
+# Matthew Bertucci 2023/01/01 for v8.2.0
 
 #include:ifxetex
 #include:ifluatex
@@ -505,6 +505,7 @@ cssmodules
 csswizardry
 cts
 cucumber
+cultura
 curl
 curseforge
 cycling74
@@ -1005,6 +1006,7 @@ ifood
 ifttt
 iheartradio
 ikea
+iledefrancemobilites
 imagej
 imdb
 imgur
@@ -1015,6 +1017,7 @@ infiniti
 influxdb
 informatica
 infosys
+infracost
 ingress
 inkdrop
 inkscape
@@ -1339,6 +1342,7 @@ mlflow
 mobx
 mobxstatetree
 mocha
+modrinth
 modx
 mojangstudios
 moleculer
@@ -1611,6 +1615,7 @@ podman
 poetry
 pointy
 pokemon
+polars
 polkadot
 poly
 polymerproject

--- a/completion/table-fct.cwl
+++ b/completion/table-fct.cwl
@@ -73,17 +73,6 @@ Bcolor=#%color
 
 # from table option of xcolor
 #include:colortbl
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum
 
 # from dvipsnames option of xcolor
 Apricot#B

--- a/completion/tablestyles.cwl
+++ b/completion/tablestyles.cwl
@@ -50,14 +50,3 @@ sansboldbw
 
 # from table option of xcolor
 #include:colortbl
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum

--- a/completion/tikz-mirror-lens.cwl
+++ b/completion/tikz-mirror-lens.cwl
@@ -1,5 +1,5 @@
 # tikz-mirror-lens package
-# 2022/12/26 for v1.0.0
+# 2022/12/28 for v1.0.1
 # adapted from cwl written by package author Fernando H. G. Zucatelli
 # original: http://mirrors.ctan.org/graphics/pgf/contrib/tikz-mirror-lens/tex/tikz-mirror-lens.cwl
 
@@ -39,10 +39,12 @@
 \mirrorBase{f}{yM}{minXaxis}{maxXaxis}#n
 \mirrorPts{v}{f}{c}#n
 \mirrorRays{p}{pp}{o}{i}#n
+\mirrorRays[arrows]{p}{pp}{o}{i}#n
 # =======================================================
 \lensBase{f}{yM}{minXaxis}{maxXaxis}#n
 \lensPts{v}{f}{a}#n
 \lensRays{p}{pp}{o}{i}#n
+\lensRays[arrows]{p}{pp}{o}{i}#n
 # =======================================================
 \mirrorMath{f}{p}{o}{epsilon}{yM}#n
 \lensMath{f}{p}{o}{epsilon}{yM}#n

--- a/completion/tipfr.cwl
+++ b/completion/tipfr.cwl
@@ -100,14 +100,6 @@ calcraise=##L
 
 # from the table option of xcolor
 #include:colortbl
-## double command as workaround for color args to be recognized properly as colors
-\rowcolors[commands]{row}{even-row-color}{odd-row-color}
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*[commands]{row}{even-row-color}{odd-row-color}
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum
 
 # from the dvipsnames option of xcolor
 Apricot#B

--- a/completion/web.cwl
+++ b/completion/web.cwl
@@ -833,17 +833,6 @@ khaki#B
 # from xcolor options
 #ifOption:table
 #include:colortbl
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum
 #endif
 
 #ifOption:fixpdftex

--- a/completion/witharrows.cwl
+++ b/completion/witharrows.cwl
@@ -1,12 +1,10 @@
 # witharrows package
-# Matthew Bertucci 4/22/2022 for v2.7
+# Matthew Bertucci 2023/01/01 for v2.8
 
-#include:expl3
 #include:l3keys2e
 #include:varwidth
 #include:tikz
 #include:tikzlibrarybending
-#include:xparse
 
 #keyvals:\usepackage/witharrows#c
 footnote
@@ -29,6 +27,7 @@ footnotehyper
 #keyvals:\begin{WithArrows},\WithArrowsOptions,\WithArrowsNewStyle
 c
 b
+right-overlap#true,false
 #endkeyvals
 
 #keyvals:\begin{WithArrows},\begin{DispWithArrows},\begin{DispWithArrows*},\WithArrowsOptions,\WithArrowsNewStyle

--- a/completion/xetex.cwl
+++ b/completion/xetex.cwl
@@ -140,3 +140,7 @@
 # Engine version
 \XeTeXversion#*
 \XeTeXrevision#*
+
+# other (not in ref guide)
+\XeTeXhyphenatablelength#*
+\XeTeXinterwordspaceshaping#*

--- a/completion/xpicture.cwl
+++ b/completion/xpicture.cwl
@@ -273,17 +273,6 @@ hideerrors
 ## from xcolor options
 #ifOption:table
 #include:colortbl
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum
 #endif
 
 #ifOption:fixpdftex

--- a/completion/yagusylo.cwl
+++ b/completion/yagusylo.cwl
@@ -127,17 +127,6 @@ enumpattern=%<name%>
 # from xcolor options
 #ifOption:XcolorOptions=table
 #include:colortbl
-\rowcolors{row}{odd-row-color}{even-row-color}
-\rowcolors[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors{row}{color}{color}#S
-\rowcolors[commands]{row}{color}{color}#S
-\rowcolors*{row}{odd-row-color}{even-row-color}
-\rowcolors*[commands]{row}{odd-row-color}{even-row-color}
-\rowcolors*{row}{color}{color}#S
-\rowcolors*[commands]{row}{color}{color}#S
-\showrowcolors
-\hiderowcolors
-\rownum
 #endif
 
 #ifOption:XcolorOptions=fixpdftex

--- a/completion/zref-vario.cwl
+++ b/completion/zref-vario.cwl
@@ -1,5 +1,5 @@
 # zref-vario package
-# Matthew Bertucci 2022/07/11 for v0.1.5
+# Matthew Bertucci 2023/01/01 for v0.1.6
 
 #include:varioref
 #include:zref-clever
@@ -115,3 +115,5 @@ vrefformat=
 vrefrangeformat=
 fullrefformat=
 #endkeyvals
+
+\zvhyperlink{text}


### PR DESCRIPTION
New cwls for `gfdl`, `luacomplex`, `luagcd`, `luamaths`, `luaset`, `maze`, and `resmes`.

Updated cwls for `keyvaltable`, `simpleicons`, and other small updates.

Redundant entries for commands incorporated into `colortbl` removed from cwls.