### PR TITLE
rectangular magnifier with shadow

### DIFF
--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -4311,17 +4311,12 @@ them here.</string>
                    <widget class="QComboBox" name="comboBoxPreviewMagnifierShape">
                     <item>
                      <property name="text">
-                      <string>Square</string>
+                      <string>Rectangle</string>
                      </property>
                     </item>
                     <item>
                      <property name="text">
                       <string>Circle</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Circle without shadow</string>
                      </property>
                     </item>
                    </widget>
@@ -4373,11 +4368,35 @@ them here.</string>
                    </widget>
                   </item>
                   <item row="7" column="1">
-                   <widget class="QCheckBox" name="checkBoxPreviewMagnifierBorder">
-                    <property name="text">
-                     <string>Border</string>
-                    </property>
-                   </widget>
+                   <layout class="QHBoxLayout" name="HBoxLayout_magnifier">
+                    <item>
+                     <widget class="QCheckBox" name="checkBoxPreviewMagnifierBorder">
+                      <property name="text">
+                       <string>Border</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QCheckBox" name="checkBoxPreviewMagnifierShadow">
+                      <property name="text">
+                       <string>Shadow</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer>
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>0</width>
+                        <height>0</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                   </layout>
                   </item>
                   <item row="1" column="1">
                    <widget class="QComboBox" name="comboBoxPreviewScale">

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -758,7 +758,8 @@ ConfigManager::ConfigManager(QObject *parent): QObject (parent),
 	registerOption("Preview/", &pdfDocumentConfig->disableHorizontalScrollingForFitToTextWidth, true, &pseudoDialog->checkBoxDisableHorizontalScrollingForFitToTextWidth);
 	registerOption("Preview/ZoomStepFactor", &pdfDocumentConfig->zoomStepFactor, 1.4142135); // sqrt(2)
 	registerOption("Preview/Magnifier Size", &pdfDocumentConfig->magnifierSize, 300, &pseudoDialog->spinBoxPreviewMagnifierSize);
-    registerOption("Preview/Magnifier Shape", reinterpret_cast<int *>(&pdfDocumentConfig->magnifierShape), static_cast<int>(PDFDocumentConfig::CircleWithShadow), &pseudoDialog->comboBoxPreviewMagnifierShape);
+	registerOption("Preview/Magnifier Shape", reinterpret_cast<int *>(&pdfDocumentConfig->magnifierShape), static_cast<int>(PDFDocumentConfig::Circle), &pseudoDialog->comboBoxPreviewMagnifierShape);
+	registerOption("Preview/Magnifier Shadow", &pdfDocumentConfig->magnifierShadow, true, &pseudoDialog->checkBoxPreviewMagnifierShadow);
 	registerOption("Preview/Magnifier Border", &pdfDocumentConfig->magnifierBorder, false, &pseudoDialog->checkBoxPreviewMagnifierBorder);
 
 	registerOption("Preview/Laser Pointer Size", &pdfDocumentConfig->laserPointerSize, 25, &pseudoDialog->spinBoxPreviewLaserPointerSize);

--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -318,15 +318,14 @@ void PDFMagnifier::reshape()
 	if (!globalConfig || globalConfig->magnifierShape == oldshape) return;
 
 	switch (globalConfig->magnifierShape) {
-    case 2: [[clang::fallthrough]];
 	case 1: { //circular
-	        int side = qMin(width(), height());
+		int side = qMin(width(), height());
 		QRegion maskedRegion(width() / 2 - side / 2, height() / 2 - side / 2, side, side, QRegion::Ellipse);
 		setMask(maskedRegion);
 		break;
 	}
-	default:
-		setMask(QRect(0, 0, width(), height())); //rectangular
+	default: //rectangular
+		setMask(QRect(0, 0, width(), height()));
 	}
 }
 
@@ -341,15 +340,23 @@ void PDFMagnifier::setImage(const QPixmap &img, int pageNr)
 	update();
 }
 
-void PDFDraggableTool::drawCircleGradient(QPainter& painter, const QRect& outline, QColor color, int padding)
+void PDFDraggableTool::drawGradient(QPainter& painter, const QRect& outline, QColor color, int padding, int magnifierShape)
 {
-	QRadialGradient gradient(outline.center(), outline.width() / 2.0 , outline.center());
-	color.setAlpha(0);
-	gradient.setColorAt(1.0, color);
-	color.setAlpha(64);
-	gradient.setColorAt(1.0 - padding * 2.0 / (outline.width()), color);
-
-	painter.fillRect(outline, gradient);
+	if(magnifierShape == PDFDocumentConfig::Circle) {
+		QRadialGradient gradient(outline.center(), outline.width() / 2.0 , outline.center());
+		color.setAlpha(0);
+		gradient.setColorAt(1.0, color);
+		color.setAlpha(64);
+		gradient.setColorAt(1.0 - padding * 2.0 / (outline.width()), color);
+		painter.fillRect(outline, gradient);
+	} else { // rectangle
+		QLinearGradient gradient(outline.bottomRight(), outline.topRight());
+		color.setAlpha(0);
+		gradient.setColorAt(1.0, color);
+		color.setAlpha(64);
+		gradient.setColorAt(1.0 - padding * 2.0 / (outline.width()), color);
+		painter.fillRect(outline, gradient);
+	}
 }
 
 void PDFMagnifier::paintEvent(QPaintEvent *event)
@@ -364,40 +371,51 @@ void PDFMagnifier::paintEvent(QPaintEvent *event)
 	// Define a path that specifies the border of the magnifier.
 	// This path is also later reused to draw the actual border.
 	QPainterPath borderPath;
-	if(globalConfig->magnifierShape == PDFDocumentConfig::CircleWithShadow) {
-		// circular magnifier with transparent shadow
-		const int shadowWidth=13;
-		const int magnifierWidth = side - 2*shadowWidth + 2;
-
-		// draw transparent shadow
-		QRect outline(width() / 2 - side / 2 + 1, height() / 2 - side / 2 + 1, side - 2, side - 2);
-		drawCircleGradient(painter, outline, QColor(Qt::black), shadowWidth);
-
-		borderPath.addRoundedRect(
-			width()/2 - side/2 + shadowWidth - 2, 
-			height()/2 - side/2 + shadowWidth - 5, // magnifier moved upwards for 3D effect
-			magnifierWidth, 
-			magnifierWidth, 
-			magnifierWidth/2, 
-			magnifierWidth/2
-		);
-
-	} else if(globalConfig->magnifierShape == PDFDocumentConfig::Circle) {
-		// circular magnifier without shadow
-		const int magnifierWidth = side - 4;
-
-		borderPath.addRoundedRect(
-			width()/2 - side/2 + 2, 
-			height()/2 - side/2 + 2, 
-			magnifierWidth, 
-			magnifierWidth, 
-			magnifierWidth/2, 
-			magnifierWidth/2
-		);
-
+	if(globalConfig->magnifierShadow) {
+		if(globalConfig->magnifierShape == PDFDocumentConfig::Circle) {
+			// circular magnifier with transparent shadow
+			const int shadowWidth=13;
+			const int magnifierWidth = side - 2*shadowWidth + 2;
+	
+			// draw transparent shadow
+			QRect outline(width() / 2 - side / 2 + 1, height() / 2 - side / 2 + 1, side - 2, side - 2);
+			drawGradient(painter, outline, QColor(Qt::black), shadowWidth, globalConfig->magnifierShape);
+	
+			borderPath.addRoundedRect(
+				width()/2 - side/2 + shadowWidth - 2, 
+				height()/2 - side/2 + shadowWidth - 5, // magnifier moved upwards for 3D effect
+				magnifierWidth, 
+				magnifierWidth, 
+				magnifierWidth/2, 
+				magnifierWidth/2
+			);
+		} else {
+			// rectangular magnifier with transparent shadow
+			const int shadowWidth = 5;
+	
+			// draw transparent shadow
+			QRect outline(1, 1, width() - 2, height() - 2);
+			drawGradient(painter, outline, QColor(Qt::black), shadowWidth, globalConfig->magnifierShape);
+	
+			borderPath.addRect(1 + shadowWidth/2, 1 + shadowWidth, width() - 1.3*shadowWidth - 2, height() - 1.8*shadowWidth - 2);
+		}
 	} else {
-		// rectangular magnifier
-		borderPath.addRect(1, 1, width() - 2, height() - 2);
+		if(globalConfig->magnifierShape == PDFDocumentConfig::Circle) {
+			// circular magnifier without shadow
+			const int magnifierWidth = side - 4;
+	
+			borderPath.addRoundedRect(
+				width()/2 - side/2 + 2, 
+				height()/2 - side/2 + 2, 
+				magnifierWidth, 
+				magnifierWidth, 
+				magnifierWidth/2, 
+				magnifierWidth/2
+			);
+		} else {
+			// rectangular magnifier without shadow
+			borderPath.addRect(1, 1, width() - 2, height() - 2);
+		}
 	}
 
 	// draw contents inside the magnifier
@@ -427,7 +445,7 @@ void PDFMagnifier::paintEvent(QPaintEvent *event)
 
 	// draw a border around the magnifier
 	if (globalConfig->magnifierBorder) {
-		if(globalConfig->magnifierShape == PDFDocumentConfig::CircleWithShadow) {
+		if(globalConfig->magnifierShadow) {
 			painter.setPen(QPen(QPalette().shadow().color(), 2)); // black outline
 		} else {
 			painter.setPen(QPen(QPalette().mid().color(), 2)); // gray outline
@@ -472,7 +490,7 @@ void PDFLaserPointer::paintEvent(QPaintEvent *event)
 	int side = qMin(width(), height()) ;
 	QRect outline(width() / 2 - side / 2 + 1, height() / 2 - side / 2 + 1, side - 2, side - 2);
 
-	drawCircleGradient(painter, outline, QColor(globalConfig ? globalConfig->laserPointerColor : "#ff0000"), 5);
+	drawGradient(painter, outline, QColor(globalConfig ? globalConfig->laserPointerColor : "#ff0000"), 5, PDFDocumentConfig::Circle);
 }
 
 #ifdef MEDIAPLAYER
@@ -690,6 +708,12 @@ PDFWidget::PDFWidget(bool embedded)
 	case 4:
 		fitTextWidth(true);
 		break;
+	}
+
+	if (globalConfig->magnifierShape != PDFDocumentConfig::Rectangle && globalConfig->magnifierShape != PDFDocumentConfig::Circle) {
+		//map outdated heighest index 2 (circle without a shadow) to 1 (circle) and no shadow
+		globalConfig->magnifierShape = PDFDocumentConfig::Circle;
+		globalConfig->magnifierShadow = false;
 	}
 
     if (magnifierCursor == nullptr) {

--- a/src/pdfviewer/PDFDocument.h
+++ b/src/pdfviewer/PDFDocument.h
@@ -67,7 +67,7 @@ class PDFDraggableTool : public QLabel
 public:
 	PDFDraggableTool(QWidget* parent): QLabel(parent) {}
 	virtual void reshape() = 0;
-	void drawCircleGradient(QPainter& painter, const QRect& outline, QColor color, int padding);
+	void drawGradient(QPainter& painter, const QRect& outline, QColor color, int padding, int magnifierShape);
 };
 
 class PDFMagnifier : public PDFDraggableTool

--- a/src/pdfviewer/PDFDocument_config.h
+++ b/src/pdfviewer/PDFDocument_config.h
@@ -25,8 +25,9 @@ struct PDFDocumentConfig {
 	double zoomStepFactor;
 
     int magnifierSize;
-    enum MagnifierShape {Rect,CircleWithShadow,Circle};
+    enum MagnifierShape {Rectangle,Circle};
     MagnifierShape magnifierShape;
+	bool magnifierShadow;
 	bool magnifierBorder;
 
 	int laserPointerSize;


### PR DESCRIPTION
This PR resolves #2885. By this the configuration of the magnifier's shape, border, and shadow are fully separated by providing a checkbox for the shadow.  In addition the user can select the shape of a rectangle (formerly called square) with a shadow:

![grafik](https://user-images.githubusercontent.com/102688820/214894017-c4b04308-d6f3-401a-8102-8fa02bd71bb3.png)

![grafik](https://user-images.githubusercontent.com/102688820/214704045-962d4896-19fd-4ef5-9396-bfbaf8083a03.png)
#### Backward compatibility
Default is _Circle with shadow_ as before. Old values are mapped like this:
```
Square (Rectangle)    --> Rectangle with shadow
Circle with shadow    --> Circle with shadow
Circle without shadow --> Circle without shadow
```
First case is exceptional because a shadow is added. But this is a very, very small change of the GUI. All other cases make no change.
On the other hand: A combobox with item _Rectangle with shadow_ appended would give a random item sequence, and anyone would ask, "border is not part of the list, so why is shadow?"