### PR TITLE
insert spacer below template's meta info

### DIFF
--- a/src/templateselector.ui
+++ b/src/templateselector.ui
@@ -122,6 +122,22 @@
         </property>
        </widget>
       </item>
+      <item>
+       <spacer>
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Expanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
This issue was mentioned in issue https://github.com/texstudio-org/texstudio/issues/2975#issuecomment-1444482797

before fix:
![grafik](https://user-images.githubusercontent.com/102688820/221320357-bf43376c-815e-47a9-ba2d-cbdfe8ea3924.png)
note: dialog window shrinked for screenshot, so vertical spacing less than in standard dialog

after fix:
![grafik](https://user-images.githubusercontent.com/102688820/221320371-de292369-db60-4455-855b-83ee20c583b1.png)
