### PR TITLE
Packages Panel in QuickStart Wizard

### DIFF
--- a/src/quickdocumentdialog.cpp
+++ b/src/quickdocumentdialog.cpp
@@ -283,30 +283,29 @@ void QuickDocumentDialog::Init()
     }
 
 	QTableWidget *table = ui.tableWidgetPackages;
-	table->clear();
-	table->setColumnCount(2);
-	table->setHorizontalHeaderLabels( QStringList( { tr("Package"), tr("Description") } ) );
+	table->clearContents();
 	table->horizontalHeader()->setStretchLastSection(true);
-	table->setSelectionMode(QAbstractItemView::ExtendedSelection);
-	table->setSelectionBehavior(QAbstractItemView::SelectRows);
+	table->setSelectionMode(QAbstractItemView::NoSelection);
+//	table->setSelectionBehavior(QAbstractItemView::SelectRows);
 	table->verticalHeader()->hide();
 
 	//each QStringList holds 2 items: the name of the package, and a short package description. These constitute a row of the table of the packages tab
 	QList<QStringList> packages = QList<QStringList>()
-		<< QStringList( {"amssymb"     , "Mathematical symbols from AMS"} )
-		<< QStringList( {"graphicx"    , "Graphics package, easily include images (s. Insert Graphic Wizard)"} )
-		<< QStringList( {"hyperref"    , "Support for hyperlinks in your document"} )
-		<< QStringList( {"mathtools"   , "Extension package to amsmath incl. fixes for bugs in amsmath, loads amsmath"} )
-		<< QStringList( {"amsthm"      , "Define your theorem like env., has to be loaded after amsmath"} )
-		<< QStringList( {"nameref"     , "Reference to names of chapters, sections, ..., loaded by hyperref"} )
-		<< QStringList( {"thmtools"    , "Extention package to amsthm"} )
-		<< QStringList( {"xcolor"      , "Sophisticated package for colors, with table option use colors in tables"} )
+		<< QStringList( {"amssymb"     , tr("Mathematical symbols from AMS")} )
+		<< QStringList( {"graphicx"    , tr("Graphics package, easily include images (s. Insert Graphic Wizard)")} )
+		<< QStringList( {"hyperref"    , tr("Support for hyperlinks in your document")} )
+		<< QStringList( {"mathtools"   , tr("Extension package to amsmath incl. fixes for bugs in amsmath, loads amsmath")} )
+		<< QStringList( {"amsthm"      , tr("Define your theorem like env., has to be loaded after amsmath")} )
+		<< QStringList( {"nameref"     , tr("Reference to names of chapters, sections, ..., loaded by hyperref")} )
+		<< QStringList( {"thmtools"    , tr("Extention package to amsthm")} )
+		<< QStringList( {"xcolor"      , tr("Sophisticated package for colors, with table option use colors in tables")} )
 		;
 	//add user given packages
 	for (const QString& package:otherPackagesList){
 		packages << QStringList( { package, "" } );
 	}
 	//setup packages table 
+	table->setRowCount(packages.size());
 	int row=-1;
 	int tableHeight = table->horizontalHeader()->height() + 2;
 	for (const QStringList& data:packages){
@@ -317,24 +316,20 @@ void QuickDocumentDialog::Init()
 		QTableWidgetItem *itemPkgName = new QTableWidgetItem(pkgName);
 		QTableWidgetItem *itemPkgDescription = new QTableWidgetItem(pkgDescription);
 
-		itemPkgName->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable);
-		itemPkgDescription->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+		itemPkgName->setFlags(Qt::ItemIsEnabled | Qt::ItemIsUserCheckable);
+		itemPkgDescription->setFlags(Qt::ItemIsEnabled);
 
-		table->setRowCount(row+1);
 		table->setItem(row,0,itemPkgName);
 		table->setItem(row,1,itemPkgDescription);
 		tableHeight += table->rowHeight(row);
 
 		bool found = packagesUsed.contains(pkgName);
 		itemPkgName->setCheckState( found ? Qt::Checked : Qt::Unchecked );
-		updateSelected(row);
 	}
 	int height = ui.GridPackages->geometry().height();
 	// prevent ever increasing window height when constantly adding user defined packages
 	if (tableHeight < height || height == 0) ui.tableWidgetPackages->setMinimumHeight(tableHeight);
 	ui.tableWidgetPackages->setMaximumHeight(tableHeight);
-	connect(ui.tableWidgetPackages, SIGNAL(itemSelectionChanged()), SLOT(updateCheckState()));
-	connect(ui.tableWidgetPackages, SIGNAL(cellClicked(int,int)), SLOT(updateSelected(int)));
 
 	configManagerInterface->linkOptionToDialogWidget(&document_class, ui.comboBoxClass);
 	configManagerInterface->linkOptionToDialogWidget(&typeface_size, ui.comboBoxSize);
@@ -563,38 +558,13 @@ void QuickDocumentDialog::addUserPackages()
 		Init();
 	}
 }
-//when package selections change
-void QuickDocumentDialog::updateCheckState()
-{
-	QTableWidget *table = ui.tableWidgetPackages;
-	for (int i=0; i < table->rowCount(); ++i) {
-		Qt::CheckState state = table->item(i,0)->checkState();
-		Qt::CheckState select = (table->item(i,0)->isSelected() ? Qt::Checked : Qt::Unchecked);
-		if (state != select) {
-			table->item(i,0)->setCheckState(select);
-		}
-	}
-}
-//when package checkState changes
-void QuickDocumentDialog::updateSelected(int row)
-{
-	QTableWidget *table = ui.tableWidgetPackages;
-	bool state = (table->item(row,0)->checkState()==Qt::Checked ? true : false);
-	bool select = table->item(row,0)->isSelected();
-
-	if (state != select) {
-		for (int i=0; i < table->columnCount(); ++i) {
-			table->item(row,i)->setSelected(state);
-		}
-	}
-}
 
 void QuickDocumentDialog::setFocusToTable(int idx)
 {
 	int tabPos = ui.tabWidget->indexOf(ui.tabPackages);
 	if (idx == tabPos) {
 		ui.tableWidgetPackages->setFocus();
-		ui.tabWidget->setTabToolTip(tabPos, tr("All packages that have the checkbox checked or are selected (Ctrl or Shift along with clicking or dragging\nthe mouse pointer) will appear in a new document within \\usepackage commands after pressing OK."));
+		ui.tabWidget->setTabToolTip(tabPos, tr("All packages that have the checkbox checked will appear in a new document within \\usepackage commands after pressing OK."));
 	}
 	else ui.tabWidget->setTabToolTip(tabPos, "");
 }

--- a/src/quickdocumentdialog.cpp
+++ b/src/quickdocumentdialog.cpp
@@ -29,9 +29,8 @@ qreal convertLatexLengthToMetre(const qreal &length, const QString &unit)
 }
 
 //options for the configmanager
-QStringList QuickDocumentDialog::otherClassList, QuickDocumentDialog::otherPaperList, QuickDocumentDialog::otherInputEncodingList, QuickDocumentDialog::otherFontEncodingList, QuickDocumentDialog::otherBabelOptionsList, QuickDocumentDialog::otherOptionsList;
+QStringList QuickDocumentDialog::otherClassList, QuickDocumentDialog::otherPaperList, QuickDocumentDialog::otherFontEncodingList, QuickDocumentDialog::otherBabelOptionsList, QuickDocumentDialog::otherOptionsList, QuickDocumentDialog::packagesUsed, QuickDocumentDialog::otherPackagesList;
 QString QuickDocumentDialog::document_class, QuickDocumentDialog::typeface_size, QuickDocumentDialog::paper_size, QuickDocumentDialog::document_encoding, QuickDocumentDialog::font_encoding, QuickDocumentDialog::babel_language, QuickDocumentDialog::author;
-bool QuickDocumentDialog::ams_packages, QuickDocumentDialog::makeidx_package, QuickDocumentDialog::graphicx_package;
 double geometryPageWidth, geometryPageHeight, geometryMarginLeft, geometryMarginRight, geometryMarginTop, geometryMarginBottom;
 QString geometryPageWidthUnit, geometryPageHeightUnit, geometryMarginLeftUnit, geometryMarginRightUnit, geometryMarginTopUnit, geometryMarginBottomUnit;
 bool geometryPageWidthEnabled, geometryPageHeightEnabled, geometryMarginLeftEnabled, geometryMarginRightEnabled, geometryMarginTopEnabled, geometryMarginBottomEnabled;
@@ -52,12 +51,16 @@ QuickDocumentDialog::QuickDocumentDialog(QWidget *parent, const QString &name)
 	ui.comboBoxSize->addItem("11pt");
 	ui.comboBoxSize->addItem("12pt");
 	connect(ui.pushButtonPaper , SIGNAL(clicked()), SLOT(addUserPaper()));
-	connect(ui.pushButtonInputEncoding , SIGNAL(clicked()), SLOT(addUserInputEncoding()));
 	connect(ui.pushButtonFontEncoding , SIGNAL(clicked()), SLOT(addUserFontEncoding()));
 	connect(ui.pushButtonBabel, SIGNAL(clicked()), SLOT(addBabelOption()));
 	connect(ui.pushButtonOptions , SIGNAL(clicked()), SLOT(addUserOptions()));
 	ui.listWidgetOptions->setSelectionMode(QAbstractItemView::ExtendedSelection);
+	connect(ui.pushButtonPackages , SIGNAL(clicked()), SLOT(addUserPackages()));
 	setWindowTitle(tr("Quick Start"));
+
+	//Package Tab
+	ui.pushButtonPackages->setFocusPolicy(Qt::NoFocus);
+	connect(ui.tabWidget, SIGNAL(tabBarClicked(int)), SLOT(setFocusToTable(int)));
 
 	//Geometry package
 	connect(ui.spinBoxUnitGeometryPageWidth, SIGNAL(editTextChanged(QString)), SLOT(geometryUnitsChanged()));
@@ -101,22 +104,12 @@ QString QuickDocumentDialog::getNewDocumentText()
 	tag += opt + QString("]{");
 	tag += ui.comboBoxClass->currentText() + QString("}");
 	tag += QString("\n");
-	if (ui.comboBoxInputEncoding->currentText() != "NONE") {
-		tag += QString("\\usepackage[") + ui.comboBoxInputEncoding->currentText() + QString("]{inputenc}");
-		tag += QString("\n");
-	}
+	// always use utf8
+	tag += QString("\\usepackage[utf8]{inputenc}\n");
 	if (ui.comboBoxFontEncoding->currentText() != "NONE") {
 		tag += QString("\\usepackage[") + ui.comboBoxFontEncoding->currentText() + QString("]{fontenc}");
 		tag += QString("\n");
 	}
-	if (ui.comboBoxInputEncoding->currentText().startsWith("utf8x"))
-		tag += QString("\\usepackage{ucs}\n");
-	if (ui.checkBoxAMS->isChecked())
-		tag += QString("\\usepackage{amsmath}\n\\usepackage{amssymb}\n");
-	if (ui.checkBoxIDX->isChecked())
-		tag += QString("\\usepackage{makeidx}\n");
-	if (ui.checkBoxGraphicx->isChecked())
-		tag += QString("\\usepackage{graphicx}\n");
 
 	if (ui.checkBoxGeometryPageWidth->isChecked() ||
 	        ui.checkBoxGeometryPageHeight->isChecked() ||
@@ -137,6 +130,16 @@ QString QuickDocumentDialog::getNewDocumentText()
 	if (ui.comboBoxBabel->currentText() != "NONE")
       tag += QString("\\usepackage[%1]{babel}\n").arg(ui.comboBoxBabel->currentText());
 
+	QTableWidget *table = ui.tableWidgetPackages;
+	packagesUsed = QStringList();
+	for (int i=0; i < table->rowCount(); ++i) {
+		QTableWidgetItem *itemPkgName = table->item(i,0);
+		if (itemPkgName->checkState()==Qt::Checked) {
+			tag += QString("\\usepackage{%1}\n").arg(itemPkgName->text());
+			packagesUsed << itemPkgName->text();
+		}
+	}
+
 	if (ui.lineEditTitle->text() != "")
 		tag += "\\title{" + ui.lineEditTitle->text() + "}\n";
 	if (ui.lineEditAuthor->text() != "")
@@ -150,20 +153,18 @@ void QuickDocumentDialog::registerOptions(ConfigManagerInterface &configManager)
 {
 	configManager.registerOption("Tools/User Class", &otherClassList);
 	configManager.registerOption("Tools/User Paper", &otherPaperList);
-	configManager.registerOption("Tools/User Encoding", &otherInputEncodingList);
 	configManager.registerOption("Tools/User Font Encoding", &otherFontEncodingList);
 	configManager.registerOption("Tools/User Babel Options", &otherBabelOptionsList);
 	configManager.registerOption("Tools/User Options", &otherOptionsList);
+	configManager.registerOption("Tools/User Packages", &otherPackagesList);
 	configManager.registerOption("Quick/Class", &document_class, "article");
 	configManager.registerOption("Quick/Typeface", &typeface_size, "10pt");
 	configManager.registerOption("Quick/Papersize", &paper_size, "a4paper");
 	configManager.registerOption("Quick/Encoding", &document_encoding, "utf8");
 	configManager.registerOption("Quick/FontEncoding", &font_encoding, "T1");
 	configManager.registerOption("Quick/Babel", &babel_language, "NONE");
-	configManager.registerOption("Quick/AMS", &ams_packages, true);
-	configManager.registerOption("Quick/MakeIndex", &makeidx_package, false);
-	configManager.registerOption("Quick/graphicx", &graphicx_package, true);
 	configManager.registerOption("Quick/Author", &author, "");
+	configManager.registerOption("Quick/Packages Used", &packagesUsed, QStringList());
 
 	configManager.registerOption("Quick/Geometry Page Width", &geometryPageWidth, 0.0f);
 	configManager.registerOption("Quick/Geometry Page Height", &geometryPageHeight, 0.0f);
@@ -227,28 +228,6 @@ void QuickDocumentDialog::Init()
 	ui.comboBoxPaper->addItem("executivepaper");
 	if (!otherPaperList.isEmpty()) ui.comboBoxPaper->addItems(otherPaperList);
 
-	ui.comboBoxInputEncoding->clear();
-	ui.comboBoxInputEncoding->addItem("latin1");
-	ui.comboBoxInputEncoding->addItem("latin2");
-	ui.comboBoxInputEncoding->addItem("latin3");
-	ui.comboBoxInputEncoding->addItem("latin5");
-	ui.comboBoxInputEncoding->addItem("utf8");
-	ui.comboBoxInputEncoding->addItem("utf8x");
-	ui.comboBoxInputEncoding->addItem("ascii");
-	ui.comboBoxInputEncoding->addItem("decmulti");
-	ui.comboBoxInputEncoding->addItem("cp850");
-	ui.comboBoxInputEncoding->addItem("cp852");
-	ui.comboBoxInputEncoding->addItem("cp437");
-	ui.comboBoxInputEncoding->addItem("cp437de");
-	ui.comboBoxInputEncoding->addItem("cp865");
-	ui.comboBoxInputEncoding->addItem("applemac");
-	ui.comboBoxInputEncoding->addItem("next");
-	ui.comboBoxInputEncoding->addItem("ansinew");
-	ui.comboBoxInputEncoding->addItem("cp1252");
-	ui.comboBoxInputEncoding->addItem("cp1250");
-	ui.comboBoxInputEncoding->addItem("NONE");
-	if (!otherInputEncodingList.isEmpty()) ui.comboBoxInputEncoding->addItems(otherInputEncodingList);
-
 	ui.comboBoxFontEncoding->clear();
 	ui.comboBoxFontEncoding->addItem("OT1");
 	ui.comboBoxFontEncoding->addItem("OT2");
@@ -288,7 +267,7 @@ void QuickDocumentDialog::Init()
 	ui.comboBoxBabel->addItems(babelLanguages);
 	if (!otherBabelOptionsList.isEmpty()) ui.comboBoxBabel->addItems(otherBabelOptionsList);
 
-	ui.listWidgetOptions->clear();
+    ui.listWidgetOptions->clear();
     QListWidgetItem *item;
     QStringList options{"landscape","draft","final","oneside","twoside","openright","openany","onecolumn",
                        "twocolumn","titlepage","notitlepage","openbib","leqno","fleqn"};
@@ -303,15 +282,65 @@ void QuickDocumentDialog::Init()
         item->setCheckState(Qt::Unchecked);
     }
 
+	QTableWidget *table = ui.tableWidgetPackages;
+	table->clear();
+	table->setColumnCount(2);
+	table->setHorizontalHeaderLabels( QStringList( { tr("Package"), tr("Description") } ) );
+	table->horizontalHeader()->setStretchLastSection(true);
+	table->setSelectionMode(QAbstractItemView::ExtendedSelection);
+	table->setSelectionBehavior(QAbstractItemView::SelectRows);
+	table->verticalHeader()->hide();
+
+	//each QStringList holds 2 items: the name of the package, and a short package description. These constitute a row of the table of the packages tab
+	QList<QStringList> packages = QList<QStringList>()
+		<< QStringList( {"amssymb"     , "Mathematical symbols from AMS"} )
+		<< QStringList( {"graphicx"    , "Graphics package, easily include images (s. Insert Graphic Wizard)"} )
+		<< QStringList( {"hyperref"    , "Support for hyperlinks in your document"} )
+		<< QStringList( {"mathtools"   , "Extension package to amsmath incl. fixes for bugs in amsmath, loads amsmath"} )
+		<< QStringList( {"amsthm"      , "Define your theorem like env., has to be loaded after amsmath"} )
+		<< QStringList( {"nameref"     , "Reference to names of chapters, sections, ..., loaded by hyperref"} )
+		<< QStringList( {"thmtools"    , "Extention package to amsthm"} )
+		<< QStringList( {"xcolor"      , "Sophisticated package for colors, with table option use colors in tables"} )
+		;
+	//add user given packages
+	for (const QString& package:otherPackagesList){
+		packages << QStringList( { package, "" } );
+	}
+	//setup packages table 
+	int row=-1;
+	int tableHeight = table->horizontalHeader()->height() + 2;
+	for (const QStringList& data:packages){
+		++row;
+		QString pkgName = data[0],
+				pkgDescription = data[1];
+
+		QTableWidgetItem *itemPkgName = new QTableWidgetItem(pkgName);
+		QTableWidgetItem *itemPkgDescription = new QTableWidgetItem(pkgDescription);
+
+		itemPkgName->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable);
+		itemPkgDescription->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+
+		table->setRowCount(row+1);
+		table->setItem(row,0,itemPkgName);
+		table->setItem(row,1,itemPkgDescription);
+		tableHeight += table->rowHeight(row);
+
+		bool found = packagesUsed.contains(pkgName);
+		itemPkgName->setCheckState( found ? Qt::Checked : Qt::Unchecked );
+		updateSelected(row);
+	}
+	int height = ui.GridPackages->geometry().height();
+	// prevent ever increasing window height when constantly adding user defined packages
+	if (tableHeight < height || height == 0) ui.tableWidgetPackages->setMinimumHeight(tableHeight);
+	ui.tableWidgetPackages->setMaximumHeight(tableHeight);
+	connect(ui.tableWidgetPackages, SIGNAL(itemSelectionChanged()), SLOT(updateCheckState()));
+	connect(ui.tableWidgetPackages, SIGNAL(cellClicked(int,int)), SLOT(updateSelected(int)));
+
 	configManagerInterface->linkOptionToDialogWidget(&document_class, ui.comboBoxClass);
 	configManagerInterface->linkOptionToDialogWidget(&typeface_size, ui.comboBoxSize);
 	configManagerInterface->linkOptionToDialogWidget(&paper_size, ui.comboBoxPaper);
-	configManagerInterface->linkOptionToDialogWidget(&document_encoding, ui.comboBoxInputEncoding);
 	configManagerInterface->linkOptionToDialogWidget(&font_encoding, ui.comboBoxFontEncoding);
 	configManagerInterface->linkOptionToDialogWidget(&babel_language, ui.comboBoxBabel);
-	configManagerInterface->linkOptionToDialogWidget(&ams_packages, ui.checkBoxAMS);
-	configManagerInterface->linkOptionToDialogWidget(&makeidx_package, ui.checkBoxIDX);
-	configManagerInterface->linkOptionToDialogWidget(&graphicx_package, ui.checkBoxGraphicx);
 	configManagerInterface->linkOptionToDialogWidget(&author, ui.lineEditAuthor);
 
 	configManagerInterface->linkOptionToDialogWidget(&geometryPageWidth, ui.spinBoxGeometryPageWidth);
@@ -491,17 +520,6 @@ void QuickDocumentDialog::addUserPaper()
 	}
 }
 
-void QuickDocumentDialog::addUserInputEncoding()
-{
-	QString newoption;
-	UniversalInputDialog dialog;
-	dialog.addVariable(&newoption, tr("New:"));
-	if (dialog.exec() && !newoption.isEmpty()) {
-		otherInputEncodingList.append(newoption);
-		Init();
-	}
-}
-
 void QuickDocumentDialog::addUserFontEncoding()
 {
 	QString newoption;
@@ -533,4 +551,50 @@ void QuickDocumentDialog::addUserOptions()
 		otherOptionsList.append(newoption);
 		Init();
 	}
+}
+
+void QuickDocumentDialog::addUserPackages()
+{
+	QString newoption;
+	UniversalInputDialog dialog;
+	dialog.addVariable(&newoption, tr("New:"));
+	if (dialog.exec() && !newoption.isEmpty()) {
+		otherPackagesList.append(newoption);
+		Init();
+	}
+}
+//when package selections change
+void QuickDocumentDialog::updateCheckState()
+{
+	QTableWidget *table = ui.tableWidgetPackages;
+	for (int i=0; i < table->rowCount(); ++i) {
+		Qt::CheckState state = table->item(i,0)->checkState();
+		Qt::CheckState select = (table->item(i,0)->isSelected() ? Qt::Checked : Qt::Unchecked);
+		if (state != select) {
+			table->item(i,0)->setCheckState(select);
+		}
+	}
+}
+//when package checkState changes
+void QuickDocumentDialog::updateSelected(int row)
+{
+	QTableWidget *table = ui.tableWidgetPackages;
+	bool state = (table->item(row,0)->checkState()==Qt::Checked ? true : false);
+	bool select = table->item(row,0)->isSelected();
+
+	if (state != select) {
+		for (int i=0; i < table->columnCount(); ++i) {
+			table->item(row,i)->setSelected(state);
+		}
+	}
+}
+
+void QuickDocumentDialog::setFocusToTable(int idx)
+{
+	int tabPos = ui.tabWidget->indexOf(ui.tabPackages);
+	if (idx == tabPos) {
+		ui.tableWidgetPackages->setFocus();
+		ui.tabWidget->setTabToolTip(tabPos, tr("All packages that have the checkbox checked or are selected (Ctrl or Shift along with clicking or dragging\nthe mouse pointer) will appear in a new document within \\usepackage commands after pressing OK."));
+	}
+	else ui.tabWidget->setTabToolTip(tabPos, "");
 }

--- a/src/quickdocumentdialog.h
+++ b/src/quickdocumentdialog.h
@@ -53,8 +53,6 @@ private slots:
 	void addBabelOption();
 	void addUserOptions();
 	void addUserPackages();
-	void updateCheckState();
-	void updateSelected(int row);
 	void setFocusToTable(int idx);
 };
 

--- a/src/quickdocumentdialog.h
+++ b/src/quickdocumentdialog.h
@@ -32,9 +32,8 @@ public:
 	static QString font_encoding;
 
 private:
-	static QStringList otherClassList, otherPaperList, otherInputEncodingList, otherFontEncodingList, otherBabelOptionsList, otherOptionsList;
+	static QStringList otherClassList, otherPaperList, otherFontEncodingList, otherBabelOptionsList, otherOptionsList, packagesUsed, otherPackagesList;
 	static QString document_class, typeface_size, paper_size, babel_language, author;
-	static bool ams_packages, makeidx_package, graphicx_package;
 	static ConfigManagerInterface* configManagerInterface;
 
 public:
@@ -50,10 +49,13 @@ public slots:
 private slots:
 	void addUserClass();
 	void addUserPaper();
-	void addUserInputEncoding();
 	void addUserFontEncoding();
 	void addBabelOption();
 	void addUserOptions();
+	void addUserPackages();
+	void updateCheckState();
+	void updateSelected(int row);
+	void setFocusToTable(int idx);
 };
 
 

--- a/src/quickdocumentdialog.ui
+++ b/src/quickdocumentdialog.ui
@@ -298,6 +298,16 @@
          </property>
          <item row="1" column="0">
           <widget class="QTableWidget" name="tableWidgetPackages">
+           <column>
+            <property name="text">
+             <string>Package</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Description</string>
+            </property>
+           </column>
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
             </sizepolicy>

--- a/src/quickdocumentdialog.ui
+++ b/src/quickdocumentdialog.ui
@@ -79,7 +79,7 @@
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
-       <string>Class Options</string>
+       <string>&amp;Class Options</string>
       </attribute>
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
@@ -162,9 +162,6 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
-          <widget class="QComboBox" name="comboBoxInputEncoding"/>
-         </item>
          <item row="9" column="0">
           <widget class="QLabel" name="labelOptions">
            <property name="sizePolicy">
@@ -192,24 +189,6 @@
          <item row="1" column="1">
           <widget class="QComboBox" name="comboBoxSize"/>
          </item>
-         <item row="6" column="1">
-          <layout class="QHBoxLayout" name="horizontalLayout_4">
-           <item>
-            <widget class="QCheckBox" name="checkBoxIDX">
-             <property name="text">
-              <string>makeidx Package</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="checkBoxGraphicx">
-             <property name="text">
-              <string>graphicx Package</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
          <item row="2" column="2">
           <widget class="QPushButton" name="pushButtonPaper">
            <property name="text">
@@ -235,16 +214,6 @@
          <item row="9" column="1">
           <widget class="QListWidget" name="listWidgetOptions"/>
          </item>
-         <item row="6" column="0">
-          <widget class="QCheckBox" name="checkBoxAMS">
-           <property name="text">
-            <string>AMS Packages</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
          <item row="2" column="0">
           <widget class="QLabel" name="labelPaper">
            <property name="sizePolicy">
@@ -255,17 +224,6 @@
            </property>
            <property name="text">
             <string>Paper Size</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="2">
-          <widget class="QPushButton" name="pushButtonInputEncoding">
-           <property name="text">
-            <string/>
-           </property>
-           <property name="icon">
-            <iconset resource="../images.qrc">
-             <normaloff>:/images-ng/list-add.svgz</normaloff>:/images-ng/list-add.svgz</iconset>
            </property>
           </widget>
          </item>
@@ -291,23 +249,10 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="labelInputEncoding">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Input encoding</string>
-           </property>
-          </widget>
-         </item>
          <item row="4" column="0">
           <widget class="QLabel" name="labelFontEncoding">
            <property name="text">
-            <string>Font encoding</string>
+            <string>Font Encoding</string>
            </property>
           </widget>
          </item>
@@ -329,9 +274,91 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tabPackages">
+      <attribute name="title">
+       <string>&amp;Packages</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="HboxPackages">
+       <item>
+        <layout class="QGridLayout" name="GridPackages">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <item row="1" column="0">
+          <widget class="QTableWidget" name="tableWidgetPackages">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <layout class="QVBoxLayout">
+           <item>
+            <spacer>
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Expanding</enum>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pushButtonPackages">
+             <property name="text">
+              <string/>
+             </property>
+             <property name="icon">
+              <iconset resource="../images.qrc">
+               <normaloff>:/images-ng/list-add.svgz</normaloff>:/images-ng/list-add.svgz</iconset>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer>
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Expanding</enum>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item row="2" column="0">
+          <spacer>
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Expanding</enum>
+           </property>
+           <property name="VerticalSizeHint">
+            <number>0</number>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="tabGeometry">
       <attribute name="title">
-       <string>Geometry</string>
+       <string>&amp;Geometry</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>


### PR DESCRIPTION
This PR closes #2831. This mainly adds a new tab to the QuickStart Wizard named Packages, It shows in a table a small selection of packages each with a short description. Also those packages which are currently selectable with a checkbox are removed from the first tab  (Class Options), as well as the combobox for the Input Encoding which is now set to utf8 in any case.