### PR TITLE
Refine rectangular shadow

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -474,7 +474,7 @@ void PDFMagnifier::paintEvent(QPaintEvent *event)
 			QRect outline(0, 0, width(), height());
 			drawGradient(painter, outline, QColor(Qt::black), shadowWidth, globalConfig->magnifierShape);
 	
-			borderPath.addRect(5, 5, width() - shadowWidth - 6, height() - shadowWidth - 6);
+			borderPath.addRect(5, 5, width() - shadowWidth - 3, height() - shadowWidth - 6);
 
 		}
 	} else {


### PR DESCRIPTION
This PR makes the shadow of the rectangular magnifier a bit less intrusive by illuminating it from the top center.

This also makes it consistent with the shadow of the round magnifier, which is also illuminated from the top center.

Before:
<img width="305" alt="before" src="https://user-images.githubusercontent.com/17005217/215293020-a686fb45-868e-47f3-a442-4bdd51e99f96.png">

After:
<img width="305" alt="after" src="https://user-images.githubusercontent.com/17005217/215321787-0877e64f-0446-4b5a-8a4d-fe3436a51c6e.png">
