### PR TITLE
remove empty property for comboboxLineNumbers

### DIFF
--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -1653,9 +1653,6 @@ Then you can select a new shortcut by one of the following ways:
                   </item>
                   <item row="11" column="1">
                    <widget class="QComboBox" name="comboboxLineNumbers">
-                    <property name="" stdset="0">
-                     <bool>true</bool>
-                    </property>
                     <item>
                      <property name="text">
                       <string>No Line Numbers</string>


### PR DESCRIPTION
This edit config option sometimes used to be an advanced option:
```
                 <widget class="QComboBox" name="comboboxLineNumbers">
                  <property name="advancedOption" stdset="0">
                   <bool>true</bool>
                  </property>
```
At the end of 2019 it was decided that this option shouldn't be an advanced option any longer. But only the name attribute had been removed from the property:
```
           <widget class="QComboBox" name="comboboxLineNumbers">
            <property stdset="0">
             <bool>true</bool>
            </property>
```
Thus an empty name attribute came back with the next file change (likely with Qt tool) at the beginning of 2020:

```
           <widget class="QComboBox" name="comboboxLineNumbers">
            <property name="" stdset="0">
             <bool>true</bool>
            </property>
```
This survived until today.