### PR TITLE
PDF pinch-zo-zoom fix for macOS

### DIFF
--- a/src/pdfviewer/PDFDocument.h
+++ b/src/pdfviewer/PDFDocument.h
@@ -30,6 +30,7 @@
 #include <QGestureEvent>
 #include <QPinchGesture>
 #include <QTapGesture>
+#include <QTouchEvent>
 #include <QProgressDialog>
 #include <QPainterPath>
 #if QT_VERSION_MAJOR>5
@@ -293,6 +294,7 @@ protected:
 	virtual bool event(QEvent *event);
 
 	bool gestureEvent(QGestureEvent *event);
+	bool touchEvent(QTouchEvent *event);
 	void pinchEvent(QPinchGesture *gesture);
 	void tapEvent(QTapGesture *gesture);
 
@@ -334,6 +336,9 @@ private:
 	int docPages;
 	qreal			saveScaleFactor;
 	autoScaleOption	saveScaleOption;
+	
+	qreal pinchStartedScaleFactor;
+	bool pinchGestureDetected;
 
 	QAction	*ctxZoomInAction;
 	QAction	*ctxZoomOutAction;


### PR DESCRIPTION
For some years, the pinch-to-zoom gesture in the integrated PDF viewer on macOS has been broken. Apparently the `QGestureEvent` returns incorrect coordinates, which causes the page to move sideways while a pinch gesture is performed. The bug still occurs in the [4.5.1beta2](https://github.com/texstudio-org/texstudio/releases/tag/4.5.1beta2) version, only on macOS.

This PR proposes a workaround for this issue. By only using the `QGestureEvent` to detect pinch gestures, while taking the coordinates from the `QTouchEvent`, correct zoom behavior can be achieved on macOS.

It has been successfully tested with macOS Ventura 13.1 and Qt 6.4.1. Please let me know your thoughts.