### PR TITLE
An Editor option which swapps line numbers column and line marks column

### DIFF
--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -1670,6 +1670,16 @@ Then you can select a new shortcut by one of the following ways:
                     </item>
                    </widget>
                   </item>
+                  <item row="11" column="2">
+                   <widget class="QCheckBox" name="checkBoxLineNumbersFirst">
+                    <property name="toolTip">
+                     <string>This moves the column with the line numbers from the right to the left of the column with the line marks.</string>
+                    </property>
+                    <property name="text">
+                     <string>Line numbers to the left of line markers</string>
+                    </property>
+                   </widget>
+                  </item>
                   <item row="15" column="0" colspan="2">
                    <widget class="QCheckBox" name="checkBoxInlineCheckNonTeXFiles">
                     <property name="text">

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -515,6 +515,7 @@ ConfigManager::ConfigManager(QObject *parent): QObject (parent),
 	registerOption("Editor/Parentheses Matching", &editorConfig->parenmatch, true); //TODO: checkbox?
 	registerOption("Editor/Parentheses Completion", &editorConfig->parenComplete, true, &pseudoDialog->checkBoxAutoCompleteParens);
 	registerOption("Editor/Line Number Multiples", &editorConfig->showlinemultiples, 0);
+	registerOption("Editor/Line Numbers First", &editorConfig->lineNumbersFirst, false, &pseudoDialog->checkBoxLineNumbersFirst);
 	registerOption("Editor/Cursor Surrounding Lines", &editorConfig->cursorSurroundLines, 5);
 	registerOption("Editor/BoldCursor", &editorConfig->boldCursor, true, &pseudoDialog->checkBoxBoldCursor);
     registerOption("Editor/CenterDocumentInEditor", &editorConfig->centerDocumentInEditor, false, &pseudoDialog->checkBoxCenterDocumentInEditor);

--- a/src/latexeditorview.cpp
+++ b/src/latexeditorview.cpp
@@ -661,9 +661,15 @@ LatexEditorView::LatexEditorView(QWidget *parent, LatexEditorViewConfig *aconfig
 	editor->setProperty("latexEditor", QVariant::fromValue<LatexEditorView *>(this));
 
 	lineMarkPanel = new QLineMarkPanel;
-	lineMarkPanelAction = codeeditor->addPanel(lineMarkPanel, QCodeEdit::West, false);
 	lineNumberPanel = new QLineNumberPanel;
-    lineNumberPanelAction = codeeditor->addPanel(lineNumberPanel, QCodeEdit::West, false);
+	if (config->lineNumbersFirst) {
+		lineNumberPanelAction = codeeditor->addPanel(lineNumberPanel, QCodeEdit::West, false);
+		lineMarkPanelAction = codeeditor->addPanel(lineMarkPanel, QCodeEdit::West, false);
+	} else {
+		lineMarkPanelAction = codeeditor->addPanel(lineMarkPanel, QCodeEdit::West, false);
+		lineNumberPanelAction = codeeditor->addPanel(lineNumberPanel, QCodeEdit::West, false);
+	}
+
 	QFoldPanel *foldPanel = new QFoldPanel;
 	lineFoldPanelAction = codeeditor->addPanel(foldPanel, QCodeEdit::West, false);
 	lineChangePanelAction = codeeditor->addPanel(new QLineChangePanel, QCodeEdit::West, false);

--- a/src/latexeditorview_config.h
+++ b/src/latexeditorview_config.h
@@ -18,6 +18,7 @@ public:
 	bool showWhitespace;
 	int tabStop;
 	int showlinemultiples;
+	bool lineNumbersFirst;
 	int cursorSurroundLines;
 	bool boldCursor;
 	bool centerDocumentInEditor;


### PR DESCRIPTION
This PR adds a checkbox option to the editor config page. This option allows the user to have the line numbers of the editor left to the line marks. Thus both columns have constant distance to the editor window independent of the  total number of lines of the editor. This PR closes #2220 where this was discussed.

Note: Changing this option takes only effect when opening new editors or when restarting txs. This seems to be ok since this option is intended to be changed only once. Even so I tried to code that all editors (visible or invisible) are changed immediately. But I didn't succeed.

Comparison Line Marks to the left (default) vs. Line Numbers to the left:

![linesAndMarks](https://user-images.githubusercontent.com/102688820/213796767-84a1a440-0d60-471b-8140-3491bdbdaeb5.gif)

Option:

![grafik](https://user-images.githubusercontent.com/102688820/213796956-9ce02901-ab0e-48ab-a7c4-7f0f3053487d.png)
