### PR TITLE
Editor config persistant Only Monospaced Fonts option

### DIFF
--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -565,6 +565,7 @@ ConfigManager::ConfigManager(QObject *parent): QObject (parent),
 	registerOption("Editor/Auto Replace Commands", &CodeSnippet::autoReplaceCommands, true, &pseudoDialog->checkBoxAutoReplaceCommands);
 
 
+	registerOption("Editor/OnlyMonospacedFonts", &onlyMonospacedFonts, false, &pseudoDialog->checkBoxShowOnlyMonospacedFonts);
 	registerOption("Editor/Font Family", &editorConfig->fontFamily, "", &pseudoDialog->comboBoxFont);
 	registerOption("Editor/Font Size", &editorConfig->fontSize, -1, &pseudoDialog->spinBoxSize);
 	registerOption("Editor/Line Spacing Percent", &editorConfig->lineSpacingPercent, 100, &pseudoDialog->spinBoxLineSpacingPercent);

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -121,6 +121,7 @@ public:
 	QTranslator *basicTranslator;
 
 	//editor
+	bool onlyMonospacedFonts;
 	LatexEditorViewConfig *const editorConfig;
 	//completion
 	LatexCompleterConfig *const completerConfig;


### PR DESCRIPTION
This PR closes #788. The value of the checkbox "Only Monospaced Fonts" from the Editor Config page is now saved in the ini file (s. below) and thus remembered. This may also be of interest in issue #2789.

Ini file:

``Editor\OnlyMonospacedFonts=true``

Right after starting txs (or after closing and reopening config dialog):

![grafik](https://user-images.githubusercontent.com/102688820/213344113-ae5329aa-a55f-4b44-a6b9-9a145f02b845.png)

Hint: This option is not set by default.