### PR TITLE
Overscroll2top

### DIFF
--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -2227,9 +2227,9 @@ Then you can select a new shortcut by one of the following ways:
                    </widget>
                   </item>
                   <item row="7" column="0" colspan="2">
-                   <widget class="QCheckBox" name="checkOverwriteOpeningBracketFollowedByPlaceholder">
+                   <widget class="QCheckBox" name="checkBoxSmoothScrolling">
                     <property name="text">
-                     <string>Overwrite Opening Bracket Followed by a Placeholder</string>
+                     <string>Smooth Scrolling</string>
                     </property>
                    </widget>
                   </item>
@@ -2241,9 +2241,9 @@ Then you can select a new shortcut by one of the following ways:
                    </widget>
                   </item>
                   <item row="4" column="0">
-                   <widget class="QCheckBox" name="checkBoxMouseWheelZoom">
+                   <widget class="QCheckBox" name="checkOverwriteOpeningBracketFollowedByPlaceholder">
                     <property name="text">
-                     <string>Mouse Wheel Zoom</string>
+                     <string>Overwrite Opening Bracket Followed by a Placeholder</string>
                     </property>
                    </widget>
                   </item>
@@ -2350,9 +2350,9 @@ to render the characters. Since unicode is not natively supported by LaTeX, you 
                    </widget>
                   </item>
                   <item row="8" column="0" colspan="2">
-                   <widget class="QCheckBox" name="checkOverwriteClosingBracketFollowingPlaceholder">
+                   <widget class="QCheckBox" name="checkBoxMouseWheelZoom">
                     <property name="text">
-                     <string>Overwrite Closing Bracket Following a Placeholder</string>
+                     <string>Mouse Wheel Zoom</string>
                     </property>
                    </widget>
                   </item>
@@ -2387,9 +2387,9 @@ to render the characters. Since unicode is not natively supported by LaTeX, you 
                    </widget>
                   </item>
                   <item row="6" column="0" colspan="2">
-                   <widget class="QCheckBox" name="checkBoxAllowDragAndDrop">
+                   <widget class="QCheckBox" name="checkBoxVerticalOverScroll">
                     <property name="text">
-                     <string>Allow Drag and Drop</string>
+                     <string>Vertical Overscroll (Scroll below end of file)</string>
                     </property>
                    </widget>
                   </item>
@@ -2433,9 +2433,9 @@ to render the characters. Since unicode is not natively supported by LaTeX, you 
                    </widget>
                   </item>
                   <item row="5" column="0">
-                   <widget class="QCheckBox" name="checkBoxSmoothScrolling">
+                   <widget class="QCheckBox" name="checkOverwriteClosingBracketFollowingPlaceholder">
                     <property name="text">
-                     <string>Smooth Scrolling</string>
+                     <string>Overwrite Closing Bracket Following a Placeholder</string>
                     </property>
                    </widget>
                   </item>
@@ -2519,16 +2519,16 @@ to render the characters. Since unicode is not natively supported by LaTeX, you 
                    </widget>
                   </item>
                   <item row="9" column="0" colspan="2">
-                   <widget class="QCheckBox" name="checkBoxDoubleClickSelectionIncludeLeadingBackslash">
+                   <widget class="QCheckBox" name="checkBoxAllowDragAndDrop">
                     <property name="text">
-                     <string>Double-Click Selection: Include Leading Backslash</string>
+                     <string>Allow Drag and Drop</string>
                     </property>
                    </widget>
                   </item>
                   <item row="10" column="0" colspan="2">
-                   <widget class="QCheckBox" name="checkBoxVerticalOverScroll">
+                   <widget class="QCheckBox" name="checkBoxDoubleClickSelectionIncludeLeadingBackslash">
                     <property name="text">
-                     <string>Vertical Overscroll (Scroll below end of file)</string>
+                     <string>Double-Click Selection: Include Leading Backslash</string>
                     </property>
                    </widget>
                   </item>

--- a/src/qcodeedit/lib/qeditor.cpp
+++ b/src/qcodeedit/lib/qeditor.cpp
@@ -3072,14 +3072,17 @@ void QEditor::selectOccurence(bool backward, bool keepMirrors, bool all)
 void QEditor::setVerticalScrollBarMaximum()
 {
 	if (!m_doc) return;
-	const QSize viewportSize = viewport()->size();
-	int viewportHeight = viewportSize.height();
-	if (flag(VerticalOverScroll))
-		viewportHeight /= 2;
-    const qreal ls = m_doc->getLineSpacing();
+	const qreal ls = m_doc->getLineSpacing();
+	const int totalLines = qRound(m_doc->height() / ls);
+	const int viewLines = qFloor(viewport()->size().height() / ls);
 	QScrollBar* vsb = verticalScrollBar();
-    vsb->setMaximum(qMax(0., 1. + (m_doc->height() - viewportHeight) / ls));
-    vsb->setPageStep(qCeil(1.* viewportSize.height() / ls));
+
+	if (flag(VerticalOverScroll)) {
+		vsb->setMaximum(totalLines - 1);    // allow last line scroll to top
+	} else {
+		vsb->setMaximum(qMax(0, totalLines - viewLines));    // disallow overscroll
+	}
+    vsb->setPageStep(viewLines);
 }
 
 /*!

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -1,7 +1,8 @@
 # CHANGELOG
 ## TeXstudio development (4.5.2)
 
-- Show changelog in about dialog
+- Show changelog in about dialog and manual
+- change Adv. Editor option "Vertical Overscroll" to scroll last line to top ([#2944](https://github.com/texstudio-org/texstudio/issues/2944))
 
 ## TeXstudio 4.5.1
 


### PR DESCRIPTION
This PR closes #2944 by changing interpretation of option "Vertical Overscroll" in Adv. Editor config. This will allow the editor to scroll down over the last line until the line reaches the top of the editor. The old behavior of stopping in the middle of the editor is dropped as discussed in #2946.

Please make CHANGELOG.html

### Description of Commits
1. reorder some Special options as depicted in following image (row numbers to the left) to fit better in terms of content:

    ![image](https://user-images.githubusercontent.com/102688820/217949443-d717c2aa-ab51-4363-a19e-88887a099724.png)

    The final result to the right shows 3 options concerned with parentheses/brackets, two with scrolling and the rest with mouse actions (including option Triple-Click Selection below lower edge of the image). Not visible options to the right are not touched.
2. change behavior of the option.
3. changelog

### Enhancing Vertical Scroll Bar Settings
The old formulae used have two drawbacks: 1. Page scrolling may conceal rows and 2. Scrolling doesn't "exactly" stop in the middle of the editor (this is not discussed here since this is no longer of relevance).

#### Page scrolling may omit rows

Old formula ``setPageStep(qCeil(1.* viewportSize.height() / ls))`` applies qCeil to the number of lines visible in the editor. This number is not an integer when the lower edge of the editor covers some fraction of a line. Thus this line is part of the pageStep and the line after it will be the line presented at the top after scrolling one page.

Example. In this case the editor shows almost nothing of line 14:

![image](https://user-images.githubusercontent.com/102688820/217954419-84a7b1f2-224c-4bf1-adf3-f2f5515eb3fa.png)

Now scroll down one page with the old formula:

![image](https://user-images.githubusercontent.com/102688820/217954557-7300a0dd-c6bc-4de8-a28b-c4dab7ef7781.png)

No one (except me) can tell what is written in line 14. And this will happen every time scrolling down one page. The new formula ``setPageStep(qFloor(viewport()->size().height() / ls))`` guarantees that the covered line will be presented again at top after scrolling:

![image](https://user-images.githubusercontent.com/102688820/217955440-3faa91a8-0c5a-4238-9eff-2acdc9c4aea0.png)

Now we know the contents of line 14.
