### PR TITLE
add Special option to Adv. Editor for Overscrolling Last Line to Top

### DIFF
--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -2227,9 +2227,9 @@ Then you can select a new shortcut by one of the following ways:
                    </widget>
                   </item>
                   <item row="7" column="0" colspan="2">
-                   <widget class="QCheckBox" name="checkOverwriteOpeningBracketFollowedByPlaceholder">
+                   <widget class="QCheckBox" name="checkBoxSmoothScrolling">
                     <property name="text">
-                     <string>Overwrite Opening Bracket Followed by a Placeholder</string>
+                     <string>Smooth Scrolling</string>
                     </property>
                    </widget>
                   </item>
@@ -2241,9 +2241,9 @@ Then you can select a new shortcut by one of the following ways:
                    </widget>
                   </item>
                   <item row="4" column="0">
-                   <widget class="QCheckBox" name="checkBoxMouseWheelZoom">
+                   <widget class="QCheckBox" name="checkOverwriteOpeningBracketFollowedByPlaceholder">
                     <property name="text">
-                     <string>Mouse Wheel Zoom</string>
+                     <string>Overwrite Opening Bracket Followed by a Placeholder</string>
                     </property>
                    </widget>
                   </item>
@@ -2350,9 +2350,9 @@ to render the characters. Since unicode is not natively supported by LaTeX, you 
                    </widget>
                   </item>
                   <item row="8" column="0" colspan="2">
-                   <widget class="QCheckBox" name="checkOverwriteClosingBracketFollowingPlaceholder">
+                   <widget class="QCheckBox" name="checkBoxMouseWheelZoom">
                     <property name="text">
-                     <string>Overwrite Closing Bracket Following a Placeholder</string>
+                     <string>Mouse Wheel Zoom</string>
                     </property>
                    </widget>
                   </item>
@@ -2387,9 +2387,9 @@ to render the characters. Since unicode is not natively supported by LaTeX, you 
                    </widget>
                   </item>
                   <item row="6" column="0" colspan="2">
-                   <widget class="QCheckBox" name="checkBoxAllowDragAndDrop">
+                   <widget class="QCheckBox" name="checkBoxVerticalOverScroll">
                     <property name="text">
-                     <string>Allow Drag and Drop</string>
+                     <string>Vertical Overscroll (Scroll below end of file)</string>
                     </property>
                    </widget>
                   </item>
@@ -2433,9 +2433,9 @@ to render the characters. Since unicode is not natively supported by LaTeX, you 
                    </widget>
                   </item>
                   <item row="5" column="0">
-                   <widget class="QCheckBox" name="checkBoxSmoothScrolling">
+                   <widget class="QCheckBox" name="checkOverwriteClosingBracketFollowingPlaceholder">
                     <property name="text">
-                     <string>Smooth Scrolling</string>
+                     <string>Overwrite Closing Bracket Following a Placeholder</string>
                     </property>
                    </widget>
                   </item>
@@ -2519,16 +2519,16 @@ to render the characters. Since unicode is not natively supported by LaTeX, you 
                    </widget>
                   </item>
                   <item row="9" column="0" colspan="2">
-                   <widget class="QCheckBox" name="checkBoxDoubleClickSelectionIncludeLeadingBackslash">
+                   <widget class="QCheckBox" name="checkBoxAllowDragAndDrop">
                     <property name="text">
-                     <string>Double-Click Selection: Include Leading Backslash</string>
+                     <string>Allow Drag and Drop</string>
                     </property>
                    </widget>
                   </item>
                   <item row="10" column="0" colspan="2">
-                   <widget class="QCheckBox" name="checkBoxVerticalOverScroll">
+                   <widget class="QCheckBox" name="checkBoxDoubleClickSelectionIncludeLeadingBackslash">
                     <property name="text">
-                     <string>Vertical Overscroll (Scroll below end of file)</string>
+                     <string>Double-Click Selection: Include Leading Backslash</string>
                     </property>
                    </widget>
                   </item>

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -2219,7 +2219,7 @@ Then you can select a new shortcut by one of the following ways:
                     </property>
                    </widget>
                   </item>
-                  <item row="3" column="2" colspan="2">
+                  <item row="2" column="2" colspan="2">
                    <widget class="QCheckBox" name="checkBoxImageToolTip">
                     <property name="text">
                      <string>Show image tooltip on image files</string>
@@ -2240,7 +2240,7 @@ Then you can select a new shortcut by one of the following ways:
                     </property>
                    </widget>
                   </item>
-                  <item row="4" column="0">
+                  <item row="3" column="0">
                    <widget class="QCheckBox" name="checkOverwriteOpeningBracketFollowedByPlaceholder">
                     <property name="text">
                      <string>Overwrite Opening Bracket Followed by a Placeholder</string>
@@ -2379,14 +2379,14 @@ to render the characters. Since unicode is not natively supported by LaTeX, you 
                   <item row="23" column="1" colspan="2">
                    <widget class="QComboBox" name="comboBoxLogFileEncoding"/>
                   </item>
-                  <item row="5" column="2" colspan="2">
+                  <item row="4" column="2" colspan="2">
                    <widget class="QCheckBox" name="checkBoxTexDocInternal">
                     <property name="text">
                      <string>Show help on commands in internal pdf viewer (texdoc)</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="6" column="0" colspan="2">
+                  <item row="5" column="0" colspan="2">
                    <widget class="QCheckBox" name="checkBoxVerticalOverScroll">
                     <property name="text">
                      <string>Vertical Overscroll (Scroll below end of file)</string>
@@ -2432,7 +2432,7 @@ to render the characters. Since unicode is not natively supported by LaTeX, you 
                     </property>
                    </widget>
                   </item>
-                  <item row="5" column="0">
+                  <item row="4" column="0">
                    <widget class="QCheckBox" name="checkOverwriteClosingBracketFollowingPlaceholder">
                     <property name="text">
                      <string>Overwrite Closing Bracket Following a Placeholder</string>
@@ -2490,7 +2490,7 @@ to render the characters. Since unicode is not natively supported by LaTeX, you 
                     </item>
                    </widget>
                   </item>
-                  <item row="4" column="2" colspan="2">
+                  <item row="3" column="2" colspan="2">
                    <widget class="QCheckBox" name="checkBoxToolTipHelp2">
                     <property name="text">
                      <string>Show help as tooltip on text in editor</string>
@@ -2511,7 +2511,7 @@ to render the characters. Since unicode is not natively supported by LaTeX, you 
                     </property>
                    </widget>
                   </item>
-                  <item row="3" column="0">
+                  <item row="2" column="0">
                    <widget class="QCheckBox" name="checkBoxAutoCompleteParens">
                     <property name="text">
                      <string>Auto Complete Parentheses</string>

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -2391,7 +2391,25 @@ to render the characters. Since unicode is not natively supported by LaTeX, you 
                     <property name="text">
                      <string>Vertical Overscroll (Scroll below end of file)</string>
                     </property>
+                    <property name="toolTip">
+                     <string>When you check this option then the editor can be scrolled down until the last line of text reaches the middle of the editor.
+If you check this option and the next one then scrolling ends when the last line of text is at top of the editor.</string>
+                    </property>
                    </widget>
+                  </item>
+                  <item row="6" column="0" colspan="2">
+                   <layout class="QVBoxLayout" name="verticalLayout_19">
+                    <property name="leftMargin">
+                     <number>16</number>
+                    </property>
+                    <item>
+                     <widget class="QCheckBox" name="checkBoxOverScrollToTop">
+                      <property name="text">
+                       <string>Last Line Scrollable to Top</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
                   </item>
                   <item row="11" column="1" colspan="2">
                    <widget class="QComboBox" name="comboBoxTripleClickSelection">

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -578,6 +578,7 @@ ConfigManager::ConfigManager(QObject *parent): QObject (parent),
 	registerOption("Editor/Mouse Wheel Zoom", &editorConfig->mouseWheelZoom, true, &pseudoDialog->checkBoxMouseWheelZoom);
 	registerOption("Editor/Smooth Scrolling", &editorConfig->smoothScrolling, true, &pseudoDialog->checkBoxSmoothScrolling);
 	registerOption("Editor/Vertical Over Scroll", &editorConfig->verticalOverScroll, false, &pseudoDialog->checkBoxVerticalOverScroll);
+	registerOption("Editor/Vertical Over Scroll To Top", &editorConfig->overScrollToTop, false, &pseudoDialog->checkBoxOverScrollToTop);
 
 	registerOption("Editor/Hack Auto Choose", &editorConfig->hackAutoChoose, true, &pseudoDialog->checkBoxHackAutoRendering);
 	registerOption("Editor/Hack Disable Fixed Pitch", &editorConfig->hackDisableFixedPitch, false, &pseudoDialog->checkBoxHackDisableFixedPitch);

--- a/src/latexeditorview.cpp
+++ b/src/latexeditorview.cpp
@@ -1735,6 +1735,7 @@ void LatexEditorView::updateSettings()
 	editor->setFlag(QEditor::MouseWheelZoom, config->mouseWheelZoom);
 	editor->setFlag(QEditor::SmoothScrolling, config->smoothScrolling);
 	editor->setFlag(QEditor::VerticalOverScroll, config->verticalOverScroll);
+	editor->setFlag(QEditor::OverScrollToTop, config->overScrollToTop);
 	editor->setFlag(QEditor::AutoInsertLRM, config->autoInsertLRM);
 	editor->setFlag(QEditor::BidiVisualColumnMode, config->visualColumnMode);
 	editor->setFlag(QEditor::OverwriteOpeningBracketFollowedByPlaceholder, config->overwriteOpeningBracketFollowedByPlaceholder);

--- a/src/latexeditorview_config.h
+++ b/src/latexeditorview_config.h
@@ -34,7 +34,7 @@ public:
 	static QString translateEditOperation(int key);
 	static QList<int> possibleEditOperations();
 	bool allowDragAndDrop;
-	bool mouseWheelZoom, smoothScrolling, verticalOverScroll;
+	bool mouseWheelZoom, smoothScrolling, verticalOverScroll, overScrollToTop;
 
 	bool hackAutoChoose, hackDisableFixedPitch, hackDisableWidthCache, hackDisableLineCache, hackDisableAccentWorkaround, hackQImageCache;
 	int hackRenderingMode; //0: normal, 1: qt (missing), 2: single letter

--- a/src/qcodeedit/lib/qeditor.h
+++ b/src/qcodeedit/lib/qeditor.h
@@ -96,6 +96,7 @@ class QCE_EXPORT QEditor : public QAbstractScrollArea
 			SmoothScrolling     = 0x00004000,
 			MouseWheelZoom      = 0x00008000,
 			VerticalOverScroll  = 0x04000000,
+			OverScrollToTop     = 0x08000000,
 
 			ReplaceIndentTabs		= 0x00010000,
 			ReplaceTextTabs			= 0x00020000,

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## TeXstudio development (4.5.2)
 
 - Show changelog in about dialog
+- add Special option to Adv. Editor for Overscrolling Last Line to Top ([#2944](https://github.com/texstudio-org/texstudio/issues/2944))
 
 ## TeXstudio 4.5.1
 

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 ## TeXstudio development (4.5.2)
 
-- Show changelog in about dialog
+- Show changelog in about dialog and manual
 - add Special option to Adv. Editor for Overscrolling Last Line to Top ([#2944](https://github.com/texstudio-org/texstudio/issues/2944))
 
 ## TeXstudio 4.5.1


### PR DESCRIPTION
This PR closes #2944 by adding a new Option to Adv. Editor Config. This option allows the editor to scroll down over the last line until the line reaches the top of the editor. Please check the option text and the tooltip.

Please make CHANGELOG.html

### Description of Commits
1. reorder some Special options as depicted in following image (row numbers to the left):

    ![image](https://user-images.githubusercontent.com/102688820/217949443-d717c2aa-ab51-4363-a19e-88887a099724.png)

    The final result to the right shows 3 options concerned with parentheses/brackets, two with scrolling and the rest with mouse actions (including option Triple-Click Selection below lower edge of the image). Not visible options to the right are not touched.
2. Since the new option should be in row 6 rows 3 to 6 are renumbered from 2 to 5.
3. Add new option and optimize vertical scrollbar settings (discussed below):

    ![image](https://user-images.githubusercontent.com/102688820/217950546-fb4c72c9-4a53-4855-b0be-8852ba303a98.png)

    The new option is not set by default. This together with the usage of two checkboxes ensures that the old setting can be reproduced exactly as it was. Option *Vertical Overscroll* shows following tooltip:
    ![image](https://user-images.githubusercontent.com/102688820/217951514-f2fa4fc3-ac2e-4169-96f2-494b9a9e8575.png)
    Be aware that the two options concerning monitoring of open files use two related checkboxes in a similar way as it is here.

### Enhancing Vertical Scroll Bar Settings
The old formulae used have two drawbacks: 1. Page scrolling may omit rows and 2. Scrolling doesn't exactly stop in the middle of the editor.

1. Page scrolling may omit rows
    Old formula ``setPageStep(qCeil(1.* viewportSize.height() / ls))`` applies qCeil to the number of lines visible in the editor. This number is not an integer when the lower edge of the editor covers some fraction of a line. Thus this line is part of the pageStep and the line after it will be the line presented at the top after scrolling one page.
    Example. In this case the editor shows almost nothing of line 14:

    ![image](https://user-images.githubusercontent.com/102688820/217954419-84a7b1f2-224c-4bf1-adf3-f2f5515eb3fa.png)

    Now scroll down one page with the old formula:

    ![image](https://user-images.githubusercontent.com/102688820/217954557-7300a0dd-c6bc-4de8-a28b-c4dab7ef7781.png)

    No one (except me) can tell what is written in line 14. And this will happen every time scrolling down one page. The new formula ``setPageStep(qFloor(viewportSize.height() / ls + 0.3))`` guarantees that the covered line will be presented again at top after scrolling as long as more than 30% of the line are covered by the edge:

    ![image](https://user-images.githubusercontent.com/102688820/217955440-3faa91a8-0c5a-4238-9eff-2acdc9c4aea0.png)

    Now we know the contents of line 14. The following image shows the exact limit when line 14 will not be presented again at top:

    ![image](https://user-images.githubusercontent.com/102688820/217955678-ed994089-cc95-4a56-94ff-e8a4eedf126e.png)

2. Scrolling doesn't exactly stop in the middle of the editor
    In this case (the dashed line divides the editor into equal parts)

    ![image](https://user-images.githubusercontent.com/102688820/217956815-4d69235f-b6c0-46df-85a1-4ee321cf040d.png)

    overscrolling should show the last 7 lines. This is not the case when using the old formula

    ![image](https://user-images.githubusercontent.com/102688820/217956876-eaa40227-39c1-4477-b177-ef304b9b290d.png)

    but with the new one:

    ![image](https://user-images.githubusercontent.com/102688820/217956948-adb03117-47bd-4b2d-a785-b4384bb60521.png)

    When the number of visible lines is odd then there is one line in the middle of the editor. So overscrolling should show the last line at this place. But with the old formula this place is empty, but not with the new one. I leave it to the reader to check this.