### PR TITLE
Align Symbols at Baseline

### DIFF
--- a/symbols-ng/arrows.xml
+++ b/symbols-ng/arrows.xml
@@ -3,729 +3,689 @@
 <!DOCTYPE KileSymbolSources>
 <symbols>
 
-   <formatVersion major="0" minor ="22" />
-
-   <symbolGroupName>user</symbolGroupName>
-
-   <preamble>
-      <class>article</class>
-      <arguments>12pt</arguments>
-      <additional>\pagestyle{empty}
-		  \setlength{\parindent}{0cm}
-		  \usepackage[T1]{fontenc}
-      </additional>
-   </preamble>
-
-   <unicodeCommandPackages>
-      <package>
-         <name>inputenc</name>
-         <arguments>utf8</arguments>
-      </package>
-   </unicodeCommandPackages>
-
-   <!-- insert stuff here    -->
-<symbolGroupName>arrows</symbolGroupName>
-<!-- arg math \leftarrow  -->
-<commandDefinition>
-   <latexCommand>\leftarrow</latexCommand>
-   <unicodeCommand>←</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \leftrightarrow  -->
-<commandDefinition>
-   <latexCommand>\leftrightarrow</latexCommand>
-   <unicodeCommand>↔</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \rightarrow  -->
-<commandDefinition>
-   <latexCommand>\rightarrow</latexCommand>
-   <unicodeCommand>→</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \mapsto  -->
-<commandDefinition>
-   <latexCommand>\mapsto</latexCommand>
-   <unicodeCommand>↦</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \longleftarrow  -->
-<commandDefinition>
-   <latexCommand>\longleftarrow</latexCommand>
-   <unicodeCommand>⟵</unicodeCommand>
-   <mathMode>true</mathMode>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \longleftrightarrow  -->
-<commandDefinition>
-   <latexCommand>\longleftrightarrow</latexCommand>
-   <unicodeCommand>⟷</unicodeCommand>
-   <mathMode>true</mathMode>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \longrightarrow  -->
-<commandDefinition>
-   <latexCommand>\longrightarrow</latexCommand>
-   <unicodeCommand>⟶</unicodeCommand>
-   <mathMode>true</mathMode>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \longmapsto  -->
-<commandDefinition>
-   <latexCommand>\longmapsto</latexCommand>
-   <unicodeCommand>⟼</unicodeCommand>
-   <mathMode>true</mathMode>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \downarrow  -->
-<commandDefinition>
-   <latexCommand>\downarrow</latexCommand>
-   <unicodeCommand>↓</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \updownarrow  -->
-<commandDefinition>
-   <latexCommand>\updownarrow</latexCommand>
-   <unicodeCommand>↕</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \uparrow  -->
-<commandDefinition>
-   <latexCommand>\uparrow</latexCommand>
-   <unicodeCommand>↑</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \nwarrow  -->
-<commandDefinition>
-   <latexCommand>\nwarrow</latexCommand>
-   <unicodeCommand>↖</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \searrow  -->
-<commandDefinition>
-   <latexCommand>\searrow</latexCommand>
-   <unicodeCommand>↘</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \nearrow  -->
-<commandDefinition>
-   <latexCommand>\nearrow</latexCommand>
-   <unicodeCommand>↗</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \swarrow  -->
-<commandDefinition>
-   <latexCommand>\swarrow</latexCommand>
-   <unicodeCommand>↙</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textdownarrow  -->
-<commandDefinition>
-   <latexCommand>\textdownarrow</latexCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textuparrow  -->
-<commandDefinition>
-   <latexCommand>\textuparrow</latexCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textleftarrow  -->
-<commandDefinition>
-   <latexCommand>\textleftarrow</latexCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textrightarrow  -->
-<commandDefinition>
-   <latexCommand>\textrightarrow</latexCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nleftarrow  -->
-<commandDefinition>
-   <latexCommand>\nleftarrow</latexCommand>
-   <unicodeCommand>↚</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nleftrightarrow  -->
-<commandDefinition>
-   <latexCommand>\nleftrightarrow</latexCommand>
-   <unicodeCommand>↮</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nrightarrow  -->
-<commandDefinition>
-   <latexCommand>\nrightarrow</latexCommand>
-   <unicodeCommand>↛</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \hookleftarrow  -->
-<commandDefinition>
-   <latexCommand>\hookleftarrow</latexCommand>
-   <unicodeCommand>↩</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \hookrightarrow  -->
-<commandDefinition>
-   <latexCommand>\hookrightarrow</latexCommand>
-   <unicodeCommand>↪</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \twoheadleftarrow  -->
-<commandDefinition>
-   <latexCommand>\twoheadleftarrow</latexCommand>
-   <unicodeCommand>↞</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \twoheadrightarrow  -->
-<commandDefinition>
-   <latexCommand>\twoheadrightarrow</latexCommand>
-   <unicodeCommand>↠</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \leftarrowtail  -->
-<commandDefinition>
-   <latexCommand>\leftarrowtail</latexCommand>
-   <unicodeCommand>↢</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \rightarrowtail  -->
-<commandDefinition>
-   <latexCommand>\rightarrowtail</latexCommand>
-   <unicodeCommand>↣</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Leftarrow  -->
-<commandDefinition>
-   <latexCommand>\Leftarrow</latexCommand>
-   <unicodeCommand>⇐</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Leftrightarrow  -->
-<commandDefinition>
-   <latexCommand>\Leftrightarrow</latexCommand>
-   <unicodeCommand>⇔</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Rightarrow  -->
-<commandDefinition>
-   <latexCommand>\Rightarrow</latexCommand>
-   <unicodeCommand>⇒</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Longleftarrow  -->
-<commandDefinition>
-   <latexCommand>\Longleftarrow</latexCommand>
-   <unicodeCommand>⟸</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Longleftrightarrow  -->
-<commandDefinition>
-   <latexCommand>\Longleftrightarrow</latexCommand>
-   <unicodeCommand>⟺</unicodeCommand>
-   <mathMode>true</mathMode>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Longrightarrow  -->
-<commandDefinition>
-   <latexCommand>\Longrightarrow</latexCommand>
-   <unicodeCommand>⟹</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Updownarrow  -->
-<commandDefinition>
-   <latexCommand>\Updownarrow</latexCommand>
-   <unicodeCommand>⇕</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Uparrow  -->
-<commandDefinition>
-   <latexCommand>\Uparrow</latexCommand>
-   <unicodeCommand>⇑</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Downarrow  -->
-<commandDefinition>
-   <latexCommand>\Downarrow</latexCommand>
-   <unicodeCommand>⇓</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nLeftarrow  -->
-<commandDefinition>
-   <latexCommand>\nLeftarrow</latexCommand>
-   <unicodeCommand>⇍</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nLeftrightarrow  -->
-<commandDefinition>
-   <latexCommand>\nLeftrightarrow</latexCommand>
-   <unicodeCommand>⇎</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nRightarrow  -->
-<commandDefinition>
-   <latexCommand>\nRightarrow</latexCommand>
-   <unicodeCommand>⇏</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \leftleftarrows  -->
-<commandDefinition>
-   <latexCommand>\leftleftarrows</latexCommand>
-   <unicodeCommand>⇇</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \leftrightarrows  -->
-<commandDefinition>
-   <latexCommand>\leftrightarrows</latexCommand>
-   <unicodeCommand>⇆</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \rightleftarrows  -->
-<commandDefinition>
-   <latexCommand>\rightleftarrows</latexCommand>
-   <unicodeCommand>⇄</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \rightrightarrows  -->
-<commandDefinition>
-   <latexCommand>\rightrightarrows</latexCommand>
-   <unicodeCommand>⇉</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \downdownarrows  -->
-<commandDefinition>
-   <latexCommand>\downdownarrows</latexCommand>
-   <unicodeCommand>⇊</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \upuparrows  -->
-<commandDefinition>
-   <latexCommand>\upuparrows</latexCommand>
-   <unicodeCommand>⇈</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \circlearrowleft  -->
-<commandDefinition>
-   <latexCommand>\circlearrowleft</latexCommand>
-   <unicodeCommand>↺</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \circlearrowright  -->
-<commandDefinition>
-   <latexCommand>\circlearrowright</latexCommand>
-   <unicodeCommand>↻</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \curvearrowleft  -->
-<commandDefinition>
-   <latexCommand>\curvearrowleft</latexCommand>
-   <unicodeCommand>↶</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \curvearrowright  -->
-<commandDefinition>
-   <latexCommand>\curvearrowright</latexCommand>
-   <unicodeCommand>↷</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \Lsh  -->
-<commandDefinition>
-   <latexCommand>\Lsh</latexCommand>
-   <unicodeCommand>↰</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \Rsh  -->
-<commandDefinition>
-   <latexCommand>\Rsh</latexCommand>
-   <unicodeCommand>↱</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \looparrowleft  -->
-<commandDefinition>
-   <latexCommand>\looparrowleft</latexCommand>
-   <unicodeCommand>↫</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \looparrowright  -->
-<commandDefinition>
-   <latexCommand>\looparrowright</latexCommand>
-   <unicodeCommand>↬</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \dashleftarrow  -->
-<commandDefinition>
-   <latexCommand>\dashleftarrow</latexCommand>
-   <unicodeCommand>⇠</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \dashrightarrow  -->
-<commandDefinition>
-   <latexCommand>\dashrightarrow</latexCommand>
-   <unicodeCommand>⇢</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \leftrightsquigarrow  -->
-<commandDefinition>
-   <latexCommand>\leftrightsquigarrow</latexCommand>
-   <unicodeCommand>↭</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \rightsquigarrow  -->
-<commandDefinition>
-   <latexCommand>\rightsquigarrow</latexCommand>
-   <unicodeCommand>⇝</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \Lleftarrow  -->
-<commandDefinition>
-   <latexCommand>\Lleftarrow</latexCommand>
-   <unicodeCommand>⇚</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \leftharpoondown  -->
-<commandDefinition>
-   <latexCommand>\leftharpoondown</latexCommand>
-   <unicodeCommand>↽</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \rightharpoondown  -->
-<commandDefinition>
-   <latexCommand>\rightharpoondown</latexCommand>
-   <unicodeCommand>⇁</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \leftharpoonup  -->
-<commandDefinition>
-   <latexCommand>\leftharpoonup</latexCommand>
-   <unicodeCommand>↼</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \rightharpoonup  -->
-<commandDefinition>
-   <latexCommand>\rightharpoonup</latexCommand>
-   <unicodeCommand>⇀</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \rightleftharpoons  -->
-<commandDefinition>
-   <latexCommand>\rightleftharpoons</latexCommand>
-   <unicodeCommand>⇌</unicodeCommand>
-   <mathMode>true</mathMode>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \leftrightharpoons  -->
-<commandDefinition>
-   <latexCommand>\leftrightharpoons</latexCommand>
-   <unicodeCommand>⇋</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \downharpoonleft  -->
-<commandDefinition>
-   <latexCommand>\downharpoonleft</latexCommand>
-   <unicodeCommand>⇃</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \upharpoonleft  -->
-<commandDefinition>
-   <latexCommand>\upharpoonleft</latexCommand>
-   <unicodeCommand>↿</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \downharpoonright  -->
-<commandDefinition>
-   <latexCommand>\downharpoonright</latexCommand>
-   <unicodeCommand>⇂</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \upharpoonright  -->
-<commandDefinition>
-   <latexCommand>\upharpoonright</latexCommand>
-   <unicodeCommand>↾</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
+	<formatVersion major="0" minor ="22"/>
+
+	<symbolGroupName>user</symbolGroupName>
+
+	<preamble>
+		<class>standalone</class>
+		<arguments>10bp,margin=1bp</arguments>
+		<additional>\usepackage[T1]{fontenc}</additional>
+	</preamble>
+
+	<unicodeCommandPackages>
+		<package>
+			<name>inputenc</name>
+			<arguments>utf8</arguments>
+		</package>
+	</unicodeCommandPackages>
+
+	<!-- insert stuff here -->
+
+	<symbolGroupName>arrows</symbolGroupName>
+
+	<!-- arg math \leftarrow -->
+	<commandDefinition>
+		<latexCommand>\leftarrow</latexCommand>
+		<unicodeCommand>←</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \leftrightarrow -->
+	<commandDefinition>
+		<latexCommand>\leftrightarrow</latexCommand>
+		<unicodeCommand>↔</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \rightarrow -->
+	<commandDefinition>
+		<latexCommand>\rightarrow</latexCommand>
+		<unicodeCommand>→</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \mapsto -->
+	<commandDefinition>
+		<latexCommand>\mapsto</latexCommand>
+		<unicodeCommand>↦</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \longleftarrow -->
+	<commandDefinition>
+		<latexCommand>\longleftarrow</latexCommand>
+		<unicodeCommand>⟵</unicodeCommand>
+		<mathMode>true</mathMode>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \longleftrightarrow -->
+	<commandDefinition>
+		<latexCommand>\longleftrightarrow</latexCommand>
+		<unicodeCommand>⟷</unicodeCommand>
+		<mathMode>true</mathMode>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \longrightarrow -->
+	<commandDefinition>
+		<latexCommand>\longrightarrow</latexCommand>
+		<unicodeCommand>⟶</unicodeCommand>
+		<mathMode>true</mathMode>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \longmapsto -->
+	<commandDefinition>
+		<latexCommand>\longmapsto</latexCommand>
+		<unicodeCommand>⟼</unicodeCommand>
+		<mathMode>true</mathMode>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \downarrow  -->
+	<commandDefinition>
+		<latexCommand>\downarrow</latexCommand>
+		<unicodeCommand>↓</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \updownarrow  -->
+	<commandDefinition>
+		<latexCommand>\updownarrow</latexCommand>
+		<unicodeCommand>↕</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \uparrow -->
+	<commandDefinition>
+		<latexCommand>\uparrow</latexCommand>
+		<unicodeCommand>↑</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \nwarrow -->
+	<commandDefinition>
+		<latexCommand>\nwarrow</latexCommand>
+		<unicodeCommand>↖</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \searrow -->
+	<commandDefinition>
+		<latexCommand>\searrow</latexCommand>
+		<unicodeCommand>↘</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \nearrow -->
+	<commandDefinition>
+		<latexCommand>\nearrow</latexCommand>
+		<unicodeCommand>↗</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \swarrow -->
+	<commandDefinition>
+		<latexCommand>\swarrow</latexCommand>
+		<unicodeCommand>↙</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg  \textdownarrow -->
+	<commandDefinition>
+		<latexCommand>\textdownarrow</latexCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg  \textuparrow -->
+	<commandDefinition>
+		<latexCommand>\textuparrow</latexCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg  \textleftarrow -->
+	<commandDefinition>
+		<latexCommand>\textleftarrow</latexCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg  \textrightarrow -->
+	<commandDefinition>
+		<latexCommand>\textrightarrow</latexCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nleftarrow -->
+	<commandDefinition>
+		<latexCommand>\nleftarrow</latexCommand>
+		<unicodeCommand>↚</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nleftrightarrow -->
+	<commandDefinition>
+		<latexCommand>\nleftrightarrow</latexCommand>
+		<unicodeCommand>↮</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nrightarrow -->
+	<commandDefinition>
+		<latexCommand>\nrightarrow</latexCommand>
+		<unicodeCommand>↛</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \hookleftarrow -->
+	<commandDefinition>
+		<latexCommand>\hookleftarrow</latexCommand>
+		<unicodeCommand>↩</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \hookrightarrow -->
+	<commandDefinition>
+		<latexCommand>\hookrightarrow</latexCommand>
+		<unicodeCommand>↪</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \twoheadleftarrow -->
+	<commandDefinition>
+		<latexCommand>\twoheadleftarrow</latexCommand>
+		<unicodeCommand>↞</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \twoheadrightarrow -->
+	<commandDefinition>
+		<latexCommand>\twoheadrightarrow</latexCommand>
+		<unicodeCommand>↠</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \leftarrowtail -->
+	<commandDefinition>
+		<latexCommand>\leftarrowtail</latexCommand>
+		<unicodeCommand>↢</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \rightarrowtail -->
+	<commandDefinition>
+		<latexCommand>\rightarrowtail</latexCommand>
+		<unicodeCommand>↣</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Leftarrow -->
+	<commandDefinition>
+		<latexCommand>\Leftarrow</latexCommand>
+		<unicodeCommand>⇐</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Leftrightarrow -->
+	<commandDefinition>
+		<latexCommand>\Leftrightarrow</latexCommand>
+		<unicodeCommand>⇔</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Rightarrow -->
+	<commandDefinition>
+		<latexCommand>\Rightarrow</latexCommand>
+		<unicodeCommand>⇒</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Longleftarrow -->
+	<commandDefinition>
+		<latexCommand>\Longleftarrow</latexCommand>
+		<unicodeCommand>⟸</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Longleftrightarrow -->
+	<commandDefinition>
+		<latexCommand>\Longleftrightarrow</latexCommand>
+		<unicodeCommand>⟺</unicodeCommand>
+		<mathMode>true</mathMode>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Longrightarrow -->
+	<commandDefinition>
+		<latexCommand>\Longrightarrow</latexCommand>
+		<unicodeCommand>⟹</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Updownarrow -->
+	<commandDefinition>
+		<latexCommand>\Updownarrow</latexCommand>
+		<unicodeCommand>⇕</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Uparrow -->
+	<commandDefinition>
+		<latexCommand>\Uparrow</latexCommand>
+		<unicodeCommand>⇑</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Downarrow -->
+	<commandDefinition>
+		<latexCommand>\Downarrow</latexCommand>
+		<unicodeCommand>⇓</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nLeftarrow -->
+	<commandDefinition>
+		<latexCommand>\nLeftarrow</latexCommand>
+		<unicodeCommand>⇍</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nLeftrightarrow -->
+	<commandDefinition>
+		<latexCommand>\nLeftrightarrow</latexCommand>
+		<unicodeCommand>⇎</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nRightarrow -->
+	<commandDefinition>
+		<latexCommand>\nRightarrow</latexCommand>
+		<unicodeCommand>⇏</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \leftleftarrows -->
+	<commandDefinition>
+		<latexCommand>\leftleftarrows</latexCommand>
+		<unicodeCommand>⇇</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \leftrightarrows -->
+	<commandDefinition>
+		<latexCommand>\leftrightarrows</latexCommand>
+		<unicodeCommand>⇆</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \rightleftarrows -->
+	<commandDefinition>
+		<latexCommand>\rightleftarrows</latexCommand>
+		<unicodeCommand>⇄</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \rightrightarrows -->
+	<commandDefinition>
+		<latexCommand>\rightrightarrows</latexCommand>
+		<unicodeCommand>⇉</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \downdownarrows -->
+	<commandDefinition>
+		<latexCommand>\downdownarrows</latexCommand>
+		<unicodeCommand>⇊</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \upuparrows -->
+	<commandDefinition>
+		<latexCommand>\upuparrows</latexCommand>
+		<unicodeCommand>⇈</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \circlearrowleft -->
+	<commandDefinition>
+		<latexCommand>\circlearrowleft</latexCommand>
+		<unicodeCommand>↺</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \circlearrowright -->
+	<commandDefinition>
+		<latexCommand>\circlearrowright</latexCommand>
+		<unicodeCommand>↻</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \curvearrowleft -->
+	<commandDefinition>
+		<latexCommand>\curvearrowleft</latexCommand>
+		<unicodeCommand>↶</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \curvearrowright -->
+	<commandDefinition>
+		<latexCommand>\curvearrowright</latexCommand>
+		<unicodeCommand>↷</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \Lsh -->
+	<commandDefinition>
+		<latexCommand>\Lsh</latexCommand>
+		<unicodeCommand>↰</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \Rsh -->
+	<commandDefinition>
+		<latexCommand>\Rsh</latexCommand>
+		<unicodeCommand>↱</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \looparrowleft  -->
+	<commandDefinition>
+		<latexCommand>\looparrowleft</latexCommand>
+		<unicodeCommand>↫</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \looparrowright -->
+	<commandDefinition>
+		<latexCommand>\looparrowright</latexCommand>
+		<unicodeCommand>↬</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \dashleftarrow -->
+	<commandDefinition>
+		<latexCommand>\dashleftarrow</latexCommand>
+		<unicodeCommand>⇠</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \dashrightarrow -->
+	<commandDefinition>
+		<latexCommand>\dashrightarrow</latexCommand>
+		<unicodeCommand>⇢</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \leftrightsquigarrow -->
+	<commandDefinition>
+		<latexCommand>\leftrightsquigarrow</latexCommand>
+		<unicodeCommand>↭</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \rightsquigarrow  -->
+	<commandDefinition>
+		<latexCommand>\rightsquigarrow</latexCommand>
+		<unicodeCommand>⇝</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \Lleftarrow -->
+	<commandDefinition>
+		<latexCommand>\Lleftarrow</latexCommand>
+		<unicodeCommand>⇚</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \leftharpoondown -->
+	<commandDefinition>
+		<latexCommand>\leftharpoondown</latexCommand>
+		<unicodeCommand>↽</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \rightharpoondown -->
+	<commandDefinition>
+		<latexCommand>\rightharpoondown</latexCommand>
+		<unicodeCommand>⇁</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \leftharpoonup -->
+	<commandDefinition>
+		<latexCommand>\leftharpoonup</latexCommand>
+		<unicodeCommand>↼</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \rightharpoonup -->
+	<commandDefinition>
+		<latexCommand>\rightharpoonup</latexCommand>
+		<unicodeCommand>⇀</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \rightleftharpoons -->
+	<commandDefinition>
+		<latexCommand>\rightleftharpoons</latexCommand>
+		<unicodeCommand>⇌</unicodeCommand>
+		<mathMode>true</mathMode>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \leftrightharpoons -->
+	<commandDefinition>
+		<latexCommand>\leftrightharpoons</latexCommand>
+		<unicodeCommand>⇋</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \downharpoonleft -->
+	<commandDefinition>
+		<latexCommand>\downharpoonleft</latexCommand>
+		<unicodeCommand>⇃</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \upharpoonleft -->
+	<commandDefinition>
+		<latexCommand>\upharpoonleft</latexCommand>
+		<unicodeCommand>↿</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \downharpoonright -->
+	<commandDefinition>
+		<latexCommand>\downharpoonright</latexCommand>
+		<unicodeCommand>⇂</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \upharpoonright -->
+	<commandDefinition>
+		<latexCommand>\upharpoonright</latexCommand>
+		<unicodeCommand>↾</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
 </symbols>

--- a/symbols-ng/cyrillic.xml
+++ b/symbols-ng/cyrillic.xml
@@ -3,2839 +3,2380 @@
 <!DOCTYPE KileSymbolSources>
 <symbols>
 
-   <formatVersion major="0" minor="22"/>
-
-   <symbolGroupName>user</symbolGroupName>
-
-   <preamble>
-      <class>article</class>
-      <arguments>12pt</arguments>
-      <additional>\pagestyle{empty}
-		  \setlength{\parindent}{0cm}
-		  \usepackage[T1]{fontenc}
-      </additional>
-   </preamble>
-
-   <unicodeCommandPackages>
-      
-   </unicodeCommandPackages>
-
-   <!-- insert stuff here    -->
-<symbolGroupName>cyrillic</symbolGroupName>
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRA  -->
-<commandDefinition>
-   <latexCommand>\CYRA</latexCommand>
-   <unicodeCommand>А</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRB  -->
-<commandDefinition>
-   <latexCommand>\CYRB</latexCommand>
-   <unicodeCommand>Б</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRV  -->
-<commandDefinition>
-   <latexCommand>\CYRV</latexCommand>
-   <unicodeCommand>В</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRG  -->
-<commandDefinition>
-   <latexCommand>\CYRG</latexCommand>
-   <unicodeCommand>Г</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRD  -->
-<commandDefinition>
-   <latexCommand>\CYRD</latexCommand>
-   <unicodeCommand>Д</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRE  -->
-<commandDefinition>
-   <latexCommand>\CYRE</latexCommand>
-   <unicodeCommand>Е</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRYO  -->
-<commandDefinition>
-   <latexCommand>\CYRYO</latexCommand>
-   <unicodeCommand>Ё</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRZH  -->
-<commandDefinition>
-   <latexCommand>\CYRZH</latexCommand>
-   <unicodeCommand>Ж</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRZ  -->
-<commandDefinition>
-   <latexCommand>\CYRZ</latexCommand>
-   <unicodeCommand>З</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRI  -->
-<commandDefinition>
-   <latexCommand>\CYRI</latexCommand>
-   <unicodeCommand>И</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRISHRT  -->
-<commandDefinition>
-   <latexCommand>\CYRISHRT</latexCommand>
-   <unicodeCommand>Й</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRK  -->
-<commandDefinition>
-   <latexCommand>\CYRK</latexCommand>
-   <unicodeCommand>К</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRL  -->
-<commandDefinition>
-   <latexCommand>\CYRL</latexCommand>
-   <unicodeCommand>Л</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRM  -->
-<commandDefinition>
-   <latexCommand>\CYRM</latexCommand>
-   <unicodeCommand>М</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRN  -->
-<commandDefinition>
-   <latexCommand>\CYRN</latexCommand>
-   <unicodeCommand>Н</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRO  -->
-<commandDefinition>
-   <latexCommand>\CYRO</latexCommand>
-   <unicodeCommand>О</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRP  -->
-<commandDefinition>
-   <latexCommand>\CYRP</latexCommand>
-   <unicodeCommand>П</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRR  -->
-<commandDefinition>
-   <latexCommand>\CYRR</latexCommand>
-   <unicodeCommand>Р</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRS  -->
-<commandDefinition>
-   <latexCommand>\CYRS</latexCommand>
-   <unicodeCommand>С</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRT  -->
-<commandDefinition>
-   <latexCommand>\CYRT</latexCommand>
-   <unicodeCommand>Т</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRU  -->
-<commandDefinition>
-   <latexCommand>\CYRU</latexCommand>
-   <unicodeCommand>У</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRF  -->
-<commandDefinition>
-   <latexCommand>\CYRF</latexCommand>
-   <unicodeCommand>Ф</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRH  -->
-<commandDefinition>
-   <latexCommand>\CYRH</latexCommand>
-   <unicodeCommand>Х</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRC  -->
-<commandDefinition>
-   <latexCommand>\CYRC</latexCommand>
-   <unicodeCommand>Ц</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRCH  -->
-<commandDefinition>
-   <latexCommand>\CYRCH</latexCommand>
-   <unicodeCommand>Ч</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRSH  -->
-<commandDefinition>
-   <latexCommand>\CYRSH</latexCommand>
-   <unicodeCommand>Ш</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRSHCH  -->
-<commandDefinition>
-   <latexCommand>\CYRSHCH</latexCommand>
-   <unicodeCommand>Щ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRHRDSN  -->
-<commandDefinition>
-   <latexCommand>\CYRHRDSN</latexCommand>
-   <unicodeCommand>Ъ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRERY  -->
-<commandDefinition>
-   <latexCommand>\CYRERY</latexCommand>
-   <unicodeCommand>Ы</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRSFTSN  -->
-<commandDefinition>
-   <latexCommand>\CYRSFTSN</latexCommand>
-   <unicodeCommand>Ь</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYREREV  -->
-<commandDefinition>
-   <latexCommand>\CYREREV</latexCommand>
-   <unicodeCommand>Э</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRYU  -->
-<commandDefinition>
-   <latexCommand>\CYRYU</latexCommand>
-   <unicodeCommand>Ю</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRYA  -->
-<commandDefinition>
-   <latexCommand>\CYRYA</latexCommand>
-   <unicodeCommand>Я</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyra  -->
-<commandDefinition>
-   <latexCommand>\cyra</latexCommand>
-   <unicodeCommand>а</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrb  -->
-<commandDefinition>
-   <latexCommand>\cyrb</latexCommand>
-   <unicodeCommand>б</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrv  -->
-<commandDefinition>
-   <latexCommand>\cyrv</latexCommand>
-   <unicodeCommand>в</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrg  -->
-<commandDefinition>
-   <latexCommand>\cyrg</latexCommand>
-   <unicodeCommand>г</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrd  -->
-<commandDefinition>
-   <latexCommand>\cyrd</latexCommand>
-   <unicodeCommand>д</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyre  -->
-<commandDefinition>
-   <latexCommand>\cyre</latexCommand>
-   <unicodeCommand>е</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyryo  -->
-<commandDefinition>
-   <latexCommand>\cyryo</latexCommand>
-   <unicodeCommand>ё</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrzh  -->
-<commandDefinition>
-   <latexCommand>\cyrzh</latexCommand>
-   <unicodeCommand>ж</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrz  -->
-<commandDefinition>
-   <latexCommand>\cyrz</latexCommand>
-   <unicodeCommand>з</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyri  -->
-<commandDefinition>
-   <latexCommand>\cyri</latexCommand>
-   <unicodeCommand>и</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrishrt  -->
-<commandDefinition>
-   <latexCommand>\cyrishrt</latexCommand>
-   <unicodeCommand>й</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrk  -->
-<commandDefinition>
-   <latexCommand>\cyrk</latexCommand>
-   <unicodeCommand>к</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrl  -->
-<commandDefinition>
-   <latexCommand>\cyrl</latexCommand>
-   <unicodeCommand>л</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrm  -->
-<commandDefinition>
-   <latexCommand>\cyrm</latexCommand>
-   <unicodeCommand>м</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrn  -->
-<commandDefinition>
-   <latexCommand>\cyrn</latexCommand>
-   <unicodeCommand>н</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyro  -->
-<commandDefinition>
-   <latexCommand>\cyro</latexCommand>
-   <unicodeCommand>о</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrp  -->
-<commandDefinition>
-   <latexCommand>\cyrp</latexCommand>
-   <unicodeCommand>п</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrr  -->
-<commandDefinition>
-   <latexCommand>\cyrr</latexCommand>
-   <unicodeCommand>р</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrs  -->
-<commandDefinition>
-   <latexCommand>\cyrs</latexCommand>
-   <unicodeCommand>с</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrt  -->
-<commandDefinition>
-   <latexCommand>\cyrt</latexCommand>
-   <unicodeCommand>т</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyru  -->
-<commandDefinition>
-   <latexCommand>\cyru</latexCommand>
-   <unicodeCommand>у</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrf  -->
-<commandDefinition>
-   <latexCommand>\cyrf</latexCommand>
-   <unicodeCommand>ф</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrh  -->
-<commandDefinition>
-   <latexCommand>\cyrh</latexCommand>
-   <unicodeCommand>х</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrc  -->
-<commandDefinition>
-   <latexCommand>\cyrc</latexCommand>
-   <unicodeCommand>ц</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrch  -->
-<commandDefinition>
-   <latexCommand>\cyrch</latexCommand>
-   <unicodeCommand>ч</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrsh  -->
-<commandDefinition>
-   <latexCommand>\cyrsh</latexCommand>
-   <unicodeCommand>ш</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrshch  -->
-<commandDefinition>
-   <latexCommand>\cyrshch</latexCommand>
-   <unicodeCommand>щ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrhrdsn  -->
-<commandDefinition>
-   <latexCommand>\cyrhrdsn</latexCommand>
-   <unicodeCommand>ъ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrery  -->
-<commandDefinition>
-   <latexCommand>\cyrery</latexCommand>
-   <unicodeCommand>ы</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrsftsn  -->
-<commandDefinition>
-   <latexCommand>\cyrsftsn</latexCommand>
-   <unicodeCommand>ь</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrerev  -->
-<commandDefinition>
-   <latexCommand>\cyrerev</latexCommand>
-   <unicodeCommand>э</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyryu  -->
-<commandDefinition>
-   <latexCommand>\cyryu</latexCommand>
-   <unicodeCommand>ю</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrya  -->
-<commandDefinition>
-   <latexCommand>\cyrya</latexCommand>
-   <unicodeCommand>я</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRABHCH  -->
-<commandDefinition>
-   <latexCommand>\CYRABHCH</latexCommand>
-   <unicodeCommand>Ҽ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRABHCHDSC  -->
-<commandDefinition>
-   <latexCommand>\CYRABHCHDSC</latexCommand>
-   <unicodeCommand>Ҿ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \CYRZHDSC  -->
-<commandDefinition>
-   <latexCommand>\CYRZHDSC</latexCommand>
-   <unicodeCommand>Җ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-   
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \CYRABHDZE  -->
-<commandDefinition>
-   <latexCommand>\CYRABHDZE</latexCommand>
-   <unicodeCommand>Ӡ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \CYRZDSC  -->
-<commandDefinition>
-   <latexCommand>\CYRZDSC</latexCommand>
-   <unicodeCommand>Ҙ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- arg  \CYRKHK  -->
-<commandDefinition>
-   <latexCommand>\CYRKHK</latexCommand>
-   <unicodeCommand>Ӄ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2B</arguments>
-   </package>
-   
-</commandDefinition>
-
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \CYRKHCRS  -->
-<commandDefinition>
-   <latexCommand>\CYRKHCRS</latexCommand>
-   <unicodeCommand>Ҟ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \CYRKDSC  -->
-<commandDefinition>
-   <latexCommand>\CYRKDSC</latexCommand>
-   <unicodeCommand>Қ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \CYRKVCRS  -->
-<commandDefinition>
-   <latexCommand>\CYRKVCRS</latexCommand>
-   <unicodeCommand>Ҝ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \CYRLJE  -->
-<commandDefinition>
-   <latexCommand>\CYRLJE</latexCommand>
-   <unicodeCommand>Љ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- arg  \CYRLDSC  -->
-<commandDefinition>
-   <latexCommand>\CYRLDSC</latexCommand>
-   <unicodeCommand>Ӆ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2B</arguments>
-   </package>
-   
-</commandDefinition>
-
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \CYRMDSC  -->
-<commandDefinition>
-   <latexCommand>\CYRMDSC</latexCommand>
-   <unicodeCommand>Ӎ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \CYRNDSC  -->
-<commandDefinition>
-   <latexCommand>\CYRNDSC</latexCommand>
-   <unicodeCommand>Ң</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \CYRNG  -->
-<commandDefinition>
-   <latexCommand>\CYRNG</latexCommand>
-   <unicodeCommand>Ҥ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \CYRNJE  -->
-<commandDefinition>
-   <latexCommand>\CYRNJE</latexCommand>
-   <unicodeCommand>Њ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- arg  \CYRNHK  -->
-<commandDefinition>
-   <latexCommand>\CYRNHK</latexCommand>
-   <unicodeCommand>Ӈ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2B</arguments>
-   </package>
-   
-</commandDefinition>
-
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYROTLD  -->
-<commandDefinition>
-   <latexCommand>\CYROTLD</latexCommand>
-   <unicodeCommand>Ө</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRPHK  -->
-<commandDefinition>
-   <latexCommand>\CYRPHK</latexCommand>
-   <unicodeCommand>Ҧ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRRTICK  -->
-<commandDefinition>
-   <latexCommand>\CYRRTICK</latexCommand>
-   <unicodeCommand>Ҏ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \CYRSDSC  -->
-<commandDefinition>
-   <latexCommand>\CYRSDSC</latexCommand>
-   <unicodeCommand>Ҫ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \CYRTDSC  -->
-<commandDefinition>
-   <latexCommand>\CYRTDSC</latexCommand>
-   <unicodeCommand>Ҭ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \CYRTSHE  -->
-<commandDefinition>
-   <latexCommand>\CYRTSHE</latexCommand>
-   <unicodeCommand>Ћ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \CYRDJE  -->
-<commandDefinition>
-   <latexCommand>\CYRDJE</latexCommand>
-   <unicodeCommand>Ђ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \CYRUSHRT  -->
-<commandDefinition>
-   <latexCommand>\CYRUSHRT</latexCommand>
-   <unicodeCommand>Ў</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \CYRSHHA  -->
-<commandDefinition>
-   <latexCommand>\CYRSHHA</latexCommand>
-   <unicodeCommand>Һ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \CYRGHK  -->
-<commandDefinition>
-   <latexCommand>\CYRGHK</latexCommand>
-   <unicodeCommand>Ҕ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \CYRGUP  -->
-<commandDefinition>
-   <latexCommand>\CYRGUP</latexCommand>
-   <unicodeCommand>Ґ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \CYRGHCRS  -->
-<commandDefinition>
-   <latexCommand>\CYRGHCRS</latexCommand>
-   <unicodeCommand>Ғ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRHDSC  -->
-<commandDefinition>
-   <latexCommand>\CYRHDSC</latexCommand>
-   <unicodeCommand>Ҳ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRDZHE  -->
-<commandDefinition>
-   <latexCommand>\CYRDZHE</latexCommand>
-   <unicodeCommand>Џ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRDZE  -->
-<commandDefinition>
-   <latexCommand>\CYRDZE</latexCommand>
-   <unicodeCommand>Ѕ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRTETSE  -->
-<commandDefinition>
-   <latexCommand>\CYRTETSE</latexCommand>
-   <unicodeCommand>Ҵ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- arg  \CYRCHLDSC  -->
-<commandDefinition>
-   <latexCommand>\CYRCHLDSC</latexCommand>
-   <unicodeCommand>Ӌ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2B</arguments>
-   </package>
-   
-</commandDefinition>
-
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \CYRCHVCRS  -->
-<commandDefinition>
-   <latexCommand>\CYRCHVCRS</latexCommand>
-   <unicodeCommand>Ҹ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \CYRCHRDSC  -->
-<commandDefinition>
-   <latexCommand>\CYRCHRDSC</latexCommand>
-   <unicodeCommand>Ҷ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \CYRSEMISFTSN  -->
-<commandDefinition>
-   <latexCommand>\CYRSEMISFTSN</latexCommand>
-   <unicodeCommand>Ҍ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \CYRIE  -->
-<commandDefinition>
-   <latexCommand>\CYRIE</latexCommand>
-   <unicodeCommand>Є</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRSCHWA  -->
-<commandDefinition>
-   <latexCommand>\CYRSCHWA</latexCommand>
-   <unicodeCommand>Ә</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRII  -->
-<commandDefinition>
-   <latexCommand>\CYRII</latexCommand>
-   <unicodeCommand>І</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRJE  -->
-<commandDefinition>
-   <latexCommand>\CYRJE</latexCommand>
-   <unicodeCommand>Ј</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \CYRYI  -->
-<commandDefinition>
-   <latexCommand>\CYRYI</latexCommand>
-   <unicodeCommand>Ї</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \CYRY  -->
-<commandDefinition>
-   <latexCommand>\CYRY</latexCommand>
-   <unicodeCommand>Ү</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \CYRYHCRS  -->
-<commandDefinition>
-   <latexCommand>\CYRYHCRS</latexCommand>
-   <unicodeCommand>Ұ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \CYRAE  -->
-<commandDefinition>
-   <latexCommand>\CYRAE</latexCommand>
-   <unicodeCommand>Ӕ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRABHHA  -->
-<commandDefinition>
-   <latexCommand>\CYRABHHA</latexCommand>
-   <unicodeCommand>Ҩ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \CYRpalochka  -->
-<commandDefinition>
-   <latexCommand>\CYRpalochka</latexCommand>
-   <unicodeCommand>Ӏ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrabhch  -->
-<commandDefinition>
-   <latexCommand>\cyrabhch</latexCommand>
-   <unicodeCommand>ҽ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrabhchdsc  -->
-<commandDefinition>
-   <latexCommand>\cyrabhchdsc</latexCommand>
-   <unicodeCommand>ҿ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \cyrzhdsc  -->
-<commandDefinition>
-   <latexCommand>\cyrzhdsc</latexCommand>
-   <unicodeCommand>җ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \cyrabhdze  -->
-<commandDefinition>
-   <latexCommand>\cyrabhdze</latexCommand>
-   <unicodeCommand>ӡ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \cyrzdsc  -->
-<commandDefinition>
-   <latexCommand>\cyrzdsc</latexCommand>
-   <unicodeCommand>ҙ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- arg  \cyrkhk  -->
-<commandDefinition>
-   <latexCommand>\cyrkhk</latexCommand>
-   <unicodeCommand>ӄ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2B</arguments>
-   </package>
-   
-</commandDefinition>
-
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \cyrkhcrs  -->
-<commandDefinition>
-   <latexCommand>\cyrkhcrs</latexCommand>
-   <unicodeCommand>ҟ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \cyrkdsc  -->
-<commandDefinition>
-   <latexCommand>\cyrkdsc</latexCommand>
-   <unicodeCommand>қ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \cyrkvcrs  -->
-<commandDefinition>
-   <latexCommand>\cyrkvcrs</latexCommand>
-   <unicodeCommand>ҝ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \cyrlje  -->
-<commandDefinition>
-   <latexCommand>\cyrlje</latexCommand>
-   <unicodeCommand>љ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- arg  \cyrldsc  -->
-<commandDefinition>
-   <latexCommand>\cyrldsc</latexCommand>
-   <unicodeCommand>ӆ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2B</arguments>
-   </package>
-   
-</commandDefinition>
-
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \cyrmdsc  -->
-<commandDefinition>
-   <latexCommand>\cyrmdsc</latexCommand>
-   <unicodeCommand>ӎ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \cyrndsc  -->
-<commandDefinition>
-   <latexCommand>\cyrndsc</latexCommand>
-   <unicodeCommand>ӊ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \cyrng  -->
-<commandDefinition>
-   <latexCommand>\cyrng</latexCommand>
-   <unicodeCommand>ҥ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \cyrnje  -->
-<commandDefinition>
-   <latexCommand>\cyrnje</latexCommand>
-   <unicodeCommand>њ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- arg  \cyrnhk  -->
-<commandDefinition>
-   <latexCommand>\cyrnhk</latexCommand>
-   <unicodeCommand>ӈ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2B</arguments>
-   </package>
-   
-</commandDefinition>
-
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrotld  -->
-<commandDefinition>
-   <latexCommand>\cyrotld</latexCommand>
-   <unicodeCommand>ө</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrphk  -->
-<commandDefinition>
-   <latexCommand>\cyrphk</latexCommand>
-   <unicodeCommand>ҧ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrrtick  -->
-<commandDefinition>
-   <latexCommand>\cyrrtick</latexCommand>
-   <unicodeCommand>ҏ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \cyrsdsc  -->
-<commandDefinition>
-   <latexCommand>\cyrsdsc</latexCommand>
-   <unicodeCommand>ҫ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \cyrtdsc  -->
-<commandDefinition>
-   <latexCommand>\cyrtdsc</latexCommand>
-   <unicodeCommand>ҭ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \cyrtshe  -->
-<commandDefinition>
-   <latexCommand>\cyrtshe</latexCommand>
-   <unicodeCommand>ћ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \cyrdje  -->
-<commandDefinition>
-   <latexCommand>\cyrdje</latexCommand>
-   <unicodeCommand>ђ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \cyrushrt  -->
-<commandDefinition>
-   <latexCommand>\cyrushrt</latexCommand>
-   <unicodeCommand>ў</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \cyrshha  -->
-<commandDefinition>
-   <latexCommand>\cyrshha</latexCommand>
-   <unicodeCommand>һ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \cyrghk  -->
-<commandDefinition>
-   <latexCommand>\cyrghk</latexCommand>
-   <unicodeCommand>ҕ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \cyrgup  -->
-<commandDefinition>
-   <latexCommand>\cyrgup</latexCommand>
-   <unicodeCommand>ґ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \cyrghcrs  -->
-<commandDefinition>
-   <latexCommand>\cyrghcrs</latexCommand>
-   <unicodeCommand>ғ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrhdsc  -->
-<commandDefinition>
-   <latexCommand>\cyrhdsc</latexCommand>
-   <unicodeCommand>ҳ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrdzhe  -->
-<commandDefinition>
-   <latexCommand>\cyrdzhe</latexCommand>
-   <unicodeCommand>џ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrdze  -->
-<commandDefinition>
-   <latexCommand>\cyrdze</latexCommand>
-   <unicodeCommand>ѕ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrtetse  -->
-<commandDefinition>
-   <latexCommand>\cyrtetse</latexCommand>
-   <unicodeCommand>ҵ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- arg  \cyrchldsc  -->
-<commandDefinition>
-   <latexCommand>\cyrchldsc</latexCommand>
-   <unicodeCommand>ӌ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2B</arguments>
-   </package>
-   
-</commandDefinition>
-
-<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \cyrchvcrs  -->
-<commandDefinition>
-   <latexCommand>\cyrchvcrs</latexCommand>
-   <unicodeCommand>ҹ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrchrdsc  -->
-<commandDefinition>
-   <latexCommand>\cyrchrdsc</latexCommand>
-   <unicodeCommand>ҷ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrsemisftsn  -->
-<commandDefinition>
-   <latexCommand>\cyrsemisftsn</latexCommand>
-   <unicodeCommand>ҍ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \cyrie  -->
-<commandDefinition>
-   <latexCommand>\cyrie</latexCommand>
-   <unicodeCommand>є</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrschwa  -->
-<commandDefinition>
-   <latexCommand>\cyrschwa</latexCommand>
-   <unicodeCommand>ә</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrii  -->
-<commandDefinition>
-   <latexCommand>\cyrii</latexCommand>
-   <unicodeCommand>і</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
-<!-- arg  \cyrje  -->
-<commandDefinition>
-   <latexCommand>\cyrje</latexCommand>
-   <unicodeCommand>ј</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \cyryi  -->
-<commandDefinition>
-   <latexCommand>\cyryi</latexCommand>
-   <unicodeCommand>ї</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \cyry  -->
-<commandDefinition>
-   <latexCommand>\cyry</latexCommand>
-   <unicodeCommand>ү</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \cyryhcrs  -->
-<commandDefinition>
-   <latexCommand>\cyryhcrs</latexCommand>
-   <unicodeCommand>ұ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- arg  \cyrae  -->
-<commandDefinition>
-   <latexCommand>\cyrae</latexCommand>
-   <unicodeCommand>ӕ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2A</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>ukrainian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \cyrabhha  -->
-<commandDefinition>
-   <latexCommand>\cyrabhha</latexCommand>
-   <unicodeCommand>ҩ</unicodeCommand>
-   
-   <package>
-      <name>fontenc</name>
-      <arguments>T2C</arguments>
-   </package>
-   
-   <package>
-      <name>babel</name>
-      <arguments>russian</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
+	<formatVersion major="0" minor="22"/>
+
+	<symbolGroupName>user</symbolGroupName>
+
+	<preamble>
+		<class>standalone</class>
+		<arguments>10bp,margin=1bp</arguments>
+		<additional>\usepackage[T1]{fontenc}</additional>
+	</preamble>
+
+	<unicodeCommandPackages>
+		<package>
+			<name>inputenc</name>
+			<arguments>utf8</arguments>
+		</package>
+	</unicodeCommandPackages>
+
+	<!-- insert stuff here -->
+
+	<symbolGroupName>cyrillic</symbolGroupName>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRA -->
+	<commandDefinition>
+		<latexCommand>\CYRA</latexCommand>
+		<unicodeCommand>А</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRB -->
+	<commandDefinition>
+		<latexCommand>\CYRB</latexCommand>
+		<unicodeCommand>Б</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRV -->
+	<commandDefinition>
+		<latexCommand>\CYRV</latexCommand>
+		<unicodeCommand>В</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRG -->
+	<commandDefinition>
+		<latexCommand>\CYRG</latexCommand>
+		<unicodeCommand>Г</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRD -->
+	<commandDefinition>
+		<latexCommand>\CYRD</latexCommand>
+		<unicodeCommand>Д</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRE -->
+	<commandDefinition>
+		<latexCommand>\CYRE</latexCommand>
+		<unicodeCommand>Е</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRYO -->
+	<commandDefinition>
+		<latexCommand>\CYRYO</latexCommand>
+		<unicodeCommand>Ё</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRZH -->
+	<commandDefinition>
+		<latexCommand>\CYRZH</latexCommand>
+		<unicodeCommand>Ж</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRZ -->
+	<commandDefinition>
+		<latexCommand>\CYRZ</latexCommand>
+		<unicodeCommand>З</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRI -->
+	<commandDefinition>
+		<latexCommand>\CYRI</latexCommand>
+		<unicodeCommand>И</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRISHRT -->
+	<commandDefinition>
+		<latexCommand>\CYRISHRT</latexCommand>
+		<unicodeCommand>Й</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRK -->
+	<commandDefinition>
+		<latexCommand>\CYRK</latexCommand>
+		<unicodeCommand>К</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRL -->
+	<commandDefinition>
+		<latexCommand>\CYRL</latexCommand>
+		<unicodeCommand>Л</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRM -->
+	<commandDefinition>
+		<latexCommand>\CYRM</latexCommand>
+		<unicodeCommand>М</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRN -->
+	<commandDefinition>
+		<latexCommand>\CYRN</latexCommand>
+		<unicodeCommand>Н</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRO -->
+	<commandDefinition>
+		<latexCommand>\CYRO</latexCommand>
+		<unicodeCommand>О</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRP -->
+	<commandDefinition>
+		<latexCommand>\CYRP</latexCommand>
+		<unicodeCommand>П</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRR -->
+	<commandDefinition>
+		<latexCommand>\CYRR</latexCommand>
+		<unicodeCommand>Р</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRS -->
+	<commandDefinition>
+		<latexCommand>\CYRS</latexCommand>
+		<unicodeCommand>С</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRT -->
+	<commandDefinition>
+		<latexCommand>\CYRT</latexCommand>
+		<unicodeCommand>Т</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRU -->
+	<commandDefinition>
+		<latexCommand>\CYRU</latexCommand>
+		<unicodeCommand>У</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRF -->
+	<commandDefinition>
+		<latexCommand>\CYRF</latexCommand>
+		<unicodeCommand>Ф</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRH -->
+	<commandDefinition>
+		<latexCommand>\CYRH</latexCommand>
+		<unicodeCommand>Х</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRC -->
+	<commandDefinition>
+		<latexCommand>\CYRC</latexCommand>
+		<unicodeCommand>Ц</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRCH -->
+	<commandDefinition>
+		<latexCommand>\CYRCH</latexCommand>
+		<unicodeCommand>Ч</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRSH -->
+	<commandDefinition>
+		<latexCommand>\CYRSH</latexCommand>
+		<unicodeCommand>Ш</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRSHCH -->
+	<commandDefinition>
+		<latexCommand>\CYRSHCH</latexCommand>
+		<unicodeCommand>Щ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRHRDSN -->
+	<commandDefinition>
+		<latexCommand>\CYRHRDSN</latexCommand>
+		<unicodeCommand>Ъ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRERY -->
+	<commandDefinition>
+		<latexCommand>\CYRERY</latexCommand>
+		<unicodeCommand>Ы</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRSFTSN -->
+	<commandDefinition>
+		<latexCommand>\CYRSFTSN</latexCommand>
+		<unicodeCommand>Ь</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYREREV -->
+	<commandDefinition>
+		<latexCommand>\CYREREV</latexCommand>
+		<unicodeCommand>Э</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRYU -->
+	<commandDefinition>
+		<latexCommand>\CYRYU</latexCommand>
+		<unicodeCommand>Ю</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRYA -->
+	<commandDefinition>
+		<latexCommand>\CYRYA</latexCommand>
+		<unicodeCommand>Я</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyra -->
+	<commandDefinition>
+		<latexCommand>\cyra</latexCommand>
+		<unicodeCommand>а</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrb -->
+	<commandDefinition>
+		<latexCommand>\cyrb</latexCommand>
+		<unicodeCommand>б</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrv -->
+	<commandDefinition>
+		<latexCommand>\cyrv</latexCommand>
+		<unicodeCommand>в</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrg -->
+	<commandDefinition>
+		<latexCommand>\cyrg</latexCommand>
+		<unicodeCommand>г</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrd -->
+	<commandDefinition>
+		<latexCommand>\cyrd</latexCommand>
+		<unicodeCommand>д</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyre -->
+	<commandDefinition>
+		<latexCommand>\cyre</latexCommand>
+		<unicodeCommand>е</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyryo -->
+	<commandDefinition>
+		<latexCommand>\cyryo</latexCommand>
+		<unicodeCommand>ё</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrzh -->
+	<commandDefinition>
+		<latexCommand>\cyrzh</latexCommand>
+		<unicodeCommand>ж</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrz -->
+	<commandDefinition>
+		<latexCommand>\cyrz</latexCommand>
+		<unicodeCommand>з</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyri -->
+	<commandDefinition>
+		<latexCommand>\cyri</latexCommand>
+		<unicodeCommand>и</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrishrt -->
+	<commandDefinition>
+		<latexCommand>\cyrishrt</latexCommand>
+		<unicodeCommand>й</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrk -->
+	<commandDefinition>
+		<latexCommand>\cyrk</latexCommand>
+		<unicodeCommand>к</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrl -->
+	<commandDefinition>
+		<latexCommand>\cyrl</latexCommand>
+		<unicodeCommand>л</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrm -->
+	<commandDefinition>
+		<latexCommand>\cyrm</latexCommand>
+		<unicodeCommand>м</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrn -->
+	<commandDefinition>
+		<latexCommand>\cyrn</latexCommand>
+		<unicodeCommand>н</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyro -->
+	<commandDefinition>
+		<latexCommand>\cyro</latexCommand>
+		<unicodeCommand>о</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrp -->
+	<commandDefinition>
+		<latexCommand>\cyrp</latexCommand>
+		<unicodeCommand>п</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrr -->
+	<commandDefinition>
+		<latexCommand>\cyrr</latexCommand>
+		<unicodeCommand>р</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrs -->
+	<commandDefinition>
+		<latexCommand>\cyrs</latexCommand>
+		<unicodeCommand>с</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrt -->
+	<commandDefinition>
+		<latexCommand>\cyrt</latexCommand>
+		<unicodeCommand>т</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyru -->
+	<commandDefinition>
+		<latexCommand>\cyru</latexCommand>
+		<unicodeCommand>у</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrf -->
+	<commandDefinition>
+		<latexCommand>\cyrf</latexCommand>
+		<unicodeCommand>ф</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrh -->
+	<commandDefinition>
+		<latexCommand>\cyrh</latexCommand>
+		<unicodeCommand>х</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrc -->
+	<commandDefinition>
+		<latexCommand>\cyrc</latexCommand>
+		<unicodeCommand>ц</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrch -->
+	<commandDefinition>
+		<latexCommand>\cyrch</latexCommand>
+		<unicodeCommand>ч</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrsh -->
+	<commandDefinition>
+		<latexCommand>\cyrsh</latexCommand>
+		<unicodeCommand>ш</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrshch -->
+	<commandDefinition>
+		<latexCommand>\cyrshch</latexCommand>
+		<unicodeCommand>щ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrhrdsn -->
+	<commandDefinition>
+		<latexCommand>\cyrhrdsn</latexCommand>
+		<unicodeCommand>ъ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrery -->
+	<commandDefinition>
+		<latexCommand>\cyrery</latexCommand>
+		<unicodeCommand>ы</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrsftsn -->
+	<commandDefinition>
+		<latexCommand>\cyrsftsn</latexCommand>
+		<unicodeCommand>ь</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrerev -->
+	<commandDefinition>
+		<latexCommand>\cyrerev</latexCommand>
+		<unicodeCommand>э</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyryu -->
+	<commandDefinition>
+		<latexCommand>\cyryu</latexCommand>
+		<unicodeCommand>ю</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrya -->
+	<commandDefinition>
+		<latexCommand>\cyrya</latexCommand>
+		<unicodeCommand>я</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRABHCH -->
+	<commandDefinition>
+		<latexCommand>\CYRABHCH</latexCommand>
+		<unicodeCommand>Ҽ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRABHCHDSC -->
+	<commandDefinition>
+		<latexCommand>\CYRABHCHDSC</latexCommand>
+		<unicodeCommand>Ҿ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRZHDSC -->
+	<commandDefinition>
+		<latexCommand>\CYRZHDSC</latexCommand>
+		<unicodeCommand>Җ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+		
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \CYRABHDZE -->
+	<commandDefinition>
+		<latexCommand>\CYRABHDZE</latexCommand>
+		<unicodeCommand>Ӡ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRZDSC -->
+	<commandDefinition>
+		<latexCommand>\CYRZDSC</latexCommand>
+		<unicodeCommand>Ҙ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
+	<!-- arg \CYRKHK -->
+	<commandDefinition>
+		<latexCommand>\CYRKHK</latexCommand>
+		<unicodeCommand>Ӄ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2B</arguments>
+		</package>
+		
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \CYRKHCRS -->
+	<commandDefinition>
+		<latexCommand>\CYRKHCRS</latexCommand>
+		<unicodeCommand>Ҟ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \CYRKDSC -->
+	<commandDefinition>
+		<latexCommand>\CYRKDSC</latexCommand>
+		<unicodeCommand>Қ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRKVCRS -->
+	<commandDefinition>
+		<latexCommand>\CYRKVCRS</latexCommand>
+		<unicodeCommand>Ҝ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRLJE -->
+	<commandDefinition>
+		<latexCommand>\CYRLJE</latexCommand>
+		<unicodeCommand>Љ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRLDSC -->
+	<commandDefinition>
+		<latexCommand>\CYRLDSC</latexCommand>
+		<unicodeCommand>Ӆ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2B</arguments>
+		</package>
+		
+	</commandDefinition>
+
+	<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
+	<!-- arg \CYRMDSC -->
+	<commandDefinition>
+		<latexCommand>\CYRMDSC</latexCommand>
+		<unicodeCommand>Ӎ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \CYRNDSC -->
+	<commandDefinition>
+		<latexCommand>\CYRNDSC</latexCommand>
+		<unicodeCommand>Ң</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRNG -->
+	<commandDefinition>
+		<latexCommand>\CYRNG</latexCommand>
+		<unicodeCommand>Ҥ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRNJE -->
+	<commandDefinition>
+		<latexCommand>\CYRNJE</latexCommand>
+		<unicodeCommand>Њ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
+	<!-- arg \CYRNHK -->
+	<commandDefinition>
+		<latexCommand>\CYRNHK</latexCommand>
+		<unicodeCommand>Ӈ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2B</arguments>
+		</package>
+		
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYROTLD -->
+	<commandDefinition>
+		<latexCommand>\CYROTLD</latexCommand>
+		<unicodeCommand>Ө</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRPHK -->
+	<commandDefinition>
+		<latexCommand>\CYRPHK</latexCommand>
+		<unicodeCommand>Ҧ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRRTICK -->
+	<commandDefinition>
+		<latexCommand>\CYRRTICK</latexCommand>
+		<unicodeCommand>Ҏ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRSDSC -->
+	<commandDefinition>
+		<latexCommand>\CYRSDSC</latexCommand>
+		<unicodeCommand>Ҫ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRTDSC -->
+	<commandDefinition>
+		<latexCommand>\CYRTDSC</latexCommand>
+		<unicodeCommand>Ҭ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRTSHE -->
+	<commandDefinition>
+		<latexCommand>\CYRTSHE</latexCommand>
+		<unicodeCommand>Ћ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRDJE -->
+	<commandDefinition>
+		<latexCommand>\CYRDJE</latexCommand>
+		<unicodeCommand>Ђ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRUSHRT -->
+	<commandDefinition>
+		<latexCommand>\CYRUSHRT</latexCommand>
+		<unicodeCommand>Ў</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRSHHA -->
+	<commandDefinition>
+		<latexCommand>\CYRSHHA</latexCommand>
+		<unicodeCommand>Һ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \CYRGHK -->
+	<commandDefinition>
+		<latexCommand>\CYRGHK</latexCommand>
+		<unicodeCommand>Ҕ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRGUP -->
+	<commandDefinition>
+		<latexCommand>\CYRGUP</latexCommand>
+		<unicodeCommand>Ґ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRGHCRS -->
+	<commandDefinition>
+		<latexCommand>\CYRGHCRS</latexCommand>
+		<unicodeCommand>Ғ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRHDSC -->
+	<commandDefinition>
+		<latexCommand>\CYRHDSC</latexCommand>
+		<unicodeCommand>Ҳ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRDZHE -->
+	<commandDefinition>
+		<latexCommand>\CYRDZHE</latexCommand>
+		<unicodeCommand>Џ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRDZE -->
+	<commandDefinition>
+		<latexCommand>\CYRDZE</latexCommand>
+		<unicodeCommand>Ѕ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRTETSE -->
+	<commandDefinition>
+		<latexCommand>\CYRTETSE</latexCommand>
+		<unicodeCommand>Ҵ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
+	<!-- arg \CYRCHLDSC -->
+	<commandDefinition>
+		<latexCommand>\CYRCHLDSC</latexCommand>
+		<unicodeCommand>Ӌ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2B</arguments>
+		</package>
+		
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRCHVCRS -->
+	<commandDefinition>
+		<latexCommand>\CYRCHVCRS</latexCommand>
+		<unicodeCommand>Ҹ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRCHRDSC -->
+	<commandDefinition>
+		<latexCommand>\CYRCHRDSC</latexCommand>
+		<unicodeCommand>Ҷ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \CYRSEMISFTSN -->
+	<commandDefinition>
+		<latexCommand>\CYRSEMISFTSN</latexCommand>
+		<unicodeCommand>Ҍ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRIE -->
+	<commandDefinition>
+		<latexCommand>\CYRIE</latexCommand>
+		<unicodeCommand>Є</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRSCHWA -->
+	<commandDefinition>
+		<latexCommand>\CYRSCHWA</latexCommand>
+		<unicodeCommand>Ә</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRII -->
+	<commandDefinition>
+		<latexCommand>\CYRII</latexCommand>
+		<unicodeCommand>І</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRJE -->
+	<commandDefinition>
+		<latexCommand>\CYRJE</latexCommand>
+		<unicodeCommand>Ј</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRYI -->
+	<commandDefinition>
+		<latexCommand>\CYRYI</latexCommand>
+		<unicodeCommand>Ї</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRY -->
+	<commandDefinition>
+		<latexCommand>\CYRY</latexCommand>
+		<unicodeCommand>Ү</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRYHCRS -->
+	<commandDefinition>
+		<latexCommand>\CYRYHCRS</latexCommand>
+		<unicodeCommand>Ұ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \CYRAE -->
+	<commandDefinition>
+		<latexCommand>\CYRAE</latexCommand>
+		<unicodeCommand>Ӕ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRABHHA -->
+	<commandDefinition>
+		<latexCommand>\CYRABHHA</latexCommand>
+		<unicodeCommand>Ҩ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \CYRpalochka -->
+	<commandDefinition>
+		<latexCommand>\CYRpalochka</latexCommand>
+		<unicodeCommand>Ӏ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrabhch -->
+	<commandDefinition>
+		<latexCommand>\cyrabhch</latexCommand>
+		<unicodeCommand>ҽ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrabhchdsc -->
+	<commandDefinition>
+		<latexCommand>\cyrabhchdsc</latexCommand>
+		<unicodeCommand>ҿ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrzhdsc -->
+	<commandDefinition>
+		<latexCommand>\cyrzhdsc</latexCommand>
+		<unicodeCommand>җ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrabhdze -->
+	<commandDefinition>
+		<latexCommand>\cyrabhdze</latexCommand>
+		<unicodeCommand>ӡ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrzdsc -->
+	<commandDefinition>
+		<latexCommand>\cyrzdsc</latexCommand>
+		<unicodeCommand>ҙ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrkhk -->
+	<commandDefinition>
+		<latexCommand>\cyrkhk</latexCommand>
+		<unicodeCommand>ӄ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2B</arguments>
+		</package>
+		
+	</commandDefinition>
+
+	<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
+	<!-- arg \cyrkhcrs -->
+	<commandDefinition>
+		<latexCommand>\cyrkhcrs</latexCommand>
+		<unicodeCommand>ҟ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \cyrkdsc -->
+	<commandDefinition>
+		<latexCommand>\cyrkdsc</latexCommand>
+		<unicodeCommand>қ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrkvcrs -->
+	<commandDefinition>
+		<latexCommand>\cyrkvcrs</latexCommand>
+		<unicodeCommand>ҝ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrlje -->
+	<commandDefinition>
+		<latexCommand>\cyrlje</latexCommand>
+		<unicodeCommand>љ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrldsc -->
+	<commandDefinition>
+		<latexCommand>\cyrldsc</latexCommand>
+		<unicodeCommand>ӆ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2B</arguments>
+		</package>
+		
+	</commandDefinition>
+
+	<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
+	<!-- arg \cyrmdsc -->
+	<commandDefinition>
+		<latexCommand>\cyrmdsc</latexCommand>
+		<unicodeCommand>ӎ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \cyrndsc -->
+	<commandDefinition>
+		<latexCommand>\cyrndsc</latexCommand>
+		<unicodeCommand>ӊ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrng -->
+	<commandDefinition>
+		<latexCommand>\cyrng</latexCommand>
+		<unicodeCommand>ҥ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrnje -->
+	<commandDefinition>
+		<latexCommand>\cyrnje</latexCommand>
+		<unicodeCommand>њ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrnhk -->
+	<commandDefinition>
+		<latexCommand>\cyrnhk</latexCommand>
+		<unicodeCommand>ӈ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2B</arguments>
+		</package>
+		
+	</commandDefinition>
+
+	<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
+	<!-- arg \cyrotld -->
+	<commandDefinition>
+		<latexCommand>\cyrotld</latexCommand>
+		<unicodeCommand>ө</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrphk -->
+	<commandDefinition>
+		<latexCommand>\cyrphk</latexCommand>
+		<unicodeCommand>ҧ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrrtick -->
+	<commandDefinition>
+		<latexCommand>\cyrrtick</latexCommand>
+		<unicodeCommand>ҏ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrsdsc -->
+	<commandDefinition>
+		<latexCommand>\cyrsdsc</latexCommand>
+		<unicodeCommand>ҫ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrtdsc -->
+	<commandDefinition>
+		<latexCommand>\cyrtdsc</latexCommand>
+		<unicodeCommand>ҭ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrtshe -->
+	<commandDefinition>
+		<latexCommand>\cyrtshe</latexCommand>
+		<unicodeCommand>ћ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrdje -->
+	<commandDefinition>
+		<latexCommand>\cyrdje</latexCommand>
+		<unicodeCommand>ђ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrushrt -->
+	<commandDefinition>
+		<latexCommand>\cyrushrt</latexCommand>
+		<unicodeCommand>ў</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrshha -->
+	<commandDefinition>
+		<latexCommand>\cyrshha</latexCommand>
+		<unicodeCommand>һ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \cyrghk -->
+	<commandDefinition>
+		<latexCommand>\cyrghk</latexCommand>
+		<unicodeCommand>ҕ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrgup -->
+	<commandDefinition>
+		<latexCommand>\cyrgup</latexCommand>
+		<unicodeCommand>ґ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrghcrs -->
+	<commandDefinition>
+		<latexCommand>\cyrghcrs</latexCommand>
+		<unicodeCommand>ғ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrhdsc -->
+	<commandDefinition>
+		<latexCommand>\cyrhdsc</latexCommand>
+		<unicodeCommand>ҳ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrdzhe -->
+	<commandDefinition>
+		<latexCommand>\cyrdzhe</latexCommand>
+		<unicodeCommand>џ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrdze -->
+	<commandDefinition>
+		<latexCommand>\cyrdze</latexCommand>
+		<unicodeCommand>ѕ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrtetse -->
+	<commandDefinition>
+		<latexCommand>\cyrtetse</latexCommand>
+		<unicodeCommand>ҵ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
+	<!-- arg \cyrchldsc -->
+	<commandDefinition>
+		<latexCommand>\cyrchldsc</latexCommand>
+		<unicodeCommand>ӌ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T2B</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=inputenc,fontenc,mathtext ,pkgsarg=koi8-r,T2B, ,savepkgs=inputenc,fontenc,mathtext ,savepkgsarg=koi8-r,T2B,-->
+	<!-- arg \cyrchvcrs -->
+	<commandDefinition>
+		<latexCommand>\cyrchvcrs</latexCommand>
+		<unicodeCommand>ҹ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrchrdsc -->
+	<commandDefinition>
+		<latexCommand>\cyrchrdsc</latexCommand>
+		<unicodeCommand>ҷ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrsemisftsn -->
+	<commandDefinition>
+		<latexCommand>\cyrsemisftsn</latexCommand>
+		<unicodeCommand>ҍ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrie -->
+	<commandDefinition>
+		<latexCommand>\cyrie</latexCommand>
+		<unicodeCommand>є</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrschwa -->
+	<commandDefinition>
+		<latexCommand>\cyrschwa</latexCommand>
+		<unicodeCommand>ә</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrii -->
+	<commandDefinition>
+		<latexCommand>\cyrii</latexCommand>
+		<unicodeCommand>і</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=russian,koi8-r,T2C, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=russian,koi8-r,T2C,-->
+	<!-- arg \cyrje -->
+	<commandDefinition>
+		<latexCommand>\cyrje</latexCommand>
+		<unicodeCommand>ј</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyryi -->
+	<commandDefinition>
+		<latexCommand>\cyryi</latexCommand>
+		<unicodeCommand>ї</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyry -->
+	<commandDefinition>
+		<latexCommand>\cyry</latexCommand>
+		<unicodeCommand>ү</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyryhcrs -->
+	<commandDefinition>
+		<latexCommand>\cyryhcrs</latexCommand>
+		<unicodeCommand>ұ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrae -->
+	<commandDefinition>
+		<latexCommand>\cyrae</latexCommand>
+		<unicodeCommand>ӕ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2A</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>ukrainian</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=babel,inputenc,fontenc,mathtext ,pkgsarg=ukrainian,koi8-r,T2A, ,savepkgs=babel,inputenc,fontenc,mathtext ,savepkgsarg=ukrainian,koi8-r,T2A,-->
+	<!-- arg \cyrabhha -->
+	<commandDefinition>
+		<latexCommand>\cyrabhha</latexCommand>
+		<unicodeCommand>ҩ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T2C</arguments>
+		</package>
+		<package>
+			<name>babel</name>
+			<arguments>russian</arguments>
+		</package>
+	</commandDefinition>
+
 </symbols>
-

--- a/symbols-ng/delimiters.xml
+++ b/symbols-ng/delimiters.xml
@@ -3,365 +3,353 @@
 <!DOCTYPE KileSymbolSources>
 <symbols>
 
-   <formatVersion major="0" minor ="22" />
+	<formatVersion major="0" minor ="22" />
 
-   <symbolGroupName>user</symbolGroupName>
+	<symbolGroupName>user</symbolGroupName>
 
-   <preamble>
-      <class>article</class>
-      <arguments>12pt</arguments>
-      <additional>\pagestyle{empty}
-		  \setlength{\parindent}{0cm}
-		  \usepackage[T1]{fontenc}
-      </additional>
-   </preamble>
+	<preamble>
+		<class>standalone</class>
+		<arguments>10bp,margin=1bp</arguments>
+		<additional>\usepackage[T1]{fontenc}</additional>
+	</preamble>
 
-   <unicodeCommandPackages>
-      <package>
-         <name>inputenc</name>
-         <arguments>utf8</arguments>
-      </package>
-   </unicodeCommandPackages>
+	<unicodeCommandPackages>
+		<package>
+			<name>inputenc</name>
+			<arguments>utf8</arguments>
+		</package>
+	</unicodeCommandPackages>
 
-   <!-- insert stuff here    -->
-<symbolGroupName>delimiters</symbolGroupName>
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \downarrow  -->
-<commandDefinition>
-   <latexCommand>\downarrow</latexCommand>
-   <unicodeCommand>↓</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- insert stuff here -->
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Downarrow  -->
-<commandDefinition>
-   <latexCommand>\Downarrow</latexCommand>
-   <unicodeCommand>⇓</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<symbolGroupName>delimiters</symbolGroupName>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math [  -->
-<commandDefinition>
-   <latexCommand>[</latexCommand>
-   <unicodeCommand>[</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \downarrow -->
+	<commandDefinition>
+		<latexCommand>\downarrow</latexCommand>
+		<unicodeCommand>↓</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math ]  -->
-<commandDefinition>
-   <latexCommand>]</latexCommand>
-   <unicodeCommand>]</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Downarrow -->
+	<commandDefinition>
+		<latexCommand>\Downarrow</latexCommand>
+		<unicodeCommand>⇓</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \langle  -->
-<commandDefinition>
-   <latexCommand>\langle</latexCommand>
-   <unicodeCommand>⟨</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math [ -->
+	<commandDefinition>
+		<latexCommand>[</latexCommand>
+		<unicodeCommand>[</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \rangle  -->
-<commandDefinition>
-   <latexCommand>\rangle</latexCommand>
-   <unicodeCommand>⟩</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math ] -->
+	<commandDefinition>
+		<latexCommand>]</latexCommand>
+		<unicodeCommand>]</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math |  -->
-<commandDefinition>
-   <latexCommand>|</latexCommand>
-   <unicodeCommand>|</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \langle -->
+	<commandDefinition>
+		<latexCommand>\langle</latexCommand>
+		<unicodeCommand>⟨</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \|  -->
-<commandDefinition>
-   <latexCommand>\|</latexCommand>
-   <unicodeCommand>‖</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \rangle -->
+	<commandDefinition>
+		<latexCommand>\rangle</latexCommand>
+		<unicodeCommand>⟩</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \lceil  -->
-<commandDefinition>
-   <latexCommand>\lceil</latexCommand>
-   <unicodeCommand>⌈</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math | -->
+	<commandDefinition>
+		<latexCommand>|</latexCommand>
+		<unicodeCommand>|</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \rceil  -->
-<commandDefinition>
-   <latexCommand>\rceil</latexCommand>
-   <unicodeCommand>⌉</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \| -->
+	<commandDefinition>
+		<latexCommand>\|</latexCommand>
+		<unicodeCommand>‖</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \uparrow  -->
-<commandDefinition>
-   <latexCommand>\uparrow</latexCommand>
-   <unicodeCommand>↑</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \lceil -->
+	<commandDefinition>
+		<latexCommand>\lceil</latexCommand>
+		<unicodeCommand>⌈</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Uparrow  -->
-<commandDefinition>
-   <latexCommand>\Uparrow</latexCommand>
-   <unicodeCommand>⇑</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \rceil -->
+	<commandDefinition>
+		<latexCommand>\rceil</latexCommand>
+		<unicodeCommand>⌉</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \lfloor  -->
-<commandDefinition>
-   <latexCommand>\lfloor</latexCommand>
-   <unicodeCommand>⌊</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \uparrow -->
+	<commandDefinition>
+		<latexCommand>\uparrow</latexCommand>
+		<unicodeCommand>↑</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \rfloor  -->
-<commandDefinition>
-   <latexCommand>\rfloor</latexCommand>
-   <unicodeCommand>⌋</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Uparrow -->
+	<commandDefinition>
+		<latexCommand>\Uparrow</latexCommand>
+		<unicodeCommand>⇑</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \updownarrow  -->
-<commandDefinition>
-   <latexCommand>\updownarrow</latexCommand>
-   <unicodeCommand>↕</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \lfloor -->
+	<commandDefinition>
+		<latexCommand>\lfloor</latexCommand>
+		<unicodeCommand>⌊</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Updownarrow  -->
-<commandDefinition>
-   <latexCommand>\Updownarrow</latexCommand>
-   <unicodeCommand>⇕</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \rfloor -->
+	<commandDefinition>
+		<latexCommand>\rfloor</latexCommand>
+		<unicodeCommand>⌋</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math (  -->
-<commandDefinition>
-   <latexCommand>(</latexCommand>
-   <unicodeCommand>(</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \updownarrow -->
+	<commandDefinition>
+		<latexCommand>\updownarrow</latexCommand>
+		<unicodeCommand>↕</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math )  -->
-<commandDefinition>
-   <latexCommand>)</latexCommand>
-   <unicodeCommand>)</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Updownarrow -->
+	<commandDefinition>
+		<latexCommand>\Updownarrow</latexCommand>
+		<unicodeCommand>⇕</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \{  -->
-<commandDefinition>
-   <latexCommand>\{</latexCommand>
-   <unicodeCommand>\{</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math ( -->
+	<commandDefinition>
+		<latexCommand>(</latexCommand>
+		<unicodeCommand>(</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \}  -->
-<commandDefinition>
-   <latexCommand>\}</latexCommand>
-   <unicodeCommand>\}</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math ) -->
+	<commandDefinition>
+		<latexCommand>)</latexCommand>
+		<unicodeCommand>)</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math /  -->
-<commandDefinition>
-   <latexCommand>/</latexCommand>
-   <unicodeCommand>/</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \{ -->
+	<commandDefinition>
+		<latexCommand>\{</latexCommand>
+		<unicodeCommand>\{</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \backslash  -->
-<commandDefinition>
-   <latexCommand>\backslash</latexCommand>
-   <unicodeCommand>\</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \} -->
+	<commandDefinition>
+		<latexCommand>\}</latexCommand>
+		<unicodeCommand>\}</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \lmoustache \left \lmoustache \right. -->
-<commandDefinition>
-   <latexCommand>\lmoustache</latexCommand>
-   <unicodeCommand>⎰</unicodeCommand>
-   <imageCommand>\left \lmoustache \right.</imageCommand>
-   <mathMode>true</mathMode>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math / -->
+	<commandDefinition>
+		<latexCommand>/</latexCommand>
+		<unicodeCommand>/</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \rmoustache \left \rmoustache \right. -->
-<commandDefinition>
-   <latexCommand>\rmoustache</latexCommand>
-   <unicodeCommand>⎱</unicodeCommand>
-   <imageCommand>\left \rmoustache \right.</imageCommand>
-   <mathMode>true</mathMode>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \backslash -->
+	<commandDefinition>
+		<latexCommand>\backslash</latexCommand>
+		<unicodeCommand>\</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \lgroup \left \lgroup \right. -->
-<commandDefinition>
-   <latexCommand>\lgroup</latexCommand>
-   <imageCommand>\left \lgroup \right.</imageCommand>
-   <mathMode>true</mathMode>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \lmoustache \left \lmoustache \right. -->
+	<commandDefinition>
+		<latexCommand>\lmoustache</latexCommand>
+		<unicodeCommand>⎰</unicodeCommand>
+		<imageCommand>\left \lmoustache \right.</imageCommand>
+		<mathMode>true</mathMode>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \rgroup \left \rgroup \right. -->
-<commandDefinition>
-   <latexCommand>\rgroup</latexCommand>
-   <imageCommand>\left \rgroup \right.</imageCommand>
-   <mathMode>true</mathMode>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \rmoustache \left \rmoustache \right. -->
+	<commandDefinition>
+		<latexCommand>\rmoustache</latexCommand>
+		<unicodeCommand>⎱</unicodeCommand>
+		<imageCommand>\left \rmoustache \right.</imageCommand>
+		<mathMode>true</mathMode>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \arrowvert \left \arrowvert \right. -->
-<commandDefinition>
-   <latexCommand>\arrowvert</latexCommand>
-   <imageCommand>\left \arrowvert \right.</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \lgroup \left \lgroup \right. -->
+	<commandDefinition>
+		<latexCommand>\lgroup</latexCommand>
+		<imageCommand>\left \lgroup \right.</imageCommand>
+		<unicodeCommand>⟮</unicodeCommand>
+		<mathMode>true</mathMode>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \Arrowvert \left \Arrowvert \right. -->
-<commandDefinition>
-   <latexCommand>\Arrowvert</latexCommand>
-   <imageCommand>\left \Arrowvert \right.</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \rgroup \left \rgroup \right. -->
+	<commandDefinition>
+		<latexCommand>\rgroup</latexCommand>
+		<imageCommand>\left \rgroup \right.</imageCommand>
+		<unicodeCommand>⟯</unicodeCommand>
+		<mathMode>true</mathMode>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \bracevert \left \bracevert \right. -->
-<commandDefinition>
-   <latexCommand>\bracevert</latexCommand>
-   <imageCommand>\left \bracevert \right.</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \arrowvert \left \arrowvert \right. -->
+	<commandDefinition>
+		<latexCommand>\arrowvert</latexCommand>
+		<imageCommand>\left \arrowvert \right.</imageCommand>
+		<unicodeCommand>│</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- arg math \lvert  -->
-<commandDefinition>
-   <latexCommand>\lvert</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \Arrowvert \left \Arrowvert \right. -->
+	<commandDefinition>
+		<latexCommand>\Arrowvert</latexCommand>
+		<imageCommand>\left \Arrowvert \right.</imageCommand>
+		<unicodeCommand>║</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- arg math \rvert  -->
-<commandDefinition>
-   <latexCommand>\rvert</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \bracevert \left \bracevert \right. -->
+	<commandDefinition>
+		<latexCommand>\bracevert</latexCommand>
+		<imageCommand>\left \bracevert \right.</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- arg math \lVert  -->
-<commandDefinition>
-   <latexCommand>\lVert</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- arg math \lvert -->
+	<commandDefinition>
+		<latexCommand>\lvert</latexCommand>
+		<unicodeCommand>⎸</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
 
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- arg math \rVert  -->
-<commandDefinition>
-   <latexCommand>\rVert</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- arg math \rvert -->
+	<commandDefinition>
+		<latexCommand>\rvert</latexCommand>
+		<unicodeCommand>⎹</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \ulcorner  -->
-<commandDefinition>
-   <latexCommand>\ulcorner</latexCommand>
-   <unicodeCommand>⌜</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- arg math \lVert -->
+	<commandDefinition>
+		<latexCommand>\lVert</latexCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
 
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \urcorner  -->
-<commandDefinition>
-   <latexCommand>\urcorner</latexCommand>
-   <unicodeCommand>⌝</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- arg math \rVert -->
+	<commandDefinition>
+		<latexCommand>\rVert</latexCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
 
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \llcorner  -->
-<commandDefinition>
-   <latexCommand>\llcorner</latexCommand>
-   <unicodeCommand>⌞</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \ulcorner -->
+	<commandDefinition>
+		<latexCommand>\ulcorner</latexCommand>
+		<unicodeCommand>⌜</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
 
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \lrcorner  -->
-<commandDefinition>
-   <latexCommand>\lrcorner</latexCommand>
-   <unicodeCommand>⌟</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \urcorner -->
+	<commandDefinition>
+		<latexCommand>\urcorner</latexCommand>
+		<unicodeCommand>⌝</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
 
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \llcorner -->
+	<commandDefinition>
+		<latexCommand>\llcorner</latexCommand>
+		<unicodeCommand>⌞</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \lrcorner -->
+	<commandDefinition>
+		<latexCommand>\lrcorner</latexCommand>
+		<unicodeCommand>⌟</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
 </symbols>

--- a/symbols-ng/fontawesome5.xml
+++ b/symbols-ng/fontawesome5.xml
@@ -5,9428 +5,9427 @@ Version History
 ===============
 
 2021-03-18 - Generated file based on a symbol list extracted from the `fontawesome5` latex
-             package documentation version "March 24, 2020"
+				 package documentation version "March 24, 2020"
 -->
 
 <!DOCTYPE KileSymbolSources>
 <symbols>
 
-   <formatVersion major="0" minor ="22" />
-
-   <symbolGroupName>user</symbolGroupName>
-
-   <preamble>
-      <class>article</class>
-      <arguments>12pt</arguments>
-      <additional>\pagestyle{empty}
-		  \setlength{\parindent}{0cm}
-      \usepackage[T1]{fontenc}
-		  \usepackage{fontawesome5}
-      </additional>
-   </preamble>
-
-   <unicodeCommandPackages>
-      <package>
-         <arguments>utf8</arguments>
-      </package>
-   </unicodeCommandPackages>
-
-<symbolGroupName>fontawesome5</symbolGroupName>
-
-<commandDefinition>
-   <latexCommand>\faIcon{500px}</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAccessibleIcon</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAccusoft</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAcquisitionsIncorporated</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAd</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAddressBook</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAddressBook[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAddressCard</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAddressCard[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAdjust</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAdn</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAdobe</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAdversal</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAffiliatetheme</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAirbnb</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAirFreshener</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAlgolia</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAlignCenter</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAlignJustify</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAlignLeft</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAlignRight</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAlipay</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAllergies</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAmazon</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAmazonPay</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAmbulance</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAmericanSignLanguageInterpreting</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAmilia</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAnchor</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAndroid</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAngellist</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAngleDoubleDown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAngleDoubleLeft</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAngleDoubleRight</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAngleDoubleUp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAngleDown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAngleLeft</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAngleRight</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAngleUp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAngry</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAngry[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAngrycreative</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAngular</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAnkh</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faApper</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faApple</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faApple*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faApplePay</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAppStore</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAppStoreIos</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArchive</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArchway</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrowAltCircleDown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrowAltCircleDown[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrowAltCircleLeft</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrowAltCircleLeft[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrowAltCircleRight</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrowAltCircleRight[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrowAltCircleUp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrowAltCircleUp[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrowCircleDown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrowCircleLeft</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrowCircleRight</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrowCircleUp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrowDown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrowLeft</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrowRight</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrows*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrowsAltH</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrowsAltV</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArrowUp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faArtstation</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAssistiveListeningSystems</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAsterisk</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAsymmetrik</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAt</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAtlas</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAtlassian</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAtom</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAudible</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAudioDescription</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAutoprefixer</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAvianex</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAviato</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAward</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faAws</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBaby</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBabyCarriage</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBackspace</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBackward</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBacon</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBahai</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBalanceScale</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBalanceScaleLeft</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBalanceScaleRight</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBan</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBandAid</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBandcamp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBarcode</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBars</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBaseballBall</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBasketballBall</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBath</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBatteryEmpty</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBatteryFull</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBatteryHalf</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBatteryQuarter</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBatteryThreeQuarters</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBattleNet</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBed</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBeer</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBehance</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBehanceSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBell</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBell[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBellSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBellSlash[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBezierCurve</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBible</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBicycle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBiking</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBimobject</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBinoculars</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBiohazard</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBirthdayCake</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBitbucket</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBitcoin</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBity</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBlackberry</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBlackTie</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBlender</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBlenderPhone</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBlind</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBlog</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBlogger</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBloggerB</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBluetooth</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBluetoothB</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBold</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBolt</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBomb</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBone</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBong</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBook</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBookDead</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBookmark</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBookmark[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBookMedical</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBookOpen</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBookReader</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBootstrap</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBorderAll</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBorderNone</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBorderStyle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBowlingBall</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBox</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBoxes</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBoxOpen</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBoxTissue</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBraille</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBrain</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBreadSlice</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBriefcase</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBriefcaseMedical</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBroadcastTower</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBroom</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBrush</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBtc</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBuffer</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBug</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBuilding</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBuilding[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBullhorn</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBullseye</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBurn</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBuromobelexperte</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBus*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBusinessTime</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBuyNLarge</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faBuysellads</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCalculator</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCalendar</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCalendar[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCalendar*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCalendar*[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCalendarCheck</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCalendarCheck[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCalendarDay</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCalendarMinus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCalendarMinus[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCalendarPlus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCalendarPlus[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCalendarTimes</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCalendarTimes[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCalendarWeek</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCamera</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCameraRetro</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCampground</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCanadianMapleLeaf</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCandyCane</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCannabis</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCapsules</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCar</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCar*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCaravan</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCarBattery</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCarCrash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCaretDown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCaretLeft</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCaretRight</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCaretSquareDown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCaretSquareDown[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCaretSquareLeft</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCaretSquareLeft[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCaretSquareRight</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCaretSquareRight[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCaretSquareUp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCaretSquareUp[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCaretUp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCarrot</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCarSide</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCartArrowDown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCartPlus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCashRegister</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCat</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCcAmazonPay</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCcAmex</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCcApplePay</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCcDinersClub</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCcDiscover</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCcJcb</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCcMastercard</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCcPaypal</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCcStripe</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCcVisa</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCentercode</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCentos</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCertificate</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChair</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChalkboard</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChalkboardTeacher</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChargingStation</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChartArea</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChartBar</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChartBar[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChartLine</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChartPie</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCheck</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCheckCircle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCheckCircle[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCheckDouble</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCheckSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCheckSquare[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCheese</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChess</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChessBishop</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChessBoard</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChessKing</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChessKnight</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChessPawn</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChessQueen</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChessRook</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChevronCircleDown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChevronCircleLeft</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChevronCircleRight</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChevronCircleUp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChevronDown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChevronLeft</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChevronRight</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChevronUp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChild</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChrome</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChromecast</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faChurch</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCircle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCircle[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCircleNotch</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCity</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faClinicMedical</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faClipboard</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faClipboard[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faClipboardCheck</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faClipboardList</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faClock</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faClock[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faClone</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faClone[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faClosedCaptioning</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faClosedCaptioning[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCloud</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCloudDownload*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCloudMeatball</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCloudMoon</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCloudMoonRain</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCloudRain</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCloudscale</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCloudShowersHeavy</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCloudsmith</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCloudSun</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCloudSunRain</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCloudUpload*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCloudversify</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCocktail</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCode</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCodeBranch</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCodepen</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCodiepie</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCoffee</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCog</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCogs</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCoins</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faColumns</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faComment</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faComment[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faComment*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faComment*[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCommentDollar</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCommentDots</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCommentDots[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCommentMedical</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faComments</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faComments[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCommentsDollar</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCommentSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCompactDisc</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCompass</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCompass[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCompress</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCompress*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCompressArrows*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faConciergeBell</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faConfluence</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faConnectdevelop</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faContao</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCookie</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCookieBite</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCopy</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCopy[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCopyright</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCopyright[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCottonBureau</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCouch</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCpanel</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCreativeCommons</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCreativeCommonsBy</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCreativeCommonsNc</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCreativeCommonsNcEu</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCreativeCommonsNcJp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCreativeCommonsNd</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCreativeCommonsPd</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCreativeCommonsPd*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCreativeCommonsRemix</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCreativeCommonsSa</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCreativeCommonsSampling</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCreativeCommonsSamplingPlus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCreativeCommonsShare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCreativeCommonsZero</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCreditCard</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCreditCard[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCriticalRole</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCrop</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCrop*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCross</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCrosshairs</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCrow</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCrown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCrutch</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCss3</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCss3*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCube</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCubes</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCut</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faCuttlefish</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDailymotion</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDAndD</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDAndDBeyond</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDashcube</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDatabase</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDeaf</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDelicious</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDemocrat</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDeploydog</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDeskpro</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDesktop</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDev</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDeviantart</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDharmachakra</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDhl</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDiagnoses</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDiaspora</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDice</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDiceD20</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDiceD6</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDiceFive</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDiceFour</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDiceOne</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDiceSix</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDiceThree</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDiceTwo</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDigg</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDigitalOcean</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDigitalTachograph</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDirections</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDiscord</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDiscourse</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDisease</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDivide</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDizzy</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDizzy[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDna</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDochub</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDocker</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDog</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDollarSign</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDolly</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDollyFlatbed</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDonate</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDoorClosed</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDoorOpen</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDotCircle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDotCircle[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDove</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDownload</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDraft2digital</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDraftingCompass</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDragon</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDrawPolygon</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDribbble</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDribbbleSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDropbox</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDrum</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDrumSteelpan</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDrumstickBite</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDrupal</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDumbbell</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDumpster</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDumpsterFire</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDungeon</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faDyalog</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEarlybirds</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEbay</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEdge</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEdit</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEdit[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEgg</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEject</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faElementor</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEllipsisH</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEllipsisV</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEllo</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEmber</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEmpire</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEnvelope</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEnvelope[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEnvelopeOpen</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEnvelopeOpen[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEnvelopeOpenText</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEnvelopeSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEnvira</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEquals</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEraser</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faErlang</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEthereum</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEthernet</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEtsy</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEuroSign</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEvernote</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faExchange*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faExclamation</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faExclamationCircle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faExclamationTriangle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faExpand</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faExpand*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faExpandArrows*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faExpeditedssl</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faExternalLink*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faExternalLinkSquare*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEye</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEye[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEyeDropper</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEyeSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faEyeSlash[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFacebook</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFacebookF</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFacebookMessenger</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFacebookSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFan</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFantasyFlightGames</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFastBackward</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFastForward</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFaucet</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFax</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFeather</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFeather*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFedex</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFedora</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFemale</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFighterJet</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFigma</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFile</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFile[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFile*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFile*[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileArchive</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileArchive[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileAudio</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileAudio[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileCode</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileCode[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileContract</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileCsv</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileDownload</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileExcel</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileExcel[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileExport</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileImage</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileImage[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileImport</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileInvoice</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileInvoiceDollar</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileMedical</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileMedical*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFilePdf</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFilePdf[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFilePowerpoint</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFilePowerpoint[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFilePrescription</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileSignature</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileUpload</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileVideo</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileVideo[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileWord</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFileWord[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFill</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFillDrip</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFilm</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFilter</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFingerprint</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFire</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFire*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFireExtinguisher</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFirefox</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFirefoxBrowser</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFirstAid</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFirstdraft</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFirstOrder</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFirstOrder*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFish</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFistRaised</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFlag</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFlag[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFlagCheckered</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFlagUsa</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFlask</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFlickr</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFlipboard</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFlushed</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFlushed[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFly</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFolder</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFolder[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFolderMinus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFolderOpen</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFolderOpen[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFolderPlus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFont</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFontAwesome</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFontAwesome*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFontAwesomeFlag</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFonticons</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFonticonsFi</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFootballBall</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFortAwesome</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFortAwesome*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faForumbee</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faForward</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFoursquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFreebsd</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFreeCodeCamp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFrog</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFrown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFrown[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFrownOpen</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFrownOpen[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFulcrum</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFunnelDollar</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFutbol</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faFutbol[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGalacticRepublic</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGalacticSenate</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGamepad</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGasPump</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGavel</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGem</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGem[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGenderless</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGetPocket</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGg</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGgCircle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGhost</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGift</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGifts</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGit</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGit*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGithub</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGithub*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGithubSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGitkraken</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGitlab</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGitSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGitter</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGlassCheers</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGlasses</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGlassMartini</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGlassMartini*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGlassWhiskey</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGlide</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGlideG</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGlobe</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGlobeAfrica</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGlobeAmericas</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGlobeAsia</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGlobeEurope</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGofore</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGolfBall</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGoodreads</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGoodreadsG</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGoogle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGoogleDrive</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGooglePlay</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGooglePlus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGooglePlusG</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGooglePlusSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGoogleWallet</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGopuram</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGraduationCap</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGratipay</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrav</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGreaterThan</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGreaterThanEqual</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrimace</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrimace[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrin</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrin[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrin*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrin*[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinBeam</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinBeam[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinBeamSweat</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinBeamSweat[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinHearts</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinHearts[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinSquint</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinSquint[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinSquintTears</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinSquintTears[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinStars</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinStars[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinTears</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinTears[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinTongue</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinTongue[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinTongueSquint</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinTongueSquint[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinTongueWink</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinTongueWink[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinWink</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrinWink[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGripfire</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGripHorizontal</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGripLines</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGripLinesVertical</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGripVertical</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGrunt</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGuitar</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faGulp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHackerNews</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHackerNewsSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHackerrank</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHamburger</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHammer</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHamsa</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandHolding</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandHoldingHeart</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandHoldingMedical</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandHoldingUsd</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandHoldingWater</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandLizard</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandLizard[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandMiddleFinger</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandPaper</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandPaper[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandPeace</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandPeace[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandPointDown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandPointDown[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandPointer</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandPointer[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandPointLeft</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandPointLeft[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandPointRight</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandPointRight[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandPointUp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandPointUp[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandRock</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandRock[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHands</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandScissors</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandScissors[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandshake</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandshake[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandshakeAltSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandshakeSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandsHelping</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandSparkles</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandSpock</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandSpock[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHandsWash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHanukiah</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHardHat</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHashtag</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHatCowboy</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHatCowboySide</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHatWizard</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHdd</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHdd[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHeading</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHeadphones</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHeadphones*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHeadset</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHeadSideCough</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHeadSideCoughSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHeadSideMask</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHeadSideVirus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHeart</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHeart[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHeartbeat</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHeartBroken</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHelicopter</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHighlighter</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHiking</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHippo</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHips</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHireAHelper</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHistory</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHockeyPuck</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHollyBerry</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHome</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHooli</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHornbill</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHorse</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHorseHead</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHospital</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHospital[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHospital*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHospitalSymbol</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHospitalUser</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHotdog</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHotel</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHotjar</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHotTub</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHourglass</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHourglass[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHourglassEnd</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHourglassHalf</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHourglassStart</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHouseDamage</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHouseUser</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHouzz</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHryvnia</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHtml5</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faHubspot</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faIceCream</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faIcicles</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faIcons</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faICursor</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faIdBadge</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faIdBadge[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faIdCard</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faIdCard[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faIdCard*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faIdeal</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faIgloo</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faImage</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faImage[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faImages</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faImages[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faImdb</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faInbox</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faIndent</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faIndustry</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faInfinity</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faInfo</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faInfoCircle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faInstagram</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faInstagramSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faIntercom</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faInternetExplorer</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faInvision</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faIoxhost</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faItalic</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faItchIo</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faItunes</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faItunesNote</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faJava</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faJedi</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faJediOrder</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faJenkins</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faJira</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faJoget</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faJoint</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faJoomla</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faJournalWhills</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faJs</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faJsfiddle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faJsSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faKaaba</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faKaggle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faKey</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faKeybase</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faKeyboard</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faKeyboard[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faKeycdn</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faKhanda</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faKickstarter</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faKickstarterK</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faKiss</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faKiss[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faKissBeam</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faKissBeam[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faKissWinkHeart</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faKissWinkHeart[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faKiwiBird</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faKorvue</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLandmark</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLanguage</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLaptop</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLaptopCode</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLaptopHouse</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLaptopMedical</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLaravel</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLastfm</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLastfmSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLaugh</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLaugh[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLaughBeam</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLaughBeam[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLaughSquint</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLaughSquint[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLaughWink</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLaughWink[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLayerGroup</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLeaf</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLeanpub</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLemon</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLemon[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLess</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLessThan</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLessThanEqual</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLevelDown*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLevelUp*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLifeRing</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLifeRing[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLightbulb</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLightbulb[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLine</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLink</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLinkedin</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLinkedinIn</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLinode</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLinux</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLiraSign</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faList</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faList*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faList*[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faListOl</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faListUl</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLocationArrow</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLock</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLockOpen</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLongArrowAltDown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLongArrowAltLeft</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLongArrowAltRight</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLongArrowAltUp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLowVision</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLuggageCart</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLungs</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLungsVirus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faLyft</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMagento</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMagic</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMagnet</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMailBulk</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMailchimp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMale</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMandalorian</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMap</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMap[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMapMarked</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMapMarked*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMapMarker</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMapMarker*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMapPin</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMapSigns</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMarkdown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMarker</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMars</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMarsDouble</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMarsStroke</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMarsStrokeH</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMarsStrokeV</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMask</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMastodon</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMaxcdn</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMdb</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMedal</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMedapps</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMedium</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMediumM</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMedkit</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMedrt</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMeetup</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMegaport</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMeh</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMeh[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMehBlank</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMehBlank[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMehRollingEyes</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMehRollingEyes[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMemory</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMendeley</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMenorah</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMercury</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMeteor</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMicroblog</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMicrochip</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMicrophone</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMicrophone*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMicrophoneAltSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMicrophoneSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMicroscope</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMicrosoft</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMinus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMinusCircle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMinusSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMinusSquare[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMitten</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMix</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMixcloud</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMixer</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMizuni</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMobile</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMobile*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faModx</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMonero</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMoneyBill</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMoneyBill*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMoneyBill*[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMoneyBillWave</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMoneyBillWave*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMoneyCheck</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMoneyCheck*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMonument</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMoon</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMoon[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMortarPestle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMosque</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMotorcycle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMountain</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMouse</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMousePointer</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMugHot</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faMusic</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faNapster</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faNeos</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faNetworkWired</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faNeuter</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faNewspaper</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faNewspaper[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faNimblr</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faNode</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faNodeJs</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faNotEqual</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faNotesMedical</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faNpm</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faNs8</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faNutritionix</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faObjectGroup</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faObjectGroup[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faObjectUngroup</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faObjectUngroup[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faOdnoklassniki</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faOdnoklassnikiSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faOilCan</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faOldRepublic</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faOm</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faOpencart</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faOpenid</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faOpera</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faOptinMonster</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faOrcid</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faOsi</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faOtter</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faOutdent</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPage4</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPagelines</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPager</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPaintBrush</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPaintRoller</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPalette</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPalfed</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPallet</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPaperclip</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPaperPlane</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPaperPlane[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faParachuteBox</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faParagraph</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faParking</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPassport</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPastafarianism</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPaste</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPatreon</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPause</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPauseCircle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPauseCircle[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPaw</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPaypal</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPeace</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPen</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPen*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPencil*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPencilRuler</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPenFancy</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPenNib</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPennyArcade</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPenSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPeopleArrows</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPeopleCarry</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPepperHot</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPercent</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPercentage</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPeriscope</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPersonBooth</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPhabricator</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPhoenixFramework</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPhoenixSquadron</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPhone</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPhone*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPhoneSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPhoneSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPhoneSquare*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPhoneVolume</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPhotoVideo</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPhp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPiedPiper</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPiedPiper*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPiedPiperHat</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPiedPiperPp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPiedPiperSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPiggyBank</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPills</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPinterest</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPinterestP</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPinterestSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPizzaSlice</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPlaceOfWorship</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPlane</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPlaneArrival</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPlaneDeparture</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPlaneSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPlay</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPlayCircle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPlayCircle[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPlaystation</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPlug</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPlus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPlusCircle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPlusSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPlusSquare[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPodcast</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPoll</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPollH</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPoo</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPoop</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPooStorm</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPortrait</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPoundSign</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPowerOff</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPray</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPrayingHands</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPrescription</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPrescriptionBottle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPrescriptionBottle*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPrint</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faProcedures</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faProductHunt</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faProjectDiagram</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPumpMedical</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPumpSoap</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPushed</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPuzzlePiece</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faPython</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faQq</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faQrcode</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faQuestion</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faQuestionCircle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faQuestionCircle[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faQuidditch</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faQuinscape</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faQuora</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faQuoteLeft</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faQuoteRight</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faQuran</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRadiation</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRadiation*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRainbow</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRandom</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRaspberryPi</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRavelry</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faReact</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faReacteurope</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faReadme</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRebel</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faReceipt</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRecordVinyl</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRecycle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faReddit</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRedditAlien</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRedditSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRedhat</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRedo</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRedo*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRedRiver</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRegistered</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRegistered[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRemoveFormat</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRenren</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faReply</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faReplyAll</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faReplyd</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRepublican</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faResearchgate</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faResolving</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRestroom</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRetweet</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRev</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRibbon</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRing</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRoad</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRobot</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRocket</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRocketchat</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRockrms</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRoute</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRProject</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRss</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRssSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRubleSign</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRuler</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRulerCombined</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRulerHorizontal</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRulerVertical</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRunning</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faRupeeSign</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSadCry</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSadCry[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSadTear</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSadTear[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSafari</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSalesforce</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSass</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSatellite</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSatelliteDish</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSave</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSave[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSchlix</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSchool</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faScrewdriver</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faScribd</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faScroll</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSdCard</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSearch</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSearchDollar</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSearchengin</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSearchLocation</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSearchMinus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSearchPlus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSeedling</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSellcast</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSellsy</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faServer</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faServicestack</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShapes</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShare*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShareAltSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShareSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShareSquare[regular]</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShekelSign</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShield*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShieldVirus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShip</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShippingFast</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShirtsinbulk</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShoePrints</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShopify</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShoppingBag</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShoppingBasket</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShoppingCart</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShopware</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShower</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faShuttleVan</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSign</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSignal</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSignature</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSignIn*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSignLanguage</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSignOut*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSimCard</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSimplybuilt</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSistrix</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSitemap</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSith</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSkating</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSketch</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSkiing</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSkiingNordic</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSkull</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSkullCrossbones</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSkyatlas</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSkype</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSlack</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSlackHash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSleigh</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSlidersH</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSlideshare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSmile</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSmileBeam</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSmileWink</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSmog</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSmoking</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSmokingBan</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSms</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSnapchat</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSnapchatGhost</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSnapchatSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSnowboarding</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSnowflake</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSnowman</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSnowplow</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSoap</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSocks</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSolarPanel</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSort</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSortAlphaDown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSortAlphaDown*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSortAlphaUp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSortAlphaUp*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSortAmountDown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSortAmountDown*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSortAmountUp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSortAmountUp*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSortDown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSortNumericDown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSortNumericDown*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSortNumericUp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSortNumericUp*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSortUp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSoundcloud</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSourcetree</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSpa</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSpaceShuttle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSpeakap</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSpeakerDeck</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSpellCheck</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSpider</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSpinner</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSplotch</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSpotify</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSprayCan</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSquareFull</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSquareRoot*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSquarespace</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStackExchange</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStackOverflow</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStackpath</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStamp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStar</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStarAndCrescent</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStarHalf</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStarHalf*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStarOfDavid</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStarOfLife</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStaylinked</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSteam</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSteamSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSteamSymbol</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStepBackward</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStepForward</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStethoscope</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStickerMule</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStickyNote</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStop</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStopCircle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStopwatch</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStopwatch20</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStore</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStore*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStoreAltSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStoreSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStrava</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStream</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStreetView</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStrikethrough</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStripe</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStripeS</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStroopwafel</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStudiovinari</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStumbleupon</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faStumbleuponCircle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSubscript</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSubway</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSuitcase</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSuitcaseRolling</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSun</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSuperpowers</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSuperscript</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSupple</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSurprise</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSuse</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSwatchbook</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSwift</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSwimmer</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSwimmingPool</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSymfony</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSynagogue</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSync</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSync*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faSyringe</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTable</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTablet</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTablet*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTableTennis</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTablets</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTachometer*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTag</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTags</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTape</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTasks</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTaxi</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTeamspeak</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTeeth</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTeethOpen</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTelegram</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTelegramPlane</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTemperatureHigh</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTemperatureLow</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTencentWeibo</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTenge</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTerminal</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTextHeight</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTextWidth</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTh</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTheaterMasks</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faThemeco</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faThemeisle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTheRedYeti</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faThermometer</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faThermometerEmpty</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faThermometerFull</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faThermometerHalf</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faThermometerQuarter</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faThermometerThreeQuarters</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faThinkPeaks</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faThLarge</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faThList</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faThumbsDown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faThumbsUp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faThumbtack</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTicket*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTimes</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTimesCircle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTint</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTintSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTired</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faToggleOff</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faToggleOn</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faToilet</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faToiletPaper</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faToiletPaperSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faToolbox</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTools</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTooth</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTorah</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faToriiGate</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTractor</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTradeFederation</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTrademark</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTrafficLight</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTrailer</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTrain</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTram</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTransgender</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTransgender*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTrash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTrash*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTrashRestore</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTrashRestore*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTree</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTrello</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTripadvisor</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTrophy</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTruck</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTruckLoading</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTruckMonster</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTruckMoving</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTruckPickup</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTshirt</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTty</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTumblr</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTumblrSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTv</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTwitch</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTwitter</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTwitterSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faTypo3</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUber</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUbuntu</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUikit</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUmbraco</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUmbrella</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUmbrellaBeach</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUnderline</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUndo</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUndo*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUniregistry</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUnity</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUniversalAccess</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUniversity</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUnlink</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUnlock</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUnlock*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUntappd</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUpload</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUps</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUsb</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUser</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUser*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserAltSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserAstronaut</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserCheck</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserCircle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserClock</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserCog</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserEdit</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserFriends</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserGraduate</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserInjured</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserLock</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserMd</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserMinus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserNinja</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserNurse</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserPlus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUsers</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUsersCog</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserSecret</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserShield</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserTag</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserTie</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUserTimes</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUsps</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUssunnah</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUtensils</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faUtensilSpoon</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVaadin</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVectorSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVenus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVenusDouble</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVenusMars</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faViacoin</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faViadeo</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faViadeoSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVial</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVials</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faViber</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVideo</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVideoSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVihara</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVimeo</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVimeoSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVimeoV</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVine</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVirus</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faViruses</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVirusSlash</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVk</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVnv</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVoicemail</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVolleyballBall</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVolumeDown</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVolumeMute</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVolumeOff</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVolumeUp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVoteYea</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVrCardboard</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faVuejs</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWalking</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWallet</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWarehouse</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWater</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWaveSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWaze</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWeebly</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWeibo</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWeight</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWeightHanging</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWeixin</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWhatsapp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWhatsappSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWheelchair</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWhmcs</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWifi</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWikipediaW</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWind</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWindowClose</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWindowMaximize</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWindowMinimize</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWindowRestore</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWindows</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWineBottle</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWineGlass</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWineGlass*</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWix</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWizardsOfTheCoast</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWolfPackBattalion</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWonSign</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWordpress</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWordpressSimple</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWpbeginner</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWpexplorer</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWpforms</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWpressr</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faWrench</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faXbox</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faXing</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faXingSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faXRay</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faYahoo</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faYammer</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faYandex</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faYandexInternational</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faYarn</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faYCombinator</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faYelp</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faYenSign</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faYinYang</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faYoast</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faYoutube</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faYoutubeSquare</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\faZhihu</latexCommand>
-   <forcePNG>false</forcePNG>
-   <iconMode>true</iconMode>
-</commandDefinition>
+	<formatVersion major="0" minor ="22" />
+
+	<symbolGroupName>user</symbolGroupName>
+
+	<preamble>
+		<class>standalone</class>
+		<arguments>10bp,margin=1bp</arguments>
+		<additional>\usepackage{fontawesome5}</additional>
+	</preamble>
+
+	<unicodeCommandPackages>
+		<package>
+			<name>inputenc</name>
+			<arguments>utf8</arguments>
+		</package>
+	</unicodeCommandPackages>
+
+	<!-- insert stuff here -->
+
+	<symbolGroupName>fontawesome5</symbolGroupName>
+
+	<commandDefinition>
+		<latexCommand>\faIcon{500px}</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAccessibleIcon</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAccusoft</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAcquisitionsIncorporated</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAd</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAddressBook</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAddressBook[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAddressCard</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAddressCard[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAdjust</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAdn</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+<!-- 	<commandDefinition>
+		<latexCommand>\faAdobe</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition> -->
+
+	<commandDefinition>
+		<latexCommand>\faAdversal</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAffiliatetheme</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAirbnb</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAirFreshener</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAlgolia</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAlignCenter</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAlignJustify</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAlignLeft</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAlignRight</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAlipay</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAllergies</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAmazon</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAmazonPay</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAmbulance</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAmericanSignLanguageInterpreting</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAmilia</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAnchor</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAndroid</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAngellist</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAngleDoubleDown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAngleDoubleLeft</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAngleDoubleRight</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAngleDoubleUp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAngleDown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAngleLeft</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAngleRight</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAngleUp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAngry</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAngry[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAngrycreative</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAngular</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAnkh</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faApper</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faApple</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faApple*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faApplePay</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAppStore</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAppStoreIos</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArchive</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArchway</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrowAltCircleDown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrowAltCircleDown[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrowAltCircleLeft</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrowAltCircleLeft[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrowAltCircleRight</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrowAltCircleRight[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrowAltCircleUp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrowAltCircleUp[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrowCircleDown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrowCircleLeft</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrowCircleRight</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrowCircleUp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrowDown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrowLeft</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrowRight</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrows*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrowsAltH</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrowsAltV</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArrowUp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faArtstation</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAssistiveListeningSystems</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAsterisk</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAsymmetrik</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAt</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAtlas</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAtlassian</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAtom</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAudible</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAudioDescription</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAutoprefixer</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAvianex</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAviato</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAward</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faAws</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBaby</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBabyCarriage</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBackspace</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBackward</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBacon</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBahai</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBalanceScale</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBalanceScaleLeft</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBalanceScaleRight</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBan</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBandAid</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBandcamp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBarcode</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBars</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBaseballBall</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBasketballBall</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBath</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBatteryEmpty</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBatteryFull</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBatteryHalf</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBatteryQuarter</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBatteryThreeQuarters</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBattleNet</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBed</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBeer</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBehance</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBehanceSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBell</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBell[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBellSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBellSlash[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBezierCurve</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBible</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBicycle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBiking</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBimobject</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBinoculars</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBiohazard</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBirthdayCake</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBitbucket</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBitcoin</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBity</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBlackberry</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBlackTie</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBlender</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBlenderPhone</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBlind</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBlog</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBlogger</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBloggerB</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBluetooth</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBluetoothB</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBold</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBolt</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBomb</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBone</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBong</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBook</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBookDead</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBookmark</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBookmark[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBookMedical</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBookOpen</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBookReader</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBootstrap</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBorderAll</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBorderNone</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBorderStyle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBowlingBall</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBox</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBoxes</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBoxOpen</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBoxTissue</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBraille</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBrain</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBreadSlice</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBriefcase</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBriefcaseMedical</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBroadcastTower</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBroom</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBrush</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBtc</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBuffer</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBug</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBuilding</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBuilding[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBullhorn</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBullseye</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBurn</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBuromobelexperte</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBus*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBusinessTime</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBuyNLarge</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faBuysellads</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCalculator</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCalendar</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCalendar[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCalendar*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCalendar*[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCalendarCheck</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCalendarCheck[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCalendarDay</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCalendarMinus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCalendarMinus[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCalendarPlus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCalendarPlus[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCalendarTimes</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCalendarTimes[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCalendarWeek</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCamera</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCameraRetro</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCampground</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCanadianMapleLeaf</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCandyCane</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCannabis</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCapsules</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCar</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCar*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCaravan</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCarBattery</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCarCrash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCaretDown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCaretLeft</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCaretRight</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCaretSquareDown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCaretSquareDown[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCaretSquareLeft</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCaretSquareLeft[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCaretSquareRight</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCaretSquareRight[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCaretSquareUp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCaretSquareUp[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCaretUp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCarrot</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCarSide</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCartArrowDown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCartPlus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCashRegister</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCat</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCcAmazonPay</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCcAmex</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCcApplePay</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCcDinersClub</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCcDiscover</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCcJcb</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCcMastercard</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCcPaypal</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCcStripe</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCcVisa</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCentercode</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCentos</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCertificate</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChair</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChalkboard</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChalkboardTeacher</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChargingStation</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChartArea</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChartBar</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChartBar[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChartLine</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChartPie</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCheck</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCheckCircle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCheckCircle[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCheckDouble</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCheckSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCheckSquare[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCheese</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChess</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChessBishop</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChessBoard</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChessKing</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChessKnight</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChessPawn</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChessQueen</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChessRook</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChevronCircleDown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChevronCircleLeft</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChevronCircleRight</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChevronCircleUp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChevronDown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChevronLeft</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChevronRight</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChevronUp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChild</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChrome</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChromecast</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faChurch</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCircle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCircle[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCircleNotch</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCity</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faClinicMedical</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faClipboard</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faClipboard[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faClipboardCheck</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faClipboardList</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faClock</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faClock[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faClone</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faClone[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faClosedCaptioning</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faClosedCaptioning[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCloud</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCloudDownload*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCloudMeatball</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCloudMoon</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCloudMoonRain</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCloudRain</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCloudscale</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCloudShowersHeavy</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCloudsmith</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCloudSun</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCloudSunRain</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCloudUpload*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCloudversify</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCocktail</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCode</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCodeBranch</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCodepen</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCodiepie</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCoffee</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCog</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCogs</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCoins</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faColumns</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faComment</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faComment[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faComment*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faComment*[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCommentDollar</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCommentDots</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCommentDots[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCommentMedical</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faComments</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faComments[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCommentsDollar</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCommentSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCompactDisc</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCompass</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCompass[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCompress</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCompress*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCompressArrows*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faConciergeBell</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faConfluence</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faConnectdevelop</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faContao</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCookie</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCookieBite</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCopy</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCopy[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCopyright</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCopyright[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCottonBureau</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCouch</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCpanel</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCreativeCommons</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCreativeCommonsBy</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCreativeCommonsNc</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCreativeCommonsNcEu</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCreativeCommonsNcJp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCreativeCommonsNd</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCreativeCommonsPd</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCreativeCommonsPd*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCreativeCommonsRemix</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCreativeCommonsSa</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCreativeCommonsSampling</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCreativeCommonsSamplingPlus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCreativeCommonsShare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCreativeCommonsZero</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCreditCard</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCreditCard[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCriticalRole</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCrop</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCrop*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCross</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCrosshairs</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCrow</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCrown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCrutch</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCss3</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCss3*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCube</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCubes</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCut</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faCuttlefish</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDailymotion</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDAndD</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDAndDBeyond</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDashcube</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDatabase</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDeaf</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDelicious</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDemocrat</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDeploydog</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDeskpro</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDesktop</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDev</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDeviantart</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDharmachakra</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDhl</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDiagnoses</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDiaspora</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDice</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDiceD20</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDiceD6</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDiceFive</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDiceFour</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDiceOne</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDiceSix</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDiceThree</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDiceTwo</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDigg</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDigitalOcean</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDigitalTachograph</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDirections</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDiscord</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDiscourse</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDisease</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDivide</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDizzy</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDizzy[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDna</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDochub</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDocker</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDog</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDollarSign</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDolly</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDollyFlatbed</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDonate</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDoorClosed</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDoorOpen</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDotCircle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDotCircle[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDove</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDownload</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDraft2digital</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDraftingCompass</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDragon</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDrawPolygon</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDribbble</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDribbbleSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDropbox</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDrum</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDrumSteelpan</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDrumstickBite</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDrupal</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDumbbell</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDumpster</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDumpsterFire</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDungeon</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faDyalog</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEarlybirds</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEbay</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEdge</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEdit</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEdit[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEgg</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEject</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faElementor</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEllipsisH</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEllipsisV</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEllo</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEmber</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEmpire</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEnvelope</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEnvelope[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEnvelopeOpen</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEnvelopeOpen[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEnvelopeOpenText</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEnvelopeSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEnvira</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEquals</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEraser</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faErlang</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEthereum</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEthernet</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEtsy</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEuroSign</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEvernote</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faExchange*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faExclamation</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faExclamationCircle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faExclamationTriangle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faExpand</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faExpand*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faExpandArrows*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faExpeditedssl</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faExternalLink*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faExternalLinkSquare*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEye</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEye[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEyeDropper</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEyeSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faEyeSlash[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFacebook</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFacebookF</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFacebookMessenger</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFacebookSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFan</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFantasyFlightGames</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFastBackward</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFastForward</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFaucet</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFax</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFeather</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFeather*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFedex</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFedora</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFemale</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFighterJet</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFigma</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFile</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFile[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFile*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFile*[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileArchive</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileArchive[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileAudio</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileAudio[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileCode</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileCode[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileContract</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileCsv</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileDownload</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileExcel</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileExcel[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileExport</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileImage</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileImage[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileImport</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileInvoice</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileInvoiceDollar</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileMedical</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileMedical*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFilePdf</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFilePdf[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFilePowerpoint</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFilePowerpoint[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFilePrescription</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileSignature</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileUpload</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileVideo</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileVideo[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileWord</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFileWord[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFill</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFillDrip</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFilm</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFilter</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFingerprint</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFire</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFire*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFireExtinguisher</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFirefox</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFirefoxBrowser</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFirstAid</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFirstdraft</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFirstOrder</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFirstOrder*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFish</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFistRaised</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFlag</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFlag[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFlagCheckered</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFlagUsa</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFlask</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFlickr</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFlipboard</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFlushed</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFlushed[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFly</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFolder</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFolder[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFolderMinus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFolderOpen</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFolderOpen[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFolderPlus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFont</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFontAwesome</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFontAwesome*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFontAwesomeFlag</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFonticons</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFonticonsFi</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFootballBall</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFortAwesome</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFortAwesome*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faForumbee</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faForward</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFoursquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFreebsd</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFreeCodeCamp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFrog</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFrown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFrown[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFrownOpen</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFrownOpen[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFulcrum</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFunnelDollar</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFutbol</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faFutbol[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGalacticRepublic</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGalacticSenate</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGamepad</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGasPump</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGavel</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGem</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGem[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGenderless</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGetPocket</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGg</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGgCircle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGhost</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGift</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGifts</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGit</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGit*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGithub</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGithub*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGithubSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGitkraken</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGitlab</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGitSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGitter</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGlassCheers</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGlasses</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGlassMartini</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGlassMartini*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGlassWhiskey</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGlide</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGlideG</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGlobe</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGlobeAfrica</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGlobeAmericas</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGlobeAsia</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGlobeEurope</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGofore</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGolfBall</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGoodreads</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGoodreadsG</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGoogle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGoogleDrive</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGooglePlay</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGooglePlus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGooglePlusG</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGooglePlusSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGoogleWallet</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGopuram</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGraduationCap</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGratipay</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrav</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGreaterThan</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGreaterThanEqual</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrimace</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrimace[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrin</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrin[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrin*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrin*[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinBeam</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinBeam[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinBeamSweat</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinBeamSweat[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinHearts</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinHearts[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinSquint</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinSquint[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinSquintTears</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinSquintTears[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinStars</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinStars[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinTears</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinTears[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinTongue</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinTongue[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinTongueSquint</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinTongueSquint[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinTongueWink</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinTongueWink[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinWink</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrinWink[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGripfire</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGripHorizontal</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGripLines</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGripLinesVertical</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGripVertical</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGrunt</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGuitar</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faGulp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHackerNews</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHackerNewsSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHackerrank</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHamburger</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHammer</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHamsa</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandHolding</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandHoldingHeart</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandHoldingMedical</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandHoldingUsd</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandHoldingWater</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandLizard</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandLizard[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandMiddleFinger</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandPaper</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandPaper[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandPeace</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandPeace[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandPointDown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandPointDown[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandPointer</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandPointer[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandPointLeft</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandPointLeft[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandPointRight</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandPointRight[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandPointUp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandPointUp[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandRock</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandRock[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHands</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandScissors</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandScissors[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandshake</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandshake[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandshakeAltSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandshakeSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandsHelping</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandSparkles</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandSpock</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandSpock[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHandsWash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHanukiah</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHardHat</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHashtag</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHatCowboy</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHatCowboySide</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHatWizard</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHdd</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHdd[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHeading</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHeadphones</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHeadphones*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHeadset</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHeadSideCough</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHeadSideCoughSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHeadSideMask</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHeadSideVirus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHeart</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHeart[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHeartbeat</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHeartBroken</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHelicopter</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHighlighter</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHiking</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHippo</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHips</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHireAHelper</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHistory</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHockeyPuck</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHollyBerry</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHome</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHooli</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHornbill</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHorse</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHorseHead</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHospital</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHospital[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHospital*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHospitalSymbol</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHospitalUser</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHotdog</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHotel</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHotjar</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHotTub</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHourglass</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHourglass[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHourglassEnd</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHourglassHalf</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHourglassStart</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHouseDamage</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHouseUser</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHouzz</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHryvnia</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHtml5</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faHubspot</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faIceCream</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faIcicles</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faIcons</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faICursor</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faIdBadge</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faIdBadge[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faIdCard</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faIdCard[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faIdCard*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faIdeal</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faIgloo</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faImage</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faImage[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faImages</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faImages[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faImdb</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faInbox</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faIndent</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faIndustry</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faInfinity</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faInfo</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faInfoCircle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faInstagram</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faInstagramSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faIntercom</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faInternetExplorer</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faInvision</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faIoxhost</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faItalic</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faItchIo</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faItunes</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faItunesNote</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faJava</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faJedi</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faJediOrder</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faJenkins</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faJira</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faJoget</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faJoint</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faJoomla</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faJournalWhills</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faJs</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faJsfiddle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faJsSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faKaaba</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faKaggle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faKey</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faKeybase</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faKeyboard</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faKeyboard[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faKeycdn</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faKhanda</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faKickstarter</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faKickstarterK</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faKiss</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faKiss[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faKissBeam</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faKissBeam[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faKissWinkHeart</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faKissWinkHeart[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faKiwiBird</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faKorvue</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLandmark</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLanguage</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLaptop</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLaptopCode</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLaptopHouse</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLaptopMedical</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLaravel</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLastfm</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLastfmSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLaugh</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLaugh[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLaughBeam</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLaughBeam[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLaughSquint</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLaughSquint[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLaughWink</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLaughWink[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLayerGroup</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLeaf</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLeanpub</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLemon</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLemon[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLess</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLessThan</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLessThanEqual</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLevelDown*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLevelUp*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLifeRing</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLifeRing[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLightbulb</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLightbulb[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLine</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLink</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLinkedin</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLinkedinIn</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLinode</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLinux</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLiraSign</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faList</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faList*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faList*[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faListOl</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faListUl</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLocationArrow</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLock</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLockOpen</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLongArrowAltDown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLongArrowAltLeft</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLongArrowAltRight</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLongArrowAltUp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLowVision</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLuggageCart</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLungs</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLungsVirus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faLyft</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMagento</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMagic</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMagnet</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMailBulk</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMailchimp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMale</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMandalorian</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMap</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMap[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMapMarked</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMapMarked*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMapMarker</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMapMarker*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMapPin</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMapSigns</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMarkdown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMarker</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMars</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMarsDouble</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMarsStroke</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMarsStrokeH</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMarsStrokeV</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMask</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMastodon</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMaxcdn</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMdb</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMedal</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMedapps</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMedium</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMediumM</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMedkit</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMedrt</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMeetup</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMegaport</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMeh</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMeh[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMehBlank</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMehBlank[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMehRollingEyes</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMehRollingEyes[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMemory</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMendeley</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMenorah</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMercury</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMeteor</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMicroblog</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMicrochip</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMicrophone</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMicrophone*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMicrophoneAltSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMicrophoneSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMicroscope</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMicrosoft</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMinus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMinusCircle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMinusSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMinusSquare[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMitten</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMix</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMixcloud</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMixer</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMizuni</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMobile</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMobile*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faModx</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMonero</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMoneyBill</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMoneyBill*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMoneyBill*[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMoneyBillWave</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMoneyBillWave*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMoneyCheck</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMoneyCheck*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMonument</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMoon</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMoon[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMortarPestle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMosque</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMotorcycle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMountain</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMouse</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMousePointer</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMugHot</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faMusic</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faNapster</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faNeos</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faNetworkWired</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faNeuter</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faNewspaper</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faNewspaper[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faNimblr</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faNode</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faNodeJs</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faNotEqual</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faNotesMedical</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faNpm</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faNs8</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faNutritionix</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faObjectGroup</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faObjectGroup[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faObjectUngroup</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faObjectUngroup[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faOdnoklassniki</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faOdnoklassnikiSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faOilCan</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faOldRepublic</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faOm</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faOpencart</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faOpenid</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faOpera</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faOptinMonster</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faOrcid</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faOsi</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faOtter</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faOutdent</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPage4</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPagelines</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPager</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPaintBrush</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPaintRoller</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPalette</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPalfed</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPallet</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPaperclip</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPaperPlane</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPaperPlane[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faParachuteBox</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faParagraph</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faParking</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPassport</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPastafarianism</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPaste</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPatreon</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPause</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPauseCircle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPauseCircle[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPaw</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPaypal</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPeace</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPen</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPen*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPencil*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPencilRuler</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPenFancy</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPenNib</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPennyArcade</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPenSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPeopleArrows</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPeopleCarry</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPepperHot</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPercent</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPercentage</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPeriscope</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPersonBooth</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPhabricator</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPhoenixFramework</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPhoenixSquadron</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPhone</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPhone*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPhoneSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPhoneSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPhoneSquare*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPhoneVolume</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPhotoVideo</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPhp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPiedPiper</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPiedPiper*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPiedPiperHat</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPiedPiperPp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPiedPiperSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPiggyBank</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPills</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPinterest</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPinterestP</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPinterestSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPizzaSlice</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPlaceOfWorship</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPlane</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPlaneArrival</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPlaneDeparture</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPlaneSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPlay</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPlayCircle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPlayCircle[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPlaystation</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPlug</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPlus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPlusCircle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPlusSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPlusSquare[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPodcast</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPoll</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPollH</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPoo</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPoop</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPooStorm</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPortrait</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPoundSign</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPowerOff</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPray</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPrayingHands</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPrescription</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPrescriptionBottle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPrescriptionBottle*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPrint</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faProcedures</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faProductHunt</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faProjectDiagram</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPumpMedical</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPumpSoap</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPushed</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPuzzlePiece</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faPython</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faQq</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faQrcode</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faQuestion</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faQuestionCircle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faQuestionCircle[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faQuidditch</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faQuinscape</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faQuora</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faQuoteLeft</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faQuoteRight</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faQuran</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRadiation</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRadiation*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRainbow</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRandom</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRaspberryPi</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRavelry</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faReact</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faReacteurope</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faReadme</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRebel</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faReceipt</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRecordVinyl</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRecycle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faReddit</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRedditAlien</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRedditSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRedhat</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRedo</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRedo*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRedRiver</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRegistered</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRegistered[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRemoveFormat</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRenren</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faReply</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faReplyAll</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faReplyd</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRepublican</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faResearchgate</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faResolving</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRestroom</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRetweet</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRev</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRibbon</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRing</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRoad</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRobot</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRocket</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRocketchat</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRockrms</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRoute</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRProject</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRss</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRssSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRubleSign</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRuler</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRulerCombined</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRulerHorizontal</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRulerVertical</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRunning</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faRupeeSign</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSadCry</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSadCry[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSadTear</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSadTear[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSafari</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSalesforce</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSass</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSatellite</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSatelliteDish</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSave</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSave[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSchlix</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSchool</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faScrewdriver</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faScribd</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faScroll</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSdCard</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSearch</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSearchDollar</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSearchengin</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSearchLocation</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSearchMinus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSearchPlus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSeedling</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSellcast</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSellsy</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faServer</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faServicestack</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShapes</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShare*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShareAltSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShareSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShareSquare[regular]</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShekelSign</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShield*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShieldVirus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShip</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShippingFast</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShirtsinbulk</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShoePrints</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShopify</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShoppingBag</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShoppingBasket</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShoppingCart</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShopware</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShower</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faShuttleVan</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSign</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSignal</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSignature</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSignIn*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSignLanguage</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSignOut*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSimCard</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSimplybuilt</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSistrix</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSitemap</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSith</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSkating</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSketch</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSkiing</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSkiingNordic</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSkull</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSkullCrossbones</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSkyatlas</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSkype</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSlack</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSlackHash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSleigh</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSlidersH</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSlideshare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSmile</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSmileBeam</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSmileWink</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSmog</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSmoking</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSmokingBan</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSms</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSnapchat</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSnapchatGhost</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSnapchatSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSnowboarding</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSnowflake</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSnowman</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSnowplow</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSoap</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSocks</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSolarPanel</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSort</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSortAlphaDown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSortAlphaDown*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSortAlphaUp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSortAlphaUp*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSortAmountDown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSortAmountDown*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSortAmountUp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSortAmountUp*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSortDown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSortNumericDown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSortNumericDown*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSortNumericUp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSortNumericUp*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSortUp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSoundcloud</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSourcetree</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSpa</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSpaceShuttle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSpeakap</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSpeakerDeck</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSpellCheck</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSpider</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSpinner</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSplotch</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSpotify</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSprayCan</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSquareFull</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSquareRoot*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSquarespace</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStackExchange</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStackOverflow</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStackpath</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStamp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStar</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStarAndCrescent</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStarHalf</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStarHalf*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStarOfDavid</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStarOfLife</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStaylinked</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSteam</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSteamSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSteamSymbol</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStepBackward</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStepForward</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStethoscope</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStickerMule</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStickyNote</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStop</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStopCircle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStopwatch</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStopwatch20</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStore</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStore*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStoreAltSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStoreSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStrava</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStream</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStreetView</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStrikethrough</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStripe</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStripeS</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStroopwafel</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStudiovinari</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStumbleupon</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faStumbleuponCircle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSubscript</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSubway</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSuitcase</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSuitcaseRolling</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSun</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSuperpowers</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSuperscript</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSupple</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSurprise</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSuse</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSwatchbook</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSwift</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSwimmer</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSwimmingPool</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSymfony</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSynagogue</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSync</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSync*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faSyringe</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTable</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTablet</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTablet*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTableTennis</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTablets</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTachometer*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTag</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTags</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTape</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTasks</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTaxi</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTeamspeak</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTeeth</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTeethOpen</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTelegram</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTelegramPlane</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTemperatureHigh</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTemperatureLow</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTencentWeibo</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTenge</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTerminal</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTextHeight</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTextWidth</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTh</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTheaterMasks</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faThemeco</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faThemeisle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTheRedYeti</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faThermometer</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faThermometerEmpty</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faThermometerFull</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faThermometerHalf</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faThermometerQuarter</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faThermometerThreeQuarters</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faThinkPeaks</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faThLarge</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faThList</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faThumbsDown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faThumbsUp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faThumbtack</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTicket*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTimes</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTimesCircle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTint</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTintSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTired</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faToggleOff</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faToggleOn</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faToilet</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faToiletPaper</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faToiletPaperSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faToolbox</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTools</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTooth</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTorah</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faToriiGate</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTractor</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTradeFederation</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTrademark</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTrafficLight</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTrailer</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTrain</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTram</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTransgender</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTransgender*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTrash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTrash*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTrashRestore</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTrashRestore*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTree</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTrello</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+<!-- 	<commandDefinition>
+		<latexCommand>\faTripadvisor</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition> -->
+
+	<commandDefinition>
+		<latexCommand>\faTrophy</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTruck</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTruckLoading</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTruckMonster</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTruckMoving</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTruckPickup</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTshirt</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTty</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTumblr</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTumblrSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTv</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTwitch</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTwitter</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTwitterSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faTypo3</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUber</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUbuntu</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUikit</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUmbraco</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUmbrella</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUmbrellaBeach</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUnderline</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUndo</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUndo*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUniregistry</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUnity</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUniversalAccess</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUniversity</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUnlink</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUnlock</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUnlock*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUntappd</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUpload</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUps</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUsb</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUser</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUser*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserAltSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserAstronaut</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserCheck</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserCircle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserClock</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserCog</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserEdit</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserFriends</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserGraduate</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserInjured</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserLock</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserMd</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserMinus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserNinja</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserNurse</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserPlus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUsers</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUsersCog</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserSecret</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserShield</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserTag</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserTie</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUserTimes</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUsps</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUssunnah</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUtensils</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faUtensilSpoon</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVaadin</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVectorSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVenus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVenusDouble</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVenusMars</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faViacoin</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faViadeo</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faViadeoSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVial</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVials</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faViber</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVideo</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVideoSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVihara</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVimeo</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVimeoSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVimeoV</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVine</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVirus</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faViruses</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVirusSlash</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVk</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVnv</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVoicemail</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVolleyballBall</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVolumeDown</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVolumeMute</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVolumeOff</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVolumeUp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVoteYea</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVrCardboard</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faVuejs</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWalking</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWallet</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWarehouse</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWater</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWaveSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWaze</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWeebly</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWeibo</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWeight</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWeightHanging</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWeixin</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWhatsapp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWhatsappSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWheelchair</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWhmcs</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWifi</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWikipediaW</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWind</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWindowClose</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWindowMaximize</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWindowMinimize</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWindowRestore</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWindows</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWineBottle</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWineGlass</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWineGlass*</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWix</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWizardsOfTheCoast</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWolfPackBattalion</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWonSign</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWordpress</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWordpressSimple</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWpbeginner</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWpexplorer</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWpforms</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWpressr</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faWrench</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faXbox</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faXing</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faXingSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faXRay</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faYahoo</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faYammer</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faYandex</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faYandexInternational</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faYarn</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faYCombinator</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faYelp</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faYenSign</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faYinYang</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faYoast</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faYoutube</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faYoutubeSquare</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\faZhihu</latexCommand>
+		<forcePNG>false</forcePNG>
+		<iconMode>true</iconMode>
+	</commandDefinition>
 
 </symbols>

--- a/symbols-ng/gesymb-ng.cpp
+++ b/symbols-ng/gesymb-ng.cpp
@@ -36,531 +36,519 @@
 #include "symbolviewclasses.h"
 
 /* TODO
-   - more error checking when parsing xml file
+	- more error checking when parsing xml file
 */
 
-void readImageComments(const QString &fileName)
-{
-   QImage image;
-   QString output;
-   
-   if(image.load(fileName)) {
-      qDebug() << QString("Image %1 has Command _%2_").arg(fileName).arg(image.text("Command"));
-      qDebug() << QString("Image %1 has Comment _%2_").arg(fileName).arg(image.text("Comment"));    
-      qDebug() << QString("image %1 has Package _%2_").arg(fileName).arg(image.text("Packages"));
-      qDebug() << QString("Image %1 has CommandUnicode _%2_").arg(fileName).arg(image.text("CommandUnicode"));
-      qDebug() << QString("Image %1 has UnicodePackages _%2_").arg(fileName).arg(image.text("UnicodePackages"));
-   }
-   else {
-      qDebug() << "===readComment=== ERROR " << fileName << " could not be loaded";
-   }
+void readImageComments(const QString &fileName) {
+	QImage image;
+	QString output;
+
+	if(image.load(fileName)) {
+		qDebug() << QString("Image %1 has Command _%2_").arg(fileName).arg(image.text("Command"));
+		qDebug() << QString("Image %1 has Comment _%2_").arg(fileName).arg(image.text("Comment"));
+		qDebug() << QString("image %1 has Package _%2_").arg(fileName).arg(image.text("Packages"));
+		qDebug() << QString("Image %1 has CommandUnicode _%2_").arg(fileName).arg(image.text("CommandUnicode"));
+		qDebug() << QString("Image %1 has UnicodePackages _%2_").arg(fileName).arg(image.text("UnicodePackages"));
+	}
+	else {
+		qDebug() << "===readComment=== ERROR " << fileName << " could not be loaded";
+	}
 }
 
-QString convertUTF8toLatin1String(const QString &string){
-
-   QVector<uint> stringAsInt;
-   QString stringAsLatin1;
-   
-   stringAsInt = string.toUcs4();
-   QVector<uint>::const_iterator it;
-   for(it = stringAsInt.begin(); it != stringAsInt.end(); it++) {
-      stringAsLatin1 += QString("U+%1,").arg(*it);
-   }
-   return stringAsLatin1;
+QString convertUTF8toLatin1String(const QString &string) {
+	QVector<uint> stringAsInt;
+	QString stringAsLatin1;
+	
+	stringAsInt = string.toUcs4();
+	QVector<uint>::const_iterator it;
+	for(it = stringAsInt.begin(); it != stringAsInt.end(); it++) {
+		stringAsLatin1 += QString("U+%1,").arg(*it,4,16,QChar('0')).toUpper();
+	}
+	return stringAsLatin1.left(stringAsLatin1.length() - 1);
 }
 
-QString pkgListToString(const QList<Package> &packages){
-   
-   QString packagesArg, packagesName;
-   int i=0;
-   for(; i < packages.count()-1 ; i++){
-      packagesArg  += packages[i].arguments + ',';
-      packagesName += packages[i].name + ',';
-   }
-   if(i<packages.count()){
-       packagesArg  += packages[i].arguments;
-       packagesName += packages[i].name;
-   }
-   QString result = ( packagesArg.isEmpty() ? "" : '[' + packagesArg + ']' ) + ( packagesName.isEmpty() ? "" : '{' + packagesName + '}' );
-   return result;
+QString pkgListToString(const QList<Package> &packages) {
+	QString packagesArg, packagesName;
+	int i=0;
+	for(; i < packages.count()-1 ; i++) {
+		packagesArg  += packages[i].arguments + ',';
+		packagesName += packages[i].name + ',';
+	}
+	if(i<packages.count()) {
+		packagesArg  += packages[i].arguments;
+		packagesName += packages[i].name;
+	}
+	QString result = ( packagesArg.isEmpty() ? "" : '[' + packagesArg + ']' ) + ( packagesName.isEmpty() ? "" : '{' + packagesName + '}' );
+	return result;
 }
 
-void writeSVGComments(const Command &cmd, const QString &fileName)
-{
-   QString unicodeCommandAsLatin1, commentAsLatin1;
-   QString packagesarg, packages;
-   
-   if(!cmd.unicodeCommand.isEmpty()) {
-      unicodeCommandAsLatin1 = convertUTF8toLatin1String(cmd.unicodeCommand);
-   }
-   if(!cmd.comment.isEmpty()) {
-      commentAsLatin1 = convertUTF8toLatin1String(cmd.comment);
-   }
+void writeSVGComments(const Command &cmd, const QString &fileName) {
+	QString unicodeCommandAsLatin1, commentAsLatin1;
+	QString packagesarg, packages;
 
-   qDebug() << "fileName is " << fileName;
-   qDebug() << "Command is " << cmd.latexCommand;
-   qDebug() << "unicodeCommandAsLatin1 is " << unicodeCommandAsLatin1;
-   qDebug() << "commentAsLatin1 is " << commentAsLatin1;
-   qDebug() << "comment is " << cmd.comment; 
+	if(!cmd.unicodeCommand.isEmpty()) {
+		unicodeCommandAsLatin1 = convertUTF8toLatin1String(cmd.unicodeCommand);
+	}
+	if(!cmd.comment.isEmpty()) {
+		commentAsLatin1 = convertUTF8toLatin1String(cmd.comment);
+	}
 
-   QFile file( fileName );
+	qDebug() << "fileName is " << fileName;
+	qDebug() << "Command is " << cmd.latexCommand;
+	qDebug() << "unicodeCommandAsLatin1 is " << unicodeCommandAsLatin1;
+	qDebug() << "commentAsLatin1 is " << commentAsLatin1;
+	qDebug() << "comment is " << cmd.comment;
 
-  if( !file.open( QIODevice::ReadOnly ) ){
-    qDebug() << "could not open file";
-    return;
-  }
+	QFile file( fileName );
 
-  QStringList fileContent;
-  QTextStream stream(&file);
-  QString line;
-  do {
-      line = stream.readLine();
-      if(!line.isNull())
-          fileContent<<line;
-  } while (!line.isNull());
+	if( !file.open( QIODevice::ReadOnly ) ) {
+		qDebug() << "could not open file";
+		return;
+	}
 
-  file.close();
+	QStringList fileContent;
+ 	QTextStream stream(&file);
+	QString line;
+	do {
+		line = stream.readLine();
+		if(!line.isNull())
+			 fileContent<<line;
+	} while (!line.isNull());
 
+	file.close();
 
-  //QFile file( fn );
-  if( !file.open( QIODevice::WriteOnly ) )
-  return;
+	//QFile file( fn );
+	if( !file.open( QIODevice::WriteOnly ) )
+	return;
 
-  QTextStream ts( &file );
-  for(int i=0;i<fileContent.size();i++){
-      line=fileContent.at(i);
-      if(line.startsWith("<defs>")){
-	  QString Command=cmd.latexCommand;
-	  Command.replace("<","&lt;");
-          ts<<"<title>"<<Command<<"</title>"<<"\n";
-          QString additional;
-          if (!commentAsLatin1.isEmpty() ) {
-              additional="Comment=\""+commentAsLatin1+"\" ";
-          }
-          if( !unicodeCommandAsLatin1.isEmpty() ) {
-              additional+="CommandUnicode=\""+unicodeCommandAsLatin1+"\" ";
-              additional+="UnicodePackages=\""+pkgListToString(cmd.unicodePackages)+"\" ";
-          }
-          ts<<"<desc "<<"Packages=\""<<pkgListToString(cmd.packages)<<"\" />\n";
-	  ts<<"<additionalInfo "<<additional<<" />\n";
-      }
-      ts<<line<<"\n";
-  }
+	QTextStream ts( &file );
+	for(int i=0;i<fileContent.size();i++) {
+		line=fileContent.at(i);
+		if(line.startsWith("<defs>")) {
+			QString Command=cmd.latexCommand;
+			Command.replace("<","&lt;");
+			ts<<"<title>"<<Command<<"</title>"<<"\n";
+			QString additional;
+			if (!commentAsLatin1.isEmpty() ) {
+				additional=" Comment='"+commentAsLatin1+"'";
+			}
+			if( !unicodeCommandAsLatin1.isEmpty() ) {
+				additional+=" CommandUnicode='"+unicodeCommandAsLatin1+"'";
+				additional+=" UnicodePackages='"+pkgListToString(cmd.unicodePackages)+"'";
+			}
+			ts<<"<desc"<<" Packages='"<<pkgListToString(cmd.packages)<<"'";
+			ts<<additional<<"/>\n";
+		}
+		ts<<line<<"\n";
+	}
 
-  file.close();
-   
+	file.close();
+
 }
 
-int readSVG(QString fn){
-    QFile file( fn );
+int readSVG(QString fn) {
+	QFile file( fn );
 
-   if( !file.open( QIODevice::ReadOnly ) ){
-     qDebug() << "could not open file";
-     return -1;
-   }
+	if( !file.open( QIODevice::ReadOnly ) ) {
+		qDebug() << "could not open file";
+		return -1;
+	}
 
-   QString errorMsg;
-   int errorLine,errorColumn;
-   QDomDocument doc( "svg" );
+	QString errorMsg;
+	int errorLine,errorColumn;
+	QDomDocument doc( "svg" );
 
-   if( !doc.setContent( &file,false, &errorMsg, &errorLine, &errorColumn) )
-   {
-     qDebug() << "could not find xml content";
-     qDebug() << errorMsg;
-     qDebug() << "line is " << errorLine;
-     qDebug() << "column is " << errorColumn;
-     file.close();
-     return -2;
-   }
-   file.close();
+	if( !doc.setContent( &file,false, &errorMsg, &errorLine, &errorColumn) ) {
+		qDebug() << "could not find xml content";
+		qDebug() << errorMsg;
+		qDebug() << "line is " << errorLine;
+		qDebug() << "column is " << errorColumn;
+		file.close();
+		return -2;
+	}
+	file.close();
 
-   // check root element
-   QDomElement root = doc.documentElement();
-   if( root.tagName() != "svg" ) {
-     qDebug() << "wrong format";
-     return -3;
-   }
-   QDomNode n=doc.createElement("title");
-   QDomNode cont=doc.createTextNode("title");
-   n.appendChild(cont);
-   //n.setNodeValue("test a");
-   root.appendChild(n);
+	// check root element
+	QDomElement root = doc.documentElement();
+	if( root.tagName() != "svg" ) {
+		qDebug() << "wrong format";
+		return -3;
+	}
+	QDomNode n=doc.createElement("title");
+	QDomNode cont=doc.createTextNode("title");
+	n.appendChild(cont);
+	//n.setNodeValue("test a");
+	root.appendChild(n);
 
-   //QFile file( fn );
-   if( !file.open( QIODevice::WriteOnly ) )
-   return -1;
+	//QFile file( fn );
+	if( !file.open( QIODevice::WriteOnly ) )
+	return -1;
 
-   QTextStream ts( &file );
-   ts << doc.toString();
+	QTextStream ts( &file );
+	ts << doc.toString();
 
-   file.close();
-   /*
-   QDomNode n = root.firstChild();
-   while( !n.isNull() ) {
-     QDomElement e = n.toElement();
+	file.close();
+	/*
+	QDomNode n = root.firstChild();
+	while( !n.isNull() ) {
+		QDomElement e = n.toElement();
 
-     if( e.isNull() ) {
-       n = n.nextSibling();
-       continue;
-     }
-     qDebug() << "element name is " << e.tagName();
-     //QString tagName = e.tagName();
-     n = n.nextSibling();
-  }*/
-  return 0;
+		if( e.isNull() ) {
+		 n = n.nextSibling();
+		 continue;
+		}
+		qDebug() << "element name is " << e.tagName();
+		//QString tagName = e.tagName();
+		n = n.nextSibling();
+	}*/
+	return 0;
 }
 
 QString generateSVG(QString latexFile, int index, QString symbolGroupName) {
-    
-   QString texfile, texfileWithoutSuffix,svgfile;
-   int latexret, dvipngret;
+	QString texfile, texfileWithoutSuffix, svgfile;
+	int latexret, dvipngret;
 
-   QTemporaryFile file("XXXXXX.tex");
-   file.setAutoRemove(false);
-   if (file.open()) {
-      QTextStream t(&file);
-      t.setCodec("UTF-8");
-      t << latexFile;
-      
-      texfile = file.fileName();
-      texfileWithoutSuffix = texfile.left(texfile.length() - 4);
-      if(index>0)
-	svgfile = QString("img%1%2.svg").arg(index,3,10,QChar('0')).arg(symbolGroupName);
-      else
-	svgfile=symbolGroupName+".svg";
-      qDebug() << texfile;
-      qDebug() << texfileWithoutSuffix;
-      qDebug() << svgfile;
-      
-      file.close();    
-   }
+	QTemporaryFile file("XXXXXX.tex");
+	file.setAutoRemove(false);
+	if (file.open()) {
+		QTextStream t(&file);
+		t.setEncoding(QStringConverter::Utf8);
+		t << latexFile;
 
-   QString texcommand=QString("latex -interaction=batchmode %1").arg(texfile);
-   QString dvipngcommand=QString("dvisvgm -e -o %1 %2.dvi").arg(svgfile).arg(texfileWithoutSuffix);
+		texfile = file.fileName();
+		texfileWithoutSuffix = texfile.left(texfile.length() - 4);
+		if (symbolGroupName=="fontawesome5")
+			svgfile = QString("img%1fontawesome5.svg").arg(index,4,10,QChar('0'));
+		else if (index>0)
+			svgfile = QString("img%1%2.svg").arg(index,3,10,QChar('0')).arg(symbolGroupName);
+		else 
+			svgfile = symbolGroupName+".svg";
+		qDebug() << texfile;
+		qDebug() << texfileWithoutSuffix;
+		qDebug() << svgfile;
 
-   qDebug() << texcommand;
-   qDebug() << dvipngcommand;
- 
-   latexret = system(texcommand.toLatin1());
-   dvipngret= system(dvipngcommand.toLatin1());
-   
-   if (latexret) {
-      qDebug() << "Error compiling the latex file";
-      return QString();
-   }
-   
-   if(dvipngret) { 
-      qDebug() << "Error producing the pngs";
-      return QString();
-   }
-   
-   return svgfile;
+		file.close();
+	}
+
+	QString texcommand=QString("latex -interaction=batchmode %1").arg(texfile);
+	QString dvipngcommand=QString("dvisvgm -n -j --bbox=papersize --scale=32bp/h --zoom=-1 -O -o %1 %2.dvi").arg(svgfile).arg(texfileWithoutSuffix);
+
+	qDebug() << texcommand;
+	qDebug() << dvipngcommand;
+
+	latexret = system(texcommand.toLatin1());
+	dvipngret= system(dvipngcommand.toLatin1());
+
+	if (latexret) {
+		qDebug() << "Error compiling the latex file";
+		return QString();
+	}
+
+	if(dvipngret) {
+		qDebug() << "Error producing the pngs";
+		return QString();
+	}
+
+	return svgfile;
 }
 
-void writeImageComments(const Command &cmd, const QString &fileName)
-{
-   
-   QImage image;
-   QString unicodeCommandAsLatin1, commentAsLatin1;
-   QString packagesarg, packages;
-   
-   if(!cmd.unicodeCommand.isEmpty()) {
-      unicodeCommandAsLatin1 = convertUTF8toLatin1String(cmd.unicodeCommand);
-   }
-   if(!cmd.comment.isEmpty()) {
-      commentAsLatin1 = convertUTF8toLatin1String(cmd.comment);
-   }
+void writeImageComments(const Command &cmd, const QString &fileName) {
+	QImage image;
+	QString unicodeCommandAsLatin1, commentAsLatin1;
+	QString packagesarg, packages;
 
-   qDebug() << "fileName is " << fileName;
-   qDebug() << "Command is " << cmd.latexCommand;
-   qDebug() << "unicodeCommandAsLatin1 is " << unicodeCommandAsLatin1;
-   qDebug() << "commentAsLatin1 is " << commentAsLatin1;
-   qDebug() << "comment is " << cmd.comment; 
-   
-   if(image.load(fileName)) {
-      
-      image.setText("Command",cmd.latexCommand);    
-      if( !unicodeCommandAsLatin1.isEmpty() ) {
-	 image.setText("CommandUnicode",unicodeCommandAsLatin1);
-	 image.setText("UnicodePackages",pkgListToString(cmd.unicodePackages));
-      }
-      if (!commentAsLatin1.isEmpty() ) {
-	 image.setText("Comment",commentAsLatin1);
-      }
-      
-      image.setText("Packages",pkgListToString(cmd.packages));     
-      if(!image.save(fileName,"PNG")) {
-	 qDebug() << "Image " << fileName << " could not be saved";
-	 exit(1);
-      }
-   }
-   else {
-      qDebug() << "===writeComment=== ERROR " << fileName << "could not be loaded";
-   }
-   
+	if(!cmd.unicodeCommand.isEmpty()) {
+		unicodeCommandAsLatin1 = convertUTF8toLatin1String(cmd.unicodeCommand);
+	}
+	if(!cmd.comment.isEmpty()) {
+		commentAsLatin1 = convertUTF8toLatin1String(cmd.comment);
+	}
+
+	qDebug() << "fileName is " << fileName;
+	qDebug() << "Command is " << cmd.latexCommand;
+	qDebug() << "unicodeCommandAsLatin1 is " << unicodeCommandAsLatin1;
+	qDebug() << "commentAsLatin1 is " << commentAsLatin1;
+	qDebug() << "comment is " << cmd.comment;
+
+	if(image.load(fileName)) {
+		image.setText("Command",cmd.latexCommand);
+		if( !unicodeCommandAsLatin1.isEmpty() ) {
+			image.setText("CommandUnicode",unicodeCommandAsLatin1);
+			image.setText("UnicodePackages",pkgListToString(cmd.unicodePackages));
+		}
+		if (!commentAsLatin1.isEmpty() ) {
+			image.setText("Comment",commentAsLatin1);
+		}
+
+		image.setText("Packages",pkgListToString(cmd.packages));
+		if(!image.save(fileName,"PNG")) {
+			qDebug() << "Image " << fileName << " could not be saved";
+			exit(1);
+		}
+	}
+	else {
+		qDebug() << "===writeComment=== ERROR " << fileName << "could not be loaded";
+	}
 }
 
-QString generatePNG(QString latexFile, int index, QString symbolGroupName,QString batikConvert) {
-    
-   QString texfile, texfileWithoutSuffix,pngfile;
-   int latexret, dvipngret,convertret,rmret;
+QString generatePNG(QString latexFile, int index, QString symbolGroupName, QString batikConvert) {
+	QString texfile, texfileWithoutSuffix, pngfile;
+	int latexret, dvipngret, convertret, rmret;
 
-   QTemporaryFile file("XXXXXX.tex");
-   file.setAutoRemove(false);
-   if (file.open()) {
-      QTextStream t(&file);
-      t.setCodec("UTF-8");
-      t << latexFile;
-      
-      texfile = file.fileName();
-      texfileWithoutSuffix = texfile.left(texfile.length() - 4);
-      if(index>0)
-	pngfile = QString("img%1%2.png").arg(index,3,10,QChar('0')).arg(symbolGroupName);
-      else
-	pngfile=symbolGroupName+".png";
-      qDebug() << texfile;
-      qDebug() << texfileWithoutSuffix;
-      qDebug() << pngfile;
-      
-      file.close();    
-   }
+	QTemporaryFile file("XXXXXX.tex");
+	file.setAutoRemove(false);
+	if (file.open()) {
+		QTextStream t(&file);
+		t.setEncoding(QStringConverter::Utf8);
+		t << latexFile;
 
-   QString texcommand=QString("latex -interaction=batchmode %1").arg(texfile);
-   QString dvipngcommand=QString("dvisvgm -e -o %1.svg %2.dvi").arg(texfileWithoutSuffix).arg(texfileWithoutSuffix);
-   QString convertCommand=QString("%1 %2.svg %3").arg(batikConvert).arg(texfileWithoutSuffix).arg(pngfile);
-   QString removeCommand=QString("rm %1.svg").arg(texfileWithoutSuffix);
-   //QString dvipngcommand=QString("dvipng  --strict --picky --freetype -x 1440 -bg Transparent -D 600 -O -1.2in,-1.2in -T bbox -z 6 -o %1 %2.dvi").arg(pngfile).arg(texfileWithoutSuffix);
+		texfile = file.fileName();
+		texfileWithoutSuffix = texfile.left(texfile.length() - 4);
+		if (symbolGroupName=="fontawesome5")
+			pngfile = QString("img%1fontawesome5.png").arg(index,4,10,QChar('0'));
+		else if (index>0)
+			pngfile = QString("img%1%2.png").arg(index,3,10,QChar('0')).arg(symbolGroupName);
+		else 
+			pngfile = symbolGroupName+".png";
+		qDebug() << texfile;
+		qDebug() << texfileWithoutSuffix;
+		qDebug() << pngfile;
 
-   qDebug() << texcommand;
-   qDebug() << dvipngcommand;
-   qDebug() << convertCommand;
- 
-   latexret = system(texcommand.toLatin1());
-   dvipngret= system(dvipngcommand.toLatin1());
-   convertret= system(convertCommand.toLatin1());
-   rmret=system(removeCommand.toLatin1());
-   
-   if (latexret) {
-      qDebug() << "Error compiling the latex file";
-      return QString();
-   }
-   
-   if(dvipngret) { 
-      qDebug() << "Error producing the svg";
-      return QString();
-   }
-   
-   if(convertret) { 
-      qDebug() << "Error converting svg to png";
-      return QString();
-   }
-   if(rmret) { 
-      qDebug() << "Error removing svg";
-      return QString();
-   }
-   
-   return pngfile;
+		file.close();
+	}
+
+	QString texcommand=QString("latex -interaction=batchmode %1").arg(texfile);
+	QString dvipngcommand=QString("dvisvgm -n -j --bbox=papersize --scale=32bp/h --zoom=-1 -O -o %1.svg %2.dvi").arg(texfileWithoutSuffix).arg(texfileWithoutSuffix);
+	QString convertCommand=QString("%1 %2.svg %3").arg(batikConvert).arg(texfileWithoutSuffix).arg(pngfile);
+	QString removeCommand=QString("rm %1.svg").arg(texfileWithoutSuffix);
+	//QString dvipngcommand=QString("dvipng  --strict --picky --freetype -x 1440 -bg Transparent -D 600 -O -1.2in,-1.2in -T bbox -z 6 -o %1 %2.dvi").arg(pngfile).arg(texfileWithoutSuffix);
+
+	qDebug() << texcommand;
+	qDebug() << dvipngcommand;
+	qDebug() << convertCommand;
+
+	latexret = system(texcommand.toLatin1());
+	dvipngret = system(dvipngcommand.toLatin1());
+	convertret = system(convertCommand.toLatin1());
+	rmret = system(removeCommand.toLatin1());
+
+	if (latexret) {
+		qDebug() << "Error compiling the latex file";
+		return QString();
+	}
+
+	if(dvipngret) {
+		qDebug() << "Error producing the svg";
+		return QString();
+	}
+
+	if(convertret) {
+		qDebug() << "Error converting svg to png";
+		return QString();
+	}
+
+	if(rmret) {
+		qDebug() << "Error removing svg";
+		return QString();
+	}
+
+	return pngfile;
 }
 
-QString generateLatexFile(const Preamble &preamble, const Command &cmd)
-{
-   QString output;
-   Package pkg;
-   QString cmdString;
-   
-   output += QString("\\documentclass[%1]{%2}\n").arg(preamble.classArguments).arg(preamble.className);
-   output += '\n';
-   output += preamble.additional;
-   output += '\n';
-   
-   for(int i=0; i < cmd.packages.count(); i++){
-      pkg = cmd.packages[i];
-      if(pkg.arguments.isEmpty()) {
-	 output += QString("\\usepackage{%1}\n").arg(pkg.name);
-      }
-      else{
-	 output += QString("\\usepackage[%1]{%2}\n").arg(pkg.arguments).arg(pkg.name);
-      }
-   }
-   
-   output += "\\begin{document}\n";
-   output += '\n';
-   if(!cmd.iconMode)
-      output += "\\special{dvisvgm:bbox 0 0}\n";
-   cmdString = !cmd.ImageCommand.isEmpty() ? cmd.ImageCommand : cmd.latexCommand;
-   output += cmd.mathMode ? QString("\\ensuremath{%1}\n").arg(cmdString) : QString("%1\n").arg(cmdString);
-   output += '\n';
-   output += "\\end{document}\n";
-   
-   return output;
+QString generateLatexFile(const Preamble &preamble, const Command &cmd) {
+	QString output;
+	Package pkg;
+	QString cmdString;
+
+	output += QString("\\documentclass[%1]{%2}\n").arg(preamble.classArguments).arg(preamble.className);
+	output += preamble.additional;
+	output += '\n';
+
+	for(int i=0; i < cmd.packages.count(); i++){
+		pkg = cmd.packages[i];
+		if(pkg.arguments.isEmpty()) {
+			output += QString("\\usepackage{%1}\n").arg(pkg.name);
+		}
+		else{
+			output += QString("\\usepackage[%1]{%2}\n").arg(pkg.arguments).arg(pkg.name);
+		}
+	}
+
+	if(!cmd.iconMode) {
+		output+="\\usepackage{calc}\n";
+		output+="\\newcommand{\\sqbox}[1]{\\rule[\\widthof{#1} * \\real{-0.3}]{0bp}{\\widthof{#1}}#1}\n";
+	}
+
+	output += "\\begin{document}\n";
+	cmdString = !cmd.ImageCommand.isEmpty() ? cmd.ImageCommand : cmd.latexCommand;
+
+	if (cmd.mathMode) 
+		cmdString = QString("\\ensuremath{%1}").arg(cmdString);
+
+	if(!cmd.iconMode)
+		cmdString = QString("\\sqbox{%1}\\strut").arg(cmdString);
+
+	output += cmdString;
+	output += '\n';
+	output += "\\end{document}\n";
+
+	return output;
 }
 
-QList<Package> getAllPackages(const QDomElement &e){
+QList<Package> getAllPackages(const QDomElement &e) {
+	QList<Package> packages;
+	Package pkg;
+	QDomElement element;
 
-   QList<Package> packages;
-   Package pkg;
-   QDomElement element;   
-   
-   if(e.isNull()){
-      return packages;
-   }
-      
-   QDomNodeList cmdNodes = e.childNodes();
-   
-   for(int i=0; i < cmdNodes.count();i++) {
-      element = cmdNodes.item(i).toElement();
-      if( element.tagName()== "package") {
-	 pkg.name = element.firstChildElement("name").text();
-	 pkg.arguments =  element.firstChildElement("arguments").text();
-	 packages.append(pkg);
-	 qDebug() << "pkg.name is " << pkg.name;
-	 qDebug() << "pkg.arguments is " << pkg.arguments;
-      }
-   }
-   return packages;
+	if(e.isNull()){
+		return packages;
+	}
+
+	QDomNodeList cmdNodes = e.childNodes();
+
+	for(int i=0; i < cmdNodes.count();i++) {
+		element = cmdNodes.item(i).toElement();
+		if( element.tagName()== "package") {
+			pkg.name = element.firstChildElement("name").text();
+			pkg.arguments =  element.firstChildElement("arguments").text();
+			packages.append(pkg);
+			qDebug() << "pkg.name is " << pkg.name;
+			qDebug() << "pkg.arguments is " << pkg.arguments;
+		}
+	}
+	return packages;
 }
 
-Command getCommandDefinition(const QDomElement &e, QList<Package> unicodePackages)
-{
-   if(e.isNull()) {
-      return Command();
-   }
+Command getCommandDefinition(const QDomElement &e, QList<Package> unicodePackages) {
+	if(e.isNull()) {
+		return Command();
+	}
 
-   Package pkg;
-   Command cmd;
-   
-   cmd.unicodePackages = unicodePackages;
-   cmd.packages = getAllPackages(e);
-   cmd.mathMode = e.firstChildElement("mathMode").text() == "true" ? true : false;
-   cmd.forcePNG = e.firstChildElement("forcePNG").text() == "true" ? true : false;
-   cmd.iconMode = e.firstChildElement("iconMode").text() == "true" ? true : false;
-   cmd.name = e.firstChildElement("name").text();
-   qDebug()<<cmd.iconMode;
-   cmd.comment = e.firstChildElement("comment").text();
-   cmd.latexCommand = e.firstChildElement("latexCommand").text();
-   cmd.unicodeCommand = e.firstChildElement("unicodeCommand").text();
-   cmd.ImageCommand = e.firstChildElement("imageCommand").text();
-   
-   qDebug() << QString("cmd: latexCommand=%1, unicodeCommand=%2, imageCommand=%3, comment=%4, mathmode=%5").arg(cmd.latexCommand).arg(cmd.unicodeCommand).arg(cmd.ImageCommand).arg(cmd.comment).arg(cmd.mathMode);
+	Package pkg;
+	Command cmd;
 
-   if(cmd.packages.count() > 0 ){
-      qDebug() << "packages are";
-      for(int i=0; i < cmd.packages.count(); i++){
-	 qDebug() << QString("name=%1, arguments=%2").arg(cmd.packages[i].name).arg(cmd.packages[i].arguments);
-      }
-   }
-   else{
-      qDebug() << "no packages to include";  
-   }
-   
-   return cmd;
+	cmd.unicodePackages = unicodePackages;
+	cmd.packages = getAllPackages(e);
+	cmd.mathMode = e.firstChildElement("mathMode").text() == "true" ? true : false;
+	cmd.forcePNG = e.firstChildElement("forcePNG").text() == "true" ? true : false;
+	cmd.iconMode = e.firstChildElement("iconMode").text() == "true" ? true : false;
+	cmd.name = e.firstChildElement("name").text();
+	qDebug()<<cmd.iconMode;
+	cmd.comment = e.firstChildElement("comment").text();
+	cmd.latexCommand = e.firstChildElement("latexCommand").text();
+	cmd.unicodeCommand = e.firstChildElement("unicodeCommand").text();
+	cmd.ImageCommand = e.firstChildElement("imageCommand").text();
+
+	qDebug() << QString("cmd: latexCommand=%1, unicodeCommand=%2, imageCommand=%3, comment=%4, mathmode=%5").arg(cmd.latexCommand).arg(cmd.unicodeCommand).arg(cmd.ImageCommand).arg(cmd.comment).arg(cmd.mathMode);
+
+	if(cmd.packages.count() > 0 ) {
+		qDebug() << "packages are";
+		for(int i=0; i < cmd.packages.count(); i++) {
+			qDebug() << QString("name=%1, arguments=%2").arg(cmd.packages[i].name).arg(cmd.packages[i].arguments);
+		}
+	}
+	else{
+		qDebug() << "no packages to include";
+	}
+
+	return cmd;
 }
 
-void usage(){
-
-   qDebug() << QString("usage: gesymb-ng mySymbols.xml path/to/batikConvert");
-   exit(1);
+void usage() {
+	qDebug() << QString("usage: gesymb-ng mySymbols.xml path/to/batikConvert");
+	exit(1);
 }
 
-int main(int argc, char** argv)
-{
-   Preamble preamble;
-   Version version;
-   QList<Command> commands;
-   QString symbolGroupName;
-   QList<Package> unicodePkgList;
-   
-   if(argc < 3){
-      usage();
-   }
-   QFile file( argv[1] );
-   QString batik=argv[2];
-   
-  if( !file.open( QIODevice::ReadOnly ) ){
-    qDebug() << "could not open file";
-    return -1;
-  }
+int main(int argc, char** argv) {
+	Preamble preamble;
+	Version version;
+	QList<Command> commands;
+	QString symbolGroupName;
+	QList<Package> unicodePkgList;
 
-  QString errorMsg;
-  int errorLine,errorColumn;
-  QDomDocument doc( "KileSymbolSources" );
-  
-  if( !doc.setContent( &file,false, &errorMsg, &errorLine, &errorColumn) )
-  {
-    qDebug() << "could not find xml content";
-    qDebug() << errorMsg;
-    qDebug() << "line is " << errorLine;
-    qDebug() << "column is " << errorColumn;
-    file.close();
-    return -2;
-  }
-  file.close();
-  
-  // check root element
-  QDomElement root = doc.documentElement();
-  if( root.tagName() != "symbols" ) {
-    qDebug() << "wrong format";
-    return -3;
-  }
-  
-  QDomNode n = root.firstChild();
-  while( !n.isNull() ) {
-    QDomElement e = n.toElement();
-    
-    if( e.isNull() ) {
-      n = n.nextSibling();  
-      continue;
-    }
-    qDebug() << "element name is " << e.tagName();
-    QString tagName = e.tagName();
-    
-    if( tagName == "formatVersion" ){
-      version.major = e.attribute("major");
-      version.minor = e.attribute("minor");
-    }
-    else if( tagName == "symbolGroupName" ){
-       symbolGroupName = e.text();
-    }
-    else if(tagName == "preamble"){
-      preamble.className = e.firstChildElement("class").text();
-      preamble.classArguments = e.firstChildElement("arguments").text();
-      preamble.additional= e.firstChildElement("additional").text();
+	if(argc < 3) {
+		usage();
+	}
+	QFile file( argv[1] );
+	QString batik=argv[2];
 
-      qDebug() << "class is " << preamble.className;
-      qDebug() << "arguments is " << preamble.classArguments;
-      qDebug() << "additional is " << preamble.additional;
-      
-    }
-    else if( tagName == "unicodeCommandPackages") {
-       unicodePkgList = getAllPackages(e);
-    }
-    else if( tagName == "commandDefinition" ){
-       commands.append(getCommandDefinition(e,unicodePkgList));
-    }
-    else{
-       qDebug() << "unexpected node: " << tagName;
-    }
-      n = n.nextSibling();   
-    }
-    
-    QString content,pngfile;
-    for(int i=0; i < commands.count();i++) {
-       content = generateLatexFile(preamble,commands[i]);
-       qDebug() << content;
-       if(commands[i].forcePNG){
-	  if(commands[i].name.isEmpty())
-	    pngfile = generatePNG(content,i+1,symbolGroupName,batik);
-	  else
-	    pngfile = generatePNG(content,-1,commands[i].name,batik);
-	  writeImageComments(commands[i],pngfile);
-       }else{
-	 if(commands[i].name.isEmpty())
-	    pngfile = generateSVG(content,i+1,symbolGroupName);
-	 else
-	    pngfile = generateSVG(content,-1,commands[i].name);
-	 writeSVGComments(commands[i],pngfile);
-       }
-       //readImageComments(pngfile);
-    }
-       
+	if( !file.open( QIODevice::ReadOnly ) ) {
+		qDebug() << "could not open file";
+		return -1;
+	}
+
+	QString errorMsg;
+	int errorLine,errorColumn;
+	QDomDocument doc( "KileSymbolSources" );
+
+	if( !doc.setContent( &file,false, &errorMsg, &errorLine, &errorColumn) ) {
+		qDebug() << "could not find xml content";
+		qDebug() << errorMsg;
+		qDebug() << "line is " << errorLine;
+		qDebug() << "column is " << errorColumn;
+		file.close();
+		return -2;
+	}
+	file.close();
+
+	// check root element
+	QDomElement root = doc.documentElement();
+	if( root.tagName() != "symbols" ) {
+		qDebug() << "wrong format";
+		return -3;
+	}
+
+	QDomNode n = root.firstChild();
+	while( !n.isNull() ) {
+		QDomElement e = n.toElement();
+
+		if( e.isNull() ) {
+			n = n.nextSibling();
+			continue;
+		}
+		qDebug() << "element name is " << e.tagName();
+		QString tagName = e.tagName();
+
+		if( tagName == "formatVersion" ) {
+			version.major = e.attribute("major");
+			version.minor = e.attribute("minor");
+		} else if( tagName == "symbolGroupName" ) {
+			symbolGroupName = e.text();
+		} else if(tagName == "preamble") {
+			preamble.className = e.firstChildElement("class").text();
+			preamble.classArguments = e.firstChildElement("arguments").text();
+			preamble.additional= e.firstChildElement("additional").text();
+
+			qDebug() << "class is " << preamble.className;
+			qDebug() << "arguments is " << preamble.classArguments;
+			qDebug() << "additional is " << preamble.additional;
+		} else if( tagName == "unicodeCommandPackages") {
+			unicodePkgList = getAllPackages(e);
+		} else if( tagName == "commandDefinition" ){
+			commands.append(getCommandDefinition(e,unicodePkgList));
+		} else{
+			qDebug() << "unexpected node: " << tagName;
+		}
+		n = n.nextSibling();
+	}
+
+	QString content,pngfile;
+	for(int i=0; i < commands.count();i++) {
+		content = generateLatexFile(preamble,commands[i]);
+		qDebug() << content;
+		if(commands[i].forcePNG){
+			if(commands[i].name.isEmpty())
+				pngfile = generatePNG(content,i+1,symbolGroupName,batik);
+			else
+				pngfile = generatePNG(content,-1,commands[i].name,batik);
+			writeImageComments(commands[i],pngfile);
+		} else {
+			if(commands[i].name.isEmpty())
+				pngfile = generateSVG(content,i+1,symbolGroupName);
+			else
+				pngfile = generateSVG(content,-1,commands[i].name);
+			writeSVGComments(commands[i],pngfile);
+		}
+		//readImageComments(pngfile);
+	}
 }

--- a/symbols-ng/greek.xml
+++ b/symbols-ng/greek.xml
@@ -3,578 +3,578 @@
 <!DOCTYPE KileSymbolSources>
 <symbols>
 
-   <formatVersion major="0" minor ="22" />
-
-   <symbolGroupName>user</symbolGroupName>
-
-   <preamble>
-      <class>article</class>
-      <arguments>12pt</arguments>
-      <additional>\pagestyle{empty}
-		  \setlength{\parindent}{0cm}
-		  \usepackage[T1]{fontenc}
-      </additional>
-   </preamble>
-
-   <unicodeCommandPackages>
-      <package>
-         <name>inputenc</name>
-         <arguments>utf8</arguments>
-      </package>
-   </unicodeCommandPackages>
-
-   <!-- insert stuff here    -->
-<symbolGroupName>greek</symbolGroupName>
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \alpha  -->
-<commandDefinition>
-   <latexCommand>\alpha</latexCommand>
-   <unicodeCommand>α</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \beta  -->
-<commandDefinition>
-   <latexCommand>\beta</latexCommand>
-   <unicodeCommand>β</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \gamma  -->
-<commandDefinition>
-   <latexCommand>\gamma</latexCommand>
-   <unicodeCommand>γ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \delta  -->
-<commandDefinition>
-   <latexCommand>\delta</latexCommand>
-   <unicodeCommand>δ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \epsilon  -->
-<commandDefinition>
-   <latexCommand>\epsilon</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \varepsilon  -->
-<commandDefinition>
-   <latexCommand>\varepsilon</latexCommand>
-   <unicodeCommand>ε</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \zeta  -->
-<commandDefinition>
-   <latexCommand>\zeta</latexCommand>
-   <unicodeCommand>ζ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \eta  -->
-<commandDefinition>
-   <latexCommand>\eta</latexCommand>
-   <unicodeCommand>η</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \theta  -->
-<commandDefinition>
-   <latexCommand>\theta</latexCommand>
-   <unicodeCommand>θ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \vartheta  -->
-<commandDefinition>
-   <latexCommand>\vartheta</latexCommand>
-   <unicodeCommand>ϑ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \iota  -->
-<commandDefinition>
-   <latexCommand>\iota</latexCommand>
-   <unicodeCommand>ι</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \kappa  -->
-<commandDefinition>
-   <latexCommand>\kappa</latexCommand>
-   <unicodeCommand>κ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \lambda  -->
-<commandDefinition>
-   <latexCommand>\lambda</latexCommand>
-   <unicodeCommand>λ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \mu  -->
-<commandDefinition>
-   <latexCommand>\mu</latexCommand>
-   <unicodeCommand>μ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \nu  -->
-<commandDefinition>
-   <latexCommand>\nu</latexCommand>
-   <unicodeCommand>ν</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \xi  -->
-<commandDefinition>
-   <latexCommand>\xi</latexCommand>
-   <unicodeCommand>ξ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math o  -->
-<commandDefinition>
-   <latexCommand>o</latexCommand>
-   <unicodeCommand>ο</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \pi  -->
-<commandDefinition>
-   <latexCommand>\pi</latexCommand>
-   <unicodeCommand>π</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \varpi  -->
-<commandDefinition>
-   <latexCommand>\varpi</latexCommand>
-   <unicodeCommand>ϖ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \rho  -->
-<commandDefinition>
-   <latexCommand>\rho</latexCommand>
-   <unicodeCommand>ρ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \varrho  -->
-<commandDefinition>
-   <latexCommand>\varrho</latexCommand>
-   <unicodeCommand>ϱ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \sigma  -->
-<commandDefinition>
-   <latexCommand>\sigma</latexCommand>
-   <unicodeCommand>σ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \varsigma  -->
-<commandDefinition>
-   <latexCommand>\varsigma</latexCommand>
-   <unicodeCommand>ς</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \tau  -->
-<commandDefinition>
-   <latexCommand>\tau</latexCommand>
-   <unicodeCommand>τ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \upsilon  -->
-<commandDefinition>
-   <latexCommand>\upsilon</latexCommand>
-   <unicodeCommand>υ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \phi  -->
-<commandDefinition>
-   <latexCommand>\phi</latexCommand>
-   <unicodeCommand>ϕ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \varphi  -->
-<commandDefinition>
-   <latexCommand>\varphi</latexCommand>
-   <unicodeCommand>φ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \chi  -->
-<commandDefinition>
-   <latexCommand>\chi</latexCommand>
-   <unicodeCommand>χ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \psi  -->
-<commandDefinition>
-   <latexCommand>\psi</latexCommand>
-   <unicodeCommand>ψ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \omega  -->
-<commandDefinition>
-   <latexCommand>\omega</latexCommand>
-   <unicodeCommand>ω</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math A  -->
-<commandDefinition>
-   <latexCommand>A</latexCommand>
-   <unicodeCommand>Α</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math B  -->
-<commandDefinition>
-   <latexCommand>B</latexCommand>
-   <unicodeCommand>Β</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Gamma  -->
-<commandDefinition>
-   <latexCommand>\Gamma</latexCommand>
-   <unicodeCommand>Γ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \varGamma  -->
-<commandDefinition>
-   <latexCommand>\varGamma</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Delta  -->
-<commandDefinition>
-   <latexCommand>\Delta</latexCommand>
-   <unicodeCommand>Δ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \varDelta  -->
-<commandDefinition>
-   <latexCommand>\varDelta</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math E  -->
-<commandDefinition>
-   <latexCommand>E</latexCommand>
-   <unicodeCommand>Ε</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math Z  -->
-<commandDefinition>
-   <latexCommand>Z</latexCommand>
-   <unicodeCommand>Ζ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math H  -->
-<commandDefinition>
-   <latexCommand>H</latexCommand>
-   <unicodeCommand>Η</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Theta  -->
-<commandDefinition>
-   <latexCommand>\Theta</latexCommand>
-   <unicodeCommand>Θ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \varTheta  -->
-<commandDefinition>
-   <latexCommand>\varTheta</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math I  -->
-<commandDefinition>
-   <latexCommand>I</latexCommand>
-   <unicodeCommand>Ι</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math K  -->
-<commandDefinition>
-   <latexCommand>K</latexCommand>
-   <unicodeCommand>Κ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Lambda  -->
-<commandDefinition>
-   <latexCommand>\Lambda</latexCommand>
-   <unicodeCommand>Λ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \varLambda  -->
-<commandDefinition>
-   <latexCommand>\varLambda</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math M  -->
-<commandDefinition>
-   <latexCommand>M</latexCommand>
-   <unicodeCommand>Μ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math N  -->
-<commandDefinition>
-   <latexCommand>N</latexCommand>
-   <unicodeCommand>Ν</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Xi  -->
-<commandDefinition>
-   <latexCommand>\Xi</latexCommand>
-   <unicodeCommand>Ξ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \varXi  -->
-<commandDefinition>
-   <latexCommand>\varXi</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math O  -->
-<commandDefinition>
-   <latexCommand>O</latexCommand>
-   <unicodeCommand>Ο</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Pi  -->
-<commandDefinition>
-   <latexCommand>\Pi</latexCommand>
-   <unicodeCommand>Π</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \varPi  -->
-<commandDefinition>
-   <latexCommand>\varPi</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math P  -->
-<commandDefinition>
-   <latexCommand>P</latexCommand>
-   <unicodeCommand>Ρ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Sigma  -->
-<commandDefinition>
-   <latexCommand>\Sigma</latexCommand>
-   <unicodeCommand>Σ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \varSigma  -->
-<commandDefinition>
-   <latexCommand>\varSigma</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math T  -->
-<commandDefinition>
-   <latexCommand>T</latexCommand>
-   <unicodeCommand>Τ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Upsilon  -->
-<commandDefinition>
-   <latexCommand>\Upsilon</latexCommand>
-   <unicodeCommand>ϒ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \varUpsilon  -->
-<commandDefinition>
-   <latexCommand>\varUpsilon</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Phi  -->
-<commandDefinition>
-   <latexCommand>\Phi</latexCommand>
-   <unicodeCommand>Φ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \varPhi  -->
-<commandDefinition>
-   <latexCommand>\varPhi</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math X  -->
-<commandDefinition>
-   <latexCommand>X</latexCommand>
-   <unicodeCommand>Χ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Psi  -->
-<commandDefinition>
-   <latexCommand>\Psi</latexCommand>
-   <unicodeCommand>Ψ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \varPsi  -->
-<commandDefinition>
-   <latexCommand>\varPsi</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Omega  -->
-<commandDefinition>
-   <latexCommand>\Omega</latexCommand>
-   <unicodeCommand>Ω</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \varOmega  -->
-<commandDefinition>
-   <latexCommand>\varOmega</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
+	<formatVersion major="0" minor ="22" />
+
+	<symbolGroupName>user</symbolGroupName>
+
+	<preamble>
+		<class>standalone</class>
+		<arguments>10bp,margin=1bp</arguments>
+		<additional>\usepackage[T1]{fontenc}</additional>
+	</preamble>
+
+	<unicodeCommandPackages>
+		<package>
+			<name>inputenc</name>
+			<arguments>utf8</arguments>
+		</package>
+	</unicodeCommandPackages>
+
+	<!-- insert stuff here -->
+
+	<symbolGroupName>greek</symbolGroupName>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \alpha -->
+	<commandDefinition>
+		<latexCommand>\alpha</latexCommand>
+		<unicodeCommand>𝛼</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \beta -->
+	<commandDefinition>
+		<latexCommand>\beta</latexCommand>
+		<unicodeCommand>𝛽</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \gamma -->
+	<commandDefinition>
+		<latexCommand>\gamma</latexCommand>
+		<unicodeCommand>𝛾</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \delta -->
+	<commandDefinition>
+		<latexCommand>\delta</latexCommand>
+		<unicodeCommand>𝛿</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \epsilon -->
+	<commandDefinition>
+		<latexCommand>\epsilon</latexCommand>
+		<unicodeCommand>𝜖</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \varepsilon -->
+	<commandDefinition>
+		<latexCommand>\varepsilon</latexCommand>
+		<unicodeCommand>𝜀</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \zeta -->
+	<commandDefinition>
+		<latexCommand>\zeta</latexCommand>
+		<unicodeCommand>𝜁</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \eta -->
+	<commandDefinition>
+		<latexCommand>\eta</latexCommand>
+		<unicodeCommand>𝜂</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \theta -->
+	<commandDefinition>
+		<latexCommand>\theta</latexCommand>
+		<unicodeCommand>𝜃</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \vartheta -->
+	<commandDefinition>
+		<latexCommand>\vartheta</latexCommand>
+		<unicodeCommand>𝜗</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \iota -->
+	<commandDefinition>
+		<latexCommand>\iota</latexCommand>
+		<unicodeCommand>𝜄</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \kappa -->
+	<commandDefinition>
+		<latexCommand>\kappa</latexCommand>
+		<unicodeCommand>𝜅</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \lambda -->
+	<commandDefinition>
+		<latexCommand>\lambda</latexCommand>
+		<unicodeCommand>𝜆</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \mu -->
+	<commandDefinition>
+		<latexCommand>\mu</latexCommand>
+		<unicodeCommand>𝜇</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \nu -->
+	<commandDefinition>
+		<latexCommand>\nu</latexCommand>
+		<unicodeCommand>𝜈</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \xi -->
+	<commandDefinition>
+		<latexCommand>\xi</latexCommand>
+		<unicodeCommand>𝜉</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math o -->
+	<commandDefinition>
+		<latexCommand>o</latexCommand>
+		<unicodeCommand>𝜊</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \pi -->
+	<commandDefinition>
+		<latexCommand>\pi</latexCommand>
+		<unicodeCommand>𝜋</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \varpi -->
+	<commandDefinition>
+		<latexCommand>\varpi</latexCommand>
+		<unicodeCommand>𝜛</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \rho -->
+	<commandDefinition>
+		<latexCommand>\rho</latexCommand>
+		<unicodeCommand>𝜌</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \varrho -->
+	<commandDefinition>
+		<latexCommand>\varrho</latexCommand>
+		<unicodeCommand>𝜚</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \sigma -->
+	<commandDefinition>
+		<latexCommand>\sigma</latexCommand>
+		<unicodeCommand>𝜎</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \varsigma -->
+	<commandDefinition>
+		<latexCommand>\varsigma</latexCommand>
+		<unicodeCommand>𝜍</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \tau -->
+	<commandDefinition>
+		<latexCommand>\tau</latexCommand>
+		<unicodeCommand>𝜏</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \upsilon -->
+	<commandDefinition>
+		<latexCommand>\upsilon</latexCommand>
+		<unicodeCommand>𝜐</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \phi -->
+	<commandDefinition>
+		<latexCommand>\phi</latexCommand>
+		<unicodeCommand>𝜙</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \varphi -->
+	<commandDefinition>
+		<latexCommand>\varphi</latexCommand>
+		<unicodeCommand>𝜑</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \chi -->
+	<commandDefinition>
+		<latexCommand>\chi</latexCommand>
+		<unicodeCommand>𝜒</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \psi -->
+	<commandDefinition>
+		<latexCommand>\psi</latexCommand>
+		<unicodeCommand>𝜓</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \omega -->
+	<commandDefinition>
+		<latexCommand>\omega</latexCommand>
+		<unicodeCommand>𝜔</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math A -->
+	<commandDefinition>
+		<latexCommand>A</latexCommand>
+		<unicodeCommand>𝛢</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math B -->
+	<commandDefinition>
+		<latexCommand>B</latexCommand>
+		<unicodeCommand>𝛣</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Gamma -->
+	<commandDefinition>
+		<latexCommand>\Gamma</latexCommand>
+		<unicodeCommand>Γ</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \varGamma -->
+	<commandDefinition>
+		<latexCommand>\varGamma</latexCommand>
+		<unicodeCommand>𝛤</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Delta -->
+	<commandDefinition>
+		<latexCommand>\Delta</latexCommand>
+		<unicodeCommand>∆</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \varDelta -->
+	<commandDefinition>
+		<latexCommand>\varDelta</latexCommand>
+		<unicodeCommand>𝛥</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math E -->
+	<commandDefinition>
+		<latexCommand>E</latexCommand>
+		<unicodeCommand>𝛦</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math Z -->
+	<commandDefinition>
+		<latexCommand>Z</latexCommand>
+		<unicodeCommand>𝛧</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math H -->
+	<commandDefinition>
+		<latexCommand>H</latexCommand>
+		<unicodeCommand>𝛨</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Theta -->
+	<commandDefinition>
+		<latexCommand>\Theta</latexCommand>
+		<unicodeCommand>𝛳</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \varTheta -->
+	<commandDefinition>
+		<latexCommand>\varTheta</latexCommand>
+		<unicodeCommand>𝛩</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math I -->
+	<commandDefinition>
+		<latexCommand>I</latexCommand>
+		<unicodeCommand>𝛪</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math K -->
+	<commandDefinition>
+		<latexCommand>K</latexCommand>
+		<unicodeCommand>𝛫</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Lambda -->
+	<commandDefinition>
+		<latexCommand>\Lambda</latexCommand>
+		<unicodeCommand>Λ</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \varLambda -->
+	<commandDefinition>
+		<latexCommand>\varLambda</latexCommand>
+		<unicodeCommand>𝛬</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math M -->
+	<commandDefinition>
+		<latexCommand>M</latexCommand>
+		<unicodeCommand>𝛭</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math N -->
+	<commandDefinition>
+		<latexCommand>N</latexCommand>
+		<unicodeCommand>𝛮</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Xi -->
+	<commandDefinition>
+		<latexCommand>\Xi</latexCommand>
+		<unicodeCommand>Ξ</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \varXi -->
+	<commandDefinition>
+		<latexCommand>\varXi</latexCommand>
+		<unicodeCommand>𝛯</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math O -->
+	<commandDefinition>
+		<latexCommand>O</latexCommand>
+		<unicodeCommand>𝛰</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Pi -->
+	<commandDefinition>
+		<latexCommand>\Pi</latexCommand>
+		<unicodeCommand>∏</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \varPi -->
+	<commandDefinition>
+		<latexCommand>\varPi</latexCommand>
+		<unicodeCommand>𝛱</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math P -->
+	<commandDefinition>
+		<latexCommand>P</latexCommand>
+		<unicodeCommand>𝛲</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Sigma -->
+	<commandDefinition>
+		<latexCommand>\Sigma</latexCommand>
+		<unicodeCommand>∑</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \varSigma -->
+	<commandDefinition>
+		<latexCommand>\varSigma</latexCommand>
+		<unicodeCommand>𝛴</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math T -->
+	<commandDefinition>
+		<latexCommand>T</latexCommand>
+		<unicodeCommand>𝛵</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Upsilon -->
+	<commandDefinition>
+		<latexCommand>\Upsilon</latexCommand>
+		<unicodeCommand>ϒ</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \varUpsilon -->
+	<commandDefinition>
+		<latexCommand>\varUpsilon</latexCommand>
+		<unicodeCommand>𝛶</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Phi -->
+	<commandDefinition>
+		<latexCommand>\Phi</latexCommand>
+		<unicodeCommand>Φ</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \varPhi -->
+	<commandDefinition>
+		<latexCommand>\varPhi</latexCommand>
+		<unicodeCommand>𝛷</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math X -->
+	<commandDefinition>
+		<latexCommand>X</latexCommand>
+		<unicodeCommand>𝛸</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Psi -->
+	<commandDefinition>
+		<latexCommand>\Psi</latexCommand>
+		<unicodeCommand>Ψ</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \varPsi -->
+	<commandDefinition>
+		<latexCommand>\varPsi</latexCommand>
+		<unicodeCommand>𝛹</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Omega -->
+	<commandDefinition>
+		<latexCommand>\Omega</latexCommand>
+		<unicodeCommand>Ω</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \varOmega -->
+	<commandDefinition>
+		<latexCommand>\varOmega</latexCommand>
+		<unicodeCommand>𝛺</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
+
 </symbols>

--- a/symbols-ng/misc-math.xml
+++ b/symbols-ng/misc-math.xml
@@ -3,958 +3,927 @@
 <!DOCTYPE KileSymbolSources>
 <symbols>
 
-   <formatVersion major="0" minor ="22" />
-
-   <symbolGroupName>user</symbolGroupName>
-
-   <preamble>
-      <class>article</class>
-      <arguments>12pt</arguments>
-      <additional>\pagestyle{empty}
-		  \setlength{\parindent}{0cm}
-		  \usepackage[T1]{fontenc}
-      </additional>
-   </preamble>
-
-   <unicodeCommandPackages>
-      <package>
-         <name>inputenc</name>
-         <arguments>utf8</arguments>
-      </package>
-   </unicodeCommandPackages>
-
-   <!-- insert stuff here    -->
-<symbolGroupName>misc-math</symbolGroupName>
-
-<commandDefinition>
-   <latexCommand>\cdotp</latexCommand>
-   <unicodeCommand>·</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \colon  -->
-<commandDefinition>
-   <latexCommand>\colon</latexCommand>
-   <unicodeCommand>:</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \ldotp  -->
-<commandDefinition>
-   <latexCommand>\ldotp</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \vdots  -->
-<commandDefinition>
-   <latexCommand>\vdots</latexCommand>
-   <unicodeCommand>⋮</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \cdots  -->
-<commandDefinition>
-   <latexCommand>\cdots</latexCommand>
-   <unicodeCommand>⋯</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \ddots  -->
-<commandDefinition>
-   <latexCommand>\ddots</latexCommand>
-   <unicodeCommand>⋱</unicodeCommand>
-   <mathMode>true</mathMode>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \ldots  -->
-<commandDefinition>
-   <latexCommand>\ldots</latexCommand>
-   <unicodeCommand>…</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \neg  -->
-<commandDefinition>
-   <latexCommand>\neg</latexCommand>
-   <unicodeCommand>¬</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \infty  -->
-<commandDefinition>
-   <latexCommand>\infty</latexCommand>
-   <unicodeCommand>∞</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \prime  -->
-<commandDefinition>
-   <latexCommand>\prime</latexCommand>
-   <unicodeCommand>′</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \backprime  -->
-<commandDefinition>
-   <latexCommand>\backprime</latexCommand>
-   <unicodeCommand>‵</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \backslash  -->
-<commandDefinition>
-   <latexCommand>\backslash</latexCommand>
-   <unicodeCommand>\</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \diagdown  -->
-<commandDefinition>
-   <latexCommand>\diagdown</latexCommand>
-   <unicodeCommand>∖</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \diagup  -->
-<commandDefinition>
-   <latexCommand>\diagup</latexCommand>
-   <unicodeCommand>∕</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \surd  -->
-<commandDefinition>
-   <latexCommand>\surd</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \emptyset  -->
-<commandDefinition>
-   <latexCommand>\emptyset</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \varnothing  -->
-<commandDefinition>
-   <latexCommand>\varnothing</latexCommand>
-   <unicodeCommand>∅</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \sharp  -->
-<commandDefinition>
-   <latexCommand>\sharp</latexCommand>
-   <unicodeCommand>♯</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \flat  -->
-<commandDefinition>
-   <latexCommand>\flat</latexCommand>
-   <unicodeCommand>♭</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \natural  -->
-<commandDefinition>
-   <latexCommand>\natural</latexCommand>
-   <unicodeCommand>♮</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \angle  -->
-<commandDefinition>
-   <latexCommand>\angle</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \sphericalangle  -->
-<commandDefinition>
-   <latexCommand>\sphericalangle</latexCommand>
-   <unicodeCommand>∢</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \measuredangle  -->
-<commandDefinition>
-   <latexCommand>\measuredangle</latexCommand>
-   <unicodeCommand>∡</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \Box  -->
-<commandDefinition>
-   <latexCommand>\Box</latexCommand>
-   <unicodeCommand>☐</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \square  -->
-<commandDefinition>
-   <latexCommand>\square</latexCommand>
-   <unicodeCommand>◻</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \triangle  -->
-<commandDefinition>
-   <latexCommand>\triangle</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \vartriangle  -->
-<commandDefinition>
-   <latexCommand>\vartriangle</latexCommand>
-   <unicodeCommand>△</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \triangledown  -->
-<commandDefinition>
-   <latexCommand>\triangledown</latexCommand>
-   <unicodeCommand>▿</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \Diamond  -->
-<commandDefinition>
-   <latexCommand>\Diamond</latexCommand>
-   <unicodeCommand>◇</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \diamondsuit  -->
-<commandDefinition>
-   <latexCommand>\diamondsuit</latexCommand>
-   <unicodeCommand>♢</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \lozenge  -->
-<commandDefinition>
-   <latexCommand>\lozenge</latexCommand>
-   <unicodeCommand>⬨</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \heartsuit  -->
-<commandDefinition>
-   <latexCommand>\heartsuit</latexCommand>
-   <unicodeCommand>♡</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \blacksquare  -->
-<commandDefinition>
-   <latexCommand>\blacksquare</latexCommand>
-   <unicodeCommand>⬛</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \blacktriangle  -->
-<commandDefinition>
-   <latexCommand>\blacktriangle</latexCommand>
-   <unicodeCommand>▴</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \blacktriangledown  -->
-<commandDefinition>
-   <latexCommand>\blacktriangledown</latexCommand>
-   <unicodeCommand>▾</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \blacklozenge  -->
-<commandDefinition>
-   <latexCommand>\blacklozenge</latexCommand>
-   <unicodeCommand>⧫</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \bigstar  -->
-<commandDefinition>
-   <latexCommand>\bigstar</latexCommand>
-   <unicodeCommand>★</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \spadesuit  -->
-<commandDefinition>
-   <latexCommand>\spadesuit</latexCommand>
-   <unicodeCommand>♠</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \clubsuit  -->
-<commandDefinition>
-   <latexCommand>\clubsuit</latexCommand>
-   <unicodeCommand>♣</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \forall  -->
-<commandDefinition>
-   <latexCommand>\forall</latexCommand>
-   <unicodeCommand>∀</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \exists  -->
-<commandDefinition>
-   <latexCommand>\exists</latexCommand>
-   <mathMode>true</mathMode>
-   <unicodeCommand>∃</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nexists  -->
-<commandDefinition>
-   <latexCommand>\nexists</latexCommand>
-   <unicodeCommand>∄</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \Finv  -->
-<commandDefinition>
-   <latexCommand>\Finv</latexCommand>
-   <unicodeCommand>Ⅎ</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \Game  -->
-<commandDefinition>
-   <latexCommand>\Game</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \ni  -->
-<commandDefinition>
-   <latexCommand>\ni</latexCommand>
-   <unicodeCommand>∋</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \in  -->
-<commandDefinition>
-   <latexCommand>\in</latexCommand>
-   <unicodeCommand>∈</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \notin  -->
-<commandDefinition>
-   <latexCommand>\notin</latexCommand>
-   <unicodeCommand>∉</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \complement  -->
-<commandDefinition>
-   <latexCommand>\complement</latexCommand>
-   <unicodeCommand>∁</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Im  -->
-<commandDefinition>
-   <latexCommand>\Im</latexCommand>
-   <unicodeCommand>ℑ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Re  -->
-<commandDefinition>
-   <latexCommand>\Re</latexCommand>
-   <unicodeCommand>ℜ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \aleph  -->
-<commandDefinition>
-   <latexCommand>\aleph</latexCommand>
-   <unicodeCommand>א</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \wp  -->
-<commandDefinition>
-   <latexCommand>\wp</latexCommand>
-   <unicodeCommand>℘</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \hslash  -->
-<commandDefinition>
-   <latexCommand>\hslash</latexCommand>
-   <unicodeCommand>ħ</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \hbar  -->
-<commandDefinition>
-   <latexCommand>\hbar</latexCommand>
-   <unicodeCommand>ℏ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \imath  -->
-<commandDefinition>
-   <latexCommand>\imath</latexCommand>
-   <unicodeCommand>ı</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \jmath  -->
-<commandDefinition>
-   <latexCommand>\jmath</latexCommand>
-   <unicodeCommand>ȷ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Bbbk  -->
-<commandDefinition>
-   <latexCommand>\Bbbk</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \ell  -->
-<commandDefinition>
-   <latexCommand>\ell</latexCommand>
-   <unicodeCommand>ℓ</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \circledR  -->
-<commandDefinition>
-   <latexCommand>\circledR</latexCommand>
-   <unicodeCommand>®</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \circledS  -->
-<commandDefinition>
-   <latexCommand>\circledS</latexCommand>
-   <unicodeCommand>Ⓢ</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \bot  -->
-<commandDefinition>
-   <latexCommand>\bot</latexCommand>
-   <unicodeCommand>⊥</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \top  -->
-<commandDefinition>
-   <latexCommand>\top</latexCommand>
-   <unicodeCommand>⊤</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \partial  -->
-<commandDefinition>
-   <latexCommand>\partial</latexCommand>
-   <unicodeCommand>∂</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \nabla  -->
-<commandDefinition>
-   <latexCommand>\nabla</latexCommand>
-   <unicodeCommand>∇</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \eth  -->
-<commandDefinition>
-   <latexCommand>\eth</latexCommand>
-   <unicodeCommand>ð</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \mho  -->
-<commandDefinition>
-   <latexCommand>\mho</latexCommand>
-   <unicodeCommand>℧</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \acute{} \acute{a} -->
-<commandDefinition>
-   <latexCommand>\acute{}</latexCommand>
-   <unicodeCommand>á</unicodeCommand>
-   <imageCommand>\acute{a}</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \grave{} \grave{a} -->
-<commandDefinition>
-   <latexCommand>\grave{}</latexCommand>
-   <unicodeCommand>à</unicodeCommand>
-   <imageCommand>\grave{a}</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \check{} \check{a} -->
-<commandDefinition>
-   <latexCommand>\check{}</latexCommand>
-   <unicodeCommand>ǎ</unicodeCommand>
-   <imageCommand>\check{a}</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \hat{} \hat{a} -->
-<commandDefinition>
-   <latexCommand>\hat{}</latexCommand>
-   <unicodeCommand>â</unicodeCommand>
-   <imageCommand>\hat{a}</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \tilde{} \tilde{a} -->
-<commandDefinition>
-   <latexCommand>\tilde{}</latexCommand>
-   <unicodeCommand>ã</unicodeCommand>
-   <imageCommand>\tilde{a}</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \bar{} \bar{a} -->
-<commandDefinition>
-   <latexCommand>\bar{}</latexCommand>
-   <unicodeCommand>ā</unicodeCommand>
-   <imageCommand>\bar{a}</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \vec{} \vec{a} -->
-<commandDefinition>
-   <latexCommand>\vec{}</latexCommand>
-   <imageCommand>\vec{a}</imageCommand>
-   <mathMode>true</mathMode>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \breve{} \breve{a} -->
-<commandDefinition>
-   <latexCommand>\breve{}</latexCommand>
-   <unicodeCommand>ă</unicodeCommand>
-   <imageCommand>\breve{a}</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \dot{} \dot{a} -->
-<commandDefinition>
-   <latexCommand>\dot{}</latexCommand>
-   <unicodeCommand>ȧ</unicodeCommand>
-   <imageCommand>\dot{a}</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \ddot{} \ddot{a} -->
-<commandDefinition>
-   <latexCommand>\ddot{}</latexCommand>
-   <unicodeCommand>ä</unicodeCommand>
-   <imageCommand>\ddot{a}</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- optarg math \dddot{} \dddot{a} -->
-<commandDefinition>
-   <latexCommand>\dddot{}</latexCommand>
-   <imageCommand>\dddot{a}</imageCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- optarg math \ddddot{} \ddddot{a} -->
-<commandDefinition>
-   <latexCommand>\ddddot{}</latexCommand>
-   <imageCommand>\ddddot{a}</imageCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \mathring{} \mathring{a} -->
-<commandDefinition>
-   <latexCommand>\mathring{}</latexCommand>
-   <unicodeCommand>å</unicodeCommand>
-   <imageCommand>\mathring{a}</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \widetilde{} \widetilde{abc} -->
-<commandDefinition>
-   <latexCommand>\widetilde{}</latexCommand>
-   <imageCommand>\widetilde{abc}</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \widehat{} \widehat{abc} -->
-<commandDefinition>
-   <latexCommand>\widehat{}</latexCommand>
-   <imageCommand>\widehat{abc}</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \overleftarrow{} \overleftarrow{abc} -->
-<commandDefinition>
-   <latexCommand>\overleftarrow{}</latexCommand>
-   <imageCommand>\overleftarrow{abc}</imageCommand>
-   <mathMode>true</mathMode>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \overrightarrow{} \overrightarrow{abc} -->
-<commandDefinition>
-   <latexCommand>\overrightarrow{}</latexCommand>
-   <imageCommand>\overrightarrow{abc}</imageCommand>
-   <mathMode>true</mathMode>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \overline{} \overline{abc} -->
-<commandDefinition>
-   <latexCommand>\overline{}</latexCommand>
-   <imageCommand>\overline{abc}</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \underline{} \underline{abc} -->
-<commandDefinition>
-   <latexCommand>\underline{}</latexCommand>
-   <imageCommand>\underline{abc}</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \overbrace{} \overbrace{abc} -->
-<commandDefinition>
-   <latexCommand>\overbrace{}</latexCommand>
-   <imageCommand>\overbrace{abc}</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \underbrace{} \underbrace{abc} -->
-<commandDefinition>
-   <latexCommand>\underbrace{}</latexCommand>
-   <imageCommand>\underbrace{abc}</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- optarg math \overleftrightarrow{} \overleftrightarrow{abc} -->
-<commandDefinition>
-   <latexCommand>\overleftrightarrow{}</latexCommand>
-   <imageCommand>\overleftrightarrow{abc}</imageCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- optarg math \underleftrightarrow{} \underleftrightarrow{abc} -->
-<commandDefinition>
-   <latexCommand>\underleftrightarrow{}</latexCommand>
-   <imageCommand>\underleftrightarrow{abc}</imageCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- optarg math \underleftarrow{} \underleftarrow{abc} -->
-<commandDefinition>
-   <latexCommand>\underleftarrow{}</latexCommand>
-   <imageCommand>\underleftarrow{abc}</imageCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- optarg math \underrightarrow{} \underrightarrow{abc} -->
-<commandDefinition>
-   <latexCommand>\underrightarrow{}</latexCommand>
-   <imageCommand>\underrightarrow{abc}</imageCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- optarg math \xleftarrow{} \xleftarrow{abc} -->
-<commandDefinition>
-   <latexCommand>\xleftarrow{}</latexCommand>
-   <imageCommand>\xleftarrow{abc}</imageCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- optarg math \xrightarrow{} \xrightarrow{abc} -->
-<commandDefinition>
-   <latexCommand>\xrightarrow{}</latexCommand>
-   <imageCommand>\xrightarrow{abc}</imageCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \stackrel{}{} \stackrel{abc}{=} -->
-<commandDefinition>
-   <latexCommand>\stackrel{}{}</latexCommand>
-   <imageCommand>\stackrel{abc}{=}</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- optarg math \sqrt{} \sqrt{a} -->
-<commandDefinition>
-   <latexCommand>\sqrt{}</latexCommand>
-   <imageCommand>\sqrt{a}</imageCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math f'  -->
-<commandDefinition>
-   <latexCommand>f'</latexCommand>
-   <unicodeCommand>f′</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math f''  -->
-<commandDefinition>
-   <latexCommand>f''</latexCommand>
-   <unicodeCommand>f′′</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
+	<formatVersion major="0" minor ="22" />
+
+	<symbolGroupName>user</symbolGroupName>
+
+	<preamble>
+		<class>standalone</class>
+		<arguments>10bp,margin=1bp</arguments>
+		<additional>\usepackage[T1]{fontenc}</additional>
+	</preamble>
+
+	<unicodeCommandPackages>
+		<package>
+			<name>inputenc</name>
+			<arguments>utf8</arguments>
+		</package>
+	</unicodeCommandPackages>
+
+	<!-- insert stuff here -->
+
+	<symbolGroupName>misc-math</symbolGroupName>
+
+	<commandDefinition>
+		<latexCommand>\cdotp</latexCommand>
+		<unicodeCommand>⋅</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \colon -->
+	<commandDefinition>
+		<latexCommand>\colon</latexCommand>
+		<unicodeCommand>∶</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \ldotp -->
+	<commandDefinition>
+		<latexCommand>\ldotp</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \vdots -->
+	<commandDefinition>
+		<latexCommand>\vdots</latexCommand>
+		<unicodeCommand>⋮</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \cdots -->
+	<commandDefinition>
+		<latexCommand>\cdots</latexCommand>
+		<unicodeCommand>⋯</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \ddots -->
+	<commandDefinition>
+		<latexCommand>\ddots</latexCommand>
+		<unicodeCommand>⋱</unicodeCommand>
+		<mathMode>true</mathMode>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \ldots -->
+	<commandDefinition>
+		<latexCommand>\ldots</latexCommand>
+		<unicodeCommand>…</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \neg -->
+	<commandDefinition>
+		<latexCommand>\neg</latexCommand>
+		<unicodeCommand>¬</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \infty -->
+	<commandDefinition>
+		<latexCommand>\infty</latexCommand>
+		<unicodeCommand>∞</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \prime -->
+	<commandDefinition>
+		<latexCommand>\prime</latexCommand>
+		<unicodeCommand>′</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \backprime -->
+	<commandDefinition>
+		<latexCommand>\backprime</latexCommand>
+		<unicodeCommand>‵</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \backslash -->
+	<commandDefinition>
+		<latexCommand>\backslash</latexCommand>
+		<unicodeCommand>\</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \diagdown -->
+	<commandDefinition>
+		<latexCommand>\diagdown</latexCommand>
+		<unicodeCommand>∖</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \diagup -->
+	<commandDefinition>
+		<latexCommand>\diagup</latexCommand>
+		<unicodeCommand>∕</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \surd -->
+	<commandDefinition>
+		<latexCommand>\surd</latexCommand>
+		<unicodeCommand>√</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \emptyset -->
+	<commandDefinition>
+		<latexCommand>\emptyset</latexCommand>
+		<unicodeCommand>∅</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \varnothing -->
+	<commandDefinition>
+		<latexCommand>\varnothing</latexCommand>
+		<unicodeCommand>⌀</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \sharp -->
+	<commandDefinition>
+		<latexCommand>\sharp</latexCommand>
+		<unicodeCommand>♯</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \flat -->
+	<commandDefinition>
+		<latexCommand>\flat</latexCommand>
+		<unicodeCommand>♭</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \natural -->
+	<commandDefinition>
+		<latexCommand>\natural</latexCommand>
+		<unicodeCommand>♮</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \angle -->
+	<commandDefinition>
+		<latexCommand>\angle</latexCommand>
+		<unicodeCommand>∠</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \sphericalangle -->
+	<commandDefinition>
+		<latexCommand>\sphericalangle</latexCommand>
+		<unicodeCommand>∢</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \measuredangle -->
+	<commandDefinition>
+		<latexCommand>\measuredangle</latexCommand>
+		<unicodeCommand>∡</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \Box -->
+	<commandDefinition>
+		<latexCommand>\Box</latexCommand>
+		<unicodeCommand>☐</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \square -->
+	<commandDefinition>
+		<latexCommand>\square</latexCommand>
+		<unicodeCommand>◻</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \triangle -->
+	<commandDefinition>
+		<latexCommand>\triangle</latexCommand>
+		<unicodeCommand>△</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \vartriangle -->
+	<commandDefinition>
+		<latexCommand>\vartriangle</latexCommand>
+		<unicodeCommand>▵</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \triangledown -->
+	<commandDefinition>
+		<latexCommand>\triangledown</latexCommand>
+		<unicodeCommand>▿</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \Diamond -->
+	<commandDefinition>
+		<latexCommand>\Diamond</latexCommand>
+		<unicodeCommand>◇</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \diamondsuit -->
+	<commandDefinition>
+		<latexCommand>\diamondsuit</latexCommand>
+		<unicodeCommand>♢</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \lozenge -->
+	<commandDefinition>
+		<latexCommand>\lozenge</latexCommand>
+		<unicodeCommand>⬨</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \heartsuit -->
+	<commandDefinition>
+		<latexCommand>\heartsuit</latexCommand>
+		<unicodeCommand>♡</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \blacksquare -->
+	<commandDefinition>
+		<latexCommand>\blacksquare</latexCommand>
+		<unicodeCommand>⬛</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \blacktriangle -->
+	<commandDefinition>
+		<latexCommand>\blacktriangle</latexCommand>
+		<unicodeCommand>▴</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \blacktriangledown -->
+	<commandDefinition>
+		<latexCommand>\blacktriangledown</latexCommand>
+		<unicodeCommand>▾</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \blacklozenge -->
+	<commandDefinition>
+		<latexCommand>\blacklozenge</latexCommand>
+		<unicodeCommand>⧫</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \bigstar -->
+	<commandDefinition>
+		<latexCommand>\bigstar</latexCommand>
+		<unicodeCommand>★</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \spadesuit -->
+	<commandDefinition>
+		<latexCommand>\spadesuit</latexCommand>
+		<unicodeCommand>♠</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \clubsuit -->
+	<commandDefinition>
+		<latexCommand>\clubsuit</latexCommand>
+		<unicodeCommand>♣</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \forall -->
+	<commandDefinition>
+		<latexCommand>\forall</latexCommand>
+		<unicodeCommand>∀</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \exists -->
+	<commandDefinition>
+		<latexCommand>\exists</latexCommand>
+		<mathMode>true</mathMode>
+		<unicodeCommand>∃</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nexists -->
+	<commandDefinition>
+		<latexCommand>\nexists</latexCommand>
+		<unicodeCommand>∄</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \Finv -->
+	<commandDefinition>
+		<latexCommand>\Finv</latexCommand>
+		<unicodeCommand>Ⅎ</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \Game -->
+	<commandDefinition>
+		<latexCommand>\Game</latexCommand>
+		<unicodeCommand>⅁</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \ni -->
+	<commandDefinition>
+		<latexCommand>\ni</latexCommand>
+		<unicodeCommand>∋</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \in -->
+	<commandDefinition>
+		<latexCommand>\in</latexCommand>
+		<unicodeCommand>∈</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \notin -->
+	<commandDefinition>
+		<latexCommand>\notin</latexCommand>
+		<unicodeCommand>∉</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \complement -->
+	<commandDefinition>
+		<latexCommand>\complement</latexCommand>
+		<unicodeCommand>∁</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Im -->
+	<commandDefinition>
+		<latexCommand>\Im</latexCommand>
+		<unicodeCommand>ℑ</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Re -->
+	<commandDefinition>
+		<latexCommand>\Re</latexCommand>
+		<unicodeCommand>ℜ</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \aleph -->
+	<commandDefinition>
+		<latexCommand>\aleph</latexCommand>
+		<unicodeCommand>א</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \wp -->
+	<commandDefinition>
+		<latexCommand>\wp</latexCommand>
+		<unicodeCommand>℘</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \hslash -->
+	<commandDefinition>
+		<latexCommand>\hslash</latexCommand>
+		<unicodeCommand>ℏ</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \hbar -->
+	<commandDefinition>
+		<latexCommand>\hbar</latexCommand>
+		<unicodeCommand>ħ</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \imath -->
+	<commandDefinition>
+		<latexCommand>\imath</latexCommand>
+		<unicodeCommand>𝚤</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \jmath -->
+	<commandDefinition>
+		<latexCommand>\jmath</latexCommand>
+		<unicodeCommand>𝚥</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Bbbk -->
+	<commandDefinition>
+		<latexCommand>\Bbbk</latexCommand>
+		<unicodeCommand>𝕜</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \ell -->
+	<commandDefinition>
+		<latexCommand>\ell</latexCommand>
+		<unicodeCommand>ℓ</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \circledR -->
+	<commandDefinition>
+		<latexCommand>\circledR</latexCommand>
+		<unicodeCommand>®</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \circledS -->
+	<commandDefinition>
+		<latexCommand>\circledS</latexCommand>
+		<unicodeCommand>Ⓢ</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \bot -->
+	<commandDefinition>
+		<latexCommand>\bot</latexCommand>
+		<unicodeCommand>⊥</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \top -->
+	<commandDefinition>
+		<latexCommand>\top</latexCommand>
+		<unicodeCommand>⊤</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \partial -->
+	<commandDefinition>
+		<latexCommand>\partial</latexCommand>
+		<unicodeCommand>∂</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \nabla -->
+	<commandDefinition>
+		<latexCommand>\nabla</latexCommand>
+		<unicodeCommand>∇</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \eth -->
+	<commandDefinition>
+		<latexCommand>\eth</latexCommand>
+		<unicodeCommand>ð</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \mho -->
+	<commandDefinition>
+		<latexCommand>\mho</latexCommand>
+		<unicodeCommand>℧</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \acute{} \acute{a} -->
+	<commandDefinition>
+		<latexCommand>\acute{}</latexCommand>
+		<unicodeCommand>&#x0301;</unicodeCommand>
+		<imageCommand>\acute{a}</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \grave{} \grave{a} -->
+	<commandDefinition>
+		<latexCommand>\grave{}</latexCommand>
+		<unicodeCommand>&#x0300;</unicodeCommand>
+		<imageCommand>\grave{a}</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \check{} \check{a} -->
+	<commandDefinition>
+		<latexCommand>\check{}</latexCommand>
+		<unicodeCommand>&#x030C;</unicodeCommand>
+		<imageCommand>\check{a}</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \hat{} \hat{a} -->
+	<commandDefinition>
+		<latexCommand>\hat{}</latexCommand>
+		<unicodeCommand>&#x0302;</unicodeCommand>
+		<imageCommand>\hat{a}</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \tilde{} \tilde{a} -->
+	<commandDefinition>
+		<latexCommand>\tilde{}</latexCommand>
+		<unicodeCommand>&#x0303;</unicodeCommand>
+		<imageCommand>\tilde{a}</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \bar{} \bar{a} -->
+	<commandDefinition>
+		<latexCommand>\bar{}</latexCommand>
+		<unicodeCommand>&#x0304;</unicodeCommand>
+		<imageCommand>\bar{a}</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \vec{} \vec{a} -->
+	<commandDefinition>
+		<latexCommand>\vec{}</latexCommand>
+		<unicodeCommand>&#x20D7;</unicodeCommand>
+		<imageCommand>\vec{a}</imageCommand>
+		<mathMode>true</mathMode>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \breve{} \breve{a} -->
+	<commandDefinition>
+		<latexCommand>\breve{}</latexCommand>
+		<unicodeCommand>&#x0306;</unicodeCommand>
+		<imageCommand>\breve{a}</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \dot{} \dot{a} -->
+	<commandDefinition>
+		<latexCommand>\dot{}</latexCommand>
+		<unicodeCommand>&#x0307;</unicodeCommand>
+		<imageCommand>\dot{a}</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \ddot{} \ddot{a} -->
+	<commandDefinition>
+		<latexCommand>\ddot{}</latexCommand>
+		<unicodeCommand>&#x0308;</unicodeCommand>
+		<imageCommand>\ddot{a}</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- optarg math \dddot{} \dddot{a} -->
+	<commandDefinition>
+		<latexCommand>\dddot{}</latexCommand>
+		<imageCommand>\dddot{a}</imageCommand>
+		<unicodeCommand>&#x20DB;</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- optarg math \ddddot{} \ddddot{a} -->
+	<commandDefinition>
+		<latexCommand>\ddddot{}</latexCommand>
+		<unicodeCommand>&#x20DC;</unicodeCommand>
+		<imageCommand>\ddddot{a}</imageCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \mathring{} \mathring{a} -->
+	<commandDefinition>
+		<latexCommand>\mathring{}</latexCommand>
+		<unicodeCommand>&#x030A;</unicodeCommand>
+		<imageCommand>\mathring{a}</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \widetilde{} \widetilde{abc} -->
+	<commandDefinition>
+		<latexCommand>\widetilde{}</latexCommand>
+		<imageCommand>\widetilde{abc}</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \widehat{} \widehat{abc} -->
+	<commandDefinition>
+		<latexCommand>\widehat{}</latexCommand>
+		<imageCommand>\widehat{abc}</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \overleftarrow{} \overleftarrow{abc} -->
+	<commandDefinition>
+		<latexCommand>\overleftarrow{}</latexCommand>
+		<imageCommand>\overleftarrow{abc}</imageCommand>
+		<mathMode>true</mathMode>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \overrightarrow{} \overrightarrow{abc} -->
+	<commandDefinition>
+		<latexCommand>\overrightarrow{}</latexCommand>
+		<imageCommand>\overrightarrow{abc}</imageCommand>
+		<mathMode>true</mathMode>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \overline{} \overline{abc} -->
+	<commandDefinition>
+		<latexCommand>\overline{}</latexCommand>
+		<imageCommand>\overline{abc}</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \underline{} \underline{abc} -->
+	<commandDefinition>
+		<latexCommand>\underline{}</latexCommand>
+		<imageCommand>\underline{abc}</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \overbrace{} \overbrace{abc} -->
+	<commandDefinition>
+		<latexCommand>\overbrace{}</latexCommand>
+		<imageCommand>\overbrace{abc}</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \underbrace{} \underbrace{abc} -->
+	<commandDefinition>
+		<latexCommand>\underbrace{}</latexCommand>
+		<imageCommand>\underbrace{abc}</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- optarg math \overleftrightarrow{} \overleftrightarrow{abc} -->
+	<commandDefinition>
+		<latexCommand>\overleftrightarrow{}</latexCommand>
+		<imageCommand>\overleftrightarrow{abc}</imageCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- optarg math \underleftrightarrow{} \underleftrightarrow{abc} -->
+	<commandDefinition>
+		<latexCommand>\underleftrightarrow{}</latexCommand>
+		<imageCommand>\underleftrightarrow{abc}</imageCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- optarg math \underleftarrow{} \underleftarrow{abc} -->
+	<commandDefinition>
+		<latexCommand>\underleftarrow{}</latexCommand>
+		<imageCommand>\underleftarrow{abc}</imageCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- optarg math \underrightarrow{} \underrightarrow{abc} -->
+	<commandDefinition>
+		<latexCommand>\underrightarrow{}</latexCommand>
+		<imageCommand>\underrightarrow{abc}</imageCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- optarg math \xleftarrow{} \xleftarrow{abc} -->
+	<commandDefinition>
+		<latexCommand>\xleftarrow{}</latexCommand>
+		<imageCommand>\xleftarrow{abc}</imageCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- optarg math \xrightarrow{} \xrightarrow{abc} -->
+	<commandDefinition>
+		<latexCommand>\xrightarrow{}</latexCommand>
+		<imageCommand>\xrightarrow{abc}</imageCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \stackrel{}{} \stackrel{abc}{=} -->
+	<commandDefinition>
+		<latexCommand>\stackrel{}{}</latexCommand>
+		<imageCommand>\stackrel{abc}{=}</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- optarg math \sqrt{} \sqrt{a} -->
+	<commandDefinition>
+		<latexCommand>\sqrt{}</latexCommand>
+		<imageCommand>\sqrt{a}</imageCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math f' -->
+	<commandDefinition>
+		<latexCommand>f'</latexCommand>
+		<unicodeCommand>𝑓′</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math f'' -->
+	<commandDefinition>
+		<latexCommand>f''</latexCommand>
+		<unicodeCommand>𝑓″</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
 </symbols>

--- a/symbols-ng/misc-text.xml
+++ b/symbols-ng/misc-text.xml
@@ -3,1278 +3,1242 @@
 <!DOCTYPE KileSymbolSources>
 <symbols>
 
-   <formatVersion major="0" minor ="22" />
-
-   <symbolGroupName>user</symbolGroupName>
-
-   <preamble>
-      <class>article</class>
-      <arguments>12pt</arguments>
-      <additional>\pagestyle{empty}
-		  \setlength{\parindent}{0cm}
-		  \usepackage[T1]{fontenc}
-      </additional>
-   </preamble>
-
-   <unicodeCommandPackages>
-      <package>
-         <name>inputenc</name>
-         <arguments>utf8</arguments>
-      </package>
-   </unicodeCommandPackages>
-
-   <!-- insert stuff here    -->
-<symbolGroupName>misc-text</symbolGroupName>
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \dots  -->
-<commandDefinition>
-   <latexCommand>\dots</latexCommand>
-   <unicodeCommand>…</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \texttildelow  -->
-<commandDefinition>
-   <latexCommand>\texttildelow</latexCommand>
-   <unicodeCommand>̰</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textasciicircum  -->
-<commandDefinition>
-   <latexCommand>\textasciicircum</latexCommand>
-   <unicodeCommand>̂</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textasciimacron  -->
-<commandDefinition>
-   <latexCommand>\textasciimacron</latexCommand>
-   <unicodeCommand>̄</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textasciiacute  -->
-<commandDefinition>
-   <latexCommand>\textasciiacute</latexCommand>
-   <unicodeCommand>́</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textasciidieresis  -->
-<commandDefinition>
-   <latexCommand>\textasciidieresis</latexCommand>
-   <unicodeCommand>̈</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textasciitilde  -->
-<commandDefinition>
-   <latexCommand>\textasciitilde</latexCommand>
-   <unicodeCommand>̃</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textasciigrave  -->
-<commandDefinition>
-   <latexCommand>\textasciigrave</latexCommand>
-   <unicodeCommand>̀</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textasciibreve  -->
-<commandDefinition>
-   <latexCommand>\textasciibreve</latexCommand>
-   <unicodeCommand>̆</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textasciicaron  -->
-<commandDefinition>
-   <latexCommand>\textasciicaron</latexCommand>
-   <unicodeCommand>̌</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textacutedbl  -->
-<commandDefinition>
-   <latexCommand>\textacutedbl</latexCommand>
-   <unicodeCommand>̋</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textgravedbl  -->
-<commandDefinition>
-   <latexCommand>\textgravedbl</latexCommand>
-   <unicodeCommand>̏</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textquotedblleft  -->
-<commandDefinition>
-   <latexCommand>\textquotedblleft</latexCommand>
-   <unicodeCommand>“</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textquotedblright  -->
-<commandDefinition>
-   <latexCommand>\textquotedblright</latexCommand>
-   <unicodeCommand>”</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textquoteleft  -->
-<commandDefinition>
-   <latexCommand>\textquoteleft</latexCommand>
-   <unicodeCommand>‘</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textquoteright  -->
-<commandDefinition>
-   <latexCommand>\textquoteright</latexCommand>
-   <unicodeCommand>’</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textquotestraightbase  -->
-<commandDefinition>
-   <latexCommand>\textquotestraightbase</latexCommand>
-   <unicodeCommand>‚</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textquotestraightdblbase  -->
-<commandDefinition>
-   <latexCommand>\textquotestraightdblbase</latexCommand>
-   <unicodeCommand>„</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textquotesingle  -->
-<commandDefinition>
-   <latexCommand>\textquotesingle</latexCommand>
-   <unicodeCommand>‛</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textdblhyphen  -->
-<commandDefinition>
-   <latexCommand>\textdblhyphen</latexCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textdblhyphenchar  -->
-<commandDefinition>
-   <latexCommand>\textdblhyphenchar</latexCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textasteriskcentered  -->
-<commandDefinition>
-   <latexCommand>\textasteriskcentered</latexCommand>
-   <unicodeCommand>∗</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textperiodcentered  -->
-<commandDefinition>
-   <latexCommand>\textperiodcentered</latexCommand>
-   <unicodeCommand>·</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textquestiondown  -->
-<commandDefinition>
-   <latexCommand>\textquestiondown</latexCommand>
-   <unicodeCommand>¿</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textinterrobang  -->
-<commandDefinition>
-   <latexCommand>\textinterrobang</latexCommand>
-   <unicodeCommand>‽</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textinterrobangdown  -->
-<commandDefinition>
-   <latexCommand>\textinterrobangdown</latexCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textexclamdown  -->
-<commandDefinition>
-   <latexCommand>\textexclamdown</latexCommand>
-   <unicodeCommand>¡</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \texttwelveudash  -->
-<commandDefinition>
-   <latexCommand>\texttwelveudash</latexCommand>
-   <unicodeCommand>—</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textemdash  -->
-<commandDefinition>
-   <latexCommand>\textemdash</latexCommand>
-   <unicodeCommand>—</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textendash  -->
-<commandDefinition>
-   <latexCommand>\textendash</latexCommand>
-   <unicodeCommand>–</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textthreequartersemdash  -->
-<commandDefinition>
-   <latexCommand>\textthreequartersemdash</latexCommand>
-   <unicodeCommand>—</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textvisiblespace  -->
-<commandDefinition>
-   <latexCommand>\textvisiblespace</latexCommand>
-   <unicodeCommand>␣</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \_  -->
-<commandDefinition>
-   <latexCommand>\_</latexCommand>
-   <unicodeCommand>_</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textcurrency  -->
-<commandDefinition>
-   <latexCommand>\textcurrency</latexCommand>
-   <unicodeCommand>¤</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textbaht  -->
-<commandDefinition>
-   <latexCommand>\textbaht</latexCommand>
-   <unicodeCommand>฿</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textguarani  -->
-<commandDefinition>
-   <latexCommand>\textguarani</latexCommand>
-   <unicodeCommand>₲</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textwon  -->
-<commandDefinition>
-   <latexCommand>\textwon</latexCommand>
-   <unicodeCommand>₩</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textcent  -->
-<commandDefinition>
-   <latexCommand>\textcent</latexCommand>
-   <unicodeCommand>¢</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textcentoldstyle  -->
-<commandDefinition>
-   <latexCommand>\textcentoldstyle</latexCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textdollar  -->
-<commandDefinition>
-   <latexCommand>\textdollar</latexCommand>
-   <unicodeCommand>\$</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textdollaroldstyle  -->
-<commandDefinition>
-   <latexCommand>\textdollaroldstyle</latexCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textlira  -->
-<commandDefinition>
-   <latexCommand>\textlira</latexCommand>
-   <unicodeCommand>₤</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textyen  -->
-<commandDefinition>
-   <latexCommand>\textyen</latexCommand>
-   <unicodeCommand>¥</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textdong  -->
-<commandDefinition>
-   <latexCommand>\textdong</latexCommand>
-   <unicodeCommand>₫</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textnaira  -->
-<commandDefinition>
-   <latexCommand>\textnaira</latexCommand>
-   <unicodeCommand>₦</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textcolonmonetary  -->
-<commandDefinition>
-   <latexCommand>\textcolonmonetary</latexCommand>
-   <unicodeCommand>₡</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textpeso  -->
-<commandDefinition>
-   <latexCommand>\textpeso</latexCommand>
-   <unicodeCommand>₱</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \pounds  -->
-<commandDefinition>
-   <latexCommand>\pounds</latexCommand>
-   <unicodeCommand>£</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textflorin  -->
-<commandDefinition>
-   <latexCommand>\textflorin</latexCommand>
-   <unicodeCommand>ƒ</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \texteuro  -->
-<commandDefinition>
-   <latexCommand>\texteuro</latexCommand>
-   <unicodeCommand>€</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=eurosym ,pkgsarg= ,savepkgs=eurosym ,savepkgsarg=-->
-<!-- pkgs=eurosym ,pkgsarg= ,savepkgs=eurosym ,savepkgsarg=-->
-<!-- arg  \geneuro  -->
-<commandDefinition>
-   <latexCommand>\geneuro</latexCommand>
-   <unicodeCommand>€</unicodeCommand>
-   <package>
-      <name>eurosym</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=eurosym ,pkgsarg= ,savepkgs=eurosym ,savepkgsarg=-->
-<!-- arg  \geneuronarrow  -->
-<commandDefinition>
-   <latexCommand>\geneuronarrow</latexCommand>
-   <unicodeCommand>€</unicodeCommand>
-   <package>
-      <name>eurosym</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=eurosym ,pkgsarg= ,savepkgs=eurosym ,savepkgsarg=-->
-<!-- arg  \geneurowide  -->
-<commandDefinition>
-   <latexCommand>\geneurowide</latexCommand>
-   <unicodeCommand>€</unicodeCommand>
-   <package>
-      <name>eurosym</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=eurosym ,pkgsarg= ,savepkgs=eurosym ,savepkgsarg=-->
-<!-- arg  \officialeuro  -->
-<commandDefinition>
-   <latexCommand>\officialeuro</latexCommand>
-   <unicodeCommand>€</unicodeCommand>
-   <package>
-      <name>eurosym</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textcircled{a}  -->
-<commandDefinition>
-   <latexCommand>\textcircled{a}</latexCommand>
-   <unicodeCommand>ⓐ</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textcopyright  -->
-<commandDefinition>
-   <latexCommand>\textcopyright</latexCommand>
-   <unicodeCommand>©</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textcopyleft  -->
-<commandDefinition>
-   <latexCommand>\textcopyleft</latexCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textregistered  -->
-<commandDefinition>
-   <latexCommand>\textregistered</latexCommand>
-   <unicodeCommand>®</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \texttrademark  -->
-<commandDefinition>
-   <latexCommand>\texttrademark</latexCommand>
-   <unicodeCommand>™</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textservicemark  -->
-<commandDefinition>
-   <latexCommand>\textservicemark</latexCommand>
-   <unicodeCommand>℠</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \oldstylenums{0}  -->
-<commandDefinition>
-   <latexCommand>\oldstylenums{0}</latexCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \oldstylenums{1}  -->
-<commandDefinition>
-   <latexCommand>\oldstylenums{1}</latexCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \oldstylenums{2}  -->
-<commandDefinition>
-   <latexCommand>\oldstylenums{2}</latexCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \oldstylenums{3}  -->
-<commandDefinition>
-   <latexCommand>\oldstylenums{3}</latexCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \oldstylenums{4}  -->
-<commandDefinition>
-   <latexCommand>\oldstylenums{4}</latexCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \oldstylenums{5}  -->
-<commandDefinition>
-   <latexCommand>\oldstylenums{5}</latexCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \oldstylenums{6}  -->
-<commandDefinition>
-   <latexCommand>\oldstylenums{6}</latexCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \oldstylenums{7}  -->
-<commandDefinition>
-   <latexCommand>\oldstylenums{7}</latexCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \oldstylenums{8}  -->
-<commandDefinition>
-   <latexCommand>\oldstylenums{8}</latexCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \oldstylenums{9}  -->
-<commandDefinition>
-   <latexCommand>\oldstylenums{9}</latexCommand>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textonehalf  -->
-<commandDefinition>
-   <latexCommand>\textonehalf</latexCommand>
-   <unicodeCommand>½</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textonequarter  -->
-<commandDefinition>
-   <latexCommand>\textonequarter</latexCommand>
-   <unicodeCommand>¼</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textthreequarters  -->
-<commandDefinition>
-   <latexCommand>\textthreequarters</latexCommand>
-   <unicodeCommand>¾</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textonesuperior  -->
-<commandDefinition>
-   <latexCommand>\textonesuperior</latexCommand>
-   <unicodeCommand>¹</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \texttwosuperior  -->
-<commandDefinition>
-   <latexCommand>\texttwosuperior</latexCommand>
-   <unicodeCommand>²</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textthreesuperior  -->
-<commandDefinition>
-   <latexCommand>\textthreesuperior</latexCommand>
-   <unicodeCommand>³</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textnumero  -->
-<commandDefinition>
-   <latexCommand>\textnumero</latexCommand>
-   <unicodeCommand>№</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textpertenthousand  -->
-<commandDefinition>
-   <latexCommand>\textpertenthousand</latexCommand>
-   <unicodeCommand>‱</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textperthousand  -->
-<commandDefinition>
-   <latexCommand>\textperthousand</latexCommand>
-   <unicodeCommand>‰</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textdiscount  -->
-<commandDefinition>
-   <latexCommand>\textdiscount</latexCommand>
-   <unicodeCommand>⁒</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textblank  -->
-<commandDefinition>
-   <latexCommand>\textblank</latexCommand>
-   <unicodeCommand>␢</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textrecipe  -->
-<commandDefinition>
-   <latexCommand>\textrecipe</latexCommand>
-   <unicodeCommand>℞</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textestimated  -->
-<commandDefinition>
-   <latexCommand>\textestimated</latexCommand>
-   <unicodeCommand>℮</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textreferencemark  -->
-<commandDefinition>
-   <latexCommand>\textreferencemark</latexCommand>
-   <unicodeCommand>※</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textmusicalnote  -->
-<commandDefinition>
-   <latexCommand>\textmusicalnote</latexCommand>
-   <unicodeCommand>♪</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \dag  -->
-<commandDefinition>
-   <latexCommand>\dag</latexCommand>
-   <unicodeCommand>†</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \ddag  -->
-<commandDefinition>
-   <latexCommand>\ddag</latexCommand>
-   <unicodeCommand>‡</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \S  -->
-<commandDefinition>
-   <latexCommand>\S</latexCommand>
-   <unicodeCommand>§</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \$  -->
-<commandDefinition>
-   <latexCommand>\$</latexCommand>
-   <unicodeCommand>\$</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textpilcrow  -->
-<commandDefinition>
-   <latexCommand>\textpilcrow</latexCommand>
-   <unicodeCommand>¶</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=marvosym ,pkgsarg= ,savepkgs=marvosym ,savepkgsarg=-->
-<!-- pkgs=marvosym ,pkgsarg= ,savepkgs=marvosym ,savepkgsarg=-->
-<!-- arg  \Cutleft  -->
-<commandDefinition>
-   <latexCommand>\Cutleft</latexCommand>
-   <package>
-      <name>marvosym</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=marvosym ,pkgsarg= ,savepkgs=marvosym ,savepkgsarg=-->
-<!-- arg  \Cutright  -->
-<commandDefinition>
-   <latexCommand>\Cutright</latexCommand>
-   <unicodeCommand>✁</unicodeCommand>
-   <package>
-      <name>marvosym</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=marvosym ,pkgsarg= ,savepkgs=marvosym ,savepkgsarg=-->
-<!-- arg  \Leftscissors  -->
-<commandDefinition>
-   <latexCommand>\Leftscissors</latexCommand>
-   <package>
-      <name>marvosym</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=marvosym ,pkgsarg= ,savepkgs=marvosym ,savepkgsarg=-->
-<!-- arg  \Cutline  -->
-<commandDefinition>
-   <latexCommand>\Cutline</latexCommand>
-   <package>
-      <name>marvosym</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=marvosym ,pkgsarg= ,savepkgs=marvosym ,savepkgsarg=-->
-<!-- arg  \Kutline  -->
-<commandDefinition>
-   <latexCommand>\Kutline</latexCommand>
-   <package>
-      <name>marvosym</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=marvosym ,pkgsarg= ,savepkgs=marvosym ,savepkgsarg=-->
-<!-- arg  \Rightscissors  -->
-<commandDefinition>
-   <latexCommand>\Rightscissors</latexCommand>
-   <unicodeCommand>✂</unicodeCommand>
-   <package>
-      <name>marvosym</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=wasysym ,pkgsarg= ,savepkgs=wasysym ,savepkgsarg=-->
-<!-- pkgs=wasysym ,pkgsarg= ,savepkgs=wasysym ,savepkgsarg=-->
-<!-- arg  \CheckedBox  -->
-<commandDefinition>
-   <latexCommand>\CheckedBox</latexCommand>
-   <unicodeCommand>☑</unicodeCommand>
-   <package>
-      <name>wasysym</name>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=wasysym ,pkgsarg= ,savepkgs=wasysym ,savepkgsarg=-->
-<!-- arg  \Square  -->
-<commandDefinition>
-   <latexCommand>\Square</latexCommand>
-   <unicodeCommand>☐</unicodeCommand>
-   <package>
-      <name>wasysym</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=wasysym ,pkgsarg= ,savepkgs=wasysym ,savepkgsarg=-->
-<!-- arg  \XBox  -->
-<commandDefinition>
-   <latexCommand>\XBox</latexCommand>
-   <unicodeCommand>☒</unicodeCommand>
-   <package>
-      <name>wasysym</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textbigcircle  -->
-<commandDefinition>
-   <latexCommand>\textbigcircle</latexCommand>
-   <unicodeCommand>○</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textopenbullet  -->
-<commandDefinition>
-   <latexCommand>\textopenbullet</latexCommand>
-   <unicodeCommand>◦</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textbullet  -->
-<commandDefinition>
-   <latexCommand>\textbullet</latexCommand>
-   <unicodeCommand>•</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \checkmark  -->
-<commandDefinition>
-   <latexCommand>\checkmark</latexCommand>
-   <unicodeCommand>✓</unicodeCommand>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \maltese  -->
-<commandDefinition>
-   <latexCommand>\maltese</latexCommand>
-   <unicodeCommand>✠</unicodeCommand>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textordmasculine  -->
-<commandDefinition>
-   <latexCommand>\textordmasculine</latexCommand>
-   <unicodeCommand>º</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textordfeminine  -->
-<commandDefinition>
-   <latexCommand>\textordfeminine</latexCommand>
-   <unicodeCommand>ª</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textborn  -->
-<commandDefinition>
-   <latexCommand>\textborn</latexCommand>
-   <unicodeCommand>★</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textdivorced  -->
-<commandDefinition>
-   <latexCommand>\textdivorced</latexCommand>
-   <unicodeCommand>⚮</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textdied  -->
-<commandDefinition>
-   <latexCommand>\textdied</latexCommand>
-   <unicodeCommand>✝</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textmarried  -->
-<commandDefinition>
-   <latexCommand>\textmarried</latexCommand>
-   <unicodeCommand>⚭</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textleaf  -->
-<commandDefinition>
-   <latexCommand>\textleaf</latexCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textcelsius  -->
-<commandDefinition>
-   <latexCommand>\textcelsius</latexCommand>
-   <unicodeCommand>℃</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textdegree  -->
-<commandDefinition>
-   <latexCommand>\textdegree</latexCommand>
-   <unicodeCommand>°</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textmho  -->
-<commandDefinition>
-   <latexCommand>\textmho</latexCommand>
-   <unicodeCommand>℧</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textohm  -->
-<commandDefinition>
-   <latexCommand>\textohm</latexCommand>
-   <unicodeCommand>Ω</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textbackslash  -->
-<commandDefinition>
-   <latexCommand>\textbackslash</latexCommand>
-   <unicodeCommand>\</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textbar  -->
-<commandDefinition>
-   <latexCommand>\textbar</latexCommand>
-   <unicodeCommand>|</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textbrokenbar  -->
-<commandDefinition>
-   <latexCommand>\textbrokenbar</latexCommand>
-   <unicodeCommand>¦</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textbardbl  -->
-<commandDefinition>
-   <latexCommand>\textbardbl</latexCommand>
-   <unicodeCommand>‖</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textfractionsolidus  -->
-<commandDefinition>
-   <latexCommand>\textfractionsolidus</latexCommand>
-   <unicodeCommand>⁄</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textlangle  -->
-<commandDefinition>
-   <latexCommand>\textlangle</latexCommand>
-   <unicodeCommand>〈</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textlnot  -->
-<commandDefinition>
-   <latexCommand>\textlnot</latexCommand>
-   <unicodeCommand>¬</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textminus  -->
-<commandDefinition>
-   <latexCommand>\textminus</latexCommand>
-   <unicodeCommand>−</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textrangle  -->
-<commandDefinition>
-   <latexCommand>\textrangle</latexCommand>
-   <unicodeCommand>〉</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textlbrackdbl  -->
-<commandDefinition>
-   <latexCommand>\textlbrackdbl</latexCommand>
-   <unicodeCommand>〚</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textrbrackdbl  -->
-<commandDefinition>
-   <latexCommand>\textrbrackdbl</latexCommand>
-   <unicodeCommand>〛</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textmu  -->
-<commandDefinition>
-   <latexCommand>\textmu</latexCommand>
-   <unicodeCommand>μ</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textpm  -->
-<commandDefinition>
-   <latexCommand>\textpm</latexCommand>
-   <unicodeCommand>±</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textlquill  -->
-<commandDefinition>
-   <latexCommand>\textlquill</latexCommand>
-   <unicodeCommand>⁅</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textrquill  -->
-<commandDefinition>
-   <latexCommand>\textrquill</latexCommand>
-   <unicodeCommand>⁆</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textless  -->
-<commandDefinition>
-   <latexCommand>\textless</latexCommand>
-   <unicodeCommand>&lt;</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textgreater  -->
-<commandDefinition>
-   <latexCommand>\textgreater</latexCommand>
-   <unicodeCommand>&gt;</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textsurd  -->
-<commandDefinition>
-   <latexCommand>\textsurd</latexCommand>
-   <unicodeCommand>√</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \texttimes  -->
-<commandDefinition>
-   <latexCommand>\texttimes</latexCommand>
-   <unicodeCommand>×</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg=-->
-<!-- arg  \textdiv  -->
-<commandDefinition>
-   <latexCommand>\textdiv</latexCommand>
-   <unicodeCommand>÷</unicodeCommand>
-   <package>
-      <name>textcomp</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
+	<formatVersion major="0" minor ="22" />
+
+	<symbolGroupName>user</symbolGroupName>
+
+	<preamble>
+		<class>standalone</class>
+		<arguments>10bp,margin=1bp</arguments>
+		<additional>\usepackage[T1]{fontenc}</additional>
+	</preamble>
+
+	<unicodeCommandPackages>
+		<package>
+			<name>inputenc</name>
+			<arguments>utf8</arguments>
+		</package>
+	</unicodeCommandPackages>
+
+	<!-- insert stuff here   -->
+
+	<symbolGroupName>misc-text</symbolGroupName>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \dots -->
+	<commandDefinition>
+		<latexCommand>\dots</latexCommand>
+		<unicodeCommand>…</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \texttildelow -->
+	<commandDefinition>
+		<latexCommand>\texttildelow</latexCommand>
+		<unicodeCommand>̰</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textasciicircum -->
+	<commandDefinition>
+		<latexCommand>\textasciicircum</latexCommand>
+		<unicodeCommand>̂</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textasciimacron -->
+	<commandDefinition>
+		<latexCommand>\textasciimacron</latexCommand>
+		<unicodeCommand>̄</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textasciiacute -->
+	<commandDefinition>
+		<latexCommand>\textasciiacute</latexCommand>
+		<unicodeCommand>́</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textasciidieresis -->
+	<commandDefinition>
+		<latexCommand>\textasciidieresis</latexCommand>
+		<unicodeCommand>̈</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textasciitilde -->
+	<commandDefinition>
+		<latexCommand>\textasciitilde</latexCommand>
+		<unicodeCommand>̃</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textasciigrave -->
+	<commandDefinition>
+		<latexCommand>\textasciigrave</latexCommand>
+		<unicodeCommand>̀</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textasciibreve -->
+	<commandDefinition>
+		<latexCommand>\textasciibreve</latexCommand>
+		<unicodeCommand>̆</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textasciicaron -->
+	<commandDefinition>
+		<latexCommand>\textasciicaron</latexCommand>
+		<unicodeCommand>̌</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textacutedbl -->
+	<commandDefinition>
+		<latexCommand>\textacutedbl</latexCommand>
+		<unicodeCommand>̋</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textgravedbl -->
+	<commandDefinition>
+		<latexCommand>\textgravedbl</latexCommand>
+		<unicodeCommand>̏</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textquotedblleft -->
+	<commandDefinition>
+		<latexCommand>\textquotedblleft</latexCommand>
+		<unicodeCommand>“</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textquotedblright -->
+	<commandDefinition>
+		<latexCommand>\textquotedblright</latexCommand>
+		<unicodeCommand>”</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textquoteleft -->
+	<commandDefinition>
+		<latexCommand>\textquoteleft</latexCommand>
+		<unicodeCommand>‘</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textquoteright -->
+	<commandDefinition>
+		<latexCommand>\textquoteright</latexCommand>
+		<unicodeCommand>’</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textquotestraightbase -->
+	<commandDefinition>
+		<latexCommand>\textquotestraightbase</latexCommand>
+		<unicodeCommand>‚</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textquotestraightdblbase -->
+	<commandDefinition>
+		<latexCommand>\textquotestraightdblbase</latexCommand>
+		<unicodeCommand>„</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textquotesingle -->
+	<commandDefinition>
+		<latexCommand>\textquotesingle</latexCommand>
+		<unicodeCommand>‛</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textdblhyphen -->
+	<commandDefinition>
+		<latexCommand>\textdblhyphen</latexCommand>
+		<unicodeCommand>⹀</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textdblhyphenchar -->
+	<commandDefinition>
+		<latexCommand>\textdblhyphenchar</latexCommand>
+		<unicodeCommand>゠</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textasteriskcentered -->
+	<commandDefinition>
+		<latexCommand>\textasteriskcentered</latexCommand>
+		<unicodeCommand>∗</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textperiodcentered -->
+	<commandDefinition>
+		<latexCommand>\textperiodcentered</latexCommand>
+		<unicodeCommand>·</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textquestiondown -->
+	<commandDefinition>
+		<latexCommand>\textquestiondown</latexCommand>
+		<unicodeCommand>¿</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textinterrobang -->
+	<commandDefinition>
+		<latexCommand>\textinterrobang</latexCommand>
+		<unicodeCommand>‽</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textinterrobangdown -->
+	<commandDefinition>
+		<latexCommand>\textinterrobangdown</latexCommand>
+		<unicodeCommand>⸘</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textexclamdown -->
+	<commandDefinition>
+		<latexCommand>\textexclamdown</latexCommand>
+		<unicodeCommand>¡</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \texttwelveudash -->
+	<commandDefinition>
+		<latexCommand>\texttwelveudash</latexCommand>
+		<unicodeCommand>—</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textemdash -->
+	<commandDefinition>
+		<latexCommand>\textemdash</latexCommand>
+		<unicodeCommand>—</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textendash -->
+	<commandDefinition>
+		<latexCommand>\textendash</latexCommand>
+		<unicodeCommand>–</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textthreequartersemdash -->
+	<commandDefinition>
+		<latexCommand>\textthreequartersemdash</latexCommand>
+		<unicodeCommand>—</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textvisiblespace -->
+	<commandDefinition>
+		<latexCommand>\textvisiblespace</latexCommand>
+		<unicodeCommand>␣</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \_ -->
+	<commandDefinition>
+		<latexCommand>\_</latexCommand>
+		<unicodeCommand>_</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textcurrency -->
+	<commandDefinition>
+		<latexCommand>\textcurrency</latexCommand>
+		<unicodeCommand>¤</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textbaht -->
+	<commandDefinition>
+		<latexCommand>\textbaht</latexCommand>
+		<unicodeCommand>฿</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textguarani -->
+	<commandDefinition>
+		<latexCommand>\textguarani</latexCommand>
+		<unicodeCommand>₲</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textwon -->
+	<commandDefinition>
+		<latexCommand>\textwon</latexCommand>
+		<unicodeCommand>₩</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textcent -->
+	<commandDefinition>
+		<latexCommand>\textcent</latexCommand>
+		<unicodeCommand>¢</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textcentoldstyle -->
+	<commandDefinition>
+		<latexCommand>\textcentoldstyle</latexCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textdollar -->
+	<commandDefinition>
+		<latexCommand>\textdollar</latexCommand>
+		<unicodeCommand>\$</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textdollaroldstyle -->
+	<commandDefinition>
+		<latexCommand>\textdollaroldstyle</latexCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textlira -->
+	<commandDefinition>
+		<latexCommand>\textlira</latexCommand>
+		<unicodeCommand>₤</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textyen -->
+	<commandDefinition>
+		<latexCommand>\textyen</latexCommand>
+		<unicodeCommand>¥</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textdong -->
+	<commandDefinition>
+		<latexCommand>\textdong</latexCommand>
+		<unicodeCommand>₫</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textnaira -->
+	<commandDefinition>
+		<latexCommand>\textnaira</latexCommand>
+		<unicodeCommand>₦</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textcolonmonetary -->
+	<commandDefinition>
+		<latexCommand>\textcolonmonetary</latexCommand>
+		<unicodeCommand>₡</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textpeso -->
+	<commandDefinition>
+		<latexCommand>\textpeso</latexCommand>
+		<unicodeCommand>₱</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \pounds -->
+	<commandDefinition>
+		<latexCommand>\pounds</latexCommand>
+		<unicodeCommand>£</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textflorin -->
+	<commandDefinition>
+		<latexCommand>\textflorin</latexCommand>
+		<unicodeCommand>ƒ</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \texteuro -->
+	<commandDefinition>
+		<latexCommand>\texteuro</latexCommand>
+		<unicodeCommand>€</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=eurosym ,pkgsarg= ,savepkgs=eurosym ,savepkgsarg= -->
+	<!-- arg \geneuro -->
+	<commandDefinition>
+		<latexCommand>\geneuro</latexCommand>
+		<unicodeCommand>€</unicodeCommand>
+		<package>
+			<name>eurosym</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=eurosym ,pkgsarg= ,savepkgs=eurosym ,savepkgsarg= -->
+	<!-- arg \geneuronarrow -->
+	<commandDefinition>
+		<latexCommand>\geneuronarrow</latexCommand>
+		<unicodeCommand>€</unicodeCommand>
+		<package>
+			<name>eurosym</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=eurosym ,pkgsarg= ,savepkgs=eurosym ,savepkgsarg= -->
+	<!-- arg \geneurowide -->
+	<commandDefinition>
+		<latexCommand>\geneurowide</latexCommand>
+		<unicodeCommand>€</unicodeCommand>
+		<package>
+			<name>eurosym</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=eurosym ,pkgsarg= ,savepkgs=eurosym ,savepkgsarg= -->
+	<!-- arg \officialeuro -->
+	<commandDefinition>
+		<latexCommand>\officialeuro</latexCommand>
+		<unicodeCommand>€</unicodeCommand>
+		<package>
+			<name>eurosym</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textcircled{a} -->
+	<commandDefinition>
+		<latexCommand>\textcircled{a}</latexCommand>
+		<unicodeCommand>ⓐ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textcopyright -->
+	<commandDefinition>
+		<latexCommand>\textcopyright</latexCommand>
+		<unicodeCommand>©</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textcopyleft -->
+	<commandDefinition>
+		<latexCommand>\textcopyleft</latexCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textregistered -->
+	<commandDefinition>
+		<latexCommand>\textregistered</latexCommand>
+		<unicodeCommand>®</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \texttrademark -->
+	<commandDefinition>
+		<latexCommand>\texttrademark</latexCommand>
+		<unicodeCommand>™</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textservicemark -->
+	<commandDefinition>
+		<latexCommand>\textservicemark</latexCommand>
+		<unicodeCommand>℠</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \oldstylenums{0} -->
+	<commandDefinition>
+		<latexCommand>\oldstylenums{0}</latexCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \oldstylenums{1} -->
+	<commandDefinition>
+		<latexCommand>\oldstylenums{1}</latexCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \oldstylenums{2} -->
+	<commandDefinition>
+		<latexCommand>\oldstylenums{2}</latexCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \oldstylenums{3} -->
+	<commandDefinition>
+		<latexCommand>\oldstylenums{3}</latexCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \oldstylenums{4} -->
+	<commandDefinition>
+		<latexCommand>\oldstylenums{4}</latexCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \oldstylenums{5} -->
+	<commandDefinition>
+		<latexCommand>\oldstylenums{5}</latexCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \oldstylenums{6} -->
+	<commandDefinition>
+		<latexCommand>\oldstylenums{6}</latexCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \oldstylenums{7} -->
+	<commandDefinition>
+		<latexCommand>\oldstylenums{7}</latexCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \oldstylenums{8} -->
+	<commandDefinition>
+		<latexCommand>\oldstylenums{8}</latexCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \oldstylenums{9} -->
+	<commandDefinition>
+		<latexCommand>\oldstylenums{9}</latexCommand>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textonehalf -->
+	<commandDefinition>
+		<latexCommand>\textonehalf</latexCommand>
+		<unicodeCommand>½</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textonequarter -->
+	<commandDefinition>
+		<latexCommand>\textonequarter</latexCommand>
+		<unicodeCommand>¼</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textthreequarters -->
+	<commandDefinition>
+		<latexCommand>\textthreequarters</latexCommand>
+		<unicodeCommand>¾</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textonesuperior -->
+	<commandDefinition>
+		<latexCommand>\textonesuperior</latexCommand>
+		<unicodeCommand>¹</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \texttwosuperior -->
+	<commandDefinition>
+		<latexCommand>\texttwosuperior</latexCommand>
+		<unicodeCommand>²</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textthreesuperior -->
+	<commandDefinition>
+		<latexCommand>\textthreesuperior</latexCommand>
+		<unicodeCommand>³</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textnumero -->
+	<commandDefinition>
+		<latexCommand>\textnumero</latexCommand>
+		<unicodeCommand>№</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textpertenthousand -->
+	<commandDefinition>
+		<latexCommand>\textpertenthousand</latexCommand>
+		<unicodeCommand>‱</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textperthousand -->
+	<commandDefinition>
+		<latexCommand>\textperthousand</latexCommand>
+		<unicodeCommand>‰</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textdiscount -->
+	<commandDefinition>
+		<latexCommand>\textdiscount</latexCommand>
+		<unicodeCommand>⁒</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textblank -->
+	<commandDefinition>
+		<latexCommand>\textblank</latexCommand>
+		<unicodeCommand>␢</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textrecipe -->
+	<commandDefinition>
+		<latexCommand>\textrecipe</latexCommand>
+		<unicodeCommand>℞</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textestimated -->
+	<commandDefinition>
+		<latexCommand>\textestimated</latexCommand>
+		<unicodeCommand>℮</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textreferencemark -->
+	<commandDefinition>
+		<latexCommand>\textreferencemark</latexCommand>
+		<unicodeCommand>※</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textmusicalnote -->
+	<commandDefinition>
+		<latexCommand>\textmusicalnote</latexCommand>
+		<unicodeCommand>♪</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \dag -->
+	<commandDefinition>
+		<latexCommand>\dag</latexCommand>
+		<unicodeCommand>†</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \ddag -->
+	<commandDefinition>
+		<latexCommand>\ddag</latexCommand>
+		<unicodeCommand>‡</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \S -->
+	<commandDefinition>
+		<latexCommand>\S</latexCommand>
+		<unicodeCommand>§</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \$ -->
+	<commandDefinition>
+		<latexCommand>\$</latexCommand>
+		<unicodeCommand>\$</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textpilcrow -->
+	<commandDefinition>
+		<latexCommand>\textpilcrow</latexCommand>
+		<unicodeCommand>¶</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=marvosym ,pkgsarg= ,savepkgs=marvosym ,savepkgsarg= -->
+	<!-- arg \Cutleft -->
+	<commandDefinition>
+		<latexCommand>\Cutleft</latexCommand>
+		<package>
+			<name>marvosym</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=marvosym ,pkgsarg= ,savepkgs=marvosym ,savepkgsarg= -->
+	<!-- arg \Cutright -->
+	<commandDefinition>
+		<latexCommand>\Cutright</latexCommand>
+		<unicodeCommand>✁</unicodeCommand>
+		<package>
+			<name>marvosym</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=marvosym ,pkgsarg= ,savepkgs=marvosym ,savepkgsarg= -->
+	<!-- arg \Leftscissors -->
+	<commandDefinition>
+		<latexCommand>\Leftscissors</latexCommand>
+		<package>
+			<name>marvosym</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=marvosym ,pkgsarg= ,savepkgs=marvosym ,savepkgsarg= -->
+	<!-- arg \Cutline -->
+	<commandDefinition>
+		<latexCommand>\Cutline</latexCommand>
+		<package>
+			<name>marvosym</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=marvosym ,pkgsarg= ,savepkgs=marvosym ,savepkgsarg= -->
+	<!-- arg \Kutline -->
+	<commandDefinition>
+		<latexCommand>\Kutline</latexCommand>
+		<package>
+			<name>marvosym</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=marvosym ,pkgsarg= ,savepkgs=marvosym ,savepkgsarg= -->
+	<!-- arg \Rightscissors -->
+	<commandDefinition>
+		<latexCommand>\Rightscissors</latexCommand>
+		<unicodeCommand>✂</unicodeCommand>
+		<package>
+			<name>marvosym</name>
+		</package>
+	</commandDefinition>
+]
+	<!-- pkgs=wasysym ,pkgsarg= ,savepkgs=wasysym ,savepkgsarg= -->
+	<!-- arg \CheckedBox -->
+	<commandDefinition>
+		<latexCommand>\CheckedBox</latexCommand>
+		<unicodeCommand>☑</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=wasysym ,pkgsarg= ,savepkgs=wasysym ,savepkgsarg= -->
+	<!-- arg \Square -->
+	<commandDefinition>
+		<latexCommand>\Square</latexCommand>
+		<unicodeCommand>☐</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=wasysym ,pkgsarg= ,savepkgs=wasysym ,savepkgsarg= -->
+	<!-- arg \XBox -->
+	<commandDefinition>
+		<latexCommand>\XBox</latexCommand>
+		<unicodeCommand>☒</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textbigcircle -->
+	<commandDefinition>
+		<latexCommand>\textbigcircle</latexCommand>
+		<unicodeCommand>○</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textopenbullet -->
+	<commandDefinition>
+		<latexCommand>\textopenbullet</latexCommand>
+		<unicodeCommand>◦</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textbullet -->
+	<commandDefinition>
+		<latexCommand>\textbullet</latexCommand>
+		<unicodeCommand>•</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \checkmark -->
+	<commandDefinition>
+		<latexCommand>\checkmark</latexCommand>
+		<unicodeCommand>✓</unicodeCommand>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \maltese -->
+	<commandDefinition>
+		<latexCommand>\maltese</latexCommand>
+		<unicodeCommand>✠</unicodeCommand>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textordmasculine -->
+	<commandDefinition>
+		<latexCommand>\textordmasculine</latexCommand>
+		<unicodeCommand>º</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textordfeminine -->
+	<commandDefinition>
+		<latexCommand>\textordfeminine</latexCommand>
+		<unicodeCommand>ª</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textborn -->
+	<commandDefinition>
+		<latexCommand>\textborn</latexCommand>
+		<unicodeCommand>★</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textdivorced -->
+	<commandDefinition>
+		<latexCommand>\textdivorced</latexCommand>
+		<unicodeCommand>⚮</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textdied -->
+	<commandDefinition>
+		<latexCommand>\textdied</latexCommand>
+		<unicodeCommand>✝</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textmarried -->
+	<commandDefinition>
+		<latexCommand>\textmarried</latexCommand>
+		<unicodeCommand>⚭</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textleaf -->
+	<commandDefinition>
+		<latexCommand>\textleaf</latexCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textcelsius -->
+	<commandDefinition>
+		<latexCommand>\textcelsius</latexCommand>
+		<unicodeCommand>℃</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textdegree -->
+	<commandDefinition>
+		<latexCommand>\textdegree</latexCommand>
+		<unicodeCommand>°</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textmho -->
+	<commandDefinition>
+		<latexCommand>\textmho</latexCommand>
+		<unicodeCommand>℧</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textohm -->
+	<commandDefinition>
+		<latexCommand>\textohm</latexCommand>
+		<unicodeCommand>Ω</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textbackslash -->
+	<commandDefinition>
+		<latexCommand>\textbackslash</latexCommand>
+		<unicodeCommand>\</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textbar -->
+	<commandDefinition>
+		<latexCommand>\textbar</latexCommand>
+		<unicodeCommand>|</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textbrokenbar -->
+	<commandDefinition>
+		<latexCommand>\textbrokenbar</latexCommand>
+		<unicodeCommand>¦</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textbardbl -->
+	<commandDefinition>
+		<latexCommand>\textbardbl</latexCommand>
+		<unicodeCommand>‖</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textfractionsolidus -->
+	<commandDefinition>
+		<latexCommand>\textfractionsolidus</latexCommand>
+		<unicodeCommand>⁄</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textlangle -->
+	<commandDefinition>
+		<latexCommand>\textlangle</latexCommand>
+		<unicodeCommand>〈</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textlnot -->
+	<commandDefinition>
+		<latexCommand>\textlnot</latexCommand>
+		<unicodeCommand>¬</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textminus -->
+	<commandDefinition>
+		<latexCommand>\textminus</latexCommand>
+		<unicodeCommand>−</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textrangle -->
+	<commandDefinition>
+		<latexCommand>\textrangle</latexCommand>
+		<unicodeCommand>〉</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textlbrackdbl -->
+	<commandDefinition>
+		<latexCommand>\textlbrackdbl</latexCommand>
+		<unicodeCommand>〚</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textrbrackdbl -->
+	<commandDefinition>
+		<latexCommand>\textrbrackdbl</latexCommand>
+		<unicodeCommand>〛</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textmu -->
+	<commandDefinition>
+		<latexCommand>\textmu</latexCommand>
+		<unicodeCommand>µ</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textpm -->
+	<commandDefinition>
+		<latexCommand>\textpm</latexCommand>
+		<unicodeCommand>±</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textlquill -->
+	<commandDefinition>
+		<latexCommand>\textlquill</latexCommand>
+		<unicodeCommand>⁅</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textrquill -->
+	<commandDefinition>
+		<latexCommand>\textrquill</latexCommand>
+		<unicodeCommand>⁆</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textless -->
+	<commandDefinition>
+		<latexCommand>\textless</latexCommand>
+		<unicodeCommand>&lt;</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textgreater -->
+	<commandDefinition>
+		<latexCommand>\textgreater</latexCommand>
+		<unicodeCommand>&gt;</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textsurd -->
+	<commandDefinition>
+		<latexCommand>\textsurd</latexCommand>
+		<unicodeCommand>√</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \texttimes -->
+	<commandDefinition>
+		<latexCommand>\texttimes</latexCommand>
+		<unicodeCommand>×</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=textcomp ,pkgsarg= ,savepkgs=textcomp ,savepkgsarg= -->
+	<!-- arg \textdiv -->
+	<commandDefinition>
+		<latexCommand>\textdiv</latexCommand>
+		<unicodeCommand>÷</unicodeCommand>
+		<package>
+			<name>textcomp</name>
+		</package>
+	</commandDefinition>
+
 </symbols>

--- a/symbols-ng/operators.xml
+++ b/symbols-ng/operators.xml
@@ -3,1025 +3,1009 @@
 <!DOCTYPE KileSymbolSources>
 <symbols>
 
-   <formatVersion major="0" minor ="22" />
-
-   <symbolGroupName>user</symbolGroupName>
-
-   <preamble>
-      <class>article</class>
-      <arguments>12pt</arguments>
-      <additional>\pagestyle{empty}
-		  \setlength{\parindent}{0cm}
-		  \usepackage[T1]{fontenc}
-      </additional>
-   </preamble>
-
-   <unicodeCommandPackages>
-      <package>
-         <name>inputenc</name>
-         <arguments>utf8</arguments>
-      </package>
-   </unicodeCommandPackages>
-
-   <!-- insert stuff here    -->
-<symbolGroupName>operators</symbolGroupName>
-
-<!-- arg math \pm  -->
-<commandDefinition>
-   <latexCommand>\pm</latexCommand>
-   <unicodeCommand>±</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \mp  -->
-<commandDefinition>
-   <latexCommand>\mp</latexCommand>
-   <unicodeCommand>∓</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \times  -->
-<commandDefinition>
-   <latexCommand>\times</latexCommand>
-   <unicodeCommand>×</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \div  -->
-<commandDefinition>
-   <latexCommand>\div</latexCommand>
-   <unicodeCommand>÷</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \ast  -->
-<commandDefinition>
-   <latexCommand>\ast</latexCommand>
-   <unicodeCommand>*</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \star  -->
-<commandDefinition>
-   <latexCommand>\star</latexCommand>
-   <unicodeCommand>⋆</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \circ  -->
-<commandDefinition>
-   <latexCommand>\circ</latexCommand>
-   <unicodeCommand>∘</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \bullet  -->
-<commandDefinition>
-   <latexCommand>\bullet</latexCommand>
-   <unicodeCommand>∙</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \divideontimes  -->
-<commandDefinition>
-   <latexCommand>\divideontimes</latexCommand>
-   <unicodeCommand>⋇</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \ltimes  -->
-<commandDefinition>
-   <latexCommand>\ltimes</latexCommand>
-   <unicodeCommand>⋉</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \rtimes  -->
-<commandDefinition>
-   <latexCommand>\rtimes</latexCommand>
-   <unicodeCommand>⋊</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \cdot  -->
-<commandDefinition>
-   <latexCommand>\cdot</latexCommand>
-   <unicodeCommand>⋅</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \dotplus  -->
-<commandDefinition>
-   <latexCommand>\dotplus</latexCommand>
-   <unicodeCommand>∔</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \leftthreetimes  -->
-<commandDefinition>
-   <latexCommand>\leftthreetimes</latexCommand>
-   <unicodeCommand>⋋</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \rightthreetimes  -->
-<commandDefinition>
-   <latexCommand>\rightthreetimes</latexCommand>
-   <unicodeCommand>⋌</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \amalg  -->
-<commandDefinition>
-   <latexCommand>\amalg</latexCommand>
-   <unicodeCommand>⨿</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \otimes  -->
-<commandDefinition>
-   <latexCommand>\otimes</latexCommand>
-   <unicodeCommand>⊗</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \oplus  -->
-<commandDefinition>
-   <latexCommand>\oplus</latexCommand>
-   <unicodeCommand>⊕</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \ominus  -->
-<commandDefinition>
-   <latexCommand>\ominus</latexCommand>
-   <unicodeCommand>⊖</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \oslash  -->
-<commandDefinition>
-   <latexCommand>\oslash</latexCommand>
-   <unicodeCommand>⊘</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \odot  -->
-<commandDefinition>
-   <latexCommand>\odot</latexCommand>
-   <unicodeCommand>⊙</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \circledcirc  -->
-<commandDefinition>
-   <latexCommand>\circledcirc</latexCommand>
-   <unicodeCommand>⊚</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \circleddash  -->
-<commandDefinition>
-   <latexCommand>\circleddash</latexCommand>
-   <unicodeCommand>⊝</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \circledast  -->
-<commandDefinition>
-   <latexCommand>\circledast</latexCommand>
-   <unicodeCommand>⊛</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \bigcirc  -->
-<commandDefinition>
-   <latexCommand>\bigcirc</latexCommand>
-   <unicodeCommand>◯</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \boxdot  -->
-<commandDefinition>
-   <latexCommand>\boxdot</latexCommand>
-   <unicodeCommand>⊡</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \boxminus  -->
-<commandDefinition>
-   <latexCommand>\boxminus</latexCommand>
-   <unicodeCommand>⊟</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \boxplus  -->
-<commandDefinition>
-   <latexCommand>\boxplus</latexCommand>
-   <unicodeCommand>⊞</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \boxtimes  -->
-<commandDefinition>
-   <latexCommand>\boxtimes</latexCommand>
-   <unicodeCommand>⊠</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \diamond  -->
-<commandDefinition>
-   <latexCommand>\diamond</latexCommand>
-   <unicodeCommand>⋄</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \bigtriangleup  -->
-<commandDefinition>
-   <latexCommand>\bigtriangleup</latexCommand>
-   <unicodeCommand>△</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \bigtriangledown  -->
-<commandDefinition>
-   <latexCommand>\bigtriangledown</latexCommand>
-   <unicodeCommand>▽</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \triangleleft  -->
-<commandDefinition>
-   <latexCommand>\triangleleft</latexCommand>
-   <unicodeCommand>◃</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \triangleright  -->
-<commandDefinition>
-   <latexCommand>\triangleright</latexCommand>
-   <unicodeCommand>▹</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \lhd  -->
-<commandDefinition>
-   <latexCommand>\lhd</latexCommand>
-   <unicodeCommand>◁</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \rhd  -->
-<commandDefinition>
-   <latexCommand>\rhd</latexCommand>
-   <unicodeCommand>▷</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \unlhd  -->
-<commandDefinition>
-   <latexCommand>\unlhd</latexCommand>
-   <unicodeCommand>⊴</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \unrhd  -->
-<commandDefinition>
-   <latexCommand>\unrhd</latexCommand>
-   <unicodeCommand>⊵</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \cup  -->
-<commandDefinition>
-   <latexCommand>\cup</latexCommand>
-   <unicodeCommand>∪</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \cap  -->
-<commandDefinition>
-   <latexCommand>\cap</latexCommand>
-   <unicodeCommand>∩</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \uplus  -->
-<commandDefinition>
-   <latexCommand>\uplus</latexCommand>
-   <unicodeCommand>⊎</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \Cup  -->
-<commandDefinition>
-   <latexCommand>\Cup</latexCommand>
-   <unicodeCommand>⋓</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \Cap  -->
-<commandDefinition>
-   <latexCommand>\Cap</latexCommand>
-   <unicodeCommand>⋒</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \wr  -->
-<commandDefinition>
-   <latexCommand>\wr</latexCommand>
-   <unicodeCommand>≀</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \setminus  -->
-<commandDefinition>
-   <latexCommand>\setminus</latexCommand>
-   <unicodeCommand>⧵</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \smallsetminus  -->
-<commandDefinition>
-   <latexCommand>\smallsetminus</latexCommand>
-   <unicodeCommand>∖</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \sqcap  -->
-<commandDefinition>
-   <latexCommand>\sqcap</latexCommand>
-   <unicodeCommand>⊓</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \sqcup  -->
-<commandDefinition>
-   <latexCommand>\sqcup</latexCommand>
-   <unicodeCommand>⊔</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \wedge  -->
-<commandDefinition>
-   <latexCommand>\wedge</latexCommand>
-   <unicodeCommand>∧</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \vee  -->
-<commandDefinition>
-   <latexCommand>\vee</latexCommand>
-   <unicodeCommand>∨</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \barwedge  -->
-<commandDefinition>
-   <latexCommand>\barwedge</latexCommand>
-   <unicodeCommand>⊼</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \veebar  -->
-<commandDefinition>
-   <latexCommand>\veebar</latexCommand>
-   <unicodeCommand>⊻</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \doublebarwedge  -->
-<commandDefinition>
-   <latexCommand>\doublebarwedge</latexCommand>
-   <unicodeCommand>⌆</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \curlywedge  -->
-<commandDefinition>
-   <latexCommand>\curlywedge</latexCommand>
-   <unicodeCommand>⋏</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \curlyvee  -->
-<commandDefinition>
-   <latexCommand>\curlyvee</latexCommand>
-   <unicodeCommand>⋎</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \dagger  -->
-<commandDefinition>
-   <latexCommand>\dagger</latexCommand>
-   <unicodeCommand>†</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \ddagger  -->
-<commandDefinition>
-   <latexCommand>\ddagger</latexCommand>
-   <unicodeCommand>‡</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \intercal  -->
-<commandDefinition>
-   <latexCommand>\intercal</latexCommand>
-   <unicodeCommand>⊺</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \bigcap  -->
-<commandDefinition>
-   <latexCommand>\bigcap</latexCommand>
-   <unicodeCommand>⋂</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \bigcup  -->
-<commandDefinition>
-   <latexCommand>\bigcup</latexCommand>
-   <unicodeCommand>⋃</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \biguplus  -->
-<commandDefinition>
-   <latexCommand>\biguplus</latexCommand>
-   <unicodeCommand>⨄</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \bigsqcup  -->
-<commandDefinition>
-   <latexCommand>\bigsqcup</latexCommand>
-   <unicodeCommand>⨆</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \prod  -->
-<commandDefinition>
-   <latexCommand>\prod</latexCommand>
-   <unicodeCommand>∏</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \coprod  -->
-<commandDefinition>
-   <latexCommand>\coprod</latexCommand>
-   <unicodeCommand>∐</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \bigwedge  -->
-<commandDefinition>
-   <latexCommand>\bigwedge</latexCommand>
-   <unicodeCommand>⋀</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \bigvee  -->
-<commandDefinition>
-   <latexCommand>\bigvee</latexCommand>
-   <unicodeCommand>⋁</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \bigodot  -->
-<commandDefinition>
-   <latexCommand>\bigodot</latexCommand>
-   <unicodeCommand>⨀</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \bigoplus  -->
-<commandDefinition>
-   <latexCommand>\bigoplus</latexCommand>
-   <unicodeCommand>⨁</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \bigotimes  -->
-<commandDefinition>
-   <latexCommand>\bigotimes</latexCommand>
-   <unicodeCommand>⨂</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \sum  -->
-<commandDefinition>
-   <latexCommand>\sum</latexCommand>
-   <unicodeCommand>∑</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \int  -->
-<commandDefinition>
-   <latexCommand>\int</latexCommand>
-   <unicodeCommand>∫</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \oint  -->
-<commandDefinition>
-   <latexCommand>\oint</latexCommand>
-   <unicodeCommand>∮</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- arg math \iint  -->
-<commandDefinition>
-   <latexCommand>\iint</latexCommand>
-   <unicodeCommand>∬</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- arg math \iiint  -->
-<commandDefinition>
-   <latexCommand>\iiint</latexCommand>
-   <unicodeCommand>∭</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- arg math \iiiint  -->
-<commandDefinition>
-   <latexCommand>\iiiint</latexCommand>
-   <unicodeCommand>⨌</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- arg math \idotsint  -->
-<commandDefinition>
-   <latexCommand>\idotsint</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \arccos  -->
-<commandDefinition>
-   <latexCommand>\arccos</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \arcsin  -->
-<commandDefinition>
-   <latexCommand>\arcsin</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \arctan  -->
-<commandDefinition>
-   <latexCommand>\arctan</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \arg  -->
-<commandDefinition>
-   <latexCommand>\arg</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \cos  -->
-<commandDefinition>
-   <latexCommand>\cos</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \cosh  -->
-<commandDefinition>
-   <latexCommand>\cosh</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \cot  -->
-<commandDefinition>
-   <latexCommand>\cot</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \coth  -->
-<commandDefinition>
-   <latexCommand>\coth</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \csc  -->
-<commandDefinition>
-   <latexCommand>\csc</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \deg  -->
-<commandDefinition>
-   <latexCommand>\deg</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \det  -->
-<commandDefinition>
-   <latexCommand>\det</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \dim  -->
-<commandDefinition>
-   <latexCommand>\dim</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \exp  -->
-<commandDefinition>
-   <latexCommand>\exp</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \gcd  -->
-<commandDefinition>
-   <latexCommand>\gcd</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \hom  -->
-<commandDefinition>
-   <latexCommand>\hom</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \inf  -->
-<commandDefinition>
-   <latexCommand>\inf</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \ker  -->
-<commandDefinition>
-   <latexCommand>\ker</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \lg  -->
-<commandDefinition>
-   <latexCommand>\lg</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \lim  -->
-<commandDefinition>
-   <latexCommand>\lim</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \liminf  -->
-<commandDefinition>
-   <latexCommand>\liminf</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \limsup  -->
-<commandDefinition>
-   <latexCommand>\limsup</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \ln  -->
-<commandDefinition>
-   <latexCommand>\ln</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \log  -->
-<commandDefinition>
-   <latexCommand>\log</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \max  -->
-<commandDefinition>
-   <latexCommand>\max</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \min  -->
-<commandDefinition>
-   <latexCommand>\min</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Pr  -->
-<commandDefinition>
-   <latexCommand>\Pr</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \projlim  -->
-<commandDefinition>
-   <latexCommand>\projlim</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \sec  -->
-<commandDefinition>
-   <latexCommand>\sec</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \sin  -->
-<commandDefinition>
-   <latexCommand>\sin</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \sinh  -->
-<commandDefinition>
-   <latexCommand>\sinh</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \sup  -->
-<commandDefinition>
-   <latexCommand>\sup</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \tan  -->
-<commandDefinition>
-   <latexCommand>\tan</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \tanh  -->
-<commandDefinition>
-   <latexCommand>\tanh</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- arg math \varlimsup  -->
-<commandDefinition>
-   <latexCommand>\varlimsup</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- arg math \varliminf  -->
-<commandDefinition>
-   <latexCommand>\varliminf</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- arg math \varinjlim  -->
-<commandDefinition>
-   <latexCommand>\varinjlim</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg=-->
-<!-- arg math \varprojlim  -->
-<commandDefinition>
-   <latexCommand>\varprojlim</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amsmath</name>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
+	<formatVersion major="0" minor ="22" />
+
+	<symbolGroupName>user</symbolGroupName>
+
+	<preamble>
+		<class>standalone</class>
+		<arguments>10bp,margin=1bp</arguments>
+		<additional>\usepackage[T1]{fontenc}</additional>
+	</preamble>
+
+	<unicodeCommandPackages>
+		<package>
+			<name>inputenc</name>
+			<arguments>utf8</arguments>
+		</package>
+	</unicodeCommandPackages>
+
+	<!-- insert stuff here -->
+
+	<symbolGroupName>operators</symbolGroupName>
+
+	<!-- arg math \pm -->
+	<commandDefinition>
+		<latexCommand>\pm</latexCommand>
+		<unicodeCommand>±</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \mp -->
+	<commandDefinition>
+		<latexCommand>\mp</latexCommand>
+		<unicodeCommand>∓</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \times -->
+	<commandDefinition>
+		<latexCommand>\times</latexCommand>
+		<unicodeCommand>×</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \div -->
+	<commandDefinition>
+		<latexCommand>\div</latexCommand>
+		<unicodeCommand>÷</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \ast -->
+	<commandDefinition>
+		<latexCommand>\ast</latexCommand>
+		<unicodeCommand>*</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \star -->
+	<commandDefinition>
+		<latexCommand>\star</latexCommand>
+		<unicodeCommand>⋆</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \circ -->
+	<commandDefinition>
+		<latexCommand>\circ</latexCommand>
+		<unicodeCommand>∘</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \bullet -->
+	<commandDefinition>
+		<latexCommand>\bullet</latexCommand>
+		<unicodeCommand>∙</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \divideontimes -->
+	<commandDefinition>
+		<latexCommand>\divideontimes</latexCommand>
+		<unicodeCommand>⋇</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \ltimes -->
+	<commandDefinition>
+		<latexCommand>\ltimes</latexCommand>
+		<unicodeCommand>⋉</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \rtimes -->
+	<commandDefinition>
+		<latexCommand>\rtimes</latexCommand>
+		<unicodeCommand>⋊</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \cdot -->
+	<commandDefinition>
+		<latexCommand>\cdot</latexCommand>
+		<unicodeCommand>⋅</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \dotplus -->
+	<commandDefinition>
+		<latexCommand>\dotplus</latexCommand>
+		<unicodeCommand>∔</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \leftthreetimes -->
+	<commandDefinition>
+		<latexCommand>\leftthreetimes</latexCommand>
+		<unicodeCommand>⋋</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \rightthreetimes -->
+	<commandDefinition>
+		<latexCommand>\rightthreetimes</latexCommand>
+		<unicodeCommand>⋌</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \amalg -->
+	<commandDefinition>
+		<latexCommand>\amalg</latexCommand>
+		<unicodeCommand>⨿</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \otimes -->
+	<commandDefinition>
+		<latexCommand>\otimes</latexCommand>
+		<unicodeCommand>⊗</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \oplus -->
+	<commandDefinition>
+		<latexCommand>\oplus</latexCommand>
+		<unicodeCommand>⊕</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \ominus -->
+	<commandDefinition>
+		<latexCommand>\ominus</latexCommand>
+		<unicodeCommand>⊖</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \oslash -->
+	<commandDefinition>
+		<latexCommand>\oslash</latexCommand>
+		<unicodeCommand>⊘</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \odot -->
+	<commandDefinition>
+		<latexCommand>\odot</latexCommand>
+		<unicodeCommand>⊙</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \circledcirc -->
+	<commandDefinition>
+		<latexCommand>\circledcirc</latexCommand>
+		<unicodeCommand>⊚</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \circleddash -->
+	<commandDefinition>
+		<latexCommand>\circleddash</latexCommand>
+		<unicodeCommand>⊝</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \circledast -->
+	<commandDefinition>
+		<latexCommand>\circledast</latexCommand>
+		<unicodeCommand>⊛</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \bigcirc -->
+	<commandDefinition>
+		<latexCommand>\bigcirc</latexCommand>
+		<unicodeCommand>◯</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \boxdot -->
+	<commandDefinition>
+		<latexCommand>\boxdot</latexCommand>
+		<unicodeCommand>⊡</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \boxminus -->
+	<commandDefinition>
+		<latexCommand>\boxminus</latexCommand>
+		<unicodeCommand>⊟</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \boxplus -->
+	<commandDefinition>
+		<latexCommand>\boxplus</latexCommand>
+		<unicodeCommand>⊞</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \boxtimes -->
+	<commandDefinition>
+		<latexCommand>\boxtimes</latexCommand>
+		<unicodeCommand>⊠</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \diamond -->
+	<commandDefinition>
+		<latexCommand>\diamond</latexCommand>
+		<unicodeCommand>⋄</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \bigtriangleup -->
+	<commandDefinition>
+		<latexCommand>\bigtriangleup</latexCommand>
+		<unicodeCommand>△</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \bigtriangledown -->
+	<commandDefinition>
+		<latexCommand>\bigtriangledown</latexCommand>
+		<unicodeCommand>▽</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \triangleleft -->
+	<commandDefinition>
+		<latexCommand>\triangleleft</latexCommand>
+		<unicodeCommand>◃</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \triangleright -->
+	<commandDefinition>
+		<latexCommand>\triangleright</latexCommand>
+		<unicodeCommand>▹</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \lhd -->
+	<commandDefinition>
+		<latexCommand>\lhd</latexCommand>
+		<unicodeCommand>◁</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \rhd -->
+	<commandDefinition>
+		<latexCommand>\rhd</latexCommand>
+		<unicodeCommand>▷</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \unlhd -->
+	<commandDefinition>
+		<latexCommand>\unlhd</latexCommand>
+		<unicodeCommand>⊴</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \unrhd -->
+	<commandDefinition>
+		<latexCommand>\unrhd</latexCommand>
+		<unicodeCommand>⊵</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \cup -->
+	<commandDefinition>
+		<latexCommand>\cup</latexCommand>
+		<unicodeCommand>∪</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \cap -->
+	<commandDefinition>
+		<latexCommand>\cap</latexCommand>
+		<unicodeCommand>∩</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \uplus -->
+	<commandDefinition>
+		<latexCommand>\uplus</latexCommand>
+		<unicodeCommand>⊎</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \Cup -->
+	<commandDefinition>
+		<latexCommand>\Cup</latexCommand>
+		<unicodeCommand>⋓</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \Cap -->
+	<commandDefinition>
+		<latexCommand>\Cap</latexCommand>
+		<unicodeCommand>⋒</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \wr -->
+	<commandDefinition>
+		<latexCommand>\wr</latexCommand>
+		<unicodeCommand>≀</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \setminus -->
+	<commandDefinition>
+		<latexCommand>\setminus</latexCommand>
+		<unicodeCommand>⧵</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \smallsetminus -->
+	<commandDefinition>
+		<latexCommand>\smallsetminus</latexCommand>
+		<unicodeCommand>∖</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \sqcap -->
+	<commandDefinition>
+		<latexCommand>\sqcap</latexCommand>
+		<unicodeCommand>⊓</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \sqcup -->
+	<commandDefinition>
+		<latexCommand>\sqcup</latexCommand>
+		<unicodeCommand>⊔</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \wedge -->
+	<commandDefinition>
+		<latexCommand>\wedge</latexCommand>
+		<unicodeCommand>∧</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \vee -->
+	<commandDefinition>
+		<latexCommand>\vee</latexCommand>
+		<unicodeCommand>∨</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \barwedge -->
+	<commandDefinition>
+		<latexCommand>\barwedge</latexCommand>
+		<unicodeCommand>⊼</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \veebar -->
+	<commandDefinition>
+		<latexCommand>\veebar</latexCommand>
+		<unicodeCommand>⊻</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \doublebarwedge -->
+	<commandDefinition>
+		<latexCommand>\doublebarwedge</latexCommand>
+		<unicodeCommand>⌆</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \curlywedge -->
+	<commandDefinition>
+		<latexCommand>\curlywedge</latexCommand>
+		<unicodeCommand>⋏</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \curlyvee -->
+	<commandDefinition>
+		<latexCommand>\curlyvee</latexCommand>
+		<unicodeCommand>⋎</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \dagger -->
+	<commandDefinition>
+		<latexCommand>\dagger</latexCommand>
+		<unicodeCommand>†</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \ddagger -->
+	<commandDefinition>
+		<latexCommand>\ddagger</latexCommand>
+		<unicodeCommand>‡</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \intercal -->
+	<commandDefinition>
+		<latexCommand>\intercal</latexCommand>
+		<unicodeCommand>⊺</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \bigcap -->
+	<commandDefinition>
+		<latexCommand>\bigcap</latexCommand>
+		<unicodeCommand>⋂</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \bigcup -->
+	<commandDefinition>
+		<latexCommand>\bigcup</latexCommand>
+		<unicodeCommand>⋃</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \biguplus -->
+	<commandDefinition>
+		<latexCommand>\biguplus</latexCommand>
+		<unicodeCommand>⨄</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \bigsqcup -->
+	<commandDefinition>
+		<latexCommand>\bigsqcup</latexCommand>
+		<unicodeCommand>⨆</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \prod -->
+	<commandDefinition>
+		<latexCommand>\prod</latexCommand>
+		<unicodeCommand>∏</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \coprod -->
+	<commandDefinition>
+		<latexCommand>\coprod</latexCommand>
+		<unicodeCommand>∐</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \bigwedge -->
+	<commandDefinition>
+		<latexCommand>\bigwedge</latexCommand>
+		<unicodeCommand>⋀</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \bigvee -->
+	<commandDefinition>
+		<latexCommand>\bigvee</latexCommand>
+		<unicodeCommand>⋁</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \bigodot -->
+	<commandDefinition>
+		<latexCommand>\bigodot</latexCommand>
+		<unicodeCommand>⨀</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \bigoplus -->
+	<commandDefinition>
+		<latexCommand>\bigoplus</latexCommand>
+		<unicodeCommand>⨁</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \bigotimes -->
+	<commandDefinition>
+		<latexCommand>\bigotimes</latexCommand>
+		<unicodeCommand>⨂</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \sum -->
+	<commandDefinition>
+		<latexCommand>\sum</latexCommand>
+		<unicodeCommand>∑</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \int -->
+	<commandDefinition>
+		<latexCommand>\int</latexCommand>
+		<unicodeCommand>∫</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \oint -->
+	<commandDefinition>
+		<latexCommand>\oint</latexCommand>
+		<unicodeCommand>∮</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- arg math \iint -->
+	<commandDefinition>
+		<latexCommand>\iint</latexCommand>
+		<unicodeCommand>∬</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- arg math \iiint -->
+	<commandDefinition>
+		<latexCommand>\iiint</latexCommand>
+		<unicodeCommand>∭</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- arg math \iiiint -->
+	<commandDefinition>
+		<latexCommand>\iiiint</latexCommand>
+		<unicodeCommand>⨌</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- arg math \idotsint -->
+	<commandDefinition>
+		<latexCommand>\idotsint</latexCommand>
+		<unicodeCommand>∫⋯∫</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \arccos -->
+	<commandDefinition>
+		<latexCommand>\arccos</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \arcsin -->
+	<commandDefinition>
+		<latexCommand>\arcsin</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \arctan -->
+	<commandDefinition>
+		<latexCommand>\arctan</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \arg -->
+	<commandDefinition>
+		<latexCommand>\arg</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \cos -->
+	<commandDefinition>
+		<latexCommand>\cos</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \cosh -->
+	<commandDefinition>
+		<latexCommand>\cosh</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \cot -->
+	<commandDefinition>
+		<latexCommand>\cot</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \coth -->
+	<commandDefinition>
+		<latexCommand>\coth</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \csc -->
+	<commandDefinition>
+		<latexCommand>\csc</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \deg -->
+	<commandDefinition>
+		<latexCommand>\deg</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \det -->
+	<commandDefinition>
+		<latexCommand>\det</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \dim -->
+	<commandDefinition>
+		<latexCommand>\dim</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \exp -->
+	<commandDefinition>
+		<latexCommand>\exp</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \gcd -->
+	<commandDefinition>
+		<latexCommand>\gcd</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \hom -->
+	<commandDefinition>
+		<latexCommand>\hom</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \inf -->
+	<commandDefinition>
+		<latexCommand>\inf</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \ker -->
+	<commandDefinition>
+		<latexCommand>\ker</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \lg -->
+	<commandDefinition>
+		<latexCommand>\lg</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \lim -->
+	<commandDefinition>
+		<latexCommand>\lim</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \liminf -->
+	<commandDefinition>
+		<latexCommand>\liminf</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \limsup -->
+	<commandDefinition>
+		<latexCommand>\limsup</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \ln -->
+	<commandDefinition>
+		<latexCommand>\ln</latexCommand>
+		<unicodeCommand>㏑</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \log -->
+	<commandDefinition>
+		<latexCommand>\log</latexCommand>
+		<unicodeCommand>㏒</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \max -->
+	<commandDefinition>
+		<latexCommand>\max</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \min -->
+	<commandDefinition>
+		<latexCommand>\min</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Pr -->
+	<commandDefinition>
+		<latexCommand>\Pr</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \projlim -->
+	<commandDefinition>
+		<latexCommand>\projlim</latexCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \sec -->
+	<commandDefinition>
+		<latexCommand>\sec</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \sin -->
+	<commandDefinition>
+		<latexCommand>\sin</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \sinh -->
+	<commandDefinition>
+		<latexCommand>\sinh</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \sup -->
+	<commandDefinition>
+		<latexCommand>\sup</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \tan -->
+	<commandDefinition>
+		<latexCommand>\tan</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \tanh -->
+	<commandDefinition>
+		<latexCommand>\tanh</latexCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- arg math \varlimsup -->
+	<commandDefinition>
+		<latexCommand>\varlimsup</latexCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- arg math \varliminf -->
+	<commandDefinition>
+		<latexCommand>\varliminf</latexCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- arg math \varinjlim -->
+	<commandDefinition>
+		<latexCommand>\varinjlim</latexCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=amsmath ,pkgsarg= ,savepkgs=amsmath ,savepkgsarg= -->
+	<!-- arg math \varprojlim -->
+	<commandDefinition>
+		<latexCommand>\varprojlim</latexCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amsmath</name>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
 
 </symbols>

--- a/symbols-ng/relation.xml
+++ b/symbols-ng/relation.xml
@@ -3,1497 +3,1453 @@
 <!DOCTYPE KileSymbolSources>
 <symbols>
 
-   <formatVersion major="0" minor ="22" />
-
-   <symbolGroupName>user</symbolGroupName>
-
-   <preamble>
-      <class>article</class>
-      <arguments>12pt</arguments>
-      <additional>\pagestyle{empty}
-		  \setlength{\parindent}{0cm}
-		  \usepackage[T1]{fontenc}
-      </additional>
-   </preamble>
-
-   <unicodeCommandPackages>
-      <package>
-         <name>inputenc</name>
-         <arguments>utf8</arguments>
-      </package>
-   </unicodeCommandPackages>
-
-   <!-- insert stuff here    -->
-<symbolGroupName>relation</symbolGroupName>
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \bowtie  -->
-<commandDefinition>
-   <latexCommand>\bowtie</latexCommand>
-   <unicodeCommand>⋈</unicodeCommand>
-   <mathMode>true</mathMode>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \Join  -->
-<commandDefinition>
-   <latexCommand>\Join</latexCommand>
-   <unicodeCommand>⨝</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \propto  -->
-<commandDefinition>
-   <latexCommand>\propto</latexCommand>
-   <unicodeCommand>∝</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \varpropto  -->
-<commandDefinition>
-   <latexCommand>\varpropto</latexCommand>
-   <unicodeCommand>∝</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \multimap  -->
-<commandDefinition>
-   <latexCommand>\multimap</latexCommand>
-   <unicodeCommand>⊸</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \pitchfork  -->
-<commandDefinition>
-   <latexCommand>\pitchfork</latexCommand>
-   <unicodeCommand>⋔</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \therefore  -->
-<commandDefinition>
-   <latexCommand>\therefore</latexCommand>
-   <unicodeCommand>∴</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \because  -->
-<commandDefinition>
-   <latexCommand>\because</latexCommand>
-   <unicodeCommand>∵</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math =  -->
-<commandDefinition>
-   <latexCommand>=</latexCommand>
-   <unicodeCommand>=</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \neq  -->
-<commandDefinition>
-   <latexCommand>\neq</latexCommand>
-   <unicodeCommand>≠</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \equiv  -->
-<commandDefinition>
-   <latexCommand>\equiv</latexCommand>
-   <unicodeCommand>≡</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \approx  -->
-<commandDefinition>
-   <latexCommand>\approx</latexCommand>
-   <unicodeCommand>≈</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \sim  -->
-<commandDefinition>
-   <latexCommand>\sim</latexCommand>
-   <unicodeCommand>∼</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-   <latexCommand>\nsim</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \simeq  -->
-<commandDefinition>
-   <latexCommand>\simeq</latexCommand>
-   <unicodeCommand>≃</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \backsimeq  -->
-<commandDefinition>
-   <latexCommand>\backsimeq</latexCommand>
-   <unicodeCommand>⋍</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \approxeq  -->
-<commandDefinition>
-   <latexCommand>\approxeq</latexCommand>
-   <unicodeCommand>≊</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \cong  -->
-<commandDefinition>
-   <latexCommand>\cong</latexCommand>
-   <unicodeCommand>≅</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \ncong  -->
-<commandDefinition>
-   <latexCommand>\ncong</latexCommand>
-   <unicodeCommand>≇</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \smile  -->
-<commandDefinition>
-   <latexCommand>\smile</latexCommand>
-   <unicodeCommand>⌣</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \frown  -->
-<commandDefinition>
-   <latexCommand>\frown</latexCommand>
-   <unicodeCommand>⌢</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \asymp  -->
-<commandDefinition>
-   <latexCommand>\asymp</latexCommand>
-   <unicodeCommand>≍</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \smallfrown  -->
-<commandDefinition>
-   <latexCommand>\smallfrown</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \smallsmile  -->
-<commandDefinition>
-   <latexCommand>\smallsmile</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \between  -->
-<commandDefinition>
-   <latexCommand>\between</latexCommand>
-   <unicodeCommand>≬</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \prec  -->
-<commandDefinition>
-   <latexCommand>\prec</latexCommand>
-   <unicodeCommand>≺</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \succ  -->
-<commandDefinition>
-   <latexCommand>\succ</latexCommand>
-   <unicodeCommand>≻</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \nprec  -->
-<commandDefinition>
-   <latexCommand>\nprec</latexCommand>
-   <unicodeCommand>⊀</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \nsucc  -->
-<commandDefinition>
-   <latexCommand>\nsucc</latexCommand>
-   <unicodeCommand>⊁</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \preceq  -->
-<commandDefinition>
-   <latexCommand>\preceq</latexCommand>
-   <unicodeCommand>⪯</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \succeq  -->
-<commandDefinition>
-   <latexCommand>\succeq</latexCommand>
-   <unicodeCommand>⪰</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \npreceq  -->
-<commandDefinition>
-   <latexCommand>\npreceq</latexCommand>
-   <unicodeCommand>⋠</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nsucceq  -->
-<commandDefinition>
-   <latexCommand>\nsucceq</latexCommand>
-   <unicodeCommand>⋡</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \preccurlyeq  -->
-<commandDefinition>
-   <latexCommand>\preccurlyeq</latexCommand>
-   <unicodeCommand>≼</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \succcurlyeq  -->
-<commandDefinition>
-   <latexCommand>\succcurlyeq</latexCommand>
-   <unicodeCommand>≽</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \curlyeqprec  -->
-<commandDefinition>
-   <latexCommand>\curlyeqprec</latexCommand>
-   <unicodeCommand>⋞</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \curlyeqsucc  -->
-<commandDefinition>
-   <latexCommand>\curlyeqsucc</latexCommand>
-   <unicodeCommand>⋟</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \precsim  -->
-<commandDefinition>
-   <latexCommand>\precsim</latexCommand>
-   <unicodeCommand>≾</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \succsim  -->
-<commandDefinition>
-   <latexCommand>\succsim</latexCommand>
-   <unicodeCommand>≿</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \precnsim  -->
-<commandDefinition>
-   <latexCommand>\precnsim</latexCommand>
-   <unicodeCommand>⋨</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \succnsim  -->
-<commandDefinition>
-   <latexCommand>\succnsim</latexCommand>
-   <unicodeCommand>⋩</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \precapprox  -->
-<commandDefinition>
-   <latexCommand>\precapprox</latexCommand>
-   <unicodeCommand>⪷</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \succapprox  -->
-<commandDefinition>
-   <latexCommand>\succapprox</latexCommand>
-   <unicodeCommand>⪸</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \precnapprox  -->
-<commandDefinition>
-   <latexCommand>\precnapprox</latexCommand>
-   <unicodeCommand>⪹</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \succnapprox  -->
-<commandDefinition>
-   <latexCommand>\succnapprox</latexCommand>
-   <unicodeCommand>⪺</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \perp  -->
-<commandDefinition>
-   <latexCommand>\perp</latexCommand>
-   <unicodeCommand>⟂</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \vdash  -->
-<commandDefinition>
-   <latexCommand>\vdash</latexCommand>
-   <unicodeCommand>⊢</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \dashv  -->
-<commandDefinition>
-   <latexCommand>\dashv</latexCommand>
-   <unicodeCommand>⊣</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nvdash  -->
-<commandDefinition>
-   <latexCommand>\nvdash</latexCommand>
-   <unicodeCommand>⊬</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \Vdash  -->
-<commandDefinition>
-   <latexCommand>\Vdash</latexCommand>
-   <unicodeCommand>⊩</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \Vvdash  -->
-<commandDefinition>
-   <latexCommand>\Vvdash</latexCommand>
-   <unicodeCommand>⊪</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \models  -->
-<commandDefinition>
-   <latexCommand>\models</latexCommand>
-   <unicodeCommand>⊧</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \vDash  -->
-<commandDefinition>
-   <latexCommand>\vDash</latexCommand>
-   <unicodeCommand>⊨</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nvDash  -->
-<commandDefinition>
-   <latexCommand>\nvDash</latexCommand>
-   <unicodeCommand>⊭</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nVDash  -->
-<commandDefinition>
-   <latexCommand>\nVDash</latexCommand>
-   <unicodeCommand>⊯</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \mid  -->
-<commandDefinition>
-   <latexCommand>\mid</latexCommand>
-   <unicodeCommand>∣</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \nmid  -->
-<commandDefinition>
-   <latexCommand>\nmid</latexCommand>
-   <unicodeCommand>∤</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \parallel  -->
-<commandDefinition>
-   <latexCommand>\parallel</latexCommand>
-   <unicodeCommand>∥</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nparallel  -->
-<commandDefinition>
-   <latexCommand>\nparallel</latexCommand>
-   <unicodeCommand>∦</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \shortmid  -->
-<commandDefinition>
-   <latexCommand>\shortmid</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nshortmid  -->
-<commandDefinition>
-   <latexCommand>\nshortmid</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \shortparallel  -->
-<commandDefinition>
-   <latexCommand>\shortparallel</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nshortparallel  -->
-<commandDefinition>
-   <latexCommand>\nshortparallel</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math <  -->
-<commandDefinition>
-   <latexCommand>&lt;</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math >  -->
-<commandDefinition>
-   <latexCommand>&gt;</latexCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nless  -->
-<commandDefinition>
-   <latexCommand>\nless</latexCommand>
-   <unicodeCommand>≮</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \ngtr  -->
-<commandDefinition>
-   <latexCommand>\ngtr</latexCommand>
-   <unicodeCommand>≯</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \lessdot  -->
-<commandDefinition>
-   <latexCommand>\lessdot</latexCommand>
-   <unicodeCommand>⋖</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \gtrdot  -->
-<commandDefinition>
-   <latexCommand>\gtrdot</latexCommand>
-   <unicodeCommand>⋗</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \ll  -->
-<commandDefinition>
-   <latexCommand>\ll</latexCommand>
-   <unicodeCommand>≪</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \gg  -->
-<commandDefinition>
-   <latexCommand>\gg</latexCommand>
-   <unicodeCommand>≫</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \lll  -->
-<commandDefinition>
-   <latexCommand>\lll</latexCommand>
-   <unicodeCommand>⋘</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \ggg  -->
-<commandDefinition>
-   <latexCommand>\ggg</latexCommand>
-   <unicodeCommand>⋙</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \leq  -->
-<commandDefinition>
-   <latexCommand>\leq</latexCommand>
-   <unicodeCommand>≤</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \geq  -->
-<commandDefinition>
-   <latexCommand>\geq</latexCommand>
-   <unicodeCommand>≥</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \lneq  -->
-<commandDefinition>
-   <latexCommand>\lneq</latexCommand>
-   <unicodeCommand>⪇</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \gneq  -->
-<commandDefinition>
-   <latexCommand>\gneq</latexCommand>
-   <unicodeCommand>⪈</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nleq  -->
-<commandDefinition>
-   <latexCommand>\nleq</latexCommand>
-   <unicodeCommand>≰</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \ngeq  -->
-<commandDefinition>
-   <latexCommand>\ngeq</latexCommand>
-   <unicodeCommand>≱</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \leqq  -->
-<commandDefinition>
-   <latexCommand>\leqq</latexCommand>
-   <unicodeCommand>≦</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \geqq  -->
-<commandDefinition>
-   <latexCommand>\geqq</latexCommand>
-   <unicodeCommand>≧</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \lneqq  -->
-<commandDefinition>
-   <latexCommand>\lneqq</latexCommand>
-   <unicodeCommand>≨</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \gneqq  -->
-<commandDefinition>
-   <latexCommand>\gneqq</latexCommand>
-   <unicodeCommand>≩</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \lvertneqq  -->
-<commandDefinition>
-   <latexCommand>\lvertneqq</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \gvertneqq  -->
-<commandDefinition>
-   <latexCommand>\gvertneqq</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nleqq  -->
-<commandDefinition>
-   <latexCommand>\nleqq</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \ngeqq  -->
-<commandDefinition>
-   <latexCommand>\ngeqq</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \leqslant  -->
-<commandDefinition>
-   <latexCommand>\leqslant</latexCommand>
-   <unicodeCommand>⩽</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \geqslant  -->
-<commandDefinition>
-   <latexCommand>\geqslant</latexCommand>
-   <unicodeCommand>⩾</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nleqslant  -->
-<commandDefinition>
-   <latexCommand>\nleqslant</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \ngeqslant  -->
-<commandDefinition>
-   <latexCommand>\ngeqslant</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \eqslantless  -->
-<commandDefinition>
-   <latexCommand>\eqslantless</latexCommand>
-   <unicodeCommand>⪕</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \eqslantgtr  -->
-<commandDefinition>
-   <latexCommand>\eqslantgtr</latexCommand>
-   <unicodeCommand>⪖</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \lessgtr  -->
-<commandDefinition>
-   <latexCommand>\lessgtr</latexCommand>
-   <unicodeCommand>≶</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \gtrless  -->
-<commandDefinition>
-   <latexCommand>\gtrless</latexCommand>
-   <unicodeCommand>≷</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \lesseqgtr  -->
-<commandDefinition>
-   <latexCommand>\lesseqgtr</latexCommand>
-   <unicodeCommand>⋚</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \gtreqless  -->
-<commandDefinition>
-   <latexCommand>\gtreqless</latexCommand>
-   <unicodeCommand>⋛</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \lesseqqgtr  -->
-<commandDefinition>
-   <latexCommand>\lesseqqgtr</latexCommand>
-   <unicodeCommand>⪋</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \gtreqqless  -->
-<commandDefinition>
-   <latexCommand>\gtreqqless</latexCommand>
-   <unicodeCommand>⪌</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \lesssim  -->
-<commandDefinition>
-   <latexCommand>\lesssim</latexCommand>
-   <unicodeCommand>≲</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \gtrsim  -->
-<commandDefinition>
-   <latexCommand>\gtrsim</latexCommand>
-   <unicodeCommand>≳</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \lnsim  -->
-<commandDefinition>
-   <latexCommand>\lnsim</latexCommand>
-   <unicodeCommand>⋦</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \gnsim  -->
-<commandDefinition>
-   <latexCommand>\gnsim</latexCommand>
-   <unicodeCommand>⋧</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \lessapprox  -->
-<commandDefinition>
-   <latexCommand>\lessapprox</latexCommand>
-   <unicodeCommand>⪅</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \gtrapprox  -->
-<commandDefinition>
-   <latexCommand>\gtrapprox</latexCommand>
-   <unicodeCommand>⪆</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \lnapprox  -->
-<commandDefinition>
-   <latexCommand>\lnapprox</latexCommand>
-   <unicodeCommand>⪉</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \gnapprox  -->
-<commandDefinition>
-   <latexCommand>\gnapprox</latexCommand>
-   <unicodeCommand>⪊</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \vartriangleleft  -->
-<commandDefinition>
-   <latexCommand>\vartriangleleft</latexCommand>
-   <unicodeCommand>⊲</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \vartriangleright  -->
-<commandDefinition>
-   <latexCommand>\vartriangleright</latexCommand>
-   <unicodeCommand>⊳</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \ntriangleleft  -->
-<commandDefinition>
-   <latexCommand>\ntriangleleft</latexCommand>
-   <unicodeCommand>⋪</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \ntriangleright  -->
-<commandDefinition>
-   <latexCommand>\ntriangleright</latexCommand>
-   <unicodeCommand>⋫</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \trianglelefteq  -->
-<commandDefinition>
-   <latexCommand>\trianglelefteq</latexCommand>
-   <unicodeCommand>⊴</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \trianglerighteq  -->
-<commandDefinition>
-   <latexCommand>\trianglerighteq</latexCommand>
-   <unicodeCommand>⊵</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \ntrianglelefteq  -->
-<commandDefinition>
-   <latexCommand>\ntrianglelefteq</latexCommand>
-   <unicodeCommand>⋬</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \ntrianglerighteq  -->
-<commandDefinition>
-   <latexCommand>\ntrianglerighteq</latexCommand>
-   <unicodeCommand>⋭</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \blacktriangleleft  -->
-<commandDefinition>
-   <latexCommand>\blacktriangleleft</latexCommand>
-   <unicodeCommand>◂</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \blacktriangleright  -->
-<commandDefinition>
-   <latexCommand>\blacktriangleright</latexCommand>
-   <unicodeCommand>▸</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \subset  -->
-<commandDefinition>
-   <latexCommand>\subset</latexCommand>
-   <unicodeCommand>⊂</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \supset  -->
-<commandDefinition>
-   <latexCommand>\supset</latexCommand>
-   <unicodeCommand>⊃</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \subseteq  -->
-<commandDefinition>
-   <latexCommand>\subseteq</latexCommand>
-   <unicodeCommand>⊆</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \supseteq  -->
-<commandDefinition>
-   <latexCommand>\supseteq</latexCommand>
-   <unicodeCommand>⊇</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \subsetneq  -->
-<commandDefinition>
-   <latexCommand>\subsetneq</latexCommand>
-   <unicodeCommand>⊊</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \supsetneq  -->
-<commandDefinition>
-   <latexCommand>\supsetneq</latexCommand>
-   <unicodeCommand>⊋</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \varsubsetneq  -->
-<commandDefinition>
-   <latexCommand>\varsubsetneq</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \varsupsetneq  -->
-<commandDefinition>
-   <latexCommand>\varsupsetneq</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nsubseteq  -->
-<commandDefinition>
-   <latexCommand>\nsubseteq</latexCommand>
-   <unicodeCommand>⊈</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nsupseteq  -->
-<commandDefinition>
-   <latexCommand>\nsupseteq</latexCommand>
-   <unicodeCommand>⊉</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \subseteqq  -->
-<commandDefinition>
-   <latexCommand>\subseteqq</latexCommand>
-   <unicodeCommand>⫅</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \supseteqq  -->
-<commandDefinition>
-   <latexCommand>\supseteqq</latexCommand>
-   <unicodeCommand>⫆</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \subsetneqq  -->
-<commandDefinition>
-   <latexCommand>\subsetneqq</latexCommand>
-   <unicodeCommand>⫋</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \supsetneqq  -->
-<commandDefinition>
-   <latexCommand>\supsetneqq</latexCommand>
-   <unicodeCommand>⫌</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nsubseteqq  -->
-<commandDefinition>
-   <latexCommand>\nsubseteqq</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \nsupseteqq  -->
-<commandDefinition>
-   <latexCommand>\nsupseteqq</latexCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \backepsilon  -->
-<commandDefinition>
-   <latexCommand>\backepsilon</latexCommand>
-   <unicodeCommand>϶</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \Subset  -->
-<commandDefinition>
-   <latexCommand>\Subset</latexCommand>
-   <unicodeCommand>⋐</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \Supset  -->
-<commandDefinition>
-   <latexCommand>\Supset</latexCommand>
-   <unicodeCommand>⋑</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \sqsubset  -->
-<commandDefinition>
-   <latexCommand>\sqsubset</latexCommand>
-   <unicodeCommand>⊏</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg=-->
-<!-- arg math \sqsupset  -->
-<commandDefinition>
-   <latexCommand>\sqsupset</latexCommand>
-   <unicodeCommand>⊐</unicodeCommand>
-   <mathMode>true</mathMode>
-   <package>
-      <name>amssymb</name>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \sqsubseteq  -->
-<commandDefinition>
-   <latexCommand>\sqsubseteq</latexCommand>
-   <unicodeCommand>⊑</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg math \sqsupseteq  -->
-<commandDefinition>
-   <latexCommand>\sqsupseteq</latexCommand>
-   <unicodeCommand>⊒</unicodeCommand>
-   <mathMode>true</mathMode>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
+	<formatVersion major="0" minor ="22" />
+
+	<symbolGroupName>user</symbolGroupName>
+
+	<preamble>
+		<class>standalone</class>
+		<arguments>10bp,margin=1bp</arguments>
+		<additional>\usepackage[T1]{fontenc}</additional>
+	</preamble>
+
+	<unicodeCommandPackages>
+		<package>
+			<name>inputenc</name>
+			<arguments>utf8</arguments>
+		</package>
+	</unicodeCommandPackages>
+
+	<!-- insert stuff here -->
+
+	<symbolGroupName>relation</symbolGroupName>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \bowtie -->
+	<commandDefinition>
+		<latexCommand>\bowtie</latexCommand>
+		<unicodeCommand>⋈</unicodeCommand>
+		<mathMode>true</mathMode>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \Join -->
+	<commandDefinition>
+		<latexCommand>\Join</latexCommand>
+		<unicodeCommand>⨝</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \propto -->
+	<commandDefinition>
+		<latexCommand>\propto</latexCommand>
+		<unicodeCommand>∝</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \varpropto -->
+	<commandDefinition>
+		<latexCommand>\varpropto</latexCommand>
+		<unicodeCommand>∝</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \multimap -->
+	<commandDefinition>
+		<latexCommand>\multimap</latexCommand>
+		<unicodeCommand>⊸</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \pitchfork -->
+	<commandDefinition>
+		<latexCommand>\pitchfork</latexCommand>
+		<unicodeCommand>⋔</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \therefore -->
+	<commandDefinition>
+		<latexCommand>\therefore</latexCommand>
+		<unicodeCommand>∴</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \because -->
+	<commandDefinition>
+		<latexCommand>\because</latexCommand>
+		<unicodeCommand>∵</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math = -->
+	<commandDefinition>
+		<latexCommand>=</latexCommand>
+		<unicodeCommand>=</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \neq -->
+	<commandDefinition>
+		<latexCommand>\neq</latexCommand>
+		<unicodeCommand>≠</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \equiv -->
+	<commandDefinition>
+		<latexCommand>\equiv</latexCommand>
+		<unicodeCommand>≡</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \approx -->
+	<commandDefinition>
+		<latexCommand>\approx</latexCommand>
+		<unicodeCommand>≈</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \sim -->
+	<commandDefinition>
+		<latexCommand>\sim</latexCommand>
+		<unicodeCommand>∼</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\nsim</latexCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \simeq -->
+	<commandDefinition>
+		<latexCommand>\simeq</latexCommand>
+		<unicodeCommand>≃</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \backsimeq -->
+	<commandDefinition>
+		<latexCommand>\backsimeq</latexCommand>
+		<unicodeCommand>⋍</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \approxeq -->
+	<commandDefinition>
+		<latexCommand>\approxeq</latexCommand>
+		<unicodeCommand>≊</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \cong -->
+	<commandDefinition>
+		<latexCommand>\cong</latexCommand>
+		<unicodeCommand>≅</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \ncong -->
+	<commandDefinition>
+		<latexCommand>\ncong</latexCommand>
+		<unicodeCommand>≇</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \smile -->
+	<commandDefinition>
+		<latexCommand>\smile</latexCommand>
+		<unicodeCommand>⌣</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \frown -->
+	<commandDefinition>
+		<latexCommand>\frown</latexCommand>
+		<unicodeCommand>⌢</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \asymp -->
+	<commandDefinition>
+		<latexCommand>\asymp</latexCommand>
+		<unicodeCommand>≍</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \smallfrown -->
+	<commandDefinition>
+		<latexCommand>\smallfrown</latexCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \smallsmile -->
+	<commandDefinition>
+		<latexCommand>\smallsmile</latexCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \between -->
+	<commandDefinition>
+		<latexCommand>\between</latexCommand>
+		<unicodeCommand>≬</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \prec -->
+	<commandDefinition>
+		<latexCommand>\prec</latexCommand>
+		<unicodeCommand>≺</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \succ -->
+	<commandDefinition>
+		<latexCommand>\succ</latexCommand>
+		<unicodeCommand>≻</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \nprec -->
+	<commandDefinition>
+		<latexCommand>\nprec</latexCommand>
+		<unicodeCommand>⊀</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \nsucc -->
+	<commandDefinition>
+		<latexCommand>\nsucc</latexCommand>
+		<unicodeCommand>⊁</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \preceq -->
+	<commandDefinition>
+		<latexCommand>\preceq</latexCommand>
+		<unicodeCommand>⪯</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \succeq -->
+	<commandDefinition>
+		<latexCommand>\succeq</latexCommand>
+		<unicodeCommand>⪰</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \npreceq -->
+	<commandDefinition>
+		<latexCommand>\npreceq</latexCommand>
+		<unicodeCommand>⋠</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nsucceq -->
+	<commandDefinition>
+		<latexCommand>\nsucceq</latexCommand>
+		<unicodeCommand>⋡</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \preccurlyeq -->
+	<commandDefinition>
+		<latexCommand>\preccurlyeq</latexCommand>
+		<unicodeCommand>≼</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \succcurlyeq -->
+	<commandDefinition>
+		<latexCommand>\succcurlyeq</latexCommand>
+		<unicodeCommand>≽</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \curlyeqprec -->
+	<commandDefinition>
+		<latexCommand>\curlyeqprec</latexCommand>
+		<unicodeCommand>⋞</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \curlyeqsucc -->
+	<commandDefinition>
+		<latexCommand>\curlyeqsucc</latexCommand>
+		<unicodeCommand>⋟</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \precsim -->
+	<commandDefinition>
+		<latexCommand>\precsim</latexCommand>
+		<unicodeCommand>≾</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \succsim -->
+	<commandDefinition>
+		<latexCommand>\succsim</latexCommand>
+		<unicodeCommand>≿</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \precnsim -->
+	<commandDefinition>
+		<latexCommand>\precnsim</latexCommand>
+		<unicodeCommand>⋨</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \succnsim -->
+	<commandDefinition>
+		<latexCommand>\succnsim</latexCommand>
+		<unicodeCommand>⋩</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \precapprox -->
+	<commandDefinition>
+		<latexCommand>\precapprox</latexCommand>
+		<unicodeCommand>⪷</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \succapprox -->
+	<commandDefinition>
+		<latexCommand>\succapprox</latexCommand>
+		<unicodeCommand>⪸</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \precnapprox -->
+	<commandDefinition>
+		<latexCommand>\precnapprox</latexCommand>
+		<unicodeCommand>⪹</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \succnapprox -->
+	<commandDefinition>
+		<latexCommand>\succnapprox</latexCommand>
+		<unicodeCommand>⪺</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \perp -->
+	<commandDefinition>
+		<latexCommand>\perp</latexCommand>
+		<unicodeCommand>⟂</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \vdash -->
+	<commandDefinition>
+		<latexCommand>\vdash</latexCommand>
+		<unicodeCommand>⊢</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \dashv -->
+	<commandDefinition>
+		<latexCommand>\dashv</latexCommand>
+		<unicodeCommand>⊣</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nvdash -->
+	<commandDefinition>
+		<latexCommand>\nvdash</latexCommand>
+		<unicodeCommand>⊬</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \Vdash -->
+	<commandDefinition>
+		<latexCommand>\Vdash</latexCommand>
+		<unicodeCommand>⊩</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \Vvdash -->
+	<commandDefinition>
+		<latexCommand>\Vvdash</latexCommand>
+		<unicodeCommand>⊪</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \models -->
+	<commandDefinition>
+		<latexCommand>\models</latexCommand>
+		<unicodeCommand>⊧</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \vDash -->
+	<commandDefinition>
+		<latexCommand>\vDash</latexCommand>
+		<unicodeCommand>⊨</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nvDash -->
+	<commandDefinition>
+		<latexCommand>\nvDash</latexCommand>
+		<unicodeCommand>⊭</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nVDash -->
+	<commandDefinition>
+		<latexCommand>\nVDash</latexCommand>
+		<unicodeCommand>⊯</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \mid -->
+	<commandDefinition>
+		<latexCommand>\mid</latexCommand>
+		<unicodeCommand>∣</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \nmid -->
+	<commandDefinition>
+		<latexCommand>\nmid</latexCommand>
+		<unicodeCommand>∤</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \parallel -->
+	<commandDefinition>
+		<latexCommand>\parallel</latexCommand>
+		<unicodeCommand>∥</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nparallel -->
+	<commandDefinition>
+		<latexCommand>\nparallel</latexCommand>
+		<unicodeCommand>∦</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \shortmid -->
+	<commandDefinition>
+		<latexCommand>\shortmid</latexCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nshortmid -->
+	<commandDefinition>
+		<latexCommand>\nshortmid</latexCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \shortparallel -->
+	<commandDefinition>
+		<latexCommand>\shortparallel</latexCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nshortparallel -->
+	<commandDefinition>
+		<latexCommand>\nshortparallel</latexCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math < -->
+	<commandDefinition>
+		<latexCommand>&lt;</latexCommand>
+		<unicodeCommand>&lt;</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math > -->
+	<commandDefinition>
+		<latexCommand>&gt;</latexCommand>
+		<unicodeCommand>&gt;</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nless -->
+	<commandDefinition>
+		<latexCommand>\nless</latexCommand>
+		<unicodeCommand>≮</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \ngtr -->
+	<commandDefinition>
+		<latexCommand>\ngtr</latexCommand>
+		<unicodeCommand>≯</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \lessdot -->
+	<commandDefinition>
+		<latexCommand>\lessdot</latexCommand>
+		<unicodeCommand>⋖</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \gtrdot -->
+	<commandDefinition>
+		<latexCommand>\gtrdot</latexCommand>
+		<unicodeCommand>⋗</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \ll -->
+	<commandDefinition>
+		<latexCommand>\ll</latexCommand>
+		<unicodeCommand>≪</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \gg -->
+	<commandDefinition>
+		<latexCommand>\gg</latexCommand>
+		<unicodeCommand>≫</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \lll -->
+	<commandDefinition>
+		<latexCommand>\lll</latexCommand>
+		<unicodeCommand>⋘</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \ggg -->
+	<commandDefinition>
+		<latexCommand>\ggg</latexCommand>
+		<unicodeCommand>⋙</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \leq -->
+	<commandDefinition>
+		<latexCommand>\leq</latexCommand>
+		<unicodeCommand>≤</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \geq -->
+	<commandDefinition>
+		<latexCommand>\geq</latexCommand>
+		<unicodeCommand>≥</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \lneq -->
+	<commandDefinition>
+		<latexCommand>\lneq</latexCommand>
+		<unicodeCommand>⪇</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \gneq -->
+	<commandDefinition>
+		<latexCommand>\gneq</latexCommand>
+		<unicodeCommand>⪈</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nleq -->
+	<commandDefinition>
+		<latexCommand>\nleq</latexCommand>
+		<unicodeCommand>≰</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \ngeq -->
+	<commandDefinition>
+		<latexCommand>\ngeq</latexCommand>
+		<unicodeCommand>≱</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \leqq -->
+	<commandDefinition>
+		<latexCommand>\leqq</latexCommand>
+		<unicodeCommand>≦</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \geqq -->
+	<commandDefinition>
+		<latexCommand>\geqq</latexCommand>
+		<unicodeCommand>≧</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \lneqq -->
+	<commandDefinition>
+		<latexCommand>\lneqq</latexCommand>
+		<unicodeCommand>≨</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \gneqq -->
+	<commandDefinition>
+		<latexCommand>\gneqq</latexCommand>
+		<unicodeCommand>≩</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \lvertneqq -->
+	<commandDefinition>
+		<latexCommand>\lvertneqq</latexCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \gvertneqq -->
+	<commandDefinition>
+		<latexCommand>\gvertneqq</latexCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nleqq -->
+	<commandDefinition>
+		<latexCommand>\nleqq</latexCommand>
+		<unicodeCommand>≦̸</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \ngeqq -->
+	<commandDefinition>
+		<latexCommand>\ngeqq</latexCommand>
+		<unicodeCommand>≧̸</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \leqslant -->
+	<commandDefinition>
+		<latexCommand>\leqslant</latexCommand>
+		<unicodeCommand>⩽</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \geqslant -->
+	<commandDefinition>
+		<latexCommand>\geqslant</latexCommand>
+		<unicodeCommand>⩾</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nleqslant -->
+	<commandDefinition>
+		<latexCommand>\nleqslant</latexCommand>
+		<unicodeCommand>⩽̷</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \ngeqslant -->
+	<commandDefinition>
+		<latexCommand>\ngeqslant</latexCommand>
+		<unicodeCommand>⩾̷</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \eqslantless -->
+	<commandDefinition>
+		<latexCommand>\eqslantless</latexCommand>
+		<unicodeCommand>⪕</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \eqslantgtr -->
+	<commandDefinition>
+		<latexCommand>\eqslantgtr</latexCommand>
+		<unicodeCommand>⪖</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \lessgtr -->
+	<commandDefinition>
+		<latexCommand>\lessgtr</latexCommand>
+		<unicodeCommand>≶</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \gtrless -->
+	<commandDefinition>
+		<latexCommand>\gtrless</latexCommand>
+		<unicodeCommand>≷</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \lesseqgtr -->
+	<commandDefinition>
+		<latexCommand>\lesseqgtr</latexCommand>
+		<unicodeCommand>⋚</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \gtreqless -->
+	<commandDefinition>
+		<latexCommand>\gtreqless</latexCommand>
+		<unicodeCommand>⋛</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \lesseqqgtr -->
+	<commandDefinition>
+		<latexCommand>\lesseqqgtr</latexCommand>
+		<unicodeCommand>⪋</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \gtreqqless -->
+	<commandDefinition>
+		<latexCommand>\gtreqqless</latexCommand>
+		<unicodeCommand>⪌</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \lesssim -->
+	<commandDefinition>
+		<latexCommand>\lesssim</latexCommand>
+		<unicodeCommand>≲</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \gtrsim -->
+	<commandDefinition>
+		<latexCommand>\gtrsim</latexCommand>
+		<unicodeCommand>≳</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \lnsim -->
+	<commandDefinition>
+		<latexCommand>\lnsim</latexCommand>
+		<unicodeCommand>⋦</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \gnsim -->
+	<commandDefinition>
+		<latexCommand>\gnsim</latexCommand>
+		<unicodeCommand>⋧</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \lessapprox -->
+	<commandDefinition>
+		<latexCommand>\lessapprox</latexCommand>
+		<unicodeCommand>⪅</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \gtrapprox -->
+	<commandDefinition>
+		<latexCommand>\gtrapprox</latexCommand>
+		<unicodeCommand>⪆</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \lnapprox -->
+	<commandDefinition>
+		<latexCommand>\lnapprox</latexCommand>
+		<unicodeCommand>⪉</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \gnapprox -->
+	<commandDefinition>
+		<latexCommand>\gnapprox</latexCommand>
+		<unicodeCommand>⪊</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \vartriangleleft -->
+	<commandDefinition>
+		<latexCommand>\vartriangleleft</latexCommand>
+		<unicodeCommand>⊲</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \vartriangleright -->
+	<commandDefinition>
+		<latexCommand>\vartriangleright</latexCommand>
+		<unicodeCommand>⊳</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \ntriangleleft -->
+	<commandDefinition>
+		<latexCommand>\ntriangleleft</latexCommand>
+		<unicodeCommand>⋪</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \ntriangleright -->
+	<commandDefinition>
+		<latexCommand>\ntriangleright</latexCommand>
+		<unicodeCommand>⋫</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \trianglelefteq -->
+	<commandDefinition>
+		<latexCommand>\trianglelefteq</latexCommand>
+		<unicodeCommand>⊴</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \trianglerighteq -->
+	<commandDefinition>
+		<latexCommand>\trianglerighteq</latexCommand>
+		<unicodeCommand>⊵</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \ntrianglelefteq -->
+	<commandDefinition>
+		<latexCommand>\ntrianglelefteq</latexCommand>
+		<unicodeCommand>⋬</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \ntrianglerighteq -->
+	<commandDefinition>
+		<latexCommand>\ntrianglerighteq</latexCommand>
+		<unicodeCommand>⋭</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \blacktriangleleft -->
+	<commandDefinition>
+		<latexCommand>\blacktriangleleft</latexCommand>
+		<unicodeCommand>◂</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \blacktriangleright -->
+	<commandDefinition>
+		<latexCommand>\blacktriangleright</latexCommand>
+		<unicodeCommand>▸</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \subset -->
+	<commandDefinition>
+		<latexCommand>\subset</latexCommand>
+		<unicodeCommand>⊂</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \supset -->
+	<commandDefinition>
+		<latexCommand>\supset</latexCommand>
+		<unicodeCommand>⊃</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \subseteq -->
+	<commandDefinition>
+		<latexCommand>\subseteq</latexCommand>
+		<unicodeCommand>⊆</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \supseteq -->
+	<commandDefinition>
+		<latexCommand>\supseteq</latexCommand>
+		<unicodeCommand>⊇</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \subsetneq -->
+	<commandDefinition>
+		<latexCommand>\subsetneq</latexCommand>
+		<unicodeCommand>⊊</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \supsetneq -->
+	<commandDefinition>
+		<latexCommand>\supsetneq</latexCommand>
+		<unicodeCommand>⊋</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \varsubsetneq -->
+	<commandDefinition>
+		<latexCommand>\varsubsetneq</latexCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \varsupsetneq -->
+	<commandDefinition>
+		<latexCommand>\varsupsetneq</latexCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nsubseteq -->
+	<commandDefinition>
+		<latexCommand>\nsubseteq</latexCommand>
+		<unicodeCommand>⊈</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nsupseteq -->
+	<commandDefinition>
+		<latexCommand>\nsupseteq</latexCommand>
+		<unicodeCommand>⊉</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \subseteqq -->
+	<commandDefinition>
+		<latexCommand>\subseteqq</latexCommand>
+		<unicodeCommand>⫅</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \supseteqq -->
+	<commandDefinition>
+		<latexCommand>\supseteqq</latexCommand>
+		<unicodeCommand>⫆</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \subsetneqq -->
+	<commandDefinition>
+		<latexCommand>\subsetneqq</latexCommand>
+		<unicodeCommand>⫋</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \supsetneqq -->
+	<commandDefinition>
+		<latexCommand>\supsetneqq</latexCommand>
+		<unicodeCommand>⫌</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nsubseteqq -->
+	<commandDefinition>
+		<latexCommand>\nsubseteqq</latexCommand>
+		<unicodeCommand>⫅̷</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \nsupseteqq -->
+	<commandDefinition>
+		<latexCommand>\nsupseteqq</latexCommand>
+		<unicodeCommand>⫆̷</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \backepsilon -->
+	<commandDefinition>
+		<latexCommand>\backepsilon</latexCommand>
+		<unicodeCommand>϶</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \Subset -->
+	<commandDefinition>
+		<latexCommand>\Subset</latexCommand>
+		<unicodeCommand>⋐</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \Supset -->
+	<commandDefinition>
+		<latexCommand>\Supset</latexCommand>
+		<unicodeCommand>⋑</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \sqsubset -->
+	<commandDefinition>
+		<latexCommand>\sqsubset</latexCommand>
+		<unicodeCommand>⊏</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=amssymb ,pkgsarg= ,savepkgs=amssymb ,savepkgsarg= -->
+	<!-- arg math \sqsupset -->
+	<commandDefinition>
+		<latexCommand>\sqsupset</latexCommand>
+		<unicodeCommand>⊐</unicodeCommand>
+		<mathMode>true</mathMode>
+		<package>
+			<name>amssymb</name>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \sqsubseteq -->
+	<commandDefinition>
+		<latexCommand>\sqsubseteq</latexCommand>
+		<unicodeCommand>⊑</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg math \sqsupseteq -->
+	<commandDefinition>
+		<latexCommand>\sqsupseteq</latexCommand>
+		<unicodeCommand>⊒</unicodeCommand>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
 </symbols>

--- a/symbols-ng/special.xml
+++ b/symbols-ng/special.xml
@@ -3,1425 +3,2673 @@
 <!DOCTYPE KileSymbolSources>
 <symbols>
 
-   <formatVersion major="0" minor ="22" />
-
-   <symbolGroupName>user</symbolGroupName>
-
-   <preamble>
-      <class>article</class>
-      <arguments>12pt</arguments>
-      <additional>\pagestyle{empty}
-		  \setlength{\parindent}{0cm}
-		  \usepackage[T1]{fontenc}
-      </additional>
-   </preamble>
-
-   <unicodeCommandPackages>
-      <package>
-         <name>inputenc</name>
-         <arguments>utf8</arguments>
-      </package>
-   </unicodeCommandPackages>
-
-   <!-- insert stuff here    -->
-<symbolGroupName>special</symbolGroupName>
-
-<commandDefinition>
-   <latexCommand>\"{A}</latexCommand>
-   <unicodeCommand>Ä</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \H{A}  -->
-<commandDefinition>
-   <latexCommand>\H{A}</latexCommand>
-   <unicodeCommand>A̋</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{A}  -->
-<commandDefinition>
-   <latexCommand>\'{A}</latexCommand>
-   <unicodeCommand>Á</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \`{A}  -->
-<commandDefinition>
-   <latexCommand>\`{A}</latexCommand>
-   <unicodeCommand>À</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \~{A}  -->
-<commandDefinition>
-   <latexCommand>\~{A}</latexCommand>
-   <unicodeCommand>Ã</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \^{A}  -->
-<commandDefinition>
-   <latexCommand>\^{A}</latexCommand>
-   <unicodeCommand>Â</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{A}  -->
-<commandDefinition>
-   <latexCommand>\v{A}</latexCommand>
-   <unicodeCommand>Ǎ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \u{A}  -->
-<commandDefinition>
-   <latexCommand>\u{A}</latexCommand>
-   <unicodeCommand>Ă</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \={A}  -->
-<commandDefinition>
-   <latexCommand>\={A}</latexCommand>
-   <unicodeCommand>Ā</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \AA{}  -->
-<commandDefinition>
-   <latexCommand>\AA{}</latexCommand>
-   <unicodeCommand>Å</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \k{A}  -->
-<commandDefinition>
-   <latexCommand>\k{A}</latexCommand>
-   <unicodeCommand>Ą</unicodeCommand>
-   <package>
-      <name>fontenc</name>
-      <arguments>T1</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \AE{}  -->
-<commandDefinition>
-   <latexCommand>\AE{}</latexCommand>
-   <unicodeCommand>Æ</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \"{a}  -->
-<commandDefinition>
-   <latexCommand>\"{a}</latexCommand>
-   <unicodeCommand>ä</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \H{a}  -->
-<commandDefinition>
-   <latexCommand>\H{a}</latexCommand>
-   <unicodeCommand>a̋</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{a}  -->
-<commandDefinition>
-   <latexCommand>\'{a}</latexCommand>
-   <unicodeCommand>á</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \`{a}  -->
-<commandDefinition>
-   <latexCommand>\`{a}</latexCommand>
-   <unicodeCommand>à</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \~{a}  -->
-<commandDefinition>
-   <latexCommand>\~{a}</latexCommand>
-   <unicodeCommand>ã</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \^{a}  -->
-<commandDefinition>
-   <latexCommand>\^{a}</latexCommand>
-   <unicodeCommand>â</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{a}  -->
-<commandDefinition>
-   <latexCommand>\v{a}</latexCommand>
-   <unicodeCommand>ǎ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \u{a}  -->
-<commandDefinition>
-   <latexCommand>\u{a}</latexCommand>
-   <unicodeCommand>ă</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \={a}  -->
-<commandDefinition>
-   <latexCommand>\={a}</latexCommand>
-   <unicodeCommand>ā</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \aa{}  -->
-<commandDefinition>
-   <latexCommand>\aa{}</latexCommand>
-   <unicodeCommand>å</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \k{a}  -->
-<commandDefinition>
-   <latexCommand>\k{a}</latexCommand>
-   <unicodeCommand>ą</unicodeCommand>
-   <package>
-      <name>fontenc</name>
-      <arguments>T1</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \ae{}  -->
-<commandDefinition>
-   <latexCommand>\ae{}</latexCommand>
-   <unicodeCommand>æ</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{C}  -->
-<commandDefinition>
-   <latexCommand>\'{C}</latexCommand>
-   <unicodeCommand>Ć</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \u{C}  -->
-<commandDefinition>
-   <latexCommand>\u{C}</latexCommand>
-   <unicodeCommand>C̆</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \c{C}  -->
-<commandDefinition>
-   <latexCommand>\c{C}</latexCommand>
-   <unicodeCommand>Ç</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{c}  -->
-<commandDefinition>
-   <latexCommand>\'{c}</latexCommand>
-   <unicodeCommand>ć</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \u{c}  -->
-<commandDefinition>
-   <latexCommand>\u{c}</latexCommand>
-   <unicodeCommand>c̆</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \c{c}  -->
-<commandDefinition>
-   <latexCommand>\c{c}</latexCommand>
-   <unicodeCommand>ç</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{D}  -->
-<commandDefinition>
-   <latexCommand>\v{D}</latexCommand>
-   <unicodeCommand>Ď</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \DJ{}  -->
-<commandDefinition>
-   <latexCommand>\DJ{}</latexCommand>
-   <unicodeCommand>Đ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   <package>
-      <name>fontenc</name>
-      <arguments>T1</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \DH{}  -->
-<commandDefinition>
-   <latexCommand>\DH{}</latexCommand>
-   <unicodeCommand>Ð</unicodeCommand>
-   <forcePNG>true</forcePNG>
-   <package>
-      <name>fontenc</name>
-      <arguments>T1</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{d}  -->
-<commandDefinition>
-   <latexCommand>\v{d}</latexCommand>
-   <unicodeCommand>ď</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \dj{}  -->
-<commandDefinition>
-   <latexCommand>\dj{}</latexCommand>
-   <unicodeCommand>đ</unicodeCommand>
-   <package>
-      <name>fontenc</name>
-      <arguments>T1</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \dh{}  -->
-<commandDefinition>
-   <latexCommand>\dh{}</latexCommand>
-   <unicodeCommand>ð</unicodeCommand>
-   <package>
-      <name>fontenc</name>
-      <arguments>T1</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \"{E}  -->
-<commandDefinition>
-   <latexCommand>\"{E}</latexCommand>
-   <unicodeCommand>Ë</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \H{E}  -->
-<commandDefinition>
-   <latexCommand>\H{E}</latexCommand>
-   <unicodeCommand>Ế</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \.{E}  -->
-<commandDefinition>
-   <latexCommand>\.{E}</latexCommand>
-   <unicodeCommand>Ė</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{E}  -->
-<commandDefinition>
-   <latexCommand>\'{E}</latexCommand>
-   <unicodeCommand>É</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \`{E}  -->
-<commandDefinition>
-   <latexCommand>\`{E}</latexCommand>
-   <unicodeCommand>È</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \^{E}  -->
-<commandDefinition>
-   <latexCommand>\^{E}</latexCommand>
-   <unicodeCommand>Ê</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{E}  -->
-<commandDefinition>
-   <latexCommand>\v{E}</latexCommand>
-   <unicodeCommand>Ě</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \u{E}  -->
-<commandDefinition>
-   <latexCommand>\u{E}</latexCommand>
-   <unicodeCommand>Ĕ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \={E}  -->
-<commandDefinition>
-   <latexCommand>\={E}</latexCommand>
-   <unicodeCommand>Ē</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \k{E}  -->
-<commandDefinition>
-   <latexCommand>\k{E}</latexCommand>
-   <unicodeCommand>Ę</unicodeCommand>
-   <package>
-      <name>fontenc</name>
-      <arguments>T1</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \"{e}  -->
-<commandDefinition>
-   <latexCommand>\"{e}</latexCommand>
-   <unicodeCommand>ë</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \H{e}  -->
-<commandDefinition>
-   <latexCommand>\H{e}</latexCommand>
-   <unicodeCommand>ế</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \.{e}  -->
-<commandDefinition>
-   <latexCommand>\.{e}</latexCommand>
-   <unicodeCommand>ė</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{e}  -->
-<commandDefinition>
-   <latexCommand>\'{e}</latexCommand>
-   <unicodeCommand>é</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \`{e}  -->
-<commandDefinition>
-   <latexCommand>\`{e}</latexCommand>
-   <unicodeCommand>è</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \^{e}  -->
-<commandDefinition>
-   <latexCommand>\^{e}</latexCommand>
-   <unicodeCommand>ê</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{e}  -->
-<commandDefinition>
-   <latexCommand>\v{e}</latexCommand>
-   <unicodeCommand>ě</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \u{e}  -->
-<commandDefinition>
-   <latexCommand>\u{e}</latexCommand>
-   <unicodeCommand>ĕ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \={e}  -->
-<commandDefinition>
-   <latexCommand>\={e}</latexCommand>
-   <unicodeCommand>ē</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \k{e}  -->
-<commandDefinition>
-   <latexCommand>\k{e}</latexCommand>
-   <unicodeCommand>ę</unicodeCommand>
-   <package>
-      <name>fontenc</name>
-      <arguments>T1</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \c{G}  -->
-<commandDefinition>
-   <latexCommand>\c{G}</latexCommand>
-   <unicodeCommand>Ģ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{G}  -->
-<commandDefinition>
-   <latexCommand>\'{G}</latexCommand>
-   <unicodeCommand>Ǵ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \c{g}  -->
-<commandDefinition>
-   <latexCommand>\c{g}</latexCommand>
-   <unicodeCommand>ģ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{g}  -->
-<commandDefinition>
-   <latexCommand>\'{g}</latexCommand>
-   <unicodeCommand>ǵ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \"{I}  -->
-<commandDefinition>
-   <latexCommand>\"{I}</latexCommand>
-   <unicodeCommand>Ï</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \H{I}  -->
-<commandDefinition>
-   <latexCommand>\H{I}</latexCommand>
-   <unicodeCommand>I̋</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{I}  -->
-<commandDefinition>
-   <latexCommand>\'{I}</latexCommand>
-   <unicodeCommand>Í</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \`{I}  -->
-<commandDefinition>
-   <latexCommand>\`{I}</latexCommand>
-   <unicodeCommand>Ì</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \~{I}  -->
-<commandDefinition>
-   <latexCommand>\~{I}</latexCommand>
-   <unicodeCommand>Ĩ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \^{I}  -->
-<commandDefinition>
-   <latexCommand>\^{I}</latexCommand>
-   <unicodeCommand>Î</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \={I}  -->
-<commandDefinition>
-   <latexCommand>\={I}</latexCommand>
-   <unicodeCommand>Ī</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \k{I}  -->
-<commandDefinition>
-   <latexCommand>\k{I}</latexCommand>
-   <unicodeCommand>Į</unicodeCommand>
-   <package>
-      <name>fontenc</name>
-      <arguments>T1</arguments>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \"{\i}  -->
-<commandDefinition>
-   <latexCommand>\"{\i}</latexCommand>
-   <unicodeCommand>ï</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \H{\i}  -->
-<commandDefinition>
-   <latexCommand>\H{\i}</latexCommand>
-   <unicodeCommand>i̋</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{\i}  -->
-<commandDefinition>
-   <latexCommand>\'{\i}</latexCommand>
-   <unicodeCommand>í</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \`{\i}  -->
-<commandDefinition>
-   <latexCommand>\`{\i}</latexCommand>
-   <unicodeCommand>ì</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \~{\i}  -->
-<commandDefinition>
-   <latexCommand>\~{\i}</latexCommand>
-   <unicodeCommand>ĩ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \^{\i}  -->
-<commandDefinition>
-   <latexCommand>\^{\i}</latexCommand>
-   <unicodeCommand>î</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \={\i}  -->
-<commandDefinition>
-   <latexCommand>\={\i}</latexCommand>
-   <unicodeCommand>ī</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \k{\i}  -->
-<commandDefinition>
-   <latexCommand>\k{\i}</latexCommand>
-   <unicodeCommand>į</unicodeCommand>
-   <package>
-      <name>fontenc</name>
-      <arguments>T1</arguments>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \c{K}  -->
-<commandDefinition>
-   <latexCommand>\c{K}</latexCommand>
-   <unicodeCommand>Ķ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \c{k}  -->
-<commandDefinition>
-   <latexCommand>\c{k}</latexCommand>
-   <unicodeCommand>ķ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \c{L}  -->
-<commandDefinition>
-   <latexCommand>\c{L}</latexCommand>
-   <unicodeCommand>Ļ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{L}  -->
-<commandDefinition>
-   <latexCommand>\'{L}</latexCommand>
-   <unicodeCommand>Ĺ</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \u{L}  -->
-<commandDefinition>
-   <latexCommand>\u{L}</latexCommand>
-   <unicodeCommand>L̆</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{L}  -->
-<commandDefinition>
-   <latexCommand>\v{L}</latexCommand>
-   <unicodeCommand>Ľ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \L{}  -->
-<commandDefinition>
-   <latexCommand>\L{}</latexCommand>
-   <unicodeCommand>Ł</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \c{l}  -->
-<commandDefinition>
-   <latexCommand>\c{l}</latexCommand>
-   <unicodeCommand>ļ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{l}  -->
-<commandDefinition>
-   <latexCommand>\'{l}</latexCommand>
-   <unicodeCommand>ĺ</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \u{l}  -->
-<commandDefinition>
-   <latexCommand>\u{l}</latexCommand>
-   <unicodeCommand>l̆</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{l}  -->
-<commandDefinition>
-   <latexCommand>\v{l}</latexCommand>
-   <unicodeCommand>ľ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \l{}  -->
-<commandDefinition>
-   <latexCommand>\l{}</latexCommand>
-   <unicodeCommand>ł</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \c{N}  -->
-<commandDefinition>
-   <latexCommand>\c{N}</latexCommand>
-   <unicodeCommand>Ņ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{N}  -->
-<commandDefinition>
-   <latexCommand>\'{N}</latexCommand>
-   <unicodeCommand>Ń</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \~{N}  -->
-<commandDefinition>
-   <latexCommand>\~{N}</latexCommand>
-   <unicodeCommand>Ñ</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{N}  -->
-<commandDefinition>
-   <latexCommand>\v{N}</latexCommand>
-   <unicodeCommand>Ň</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \u{N}  -->
-<commandDefinition>
-   <latexCommand>\u{N}</latexCommand>
-   <unicodeCommand>N̆</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \NG{}  -->
-<commandDefinition>
-   <latexCommand>\NG{}</latexCommand>
-   <unicodeCommand>Ŋ</unicodeCommand>
-   <package>
-      <name>fontenc</name>
-      <arguments>T1</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \c{n}  -->
-<commandDefinition>
-   <latexCommand>\c{n}</latexCommand>
-   <unicodeCommand>ņ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{n}  -->
-<commandDefinition>
-   <latexCommand>\'{n}</latexCommand>
-   <unicodeCommand>ń</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \~{n}  -->
-<commandDefinition>
-   <latexCommand>\~{n}</latexCommand>
-   <unicodeCommand>ñ</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{n}  -->
-<commandDefinition>
-   <latexCommand>\v{n}</latexCommand>
-   <unicodeCommand>ň</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \u{n}  -->
-<commandDefinition>
-   <latexCommand>\u{n}</latexCommand>
-   <unicodeCommand>n̆</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \ng{}  -->
-<commandDefinition>
-   <latexCommand>\ng{}</latexCommand>
-   <unicodeCommand>ŋ</unicodeCommand>
-   <package>
-      <name>fontenc</name>
-      <arguments>T1</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \"{O}  -->
-<commandDefinition>
-   <latexCommand>\"{O}</latexCommand>
-   <unicodeCommand>Ö</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \H{O}  -->
-<commandDefinition>
-   <latexCommand>\H{O}</latexCommand>
-   <unicodeCommand>Ő</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{O}  -->
-<commandDefinition>
-   <latexCommand>\'{O}</latexCommand>
-   <unicodeCommand>Ó</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \`{O}  -->
-<commandDefinition>
-   <latexCommand>\`{O}</latexCommand>
-   <unicodeCommand>Ò</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \~{O}  -->
-<commandDefinition>
-   <latexCommand>\~{O}</latexCommand>
-   <unicodeCommand>Õ</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \^{O}  -->
-<commandDefinition>
-   <latexCommand>\^{O}</latexCommand>
-   <unicodeCommand>Ô</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{O}  -->
-<commandDefinition>
-   <latexCommand>\v{O}</latexCommand>
-   <unicodeCommand>Ǒ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \u{O}  -->
-<commandDefinition>
-   <latexCommand>\u{O}</latexCommand>
-   <unicodeCommand>Ŏ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \={O}  -->
-<commandDefinition>
-   <latexCommand>\={O}</latexCommand>
-   <unicodeCommand>Ō</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \O{}  -->
-<commandDefinition>
-   <latexCommand>\O{}</latexCommand>
-   <unicodeCommand>Ø</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \OE{}  -->
-<commandDefinition>
-   <latexCommand>\OE{}</latexCommand>
-   <unicodeCommand>Œ</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \k{O}  -->
-<commandDefinition>
-   <latexCommand>\k{O}</latexCommand>
-   <unicodeCommand>Ǫ</unicodeCommand>
-   <package>
-      <name>fontenc</name>
-      <arguments>T1</arguments>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \"{o}  -->
-<commandDefinition>
-   <latexCommand>\"{o}</latexCommand>
-   <unicodeCommand>ö</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \H{o}  -->
-<commandDefinition>
-   <latexCommand>\H{o}</latexCommand>
-   <unicodeCommand>ő</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{o}  -->
-<commandDefinition>
-   <latexCommand>\'{o}</latexCommand>
-   <unicodeCommand>ó</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \`{o}  -->
-<commandDefinition>
-   <latexCommand>\`{o}</latexCommand>
-   <unicodeCommand>ò</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \~{o}  -->
-<commandDefinition>
-   <latexCommand>\~{o}</latexCommand>
-   <unicodeCommand>õ</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \^{o}  -->
-<commandDefinition>
-   <latexCommand>\^{o}</latexCommand>
-   <unicodeCommand>ô</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{o}  -->
-<commandDefinition>
-   <latexCommand>\v{o}</latexCommand>
-   <unicodeCommand>ǒ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \u{o}  -->
-<commandDefinition>
-   <latexCommand>\u{o}</latexCommand>
-   <unicodeCommand>ŏ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \={o}  -->
-<commandDefinition>
-   <latexCommand>\={o}</latexCommand>
-   <unicodeCommand>ō</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \o{}  -->
-<commandDefinition>
-   <latexCommand>\o{}</latexCommand>
-   <unicodeCommand>ø</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \oe{}  -->
-<commandDefinition>
-   <latexCommand>\oe{}</latexCommand>
-   <unicodeCommand>œ</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \k{o}  -->
-<commandDefinition>
-   <latexCommand>\k{o}</latexCommand>
-   <unicodeCommand>ǫ</unicodeCommand>
-   <package>
-      <name>fontenc</name>
-      <arguments>T1</arguments>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \TH{}  -->
-<commandDefinition>
-   <latexCommand>\TH{}</latexCommand>
-   <unicodeCommand>Þ</unicodeCommand>
-   <package>
-      <name>fontenc</name>
-      <arguments>T1</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \th{}  -->
-<commandDefinition>
-   <latexCommand>\th{}</latexCommand>
-   <unicodeCommand>þ</unicodeCommand>
-   <package>
-      <name>fontenc</name>
-      <arguments>T1</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \c{R}  -->
-<commandDefinition>
-   <latexCommand>\c{R}</latexCommand>
-   <unicodeCommand>Ŗ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{R}  -->
-<commandDefinition>
-   <latexCommand>\'{R}</latexCommand>
-   <unicodeCommand>Ŕ</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{R}  -->
-<commandDefinition>
-   <latexCommand>\v{R}</latexCommand>
-   <unicodeCommand>Ř</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \c{r}  -->
-<commandDefinition>
-   <latexCommand>\c{r}</latexCommand>
-   <unicodeCommand>ŗ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{r}  -->
-<commandDefinition>
-   <latexCommand>\'{r}</latexCommand>
-   <unicodeCommand>ŕ</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{r}  -->
-<commandDefinition>
-   <latexCommand>\v{r}</latexCommand>
-   <unicodeCommand>ř</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \c{S}  -->
-<commandDefinition>
-   <latexCommand>\c{S}</latexCommand>
-   <unicodeCommand>Ş</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=inputenc ,pkgsarg=latin10 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textcommabelow{S}  -->
-<commandDefinition>
-   <latexCommand>\textcommabelow{S}</latexCommand>
-   <unicodeCommand>Ș</unicodeCommand>
-   <package>
-      <name>inputenc</name>
-      <arguments>latin10</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{S}  -->
-<commandDefinition>
-   <latexCommand>\'{S}</latexCommand>
-   <unicodeCommand>Ś</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{S}  -->
-<commandDefinition>
-   <latexCommand>\v{S}</latexCommand>
-   <unicodeCommand>Š</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \c{s}  -->
-<commandDefinition>
-   <latexCommand>\c{s}</latexCommand>
-   <unicodeCommand>ş</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=inputenc ,pkgsarg=latin10 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textcommabelow{s}  -->
-<commandDefinition>
-   <latexCommand>\textcommabelow{s}</latexCommand>
-   <unicodeCommand>ș</unicodeCommand>
-   <package>
-      <name>inputenc</name>
-      <arguments>latin10</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{s}  -->
-<commandDefinition>
-   <latexCommand>\'{s}</latexCommand>
-   <unicodeCommand>ś</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{s}  -->
-<commandDefinition>
-   <latexCommand>\v{s}</latexCommand>
-   <unicodeCommand>š</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \ss{}  -->
-<commandDefinition>
-   <latexCommand>\ss{}</latexCommand>
-   <unicodeCommand>ß</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \SS{}  -->
-<commandDefinition>
-   <latexCommand>\SS{}</latexCommand>
-   <unicodeCommand>SS</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \c{T}  -->
-<commandDefinition>
-   <latexCommand>\c{T}</latexCommand>
-   <unicodeCommand>Ţ</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=inputenc ,pkgsarg=latin10 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textcommabelow{T}  -->
-<commandDefinition>
-   <latexCommand>\textcommabelow{T}</latexCommand>
-   <unicodeCommand>Ț</unicodeCommand>
-   <package>
-      <name>inputenc</name>
-      <arguments>latin10</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{T}  -->
-<commandDefinition>
-   <latexCommand>\v{T}</latexCommand>
-   <unicodeCommand>Ť</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \mbox{T\hspace{-.5em}-}  -->
-<commandDefinition>
-   <latexCommand>\mbox{T\hspace{-.5em}-}</latexCommand>
-   <unicodeCommand>Ŧ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \c{t}  -->
-<commandDefinition>
-   <latexCommand>\c{t}</latexCommand>
-   <unicodeCommand>ţ</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=inputenc ,pkgsarg=latin10 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \textcommabelow{t}  -->
-<commandDefinition>
-   <latexCommand>\textcommabelow{t}</latexCommand>
-   <unicodeCommand>ț</unicodeCommand>
-   <package>
-      <name>inputenc</name>
-      <arguments>latin10</arguments>
-   </package>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{t}  -->
-<commandDefinition>
-   <latexCommand>\v{t}</latexCommand>
-   <unicodeCommand>ť</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \mbox{t\hspace{-.35em}-}  -->
-<commandDefinition>
-   <latexCommand>\mbox{t\hspace{-.35em}-}</latexCommand>
-   <unicodeCommand>ŧ̌</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \"{U}  -->
-<commandDefinition>
-   <latexCommand>\"{U}</latexCommand>
-   <unicodeCommand>Ü</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \H{U}  -->
-<commandDefinition>
-   <latexCommand>\H{U}</latexCommand>
-   <unicodeCommand>Ű</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{U}  -->
-<commandDefinition>
-   <latexCommand>\'{U}</latexCommand>
-   <unicodeCommand>Ú</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \`{U}  -->
-<commandDefinition>
-   <latexCommand>\`{U}</latexCommand>
-   <unicodeCommand>Ù</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \~{U}  -->
-<commandDefinition>
-   <latexCommand>\~{U}</latexCommand>
-   <unicodeCommand>Ũ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \^{U}  -->
-<commandDefinition>
-   <latexCommand>\^{U}</latexCommand>
-   <unicodeCommand>Û</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \={U}  -->
-<commandDefinition>
-   <latexCommand>\={U}</latexCommand>
-   <unicodeCommand>Ū</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \r{U}  -->
-<commandDefinition>
-   <latexCommand>\r{U}</latexCommand>
-   <unicodeCommand>Ů</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \k{U}  -->
-<commandDefinition>
-   <latexCommand>\k{U}</latexCommand>
-   <unicodeCommand>Ų</unicodeCommand>
-   <package>
-      <name>fontenc</name>
-      <arguments>T1</arguments>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \"{u}  -->
-<commandDefinition>
-   <latexCommand>\"{u}</latexCommand>
-   <unicodeCommand>ü</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \H{u}  -->
-<commandDefinition>
-   <latexCommand>\H{u}</latexCommand>
-   <unicodeCommand>ű</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{u}  -->
-<commandDefinition>
-   <latexCommand>\'{u}</latexCommand>
-   <unicodeCommand>ú</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \`{u}  -->
-<commandDefinition>
-   <latexCommand>\`{u}</latexCommand>
-   <unicodeCommand>ù</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \~{u}  -->
-<commandDefinition>
-   <latexCommand>\~{u}</latexCommand>
-   <unicodeCommand>ũ</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \^{u}  -->
-<commandDefinition>
-   <latexCommand>\^{u}</latexCommand>
-   <unicodeCommand>û</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \={u}  -->
-<commandDefinition>
-   <latexCommand>\={u}</latexCommand>
-   <unicodeCommand>ū</unicodeCommand>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \r{u}  -->
-<commandDefinition>
-   <latexCommand>\r{u}</latexCommand>
-   <unicodeCommand>ů</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \k{u}  -->
-<commandDefinition>
-   <latexCommand>\k{u}</latexCommand>
-   <unicodeCommand>ų</unicodeCommand>
-   <package>
-      <name>fontenc</name>
-      <arguments>T1</arguments>
-   </package>
-   <forcePNG>true</forcePNG>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \"{Y}  -->
-<commandDefinition>
-   <latexCommand>\"{Y}</latexCommand>
-   <unicodeCommand>Ÿ</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{Y}  -->
-<commandDefinition>
-   <latexCommand>\'{Y}</latexCommand>
-   <unicodeCommand>Ý</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \"{y}  -->
-<commandDefinition>
-   <latexCommand>\"{y}</latexCommand>
-   <unicodeCommand>ÿ</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{y}  -->
-<commandDefinition>
-   <latexCommand>\'{y}</latexCommand>
-   <unicodeCommand>ý</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \.{Z}  -->
-<commandDefinition>
-   <latexCommand>\.{Z}</latexCommand>
-   <unicodeCommand>Ż</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{Z}  -->
-<commandDefinition>
-   <latexCommand>\'{Z}</latexCommand>
-   <unicodeCommand>Ź</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{Z}  -->
-<commandDefinition>
-   <latexCommand>\v{Z}</latexCommand>
-   <unicodeCommand>Ž</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \.{z}  -->
-<commandDefinition>
-   <latexCommand>\.{z}</latexCommand>
-   <unicodeCommand>ż</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \'{z}  -->
-<commandDefinition>
-   <latexCommand>\'{z}</latexCommand>
-   <unicodeCommand>ź</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- arg  \v{z}  -->
-<commandDefinition>
-   <latexCommand>\v{z}</latexCommand>
-   <unicodeCommand>ž</unicodeCommand>
-</commandDefinition>
-
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
-<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg=-->
+	<formatVersion major="0" minor ="22" />
+
+	<symbolGroupName>user</symbolGroupName>
+
+	<preamble>
+		<class>standalone</class>
+		<arguments>10bp,margin=1bp</arguments>
+		<additional>\usepackage[T1]{fontenc}</additional>
+	</preamble>
+
+	<unicodeCommandPackages>
+		<package>
+			<name>inputenc</name>
+			<arguments>utf8</arguments>
+		</package>
+	</unicodeCommandPackages>
+
+	<!-- insert stuff here -->
+
+	<symbolGroupName>special</symbolGroupName>
+
+	<commandDefinition>
+		<latexCommand>\"{A}</latexCommand>
+		<unicodeCommand>Ä</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \H{A} -->
+	<commandDefinition>
+		<latexCommand>\H{A}</latexCommand>
+		<unicodeCommand>A̋</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{A} -->
+	<commandDefinition>
+		<latexCommand>\.{A}</latexCommand>
+		<unicodeCommand>Ȧ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{A} -->
+	<commandDefinition>
+		<latexCommand>\'{A}</latexCommand>
+		<unicodeCommand>Á</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \`{A} -->
+	<commandDefinition>
+		<latexCommand>\`{A}</latexCommand>
+		<unicodeCommand>À</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \~{A} -->
+	<commandDefinition>
+		<latexCommand>\~{A}</latexCommand>
+		<unicodeCommand>Ã</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{A} -->
+	<commandDefinition>
+		<latexCommand>\^{A}</latexCommand>
+		<unicodeCommand>Â</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{A} -->
+	<commandDefinition>
+		<latexCommand>\v{A}</latexCommand>
+		<unicodeCommand>Ǎ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \u{A} -->
+	<commandDefinition>
+		<latexCommand>\u{A}</latexCommand>
+		<unicodeCommand>Ă</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \={A} -->
+	<commandDefinition>
+		<latexCommand>\={A}</latexCommand>
+		<unicodeCommand>Ā</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \AA{} -->
+	<commandDefinition>
+		<latexCommand>\AA{}</latexCommand>
+		<unicodeCommand>Å</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \k{A} -->
+	<commandDefinition>
+		<latexCommand>\k{A}</latexCommand>
+		<unicodeCommand>Ą</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T1</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{A} -->
+	<commandDefinition>
+		<latexCommand>\d{A}</latexCommand>
+		<unicodeCommand>Ạ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{a} -->
+	<commandDefinition>
+		<latexCommand>\"{a}</latexCommand>
+		<unicodeCommand>ä</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \H{a} -->
+	<commandDefinition>
+		<latexCommand>\H{a}</latexCommand>
+		<unicodeCommand>a̋</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{A} -->
+	<commandDefinition>
+		<latexCommand>\.{A}</latexCommand>
+		<unicodeCommand>ȧ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{a} -->
+	<commandDefinition>
+		<latexCommand>\'{a}</latexCommand>
+		<unicodeCommand>á</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \`{a} -->
+	<commandDefinition>
+		<latexCommand>\`{a}</latexCommand>
+		<unicodeCommand>à</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \~{a} -->
+	<commandDefinition>
+		<latexCommand>\~{a}</latexCommand>
+		<unicodeCommand>ã</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{a} -->
+	<commandDefinition>
+		<latexCommand>\^{a}</latexCommand>
+		<unicodeCommand>â</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{a} -->
+	<commandDefinition>
+		<latexCommand>\v{a}</latexCommand>
+		<unicodeCommand>ǎ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \u{a} -->
+	<commandDefinition>
+		<latexCommand>\u{a}</latexCommand>
+		<unicodeCommand>ă</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \={a} -->
+	<commandDefinition>
+		<latexCommand>\={a}</latexCommand>
+		<unicodeCommand>ā</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \aa{} -->
+	<commandDefinition>
+		<latexCommand>\aa{}</latexCommand>
+		<unicodeCommand>å</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \k{a} -->
+	<commandDefinition>
+		<latexCommand>\k{a}</latexCommand>
+		<unicodeCommand>ą</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T1</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{a} -->
+	<commandDefinition>
+		<latexCommand>\d{a}</latexCommand>
+		<unicodeCommand>ạ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \AE{} -->
+	<commandDefinition>
+		<latexCommand>\AE{}</latexCommand>
+		<unicodeCommand>Æ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \ae{} -->
+	<commandDefinition>
+		<latexCommand>\ae{}</latexCommand>
+		<unicodeCommand>æ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{B} -->
+	<commandDefinition>
+		<latexCommand>\.{B}</latexCommand>
+		<unicodeCommand>Ḃ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \b{B} -->
+	<commandDefinition>
+		<latexCommand>\b{B}</latexCommand>
+		<unicodeCommand>Ḇ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{B} -->
+	<commandDefinition>
+		<latexCommand>\d{B}</latexCommand>
+		<unicodeCommand>Ḅ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{b} -->
+	<commandDefinition>
+		<latexCommand>\.{b}</latexCommand>
+		<unicodeCommand>ḃ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \b{b} -->
+	<commandDefinition>
+		<latexCommand>\b{b}</latexCommand>
+		<unicodeCommand>ḇ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{b} -->
+	<commandDefinition>
+		<latexCommand>\d{b}</latexCommand>
+		<unicodeCommand>ḅ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{C} -->
+	<commandDefinition>
+		<latexCommand>\.{C}</latexCommand>
+		<unicodeCommand>Ċ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{C} -->
+	<commandDefinition>
+		<latexCommand>\'{C}</latexCommand>
+		<unicodeCommand>Ć</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{C} -->
+	<commandDefinition>
+		<latexCommand>\^{C}</latexCommand>
+		<unicodeCommand>Ĉ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{C} -->
+	<commandDefinition>
+		<latexCommand>\v{C}</latexCommand>
+		<unicodeCommand>Č</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \u{C} -->
+	<commandDefinition>
+		<latexCommand>\u{C}</latexCommand>
+		<unicodeCommand>C̆</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{C} -->
+	<commandDefinition>
+		<latexCommand>\c{C}</latexCommand>
+		<unicodeCommand>Ç</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{c} -->
+	<commandDefinition>
+		<latexCommand>\.{c}</latexCommand>
+		<unicodeCommand>ċ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{c} -->
+	<commandDefinition>
+		<latexCommand>\'{c}</latexCommand>
+		<unicodeCommand>ć</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{c} -->
+	<commandDefinition>
+		<latexCommand>\^{c}</latexCommand>
+		<unicodeCommand>ĉ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{c} -->
+	<commandDefinition>
+		<latexCommand>\v{c}</latexCommand>
+		<unicodeCommand>č</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \u{c} -->
+	<commandDefinition>
+		<latexCommand>\u{c}</latexCommand>
+		<unicodeCommand>c̆</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{c} -->
+	<commandDefinition>
+		<latexCommand>\c{c}</latexCommand>
+		<unicodeCommand>ç</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{D} -->
+	<commandDefinition>
+		<latexCommand>\c{D}</latexCommand>
+		<unicodeCommand>Ḑ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{D} -->
+	<commandDefinition>
+		<latexCommand>\.{D}</latexCommand>
+		<unicodeCommand>Ḋ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{D} -->
+	<commandDefinition>
+		<latexCommand>\v{D}</latexCommand>
+		<unicodeCommand>Ď</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \b{D} -->
+	<commandDefinition>
+		<latexCommand>\b{D}</latexCommand>
+		<unicodeCommand>Ḏ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{D} -->
+	<commandDefinition>
+		<latexCommand>\d{D}</latexCommand>
+		<unicodeCommand>Ḍ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{d} -->
+	<commandDefinition>
+		<latexCommand>\c{d}</latexCommand>
+		<unicodeCommand>ḑ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{d} -->
+	<commandDefinition>
+		<latexCommand>\.{d}</latexCommand>
+		<unicodeCommand>ḋ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{d} -->
+	<commandDefinition>
+		<latexCommand>\v{d}</latexCommand>
+		<unicodeCommand>ď</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \b{d} -->
+	<commandDefinition>
+		<latexCommand>\b{d}</latexCommand>
+		<unicodeCommand>ḏ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{d} -->
+	<commandDefinition>
+		<latexCommand>\d{d}</latexCommand>
+		<unicodeCommand>ḍ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \DJ{} -->
+	<commandDefinition>
+		<latexCommand>\DJ{}</latexCommand>
+		<unicodeCommand>Đ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T1</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \dj{} -->
+	<commandDefinition>
+		<latexCommand>\dj{}</latexCommand>
+		<unicodeCommand>đ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T1</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \DH{} -->
+	<commandDefinition>
+		<latexCommand>\DH{}</latexCommand>
+		<unicodeCommand>Ð</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+		<package>
+			<name>fontenc</name>
+			<arguments>T1</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \dh{} -->
+	<commandDefinition>
+		<latexCommand>\dh{}</latexCommand>
+		<unicodeCommand>ð</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T1</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{E} -->
+	<commandDefinition>
+		<latexCommand>\"{E}</latexCommand>
+		<unicodeCommand>Ë</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \H{E} -->
+	<commandDefinition>
+		<latexCommand>\H{E}</latexCommand>
+		<unicodeCommand>E̋</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{E} -->
+	<commandDefinition>
+		<latexCommand>\c{E}</latexCommand>
+		<unicodeCommand>Ȩ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{E} -->
+	<commandDefinition>
+		<latexCommand>\.{E}</latexCommand>
+		<unicodeCommand>Ė</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{E} -->
+	<commandDefinition>
+		<latexCommand>\'{E}</latexCommand>
+		<unicodeCommand>É</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \`{E} -->
+	<commandDefinition>
+		<latexCommand>\`{E}</latexCommand>
+		<unicodeCommand>È</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \~{E} -->
+	<commandDefinition>
+		<latexCommand>\~{E}</latexCommand>
+		<unicodeCommand>Ẽ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{E} -->
+	<commandDefinition>
+		<latexCommand>\^{E}</latexCommand>
+		<unicodeCommand>Ê</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{E} -->
+	<commandDefinition>
+		<latexCommand>\v{E}</latexCommand>
+		<unicodeCommand>Ě</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \u{E} -->
+	<commandDefinition>
+		<latexCommand>\u{E}</latexCommand>
+		<unicodeCommand>Ĕ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \={E} -->
+	<commandDefinition>
+		<latexCommand>\={E}</latexCommand>
+		<unicodeCommand>Ē</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \k{E} -->
+	<commandDefinition>
+		<latexCommand>\k{E}</latexCommand>
+		<unicodeCommand>Ę</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T1</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{E} -->
+	<commandDefinition>
+		<latexCommand>\d{E}</latexCommand>
+		<unicodeCommand>Ẹ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{e} -->
+	<commandDefinition>
+		<latexCommand>\"{e}</latexCommand>
+		<unicodeCommand>ë</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \H{e} -->
+	<commandDefinition>
+		<latexCommand>\H{e}</latexCommand>
+		<unicodeCommand>e̋</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{e} -->
+	<commandDefinition>
+		<latexCommand>\c{e}</latexCommand>
+		<unicodeCommand>ȩ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{e} -->
+	<commandDefinition>
+		<latexCommand>\.{e}</latexCommand>
+		<unicodeCommand>ė</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{e} -->
+	<commandDefinition>
+		<latexCommand>\'{e}</latexCommand>
+		<unicodeCommand>é</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \`{e} -->
+	<commandDefinition>
+		<latexCommand>\`{e}</latexCommand>
+		<unicodeCommand>è</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \~{e} -->
+	<commandDefinition>
+		<latexCommand>\~{e}</latexCommand>
+		<unicodeCommand>ẽ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{e} -->
+	<commandDefinition>
+		<latexCommand>\^{e}</latexCommand>
+		<unicodeCommand>ê</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{e} -->
+	<commandDefinition>
+		<latexCommand>\v{e}</latexCommand>
+		<unicodeCommand>ě</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \u{e} -->
+	<commandDefinition>
+		<latexCommand>\u{e}</latexCommand>
+		<unicodeCommand>ĕ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \={e} -->
+	<commandDefinition>
+		<latexCommand>\={e}</latexCommand>
+		<unicodeCommand>ē</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \k{e} -->
+	<commandDefinition>
+		<latexCommand>\k{e}</latexCommand>
+		<unicodeCommand>ę</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T1</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{e} -->
+	<commandDefinition>
+		<latexCommand>\d{e}</latexCommand>
+		<unicodeCommand>ẹ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{F} -->
+	<commandDefinition>
+		<latexCommand>\.{F}</latexCommand>
+		<unicodeCommand>Ḟ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{f} -->
+	<commandDefinition>
+		<latexCommand>\.{f}</latexCommand>
+		<unicodeCommand>ḟ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{G} -->
+	<commandDefinition>
+		<latexCommand>\.{G}</latexCommand>
+		<unicodeCommand>Ġ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{G} -->
+	<commandDefinition>
+		<latexCommand>\c{G}</latexCommand>
+		<unicodeCommand>Ģ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{G} -->
+	<commandDefinition>
+		<latexCommand>\'{G}</latexCommand>
+		<unicodeCommand>Ǵ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{G} -->
+	<commandDefinition>
+		<latexCommand>\^{G}</latexCommand>
+		<unicodeCommand>Ĝ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{G} -->
+	<commandDefinition>
+		<latexCommand>\v{G}</latexCommand>
+		<unicodeCommand>Ǧ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \u{G} -->
+	<commandDefinition>
+		<latexCommand>\u{G}</latexCommand>
+		<unicodeCommand>Ğ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \={G} -->
+	<commandDefinition>
+		<latexCommand>\={G}</latexCommand>
+		<unicodeCommand>Ḡ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{g} -->
+	<commandDefinition>
+		<latexCommand>\.{g}</latexCommand>
+		<unicodeCommand>ġ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{g} -->
+	<commandDefinition>
+		<latexCommand>\c{g}</latexCommand>
+		<unicodeCommand>ģ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{g} -->
+	<commandDefinition>
+		<latexCommand>\'{g}</latexCommand>
+		<unicodeCommand>ǵ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{g} -->
+	<commandDefinition>
+		<latexCommand>\^{g}</latexCommand>
+		<unicodeCommand>ĝ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{g} -->
+	<commandDefinition>
+		<latexCommand>\v{g}</latexCommand>
+		<unicodeCommand>ǧ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \u{g} -->
+	<commandDefinition>
+		<latexCommand>\u{g}</latexCommand>
+		<unicodeCommand>ğ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \={g} -->
+	<commandDefinition>
+		<latexCommand>\={g}</latexCommand>
+		<unicodeCommand>ḡ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{H} -->
+	<commandDefinition>
+		<latexCommand>\"{H}</latexCommand>
+		<unicodeCommand>Ḧ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{H} -->
+	<commandDefinition>
+		<latexCommand>\c{H}</latexCommand>
+		<unicodeCommand>Ḩ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{H} -->
+	<commandDefinition>
+		<latexCommand>\.{H}</latexCommand>
+		<unicodeCommand>Ḣ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{H} -->
+	<commandDefinition>
+		<latexCommand>\^{H}</latexCommand>
+		<unicodeCommand>Ĥ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{H} -->
+	<commandDefinition>
+		<latexCommand>\v{H}</latexCommand>
+		<unicodeCommand>Ȟ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \b{H} -->
+	<commandDefinition>
+		<latexCommand>\b{H}</latexCommand>
+		<unicodeCommand>H̱</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{H} -->
+	<commandDefinition>
+		<latexCommand>\d{H}</latexCommand>
+		<unicodeCommand>Ḥ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=fclfont ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \B{H} -->
+	<commandDefinition>
+		<latexCommand>\B{H}</latexCommand>
+		<unicodeCommand>Ħ</unicodeCommand>
+		<package>
+			<name>fclfont</name>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{h} -->
+	<commandDefinition>
+		<latexCommand>\"{h}</latexCommand>
+		<unicodeCommand>ḧ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{h} -->
+	<commandDefinition>
+		<latexCommand>\c{h}</latexCommand>
+		<unicodeCommand>ḩ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{h} -->
+	<commandDefinition>
+		<latexCommand>\.{h}</latexCommand>
+		<unicodeCommand>ḣ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{h} -->
+	<commandDefinition>
+		<latexCommand>\^{h}</latexCommand>
+		<unicodeCommand>ĥ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{h} -->
+	<commandDefinition>
+		<latexCommand>\v{h}</latexCommand>
+		<unicodeCommand>ȟ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \b{h} -->
+	<commandDefinition>
+		<latexCommand>\b{h}</latexCommand>
+		<unicodeCommand>ẖ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{h} -->
+	<commandDefinition>
+		<latexCommand>\d{h}</latexCommand>
+		<unicodeCommand>ḥ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=fclfont ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \B{h} -->
+	<commandDefinition>
+		<latexCommand>\B{h}</latexCommand>
+		<unicodeCommand>ħ</unicodeCommand>
+		<package>
+			<name>fclfont</name>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{I} -->
+	<commandDefinition>
+		<latexCommand>\"{I}</latexCommand>
+		<unicodeCommand>Ï</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{I} -->
+	<commandDefinition>
+		<latexCommand>\.{I}</latexCommand>
+		<unicodeCommand>İ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \H{I} -->
+	<commandDefinition>
+		<latexCommand>\H{I}</latexCommand>
+		<unicodeCommand>I̋</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{I} -->
+	<commandDefinition>
+		<latexCommand>\'{I}</latexCommand>
+		<unicodeCommand>Í</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \`{I} -->
+	<commandDefinition>
+		<latexCommand>\`{I}</latexCommand>
+		<unicodeCommand>Ì</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \~{I} -->
+	<commandDefinition>
+		<latexCommand>\~{I}</latexCommand>
+		<unicodeCommand>Ĩ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{I} -->
+	<commandDefinition>
+		<latexCommand>\^{I}</latexCommand>
+		<unicodeCommand>Î</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{I} -->
+	<commandDefinition>
+		<latexCommand>\v{I}</latexCommand>
+		<unicodeCommand>Ǐ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \u{I} -->
+	<commandDefinition>
+		<latexCommand>\u{I}</latexCommand>
+		<unicodeCommand>Ĭ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \={I} -->
+	<commandDefinition>
+		<latexCommand>\={I}</latexCommand>
+		<unicodeCommand>Ī</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \k{I} -->
+	<commandDefinition>
+		<latexCommand>\k{I}</latexCommand>
+		<unicodeCommand>Į</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T1</arguments>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{I} -->
+	<commandDefinition>
+		<latexCommand>\d{I}</latexCommand>
+		<unicodeCommand>Ị</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \i{} -->
+	<commandDefinition>
+		<latexCommand>\i{}</latexCommand>
+		<unicodeCommand>ı</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{\i} -->
+	<commandDefinition>
+		<latexCommand>\"{\i}</latexCommand>
+		<unicodeCommand>ï</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \H{\i} -->
+	<commandDefinition>
+		<latexCommand>\H{\i}</latexCommand>
+		<unicodeCommand>ı̋</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{\i} -->
+	<commandDefinition>
+		<latexCommand>\'{\i}</latexCommand>
+		<unicodeCommand>í</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \`{\i} -->
+	<commandDefinition>
+		<latexCommand>\`{\i}</latexCommand>
+		<unicodeCommand>ì</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \~{\i} -->
+	<commandDefinition>
+		<latexCommand>\~{\i}</latexCommand>
+		<unicodeCommand>ĩ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{\i} -->
+	<commandDefinition>
+		<latexCommand>\^{\i}</latexCommand>
+		<unicodeCommand>î</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{i} -->
+	<commandDefinition>
+		<latexCommand>\v{\i}</latexCommand>
+		<unicodeCommand>ǐ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \u{i} -->
+	<commandDefinition>
+		<latexCommand>\u{\i}</latexCommand>
+		<unicodeCommand>ĭ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \={\i} -->
+	<commandDefinition>
+		<latexCommand>\={\i}</latexCommand>
+		<unicodeCommand>ī</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \k{i} -->
+	<commandDefinition>
+		<latexCommand>\k{i}</latexCommand>
+		<unicodeCommand>į</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T1</arguments>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{i} -->
+	<commandDefinition>
+		<latexCommand>\d{i}</latexCommand>
+		<unicodeCommand>ị</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \IJ{} -->
+	<commandDefinition>
+		<latexCommand>\IJ{}</latexCommand>
+		<unicodeCommand>Ĳ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \ij{} -->
+	<commandDefinition>
+		<latexCommand>\ij{}</latexCommand>
+		<unicodeCommand>ĳ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{J} -->
+	<commandDefinition>
+		<latexCommand>\^{J}</latexCommand>
+		<unicodeCommand>Ĵ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{J} -->
+	<commandDefinition>
+		<latexCommand>\v{J}</latexCommand>
+		<unicodeCommand>J̌</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{j} -->
+	<commandDefinition>
+		<latexCommand>\^{\j}</latexCommand>
+		<unicodeCommand>ĵ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{j} -->
+	<commandDefinition>
+		<latexCommand>\v{\j}</latexCommand>
+		<unicodeCommand>ǰ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{K} -->
+	<commandDefinition>
+		<latexCommand>\c{K}</latexCommand>
+		<unicodeCommand>Ķ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{K} -->
+	<commandDefinition>
+		<latexCommand>\'{K}</latexCommand>
+		<unicodeCommand>Ḱ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{K} -->
+	<commandDefinition>
+		<latexCommand>\v{K}</latexCommand>
+		<unicodeCommand>Ǩ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \b{K} -->
+	<commandDefinition>
+		<latexCommand>\b{K}</latexCommand>
+		<unicodeCommand>Ḵ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{K} -->
+	<commandDefinition>
+		<latexCommand>\d{K}</latexCommand>
+		<unicodeCommand>Ḳ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{k} -->
+	<commandDefinition>
+		<latexCommand>\c{k}</latexCommand>
+		<unicodeCommand>ķ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{k} -->
+	<commandDefinition>
+		<latexCommand>\'{k}</latexCommand>
+		<unicodeCommand>ḱ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{k} -->
+	<commandDefinition>
+		<latexCommand>\v{k}</latexCommand>
+		<unicodeCommand>ǩ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \b{k} -->
+	<commandDefinition>
+		<latexCommand>\b{k}</latexCommand>
+		<unicodeCommand>ḵ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{k} -->
+	<commandDefinition>
+		<latexCommand>\d{k}</latexCommand>
+		<unicodeCommand>ḳ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{L} -->
+	<commandDefinition>
+		<latexCommand>\c{L}</latexCommand>
+		<unicodeCommand>Ļ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{L} -->
+	<commandDefinition>
+		<latexCommand>\'{L}</latexCommand>
+		<unicodeCommand>Ĺ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \u{L} -->
+	<commandDefinition>
+		<latexCommand>\u{L}</latexCommand>
+		<unicodeCommand>L̆</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{L} -->
+	<commandDefinition>
+		<latexCommand>\v{L}</latexCommand>
+		<unicodeCommand>Ľ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \L{} -->
+	<commandDefinition>
+		<latexCommand>\L{}</latexCommand>
+		<unicodeCommand>Ł</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \b{L} -->
+	<commandDefinition>
+		<latexCommand>\b{L}</latexCommand>
+		<unicodeCommand>Ḻ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{L} -->
+	<commandDefinition>
+		<latexCommand>\d{L}</latexCommand>
+		<unicodeCommand>Ḷ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{l} -->
+	<commandDefinition>
+		<latexCommand>\c{l}</latexCommand>
+		<unicodeCommand>ļ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{l} -->
+	<commandDefinition>
+		<latexCommand>\'{l}</latexCommand>
+		<unicodeCommand>ĺ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \u{l} -->
+	<commandDefinition>
+		<latexCommand>\u{l}</latexCommand>
+		<unicodeCommand>l̆</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{l} -->
+	<commandDefinition>
+		<latexCommand>\v{l}</latexCommand>
+		<unicodeCommand>ľ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \l{} -->
+	<commandDefinition>
+		<latexCommand>\l{}</latexCommand>
+		<unicodeCommand>ł</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \b{l} -->
+	<commandDefinition>
+		<latexCommand>\b{l}</latexCommand>
+		<unicodeCommand>ḻ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{l} -->
+	<commandDefinition>
+		<latexCommand>\d{l}</latexCommand>
+		<unicodeCommand>ḷ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \H{M} -->
+	<commandDefinition>
+		<latexCommand>\H{M}</latexCommand>
+		<unicodeCommand>M̋</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{M} -->
+	<commandDefinition>
+		<latexCommand>\.{M}</latexCommand>
+		<unicodeCommand>Ṁ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{M} -->
+	<commandDefinition>
+		<latexCommand>\'{M}</latexCommand>
+		<unicodeCommand>Ḿ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{M} -->
+	<commandDefinition>
+		<latexCommand>\d{M}</latexCommand>
+		<unicodeCommand>Ṃ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \H{m} -->
+	<commandDefinition>
+		<latexCommand>\H{m}</latexCommand>
+		<unicodeCommand>m̋</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{m} -->
+	<commandDefinition>
+		<latexCommand>\.{m}</latexCommand>
+		<unicodeCommand>ṁ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{m} -->
+	<commandDefinition>
+		<latexCommand>\'{m}</latexCommand>
+		<unicodeCommand>ḿ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{m} -->
+	<commandDefinition>
+		<latexCommand>\d{m}</latexCommand>
+		<unicodeCommand>ṃ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{N} -->
+	<commandDefinition>
+		<latexCommand>\c{N}</latexCommand>
+		<unicodeCommand>Ņ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{N} -->
+	<commandDefinition>
+		<latexCommand>\.{N}</latexCommand>
+		<unicodeCommand>Ṅ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{N} -->
+	<commandDefinition>
+		<latexCommand>\'{N}</latexCommand>
+		<unicodeCommand>Ń</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \`{N} -->
+	<commandDefinition>
+		<latexCommand>\`{N}</latexCommand>
+		<unicodeCommand>Ǹ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \~{N} -->
+	<commandDefinition>
+		<latexCommand>\~{N}</latexCommand>
+		<unicodeCommand>Ñ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{N} -->
+	<commandDefinition>
+		<latexCommand>\v{N}</latexCommand>
+		<unicodeCommand>Ň</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \u{N} -->
+	<commandDefinition>
+		<latexCommand>\u{N}</latexCommand>
+		<unicodeCommand>N̆</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \b{N} -->
+	<commandDefinition>
+		<latexCommand>\b{N}</latexCommand>
+		<unicodeCommand>Ṉ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{N} -->
+	<commandDefinition>
+		<latexCommand>\d{N}</latexCommand>
+		<unicodeCommand>Ṇ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{n} -->
+	<commandDefinition>
+		<latexCommand>\c{n}</latexCommand>
+		<unicodeCommand>ņ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{n} -->
+	<commandDefinition>
+		<latexCommand>\.{n}</latexCommand>
+		<unicodeCommand>ṅ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{n} -->
+	<commandDefinition>
+		<latexCommand>\'{n}</latexCommand>
+		<unicodeCommand>ń</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \`{n} -->
+	<commandDefinition>
+		<latexCommand>\`{n}</latexCommand>
+		<unicodeCommand>ǹ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \~{n} -->
+	<commandDefinition>
+		<latexCommand>\~{n}</latexCommand>
+		<unicodeCommand>ñ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{n} -->
+	<commandDefinition>
+		<latexCommand>\v{n}</latexCommand>
+		<unicodeCommand>ň</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \u{n} -->
+	<commandDefinition>
+		<latexCommand>\u{n}</latexCommand>
+		<unicodeCommand>n̆</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \b{n} -->
+	<commandDefinition>
+		<latexCommand>\b{n}</latexCommand>
+		<unicodeCommand>ṉ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{n} -->
+	<commandDefinition>
+		<latexCommand>\d{n}</latexCommand>
+		<unicodeCommand>ṇ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \NG{} -->
+	<commandDefinition>
+		<latexCommand>\NG{}</latexCommand>
+		<unicodeCommand>Ŋ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T1</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \ng{} -->
+	<commandDefinition>
+		<latexCommand>\ng{}</latexCommand>
+		<unicodeCommand>ŋ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T1</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{O} -->
+	<commandDefinition>
+		<latexCommand>\"{O}</latexCommand>
+		<unicodeCommand>Ö</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \H{O} -->
+	<commandDefinition>
+		<latexCommand>\H{O}</latexCommand>
+		<unicodeCommand>Ő</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \H{O} -->
+	<commandDefinition>
+		<latexCommand>\.{O}</latexCommand>
+		<unicodeCommand>Ȯ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{O} -->
+	<commandDefinition>
+		<latexCommand>\'{O}</latexCommand>
+		<unicodeCommand>Ó</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \`{O} -->
+	<commandDefinition>
+		<latexCommand>\`{O}</latexCommand>
+		<unicodeCommand>Ò</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \~{O} -->
+	<commandDefinition>
+		<latexCommand>\~{O}</latexCommand>
+		<unicodeCommand>Õ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{O} -->
+	<commandDefinition>
+		<latexCommand>\^{O}</latexCommand>
+		<unicodeCommand>Ô</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{O} -->
+	<commandDefinition>
+		<latexCommand>\v{O}</latexCommand>
+		<unicodeCommand>Ǒ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \u{O} -->
+	<commandDefinition>
+		<latexCommand>\u{O}</latexCommand>
+		<unicodeCommand>Ŏ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \={O} -->
+	<commandDefinition>
+		<latexCommand>\={O}</latexCommand>
+		<unicodeCommand>Ō</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \O{} -->
+	<commandDefinition>
+		<latexCommand>\O{}</latexCommand>
+		<unicodeCommand>Ø</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \k{O} -->
+	<commandDefinition>
+		<latexCommand>\k{O}</latexCommand>
+		<unicodeCommand>Ǫ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T1</arguments>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{O} -->
+	<commandDefinition>
+		<latexCommand>\d{O}</latexCommand>
+		<unicodeCommand>Ọ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{o} -->
+	<commandDefinition>
+		<latexCommand>\"{o}</latexCommand>
+		<unicodeCommand>ö</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \H{o} -->
+	<commandDefinition>
+		<latexCommand>\H{o}</latexCommand>
+		<unicodeCommand>ő</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{o} -->
+	<commandDefinition>
+		<latexCommand>\.{o}</latexCommand>
+		<unicodeCommand>ȯ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{o} -->
+	<commandDefinition>
+		<latexCommand>\'{o}</latexCommand>
+		<unicodeCommand>ó</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \`{o} -->
+	<commandDefinition>
+		<latexCommand>\`{o}</latexCommand>
+		<unicodeCommand>ò</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \~{o} -->
+	<commandDefinition>
+		<latexCommand>\~{o}</latexCommand>
+		<unicodeCommand>õ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{o} -->
+	<commandDefinition>
+		<latexCommand>\^{o}</latexCommand>
+		<unicodeCommand>ô</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{o} -->
+	<commandDefinition>
+		<latexCommand>\v{o}</latexCommand>
+		<unicodeCommand>ǒ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \u{o} -->
+	<commandDefinition>
+		<latexCommand>\u{o}</latexCommand>
+		<unicodeCommand>ŏ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \={o} -->
+	<commandDefinition>
+		<latexCommand>\={o}</latexCommand>
+		<unicodeCommand>ō</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \o{} -->
+	<commandDefinition>
+		<latexCommand>\o{}</latexCommand>
+		<unicodeCommand>ø</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \k{o} -->
+	<commandDefinition>
+		<latexCommand>\k{o}</latexCommand>
+		<unicodeCommand>ǫ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T1</arguments>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{o} -->
+	<commandDefinition>
+		<latexCommand>\d{o}</latexCommand>
+		<unicodeCommand>ọ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \OE{} -->
+	<commandDefinition>
+		<latexCommand>\OE{}</latexCommand>
+		<unicodeCommand>Œ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \oe{} -->
+	<commandDefinition>
+		<latexCommand>\oe{}</latexCommand>
+		<unicodeCommand>œ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{P} -->
+	<commandDefinition>
+		<latexCommand>\.{P}</latexCommand>
+		<unicodeCommand>Ṗ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{P} -->
+	<commandDefinition>
+		<latexCommand>\'{P}</latexCommand>
+		<unicodeCommand>Ṕ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{p} -->
+	<commandDefinition>
+		<latexCommand>\.{p}</latexCommand>
+		<unicodeCommand>ṗ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{p} -->
+	<commandDefinition>
+		<latexCommand>\'{p}</latexCommand>
+		<unicodeCommand>ṕ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{R} -->
+	<commandDefinition>
+		<latexCommand>\c{R}</latexCommand>
+		<unicodeCommand>Ŗ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{R} -->
+	<commandDefinition>
+		<latexCommand>\.{R}</latexCommand>
+		<unicodeCommand>Ṙ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{R} -->
+	<commandDefinition>
+		<latexCommand>\'{R}</latexCommand>
+		<unicodeCommand>Ŕ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{R} -->
+	<commandDefinition>
+		<latexCommand>\v{R}</latexCommand>
+		<unicodeCommand>Ř</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \b{R} -->
+	<commandDefinition>
+		<latexCommand>\b{R}</latexCommand>
+		<unicodeCommand>Ṟ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{R} -->
+	<commandDefinition>
+		<latexCommand>\d{R}</latexCommand>
+		<unicodeCommand>Ṛ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{r} -->
+	<commandDefinition>
+		<latexCommand>\c{r}</latexCommand>
+		<unicodeCommand>ŗ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{r} -->
+	<commandDefinition>
+		<latexCommand>\.{r}</latexCommand>
+		<unicodeCommand>ṙ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{r} -->
+	<commandDefinition>
+		<latexCommand>\'{r}</latexCommand>
+		<unicodeCommand>ŕ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{r} -->
+	<commandDefinition>
+		<latexCommand>\v{r}</latexCommand>
+		<unicodeCommand>ř</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \b{r} -->
+	<commandDefinition>
+		<latexCommand>\b{r}</latexCommand>
+		<unicodeCommand>ṟ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{r} -->
+	<commandDefinition>
+		<latexCommand>\d{r}</latexCommand>
+		<unicodeCommand>ṛ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{S} -->
+	<commandDefinition>
+		<latexCommand>\c{S}</latexCommand>
+		<unicodeCommand>Ş</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{S} -->
+	<commandDefinition>
+		<latexCommand>\.{S}</latexCommand>
+		<unicodeCommand>Ṡ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=inputenc ,pkgsarg=latin10 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textcommabelow{S} -->
+	<commandDefinition>
+		<latexCommand>\textcommabelow{S}</latexCommand>
+		<unicodeCommand>Ș</unicodeCommand>
+		<package>
+			<name>inputenc</name>
+			<arguments>latin10</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{S} -->
+	<commandDefinition>
+		<latexCommand>\'{S}</latexCommand>
+		<unicodeCommand>Ś</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{S} -->
+	<commandDefinition>
+		<latexCommand>\^{S}</latexCommand>
+		<unicodeCommand>Ŝ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{S} -->
+	<commandDefinition>
+		<latexCommand>\v{S}</latexCommand>
+		<unicodeCommand>Š</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{S} -->
+	<commandDefinition>
+		<latexCommand>\d{S}</latexCommand>
+		<unicodeCommand>Ṣ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{s} -->
+	<commandDefinition>
+		<latexCommand>\c{s}</latexCommand>
+		<unicodeCommand>ş</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{s} -->
+	<commandDefinition>
+		<latexCommand>\.{s}</latexCommand>
+		<unicodeCommand>ṡ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=inputenc ,pkgsarg=latin10 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textcommabelow{s} -->
+	<commandDefinition>
+		<latexCommand>\textcommabelow{s}</latexCommand>
+		<unicodeCommand>ș</unicodeCommand>
+		<package>
+			<name>inputenc</name>
+			<arguments>latin10</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{s} -->
+	<commandDefinition>
+		<latexCommand>\'{s}</latexCommand>
+		<unicodeCommand>ś</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{s} -->
+	<commandDefinition>
+		<latexCommand>\^{s}</latexCommand>
+		<unicodeCommand>ŝ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{s} -->
+	<commandDefinition>
+		<latexCommand>\v{s}</latexCommand>
+		<unicodeCommand>š</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{s} -->
+	<commandDefinition>
+		<latexCommand>\d{s}</latexCommand>
+		<unicodeCommand>ṣ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \SS{} -->
+	<commandDefinition>
+		<latexCommand>\SS{}</latexCommand>
+		<unicodeCommand>SS</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \ss{} -->
+	<commandDefinition>
+		<latexCommand>\ss{}</latexCommand>
+		<unicodeCommand>ß</unicodeCommand>
+	</commandDefinition>
+
+		<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{T} -->
+	<commandDefinition>
+		<latexCommand>\"{T}</latexCommand>
+		<unicodeCommand>T̈</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{T} -->
+	<commandDefinition>
+		<latexCommand>\c{T}</latexCommand>
+		<unicodeCommand>Ţ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{T} -->
+	<commandDefinition>
+		<latexCommand>\.{T}</latexCommand>
+		<unicodeCommand>Ṫ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=inputenc ,pkgsarg=latin10 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textcommabelow{T} -->
+	<commandDefinition>
+		<latexCommand>\textcommabelow{T}</latexCommand>
+		<unicodeCommand>Ț</unicodeCommand>
+		<package>
+			<name>inputenc</name>
+			<arguments>latin10</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{T} -->
+	<commandDefinition>
+		<latexCommand>\v{T}</latexCommand>
+		<unicodeCommand>Ť</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \b{T} -->
+	<commandDefinition>
+		<latexCommand>\b{T}</latexCommand>
+		<unicodeCommand>Ṯ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{T} -->
+	<commandDefinition>
+		<latexCommand>\d{T}</latexCommand>
+		<unicodeCommand>Ṭ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=fclfont ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \mbox{T\hspace{-.5em}-} -->
+	<commandDefinition>
+		<latexCommand>\B{T}</latexCommand>
+		<unicodeCommand>Ŧ</unicodeCommand>
+		<package>
+			<name>fclfont</name>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{t} -->
+	<commandDefinition>
+		<latexCommand>\"{t}</latexCommand>
+		<unicodeCommand>ẗ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \c{t} -->
+	<commandDefinition>
+		<latexCommand>\c{t}</latexCommand>
+		<unicodeCommand>ţ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{t} -->
+	<commandDefinition>
+		<latexCommand>\.{t}</latexCommand>
+		<unicodeCommand>ṫ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=inputenc ,pkgsarg=latin10 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \textcommabelow{t} -->
+	<commandDefinition>
+		<latexCommand>\textcommabelow{t}</latexCommand>
+		<unicodeCommand>ț</unicodeCommand>
+		<package>
+			<name>inputenc</name>
+			<arguments>latin10</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{t} -->
+	<commandDefinition>
+		<latexCommand>\v{t}</latexCommand>
+		<unicodeCommand>ť</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \b{t} -->
+	<commandDefinition>
+		<latexCommand>\b{t}</latexCommand>
+		<unicodeCommand>ṯ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{t} -->
+	<commandDefinition>
+		<latexCommand>\d{t}</latexCommand>
+		<unicodeCommand>ṭ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=fclfont ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \mbox{t\hspace{-.35em}-} -->
+	<commandDefinition>
+		<latexCommand>\B{t}</latexCommand>
+		<unicodeCommand>ŧ</unicodeCommand>
+		<package>
+			<name>fclfont</name>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \TH{} -->
+	<commandDefinition>
+		<latexCommand>\TH{}</latexCommand>
+		<unicodeCommand>Þ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T1</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \th{} -->
+	<commandDefinition>
+		<latexCommand>\th{}</latexCommand>
+		<unicodeCommand>þ</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T1</arguments>
+		</package>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{U} -->
+	<commandDefinition>
+		<latexCommand>\"{U}</latexCommand>
+		<unicodeCommand>Ü</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \H{U} -->
+	<commandDefinition>
+		<latexCommand>\H{U}</latexCommand>
+		<unicodeCommand>Ű</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{U} -->
+	<commandDefinition>
+		<latexCommand>\'{U}</latexCommand>
+		<unicodeCommand>Ú</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \`{U} -->
+	<commandDefinition>
+		<latexCommand>\`{U}</latexCommand>
+		<unicodeCommand>Ù</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \~{U} -->
+	<commandDefinition>
+		<latexCommand>\~{U}</latexCommand>
+		<unicodeCommand>Ũ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{U} -->
+	<commandDefinition>
+		<latexCommand>\^{U}</latexCommand>
+		<unicodeCommand>Û</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{U} -->
+	<commandDefinition>
+		<latexCommand>\v{U}</latexCommand>
+		<unicodeCommand>Ǔ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \u{U} -->
+	<commandDefinition>
+		<latexCommand>\u{U}</latexCommand>
+		<unicodeCommand>Ŭ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \={U} -->
+	<commandDefinition>
+		<latexCommand>\={U}</latexCommand>
+		<unicodeCommand>Ū</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \r{U} -->
+	<commandDefinition>
+		<latexCommand>\r{U}</latexCommand>
+		<unicodeCommand>Ů</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \k{U} -->
+	<commandDefinition>
+		<latexCommand>\k{U}</latexCommand>
+		<unicodeCommand>Ų</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T1</arguments>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{U} -->
+	<commandDefinition>
+		<latexCommand>\d{U}</latexCommand>
+		<unicodeCommand>Ụ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{u} -->
+	<commandDefinition>
+		<latexCommand>\"{u}</latexCommand>
+		<unicodeCommand>ü</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \H{u} -->
+	<commandDefinition>
+		<latexCommand>\H{u}</latexCommand>
+		<unicodeCommand>ű</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{u} -->
+	<commandDefinition>
+		<latexCommand>\'{u}</latexCommand>
+		<unicodeCommand>ú</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \`{u} -->
+	<commandDefinition>
+		<latexCommand>\`{u}</latexCommand>
+		<unicodeCommand>ù</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \~{u} -->
+	<commandDefinition>
+		<latexCommand>\~{u}</latexCommand>
+		<unicodeCommand>ũ</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{u} -->
+	<commandDefinition>
+		<latexCommand>\^{u}</latexCommand>
+		<unicodeCommand>û</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{u} -->
+	<commandDefinition>
+		<latexCommand>\v{u}</latexCommand>
+		<unicodeCommand>ǔ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \u{u} -->
+	<commandDefinition>
+		<latexCommand>\u{u}</latexCommand>
+		<unicodeCommand>ŭ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \={u} -->
+	<commandDefinition>
+		<latexCommand>\={u}</latexCommand>
+		<unicodeCommand>ū</unicodeCommand>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \{} -->
+	<commandDefinition>
+		<latexCommand>\d{u}</latexCommand>
+		<unicodeCommand>ụ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \r{u} -->
+	<commandDefinition>
+		<latexCommand>\r{u}</latexCommand>
+		<unicodeCommand>ů</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs=fontenc ,pkgsarg=T1 ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \k{u} -->
+	<commandDefinition>
+		<latexCommand>\k{u}</latexCommand>
+		<unicodeCommand>ų</unicodeCommand>
+		<package>
+			<name>fontenc</name>
+			<arguments>T1</arguments>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \~{V} -->
+	<commandDefinition>
+		<latexCommand>\~{V}</latexCommand>
+		<unicodeCommand>Ṽ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{V} -->
+	<commandDefinition>
+		<latexCommand>\d{V}</latexCommand>
+		<unicodeCommand>Ṿ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \~{v} -->
+	<commandDefinition>
+		<latexCommand>\~{v}</latexCommand>
+		<unicodeCommand>ṽ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{v} -->
+	<commandDefinition>
+		<latexCommand>\d{v}</latexCommand>
+		<unicodeCommand>ṿ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{W} -->
+	<commandDefinition>
+		<latexCommand>\"{W}</latexCommand>
+		<unicodeCommand>Ẅ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{W} -->
+	<commandDefinition>
+		<latexCommand>\.{W}</latexCommand>
+		<unicodeCommand>Ẇ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{W} -->
+	<commandDefinition>
+		<latexCommand>\'{W}</latexCommand>
+		<unicodeCommand>Ẃ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \`{W} -->
+	<commandDefinition>
+		<latexCommand>\`{W}</latexCommand>
+		<unicodeCommand>Ẁ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{W} -->
+	<commandDefinition>
+		<latexCommand>\^{W}</latexCommand>
+		<unicodeCommand>Ŵ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \r{W} -->
+	<commandDefinition>
+		<latexCommand>\r{W}</latexCommand>
+		<unicodeCommand>W̊</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{W} -->
+	<commandDefinition>
+		<latexCommand>\d{W}</latexCommand>
+		<unicodeCommand>Ẉ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{w} -->
+	<commandDefinition>
+		<latexCommand>\"{w}</latexCommand>
+		<unicodeCommand>ẅ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{w} -->
+	<commandDefinition>
+		<latexCommand>\.{w}</latexCommand>
+		<unicodeCommand>ẇ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{w} -->
+	<commandDefinition>
+		<latexCommand>\'{w}</latexCommand>
+		<unicodeCommand>ẃ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \`{w} -->
+	<commandDefinition>
+		<latexCommand>\`{w}</latexCommand>
+		<unicodeCommand>ẁ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{w} -->
+	<commandDefinition>
+		<latexCommand>\^{w}</latexCommand>
+		<unicodeCommand>ŵ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{w} -->
+	<commandDefinition>
+		<latexCommand>\d{w}</latexCommand>
+		<unicodeCommand>ẉ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \r{w} -->
+	<commandDefinition>
+		<latexCommand>\r{w}</latexCommand>
+		<unicodeCommand>ẘ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{X} -->
+	<commandDefinition>
+		<latexCommand>\"{X}</latexCommand>
+		<unicodeCommand>Ẍ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{X} -->
+	<commandDefinition>
+		<latexCommand>\.{X}</latexCommand>
+		<unicodeCommand>Ẋ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{x} -->
+	<commandDefinition>
+		<latexCommand>\"{x}</latexCommand>
+		<unicodeCommand>ẍ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{x} -->
+	<commandDefinition>
+		<latexCommand>\.{x}</latexCommand>
+		<unicodeCommand>ẋ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{Y} -->
+	<commandDefinition>
+		<latexCommand>\"{Y}</latexCommand>
+		<unicodeCommand>Ÿ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{Y} -->
+	<commandDefinition>
+		<latexCommand>\.{Y}</latexCommand>
+		<unicodeCommand>Ẏ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{Y} -->
+	<commandDefinition>
+		<latexCommand>\'{Y}</latexCommand>
+		<unicodeCommand>Ý</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \`{Y} -->
+	<commandDefinition>
+		<latexCommand>\`{Y}</latexCommand>
+		<unicodeCommand>Ỳ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \~{Y} -->
+	<commandDefinition>
+		<latexCommand>\~{Y}</latexCommand>
+		<unicodeCommand>Ỹ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{Y} -->
+	<commandDefinition>
+		<latexCommand>\^{Y}</latexCommand>
+		<unicodeCommand>Ŷ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \={Y} -->
+	<commandDefinition>
+		<latexCommand>\={Y}</latexCommand>
+		<unicodeCommand>Ȳ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{} -->
+	<commandDefinition>
+		<latexCommand>\d{Y}</latexCommand>
+		<unicodeCommand>Ỵ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \r{} -->
+	<commandDefinition>
+		<latexCommand>\r{Y}</latexCommand>
+		<unicodeCommand>Y̊</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \"{y} -->
+	<commandDefinition>
+		<latexCommand>\"{y}</latexCommand>
+		<unicodeCommand>ÿ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{y} -->
+	<commandDefinition>
+		<latexCommand>\.{y}</latexCommand>
+		<unicodeCommand>ẏ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{y} -->
+	<commandDefinition>
+		<latexCommand>\'{y}</latexCommand>
+		<unicodeCommand>ý</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \`{y} -->
+	<commandDefinition>
+		<latexCommand>\`{y}</latexCommand>
+		<unicodeCommand>ỳ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \~{y} -->
+	<commandDefinition>
+		<latexCommand>\~{y}</latexCommand>
+		<unicodeCommand>ỹ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{y} -->
+	<commandDefinition>
+		<latexCommand>\^{y}</latexCommand>
+		<unicodeCommand>ŷ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \={y} -->
+	<commandDefinition>
+		<latexCommand>\={y}</latexCommand>
+		<unicodeCommand>ȳ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{y} -->
+	<commandDefinition>
+		<latexCommand>\d{y}</latexCommand>
+		<unicodeCommand>ỵ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \r{y} -->
+	<commandDefinition>
+		<latexCommand>\r{y}</latexCommand>
+		<unicodeCommand>ẙ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{Z} -->
+	<commandDefinition>
+		<latexCommand>\.{Z}</latexCommand>
+		<unicodeCommand>Ż</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{Z} -->
+	<commandDefinition>
+		<latexCommand>\'{Z}</latexCommand>
+		<unicodeCommand>Ź</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{Z} -->
+	<commandDefinition>
+		<latexCommand>\^{Z}</latexCommand>
+		<unicodeCommand>Ẑ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{Z} -->
+	<commandDefinition>
+		<latexCommand>\v{Z}</latexCommand>
+		<unicodeCommand>Ž</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \b{Z} -->
+	<commandDefinition>
+		<latexCommand>\b{Z}</latexCommand>
+		<unicodeCommand>Ẕ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{Z} -->
+	<commandDefinition>
+		<latexCommand>\d{Z}</latexCommand>
+		<unicodeCommand>Ẓ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \.{z} -->
+	<commandDefinition>
+		<latexCommand>\.{z}</latexCommand>
+		<unicodeCommand>ż</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \'{z} -->
+	<commandDefinition>
+		<latexCommand>\'{z}</latexCommand>
+		<unicodeCommand>ź</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \^{z} -->
+	<commandDefinition>
+		<latexCommand>\^{z}</latexCommand>
+		<unicodeCommand>ẑ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \v{z} -->
+	<commandDefinition>
+		<latexCommand>\v{z}</latexCommand>
+		<unicodeCommand>ž</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \b{z} -->
+	<commandDefinition>
+		<latexCommand>\b{z}</latexCommand>
+		<unicodeCommand>ẕ</unicodeCommand>
+	</commandDefinition>
+
+	<!-- pkgs= ,pkgsarg= ,savepkgs= ,savepkgsarg= -->
+	<!-- arg \d{z} -->
+	<commandDefinition>
+		<latexCommand>\d{z}</latexCommand>
+		<unicodeCommand>ẓ</unicodeCommand>
+	</commandDefinition>
+
 </symbols>

--- a/symbols-ng/wasysym.xml
+++ b/symbols-ng/wasysym.xml
@@ -3,972 +3,1095 @@
 <!DOCTYPE KileSymbolSources>
 <symbols>
 
-   <formatVersion major="0" minor ="22" />
-
-   <symbolGroupName>user</symbolGroupName>
-
-   <preamble>
-      <class>article</class>
-      <arguments>12pt</arguments>
-      <additional>\pagestyle{empty}
-		  \setlength{\parindent}{0cm}
-		  \usepackage[T1]{fontenc}
-      </additional>
-   </preamble>
-
-   <unicodeCommandPackages>
-      <package>
-         <name>inputenc</name>
-         <arguments>utf8</arguments>
-      </package>
-   </unicodeCommandPackages>
-
-   <!-- insert stuff here    -->
-<symbolGroupName>wasysym</symbolGroupName>
-
-<commandDefinition>
-<latexCommand>\male</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\female</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\currency</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\phone</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\recorder</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\clock</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\lightning</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\pointer</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\RIGHTarrow</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\LEFTarrow</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\UParrow</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\DOWNarrow</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\AC</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\HF</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\VHF</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\Square</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\CheckedBox</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<forcePNG>true</forcePNG>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\XBox</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\hexagon</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\pentagon</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\octagon</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\varhexagon</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\hexstar</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\varhexstar</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\davidsstar</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\diameter</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\invdiameter</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\varangle</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\wasylozenge</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\kreuz</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\smiley</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\frownie</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\blacksmiley</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\sun</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\checked</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\bell</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\eighthnote</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\quarternote</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\halfnote</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\fullnote</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\twonotes</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\brokenvert</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\ataribox</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\wasytherefore</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\Circle</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\CIRCLE</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\Leftcircle</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\LEFTCIRCLE</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\Rightcircle</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\RIGHTCIRCLE</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\LEFTcircle</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\RIGHTcircle</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\vernal</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\ascnode</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\descnode</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\fullmoon</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\newmoon</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\leftmoon</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\rightmoon</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\astrosun</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\mercury</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\venus</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\earth</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\mars</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\jupiter</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\saturn</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\uranus</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\neptune</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\pluto</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\aries</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\taurus</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\gemini</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\cancer</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\leo</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\virgo</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\libra</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\scorpio</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\sagittarius</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\capricornus</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\aquarius</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\pisces</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\conjunction</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\opposition</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\APLstar</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\APLlog</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\APLbox</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\APLup</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\APLdown</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\APLinput</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\APLcomment</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\APLinv</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\APLuparrowbox</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\APLdownarrowbox</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\APLleftarrowbox</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\APLrightarrowbox</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\notbackslash</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\notslash</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\APLminus</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\APLnot{}</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\APLcirc{}</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\APLvert{}</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\Bowtie</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\leftturn</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\rightturn</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\photon</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\gluon</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\cent</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\permil</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\agemO</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\thorn</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\Thorn</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\openo</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\inve</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\mho</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\Join</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\Box</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\Diamond</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\leadsto</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\sqsubset</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\sqsupset</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\lhd</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\unlhd</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\LHD</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\rhd</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\unrhd</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\RHD</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\apprle</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\apprge</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\wasypropto</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\invneg</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\ocircle</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
-<commandDefinition>
-<latexCommand>\logof</latexCommand>
-<package>
-<name>wasysym</name>
-</package>
-<mathMode>true</mathMode>
-</commandDefinition>
-
+	<formatVersion major="0" minor ="22" />
+
+	<symbolGroupName>user</symbolGroupName>
+
+	<preamble>
+		<class>standalone</class>
+		<arguments>10bp,margin=1bp</arguments>
+		<additional>\usepackage[T1]{fontenc}</additional>
+	</preamble>
+
+	<unicodeCommandPackages>
+		<package>
+			<name>inputenc</name>
+			<arguments>utf8</arguments>
+		</package>
+	</unicodeCommandPackages>
+
+	<!-- insert stuff here -->
+
+	<symbolGroupName>wasysym</symbolGroupName>
+
+	<commandDefinition>
+		<latexCommand>\male</latexCommand>
+		<unicodeCommand>♂</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\female</latexCommand>
+		<unicodeCommand>♀</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\currency</latexCommand>
+		<unicodeCommand>¤</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\phone</latexCommand>
+		<unicodeCommand>☎</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\recorder</latexCommand>
+		<unicodeCommand>⌕</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\clock</latexCommand>
+		<unicodeCommand>⏲</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\lightning</latexCommand>
+		<unicodeCommand>↯</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\pointer</latexCommand>
+		<unicodeCommand>⇨</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\RIGHTarrow</latexCommand>
+		<unicodeCommand>⏵</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\LEFTarrow</latexCommand>
+		<unicodeCommand>⏴</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\UParrow</latexCommand>
+		<unicodeCommand>⏶</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\DOWNarrow</latexCommand>
+		<unicodeCommand>⏷</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\AC</latexCommand>
+		<unicodeCommand>⁓</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\HF</latexCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\VHF</latexCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\Square</latexCommand>
+		<unicodeCommand>☐</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\CheckedBox</latexCommand>
+		<unicodeCommand>☑</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<!-- <forcePNG>true</forcePNG> -->
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\XBox</latexCommand>
+		<unicodeCommand>☒</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\hexagon</latexCommand>
+		<unicodeCommand>⎔</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\pentagon</latexCommand>
+		<unicodeCommand>⬠</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\octagon</latexCommand>
+		<unicodeCommand>⯃</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\varhexagon</latexCommand>
+		<unicodeCommand>⬡</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\hexstar</latexCommand>
+		<unicodeCommand>⚹</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\varhexstar</latexCommand>
+		<unicodeCommand>✲</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\davidsstar</latexCommand>
+		<unicodeCommand>✡</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\diameter</latexCommand>
+		<unicodeCommand>⌀</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\invdiameter</latexCommand>
+		<unicodeCommand>⍉</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\varangle</latexCommand>
+		<unicodeCommand>∢</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\wasylozenge</latexCommand>
+		<unicodeCommand>⌑</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\kreuz</latexCommand>
+		<unicodeCommand>🕂</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\smiley</latexCommand>
+		<unicodeCommand>☺</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\frownie</latexCommand>
+		<unicodeCommand>☹</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\blacksmiley</latexCommand>
+		<unicodeCommand>☻</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\sun</latexCommand>
+		<unicodeCommand>☼</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\checked</latexCommand>
+		<unicodeCommand>🗸</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\bell</latexCommand>
+		<unicodeCommand>🕭</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\eighthnote</latexCommand>
+		<unicodeCommand>♪</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\quarternote</latexCommand>
+		<unicodeCommand>♩</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\halfnote</latexCommand>
+		<unicodeCommand>𝅗𝅥</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\fullnote</latexCommand>
+		<unicodeCommand>𝅝</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\twonotes</latexCommand>
+		<unicodeCommand>🎝</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\brokenvert</latexCommand>
+		<unicodeCommand>¦</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\ataribox</latexCommand>
+		<unicodeCommand>⌺</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\wasytherefore</latexCommand>
+		<unicodeCommand>∴</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\Circle</latexCommand>
+		<unicodeCommand>○</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\CIRCLE</latexCommand>
+		<unicodeCommand>●</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\Leftcircle</latexCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\Rightcircle</latexCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\LEFTCIRCLE</latexCommand>
+		<unicodeCommand>◖</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\RIGHTCIRCLE</latexCommand>
+		<unicodeCommand>◗</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\LEFTcircle</latexCommand>
+		<unicodeCommand>◐</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\RIGHTcircle</latexCommand>
+		<unicodeCommand>◑</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\vernal</latexCommand>
+		<unicodeCommand>♈︎</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\ascnode</latexCommand>
+		<unicodeCommand>☊</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\descnode</latexCommand>
+		<unicodeCommand>☋</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\fullmoon</latexCommand>
+		<unicodeCommand>🌕</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\newmoon</latexCommand>
+		<unicodeCommand>🌑</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\leftmoon</latexCommand>
+		<unicodeCommand>☾</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\rightmoon</latexCommand>
+		<unicodeCommand>☽</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\astrosun</latexCommand>
+		<unicodeCommand>☉</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\mercury</latexCommand>
+		<unicodeCommand>☿</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\venus</latexCommand>
+		<unicodeCommand>♀</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\earth</latexCommand>
+		<unicodeCommand>♁</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\mars</latexCommand>
+		<unicodeCommand>♂</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\jupiter</latexCommand>
+		<unicodeCommand>♃</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\saturn</latexCommand>
+		<unicodeCommand>♄</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\uranus</latexCommand>
+		<unicodeCommand>♅</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\neptune</latexCommand>
+		<unicodeCommand>♆</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\pluto</latexCommand>
+		<unicodeCommand>♇</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\aries</latexCommand>
+		<unicodeCommand>♈</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\taurus</latexCommand>
+		<unicodeCommand>♉</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\gemini</latexCommand>
+		<unicodeCommand>♊</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\cancer</latexCommand>
+		<unicodeCommand>♋</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\leo</latexCommand>
+		<unicodeCommand>♌</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\virgo</latexCommand>
+		<unicodeCommand>♍</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\libra</latexCommand>
+		<unicodeCommand>♎</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\scorpio</latexCommand>
+		<unicodeCommand>♏</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\sagittarius</latexCommand>
+		<unicodeCommand>♐</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\capricornus</latexCommand>
+		<unicodeCommand>♑</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\aquarius</latexCommand>
+		<unicodeCommand>♒</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\pisces</latexCommand>
+		<unicodeCommand>♓</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\conjunction</latexCommand>
+		<unicodeCommand>☌</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\opposition</latexCommand>
+		<unicodeCommand>☍</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\APLstar</latexCommand>
+		<unicodeCommand>＊</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\APLlog</latexCommand>
+		<unicodeCommand>⍟</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\APLbox</latexCommand>
+		<unicodeCommand>⎕</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\APLup</latexCommand>
+		<unicodeCommand>∆</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\APLdown</latexCommand>
+		<unicodeCommand>∇</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\APLinput</latexCommand>
+		<unicodeCommand>⍞</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\APLcomment</latexCommand>
+		<unicodeCommand>⍝</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\APLinv</latexCommand>
+		<unicodeCommand>⌹</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\APLuparrowbox</latexCommand>
+		<unicodeCommand>⍐</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\APLdownarrowbox</latexCommand>
+		<unicodeCommand>⍗</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\APLleftarrowbox</latexCommand>
+		<unicodeCommand>⍇</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\APLrightarrowbox</latexCommand>
+		<unicodeCommand>⍈</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\notbackslash</latexCommand>
+		<unicodeCommand>⍀</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\notslash</latexCommand>
+		<unicodeCommand>⌿</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\APLminus</latexCommand>
+		<unicodeCommand>-</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\APLnot{}</latexCommand>
+		<unicodeCommand>∼</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\APLcirc{}</latexCommand>
+		<unicodeCommand>○</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\APLvert{}</latexCommand>
+		<unicodeCommand>∣</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\Bowtie</latexCommand>
+		<unicodeCommand>⑅</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\leftturn</latexCommand>
+		<unicodeCommand>↺</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\rightturn</latexCommand>
+		<unicodeCommand>↻</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\photon</latexCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\gluon</latexCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\cent</latexCommand>
+		<unicodeCommand>¢</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\permil</latexCommand>
+		<unicodeCommand>‰</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\agemO</latexCommand>
+		<unicodeCommand>Ʊ</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\thorn</latexCommand>
+		<unicodeCommand>þ</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\Thorn</latexCommand>
+		<unicodeCommand>Þ</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\openo</latexCommand>
+		<unicodeCommand>ɔ</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\inve</latexCommand>
+		<unicodeCommand>ǝ</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\mho</latexCommand>
+		<unicodeCommand></unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\Join</latexCommand>
+		<unicodeCommand>⨝</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\Box</latexCommand>
+		<unicodeCommand>□</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\Diamond</latexCommand>
+		<unicodeCommand>◇</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\leadsto</latexCommand>
+		<unicodeCommand>↝</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\sqsubset</latexCommand>
+		<unicodeCommand>⊏</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\sqsupset</latexCommand>
+		<unicodeCommand>⊐</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\lhd</latexCommand>
+		<unicodeCommand>⊲</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\unlhd</latexCommand>
+		<unicodeCommand>⊴</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\LHD</latexCommand>
+		<unicodeCommand>◄</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\rhd</latexCommand>
+		<unicodeCommand>⊳</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\unrhd</latexCommand>
+		<unicodeCommand>⊵</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\RHD</latexCommand>
+		<unicodeCommand>►</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\apprle</latexCommand>
+		<unicodeCommand>≲</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\apprge</latexCommand>
+		<unicodeCommand>≳</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\wasypropto</latexCommand>
+		<unicodeCommand>∝</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\invneg</latexCommand>
+		<unicodeCommand>⌐</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\ocircle</latexCommand>
+		<unicodeCommand>○</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
+
+	<commandDefinition>
+		<latexCommand>\logof</latexCommand>
+		<unicodeCommand>⍟</unicodeCommand>
+		<package>
+			<name>wasysym</name>
+		</package>
+		<mathMode>true</mathMode>
+	</commandDefinition>
 
 </symbols>


### PR DESCRIPTION
Align symbols at typesetting baseline (same height and same depth) whenever possible (unless the symbol is an icon). So the symbol glyphs are the same as in the pdf in terms of relative font sizes and vertical alignment. Meanwhile correct a couple of wrong glyphs or unicodes.