### PR TITLE
fix URL file schema used in About dialog

### DIFF
--- a/src/aboutdialog.cpp
+++ b/src/aboutdialog.cpp
@@ -21,7 +21,7 @@ AboutDialog::AboutDialog(QWidget *parent)
     if(changelogPath.isEmpty()){
         changelogPath="https://texstudio-org.github.io/CHANGELOG.html";
     }else{
-        changelogPath="file://"+changelogPath;
+        changelogPath="file:///"+changelogPath;
     }
 	ui.textBrowser->setOpenExternalLinks(true);
     ui.textBrowser->setHtml(QString("<b>%1 %2</b> (git %3)").arg(TEXSTUDIO,TXSVERSION,TEXSTUDIO_GIT_REVISION ? TEXSTUDIO_GIT_REVISION : "n/a") + "<br>" +


### PR DESCRIPTION
This PR fixes #2927. Without this fix even a simple text file will not be loaded by QTextBrowser.