### PR TITLE
Improve pinch-to-zoom performance on macOS

### DIFF
--- a/src/pdfviewer/PDFDocument.h
+++ b/src/pdfviewer/PDFDocument.h
@@ -337,8 +337,8 @@ private:
 	qreal			saveScaleFactor;
 	autoScaleOption	saveScaleOption;
 	
-	qreal pinchStartedScaleFactor;
-	bool pinchGestureDetected;
+	qreal pinchZoomXPos;
+	qreal pinchZoomYPos;
 
 	QAction	*ctxZoomInAction;
 	QAction	*ctxZoomOutAction;


### PR DESCRIPTION
While testing the changes introduced in #2840 on multiple machines, two issues were discovered and fixed in this PR:

 ### Degraded performance while zooming

This issue was fixed by taking the zoom scale from the `QGestureEvent` instead of the `QTouchEvent`. This way, no more calculations are performed to determine the zoom scale. The `QTouchEvent` is now used only for the zoom coordinates:

- `QTouchEvent` <= unreliably generated
  - Zoom coordinates

- `QGestureEvent`
  - ~~*Zoom coordinates*~~ <= broken on macOS
  - Zoom scale
  - Zoom event detection

The performance with this fix is identical to the release version of Texstudio.

### Qt sometimes stops generating `QTouchEvent`s

Texstudio would sometimes zoom to the wrong coordinates when no `QTouchEvent`s were generated. This was fixed by setting the `Qt::WA_AcceptTouchEvents` attribute on the `PDFWidget`.

All changes affect the macOS version only.