### PR TITLE
add tooltips to items in comboboxes in toolbars

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -786,19 +786,20 @@ void Texstudio::updateToolBarMenu(const QString &menuName)
 					REQUIRE(combo);
 
 					QStringList actionTexts;
+					QStringList actionInfos;
 					QList<QIcon> actionIcons;
 					int defaultIndex = -1;
-					foreach (const QAction *act, menu->actions())
+					foreach (const QAction *act, menu->actions()) {
 						if (!act->isSeparator()) {
 							actionTexts.append(act->text());
+							actionInfos.append(act->toolTip());
 							actionIcons.append(act->icon());
 							if (menuName == "main/view/documents" && edView == act->data().value<LatexEditorView *>()) {
 								defaultIndex = actionTexts.length() - 1;
 							}
 						}
-
-					//qDebug() << "**" << actionTexts;
-					UtilsUi::createComboToolButton(tb.toolbar, actionTexts, actionIcons, -1, this, SLOT(callToolButtonAction()), defaultIndex, combo);
+					}
+					UtilsUi::createComboToolButton(tb.toolbar, actionTexts, actionInfos, actionIcons, -1, this, SLOT(callToolButtonAction()), defaultIndex, combo);
 
 					if (menuName == "main/view/documents") {
 						// workaround to select the current document
@@ -807,18 +808,9 @@ void Texstudio::updateToolBarMenu(const QString &menuName)
 						// TODO: should this menu be provided by Editors?
 						LatexEditorView *edView = currentEditorView();
 						foreach (QAction* act, menu->actions()) {
-							qDebug() << act->data().value<LatexEditorView *>() << combo;
 							if (edView == act->data().value<LatexEditorView *>()) {
 								int i = menu->actions().indexOf(act);
-								qDebug() << i << combo->menu()->actions().length();
 								if (i < 0 || i>= combo->menu()->actions().length()) continue;
-								foreach (QAction *act, menu->actions()) {
-									qDebug() << "menu" << act->text();
-								}
-								foreach (QAction *act, combo->menu()->actions()) {
-									qDebug() << "cmb" << act->text();
-								}
-
 								combo->setDefaultAction(combo->menu()->actions()[i]);
 							}
 						}
@@ -1546,7 +1538,7 @@ void Texstudio::setupToolBars()
 					tagsWidget->populate();
 				QStringList list = tagsWidget->tagsTxtFromCategory(actionName.mid(tagCategorySep + 1));
 				if (list.isEmpty()) continue;
-				QToolButton *combo = UtilsUi::createComboToolButton(mtb.toolbar, list, QList<QIcon>(), 0, this, SLOT(insertXmlTagFromToolButtonAction()));
+				QToolButton *combo = UtilsUi::createComboToolButton(mtb.toolbar, list, QStringList(), QList<QIcon>(), 0, this, SLOT(insertXmlTagFromToolButtonAction()));
 				combo->setProperty("tagsID", actionName);
 				mtb.toolbar->addWidget(combo);
 			} else {
@@ -1567,14 +1559,16 @@ void Texstudio::setupToolBars()
 					//Case 4: A submenu mapped on a toolbutton
 					configManager.watchedMenus << actionName;
 					QStringList list;
+					QStringList infos;
 					QList<QIcon> icons;
 					foreach (const QAction *act, menu->actions())
 						if (!act->isSeparator()) {
 							list.append(act->text());
+							infos.append(act->toolTip());
 							icons.append(act->icon());
 						}
 					//TODO: Is the callToolButtonAction()-slot really needed? Can't we just add the menu itself as the menu of the qtoolbutton, without creating a copy? (should be much faster)
-					QToolButton *combo = UtilsUi::createComboToolButton(mtb.toolbar, list, icons, 0, this, SLOT(callToolButtonAction()));
+					QToolButton *combo = UtilsUi::createComboToolButton(mtb.toolbar, list, infos, icons, 0, this, SLOT(callToolButtonAction()));
 					combo->setProperty("menuID", actionName);
 					mtb.toolbar->addWidget(combo);
 				}

--- a/src/utilsUI.cpp
+++ b/src/utilsUI.cpp
@@ -118,7 +118,7 @@ void txsCritical(const QString &message)
 	QMessageBox::critical(QApplication::activeWindow(), TEXSTUDIO, message, QMessageBox::Ok);
 }
 
-QToolButton *createComboToolButton(QWidget *parent, const QStringList &list, const QList<QIcon> &icons, int height, const QObject *receiver, const char *member, int defaultIndex, QToolButton *combo)
+QToolButton *createComboToolButton(QWidget *parent, const QStringList &list, const QStringList &infos, const QList<QIcon> &icons, int height, const QObject *receiver, const char *member, int defaultIndex, QToolButton *combo)
 {
 	Q_UNUSED(icons)
 	const QFontMetrics &fm = parent->fontMetrics();
@@ -143,12 +143,14 @@ QToolButton *createComboToolButton(QWidget *parent, const QStringList &list, con
 		combo->removeAction(mAction);
 
 	QMenu *mMenu = new QMenu(combo);
+	mMenu->setToolTipsVisible(true);
 	int max = 0;
 	bool defaultSet = false;
 	for (int i = 0; i < list.length(); i++) {
 		QString text = list[i];
 		//QIcon icon = (i<icons.length()) ? icons[i] : QIcon();
 		QAction *mAction = mMenu->addAction(text, receiver, member);
+		if (infos.count()>0) mAction->setToolTip(infos[i]);
 		max = qMax(max, getFmWidth(fm, text + "        "));
 		if (i == defaultIndex) {
 			combo->setDefaultAction(mAction);

--- a/src/utilsUI.h
+++ b/src/utilsUI.h
@@ -18,7 +18,7 @@ void txsWarning(const QString &message, bool &noWarnAgain);
 void txsCritical(const QString &message);
 
 //setup toolbutton as substitute for const combobox
-QToolButton* createComboToolButton(QWidget *parent, const QStringList &list, const QList<QIcon> &icons, int height, const QObject *receiver, const char *member, int defaultIndex = -1, QToolButton *combo = nullptr);
+QToolButton* createComboToolButton(QWidget *parent, const QStringList &list, const QStringList &infos, const QList<QIcon> &icons, int height, const QObject *receiver, const char *member, int defaultIndex = -1, QToolButton *combo = nullptr);
 
 //find the tool button which contains a given action
 QToolButton *comboToolButtonFromAction(QAction *action);


### PR DESCRIPTION
This PR resolves #2881.
Inserted additional parameter infos to createComboToolButton.
Removed several lines for debugging.

Note: I observed that separator lines from the source menu (s. math/equations between multline* and cases as an example are not copied to the menu in the combobox (s. image). But this is not new behavior.

![image](https://user-images.githubusercontent.com/102688820/215268663-147a8849-2ea5-46ae-8c51-18336a850f31.png)
