### PR TITLE
cwl: fix arg-spec for `\pgfmathrandom`

### DIFF
--- a/completion/pgfmath.cwl
+++ b/completion/pgfmath.cwl
@@ -135,9 +135,8 @@
 \pgfmathgeneratepseudorandomnumber#*
 \pgfmathrnd#*
 \pgfmathrand#*
-\pgfmathrandom{maximum int}#*
-\pgfmathrandom{minimum int}{maximum int}#*
-\pgfmathrandominteger{cmd}{minimum}{maximum}#*d
+\pgfmathrandom{%<[[min int,] max int]%>}#*
+\pgfmathrandominteger{cmd}{min}{max}#*d
 \pgfmathdeclarerandomlist{list name}{list of items}#*
 \pgfmathrandomitem{cmd}{list name}#*d
 


### PR DESCRIPTION
It always takes single arg, only the arg content can be a 0-, 1-, or 2-element comma-separated list.

A LaTeX example to play with:
```tex
\documentclass{article}
\usepackage{pgffor, pgfmath}
\usepackage{testcwl}

\begin{document}
% online doc: https://tikz.dev/math-parsing#\pgfmathrandom

% random decimal number between 0 and 1
\foreach \i in {1,...,10} {\pgfmathrandom{}\pgfmathresult, }

% random integer between 1 and 5
\foreach \i in {1,...,10} {\pgfmathrandom{5}\pgfmathresult, }

% random integer between 4 and 5
\foreach \i in {1,...,10} {\pgfmathrandom{4,5}\pgfmathresult, }
\end{document}
```