### PR TITLE
fix some units of measurement in config dialog

### DIFF
--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -3092,7 +3092,7 @@ to render the characters. Since unicode is not natively supported by LaTeX, you 
                    <string>Size of the command set tabs at the bottom or top of the completer</string>
                   </property>
                   <property name="suffix">
-                   <string notr="true"> %</string>
+                   <string notr="true">%</string>
                   </property>
                   <property name="maximum">
                    <number>10000</number>
@@ -3998,6 +3998,9 @@ them here.</string>
                   </item>
                   <item row="4" column="1">
                    <widget class="QSpinBox" name="spinBoxAutoPreviewDelay">
+                    <property name="suffix">
+                     <string> ms</string>
+                    </property>
                     <property name="minimum">
                      <number>40</number>
                     </property>
@@ -4549,7 +4552,11 @@ Note: Changing this setting will only affect documents that are opened afterward
                    </widget>
                   </item>
                   <item row="8" column="1">
-                   <widget class="QSpinBox" name="spinBoxPreviewLaserPointerSize"/>
+                   <widget class="QSpinBox" name="spinBoxPreviewLaserPointerSize">
+                    <property name="suffix">
+                     <string> px</string>
+                    </property>
+                   </widget>
                   </item>
                   <item row="9" column="1">
                    <widget class="QLineEdit" name="lineEditLaserPointerColor"/>


### PR DESCRIPTION
This PR fixes some issues with units in the config dialog. Looking through the pages I found following items affected from units:

1.  General: Check every 7 days
2. Completion: **Tab Bar Size 100 %** --> % character without space in all other cases
3. Preview: **Auto Update Delay: 300** -->Unit "ms" missing
4. PDF Viewer:
   - Screen Resolution 94 dpi
   - Magnifier Size 400 px
   - **Laser Pointer Size 25** --> Unit "px" missing
   - Highlight Duration 2000 ms
   - Cache Size 512 MB

The three bold values above are fixed:

![grafik](https://user-images.githubusercontent.com/102688820/214978061-83eee4d7-1aa6-460f-80ac-5e0e9ccd882b.png)

![grafik](https://user-images.githubusercontent.com/102688820/214978096-280a7d64-faf9-442c-9b0e-7ca5ab868681.png)

![grafik](https://user-images.githubusercontent.com/102688820/214978125-a600219f-7156-48f1-baaf-38ac49949e02.png)
