### PR TITLE
cwl: add `\hyperlinkCMD{...}<...>` variants

### DIFF
--- a/completion/beamerbasenavigation.cwl
+++ b/completion/beamerbasenavigation.cwl
@@ -2,54 +2,78 @@
 # Matthew Bertucci 1/30/2022 for v3.65
 
 \hyperlinkslideprev<overlay specification>{link text}
+\hyperlinkslideprev{link text}<overlay specification>
 \hyperlinkslideprev{link text}
 \hyperlinkslidenext<overlay specification>{link text}
+\hyperlinkslidenext{link text}<overlay specification>
 \hyperlinkslidenext{link text}
 \hyperlinkframestart<overlay specification>{link text}
+\hyperlinkframestart{link text}<overlay specification>
 \hyperlinkframestart{link text}
 \hyperlinkframeend<overlay specification>{link text}
+\hyperlinkframeend{link text}<overlay specification>
 \hyperlinkframeend{link text}
 \hyperlinkframestartnext<overlay specification>{link text}
+\hyperlinkframestartnext{link text}<overlay specification>
 \hyperlinkframestartnext{link text}
 \hyperlinkframeendprev<overlay specification>{link text}
+\hyperlinkframeendprev{link text}<overlay specification>
 \hyperlinkframeendprev{link text}
 \hyperlinkpresentationstart<overlay specification>{link text}
+\hyperlinkpresentationstart{link text}<overlay specification>
 \hyperlinkpresentationstart{link text}
 \hyperlinkpresentationend<overlay specification>{link text}
+\hyperlinkpresentationend{link text}<overlay specification>
 \hyperlinkpresentationend{link text}
 \hyperlinkappendixstart<overlay specification>{link text}
+\hyperlinkappendixstart{link text}<overlay specification>
 \hyperlinkappendixstart{link text}
 \hyperlinkappendixend<overlay specification>{link text}
+\hyperlinkappendixend{link text}<overlay specification>
 \hyperlinkappendixend{link text}
 \hyperlinkdocumentstart<overlay specification>{link text}
+\hyperlinkdocumentstart{link text}<overlay specification>
 \hyperlinkdocumentstart{link text}
 \hyperlinkdocumentend<overlay specification>{link text}
+\hyperlinkdocumentend{link text}<overlay specification>
 \hyperlinkdocumentend{link text}
 
 \hyperlinksubsectionstart{link text}#*
 \hyperlinksubsectionstart<overlay specification>{link text}#*
+\hyperlinksubsectionstart{link text}<overlay specification>#*
 \hyperlinksubsectionend{link text}#*
 \hyperlinksubsectionend<overlay specification>{link text}#*
+\hyperlinksubsectionend{link text}<overlay specification>#*
 \hyperlinksubsectionstartnext{link text}#*
 \hyperlinksubsectionstartnext<overlay specification>{link text}#*
+\hyperlinksubsectionstartnext{link text}<overlay specification>#*
 \hyperlinksubsectionendprev{link text}#*
 \hyperlinksubsectionendprev<overlay specification>{link text}#*
+\hyperlinksubsectionendprev{link text}<overlay specification>#*
 \hyperlinksectionstart{link text}#*
 \hyperlinksectionstart<overlay specification>{link text}#*
+\hyperlinksectionstart{link text}<overlay specification>#*
 \hyperlinksectionend{link text}#*
 \hyperlinksectionend<overlay specification>{link text}#*
+\hyperlinksectionend{link text}<overlay specification>#*
 \hyperlinksectionstartnext{link text}#*
 \hyperlinksectionstartnext<overlay specification>{link text}#*
+\hyperlinksectionstartnext{link text}<overlay specification>#*
 \hyperlinksectionendprev{link text}#*
 \hyperlinksectionendprev<overlay specification>{link text}#*
+\hyperlinksectionendprev{link text}<overlay specification>#*
 \hyperlinkpartstart{link text}#*
 \hyperlinkpartstart<overlay specification>{link text}#*
+\hyperlinkpartstart{link text}<overlay specification>#*
 \hyperlinkpartend{link text}#*
 \hyperlinkpartend<overlay specification>{link text}#*
+\hyperlinkpartend{link text}<overlay specification>#*
 \hyperlinkpartstartnext{link text}#*
 \hyperlinkpartstartnext<overlay specification>{link text}#*
+\hyperlinkpartstartnext{link text}<overlay specification>#*
 \hyperlinkpartendprev{link text}#*
 \hyperlinkpartendprev<overlay specification>{link text}#*
+\hyperlinkpartendprev{link text}<overlay specification>#*
 
 \insertframestartpage#*
 \insertframeendpage#*

--- a/completion/beamerbaseoverlay.cwl
+++ b/completion/beamerbaseoverlay.cwl
@@ -110,6 +110,7 @@ again covered=%<once more list%>
 \textup<overlay specification>{text}
 \hypertarget<overlay specification>{target name}{anchor text%text}
 \hyperlink<overlay specification>{target name}{link text%text}
+\hyperlink{target name}{link text%text}<overlay specification>
 \emph<overlay specification>{text}
 
 \begin{overlayarea}{area width%l}{area height%l}


### PR DESCRIPTION
According to `beamer`'s user guide, sec. 11.1 _Adding Hyperlinks and Buttons_,
- add `\hyperlink{}{}<>` variant
- add `\hyperlinkXXX{}<>` variants

![image](https://user-images.githubusercontent.com/6376638/216749434-cd3a2767-854b-4600-bd72-fb70bf246970.png)
