### PR TITLE
Fix a cwl typo

### DIFF
--- a/completion/latex-document.cwl
+++ b/completion/latex-document.cwl
@@ -390,7 +390,7 @@
 \rule{width}{thickness%l}
 \SS
 \samepage#*
-\sbox{cmd}[text]
+\sbox{cmd}{text}
 \sc#*
 \scriptsize
 \scshape


### PR DESCRIPTION
`\sbox` takes two margs, rather than a marg followed by an oarg.
See for example https://latexref.xyz/_005csbox-_0026-_005csavebox.html .