### PR TITLE
Stop displaying the pointing hand cursor on top of tools

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -1849,6 +1849,7 @@ void listAnnotationDetails(const Poppler::Annotation *an)
 void PDFWidget::updateCursor(const QPoint &pos)
 {
 	if (document.isNull()) return;
+	if (usingTool != kNone) return;
 
 	QPointF scaledPos;
 	int pageNr;


### PR DESCRIPTION
When dragging a tool (e.g. the magnifier) over a hyperlink, the pointing hand cursor would be displayed on top of the tool until the mouse button was released. This was caused by a missing check in one of the two `PDFWidget::updateCursor` methods.

This PR fixes this issue.