### PR TITLE
Add search field to menu bar in macOS

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -2955,7 +2955,11 @@ void PDFDocument::setupMenus(bool embedded)
     menuGrid=configManager->newManagedMenu(menuView,nullptr,"pdf/view/grid",QApplication::translate("PDFDocument", "Grid"));
     menuWindow=configManager->newManagedMenu(menuroot,menubar,"pdf/window",QApplication::translate("PDFDocument", "&Window"));
     menuEdit=configManager->newManagedMenu(menuroot,menubar,"pdf/config",QApplication::translate("PDFDocument", "&Configure"));
+#ifdef Q_OS_MAC // enable search field in help menu in macOS
+    menuHelp=configManager->newManagedMenu(menuroot,menubar,"pdf/help",QApplication::translate("PDFDocument", "Help"));
+#else
     menuHelp=configManager->newManagedMenu(menuroot,menubar,"pdf/help",QApplication::translate("PDFDocument", "&Help"));
+#endif
     menus<<menuFile<<menuEdit<<menuEdit_2<<menuGrid<<menuHelp<<menuWindow<<menuView; // housekeeping for later removal
 
     if(!embedded)


### PR DESCRIPTION
The `Help` menu bar item is instantiated with the string `&Help` to enable the Alt+H keyboard shortcut in Windows.

Usually macOS automatically adds a search field to the `Help` menu, but it doesn't in TexStudio because it gets confused about the prefixed ampersand.

This PR removes the ampersand when building for macOS, which enables the menu bar search field:

<img width="725" alt="help_menu_search" src="https://user-images.githubusercontent.com/17005217/222255332-53d7bbef-4a03-4bc6-8998-09a9d6c8d584.png">
