### PR TITLE
fix a cwl typoe

### DIFF
--- a/completion/tcolorbox.cwl
+++ b/completion/tcolorbox.cwl
@@ -284,7 +284,7 @@ upperbox=#visible,invisible
 visible
 invisible
 saveto=%<file name%>
-lowerbox=#visible,invisible,ignore
+lowerbox=#visible,invisible,ignored
 savelowerto=%<file name%>
 lower separated#true,false
 savedelimiter=%<name%>


### PR DESCRIPTION
tcolorbox choice option `/tcb/lowerbox` accepts `ignored`, not `ignore`.

Screenshot from the tcolorbox manual:
![image](https://user-images.githubusercontent.com/6376638/218344203-3912cc5d-9799-43d9-9cab-6bde3c6b33d7.png)
