### PR TITLE
add Min/Max/Close buttons to Usermenudialog (macro editor)

### DIFF
--- a/src/usermenudialog.cpp
+++ b/src/usermenudialog.cpp
@@ -26,7 +26,7 @@
 #include "utilsUI.h"
 
 UserMenuDialog::UserMenuDialog(QWidget *parent,  QString name, QLanguageFactory *languageFactory)
-    : QDialog(parent), languages(languageFactory)
+    : QDialog(parent,Qt::Dialog|Qt::WindowMinMaxButtonsHint|Qt::WindowCloseButtonHint), languages(languageFactory)
 {
 	setWindowTitle(name);
 	ui.setupUi(this);


### PR DESCRIPTION
so no need to change the window size with the mouse

![grafik](https://user-images.githubusercontent.com/102688820/222925465-d5c164e0-a068-4103-b7f7-7b02eaca0078.png)

This makes reading and editing macros easier. There will be support for Win10 features such as maximum vertical stretching with a double click on the upper or lower border, or special window sizing by dragging the window to the screen borders or screen corners.