### PR TITLE
cd: update to ubuntu 20.04

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -90,7 +90,7 @@ jobs:
   build-linux-release:
     name: linux appimage
     if: github.event_name == 'push'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
Ubuntu 18.04 will be deprecated by 2023/04/01, see
 - https://github.com/actions/runner-images/issues/6002

In recent workflow run https://github.com/texstudio-org/texstudio/actions/runs/4116541834, build on Linux is skipped because one of the scheduled brownout periods is hit:

- February 7, 16.00 UTC – February 7, 22.00 UTC

Future periods are

- February 21, 10.00 UTC – February 21, 22.00 UTC
- March 6, 00.00 UTC – March 7, 00.00 UTC
- March 13, 00.00 UTC – March 14, 00.00 UTC
- March 21, 00.00 UTC – March 22, 00.00 UTC
- March 28, 00.00 UTC – March 29, 00.00 UTC