### PR TITLE
tooltips for macros in treewidget (Edit Macro dialog)

### DIFF
--- a/src/macrobrowserui.cpp
+++ b/src/macrobrowserui.cpp
@@ -65,7 +65,7 @@ QList<Macro> MacroBrowserUI::getSelectedMacros()
                 QString macroJson=cache.value(url);
                 if(!macroJson.isEmpty()){
                     Macro m;
-                    m.loadFromText(macroJson);
+                    m.loadFromText(macroJson,url);
                     lst << m;
                 }
             }

--- a/src/usermacro.cpp
+++ b/src/usermacro.cpp
@@ -273,10 +273,10 @@ bool Macro::load(const QString &fileName){
     in.setCodec("UTF-8");
 #endif
     QString text=in.readAll();
-    return loadFromText(text);
+    return loadFromText(text,fileName);
 }
 
-bool Macro::loadFromText(const QString &text)
+bool Macro::loadFromText(const QString &text, const QString &sourceInfo)
 {
     QHash<QString,QString>rawData;
     QJsonParseError parseError;
@@ -308,6 +308,7 @@ bool Macro::loadFromText(const QString &text)
                 rawData.insert(key,text);
             }
         }
+        rawData.insert(QString("sourceinfo"),sourceInfo);
     }else{
         //old format
         qDebug()<<"support for old macro format was removed!";
@@ -321,6 +322,7 @@ bool Macro::loadFromText(const QString &text)
     m_shortcut=rawData.value("shortcut");
     menu=rawData.value("menu");
     description=rawData.value("description");
+	sourceinfo=rawData.value("sourceinfo");
     return true;
 }
 

--- a/src/usermacro.h
+++ b/src/usermacro.h
@@ -27,7 +27,7 @@ public:
 
 	static Macro fromTypedTag(const QString &typedTag);
 
-    QString name, abbrev,description,menu;
+    QString name, abbrev,description, sourceinfo, menu;
 	Type type;
 	QString trigger;
     QRegularExpression triggerRegex;
@@ -54,7 +54,7 @@ public:
 	bool isActiveForFormat(int format) const;
 
     bool load(const QString &fileName);
-    bool loadFromText(const QString &text);
+    bool loadFromText(const QString &text, const QString &sourceInfo);
     bool save(const QString &fileName) const;
 
 	LatexDocument *document;

--- a/src/usermenudialog.cpp
+++ b/src/usermenudialog.cpp
@@ -132,6 +132,7 @@ void UserMenuDialog::addMacro(const Macro &m,bool insertRow)
     auto *item=new QTreeWidgetItem();
     item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsDragEnabled);
     item->setText(0,m.name);
+    item->setToolTip(0,m.sourceinfo);
     item->setText(1,m.shortcut());
     item->setText(2,m.trigger);
     item->setText(3,m.abbrev);
@@ -314,6 +315,8 @@ void UserMenuDialog::slotAdd()
     item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsDragEnabled);
     item->setText(0,"");
     Macro m;
+    m.sourceinfo = tr("new");
+    item->setToolTip(0,m.sourceinfo);
     item->setData(0,Qt::UserRole,QVariant::fromValue(m));
     ui.treeWidget->addTopLevelItem(item);
     ui.treeWidget->setCurrentItem(item);


### PR DESCRIPTION
This PR helps identifying the macro files used. Thus one can figure out easily the pathname of the macro file. This is useful in occasions where you want to edit the macro in a different editor or need to knwo which file you want to upload to the repository. Counting lines to figure out the number used in the filename may not succeed for example after inserting, deleting, or reordering items in the treewidget, or because you not even know where macros are stored. Furthermore the tooltip shows either the repository url for macros just downloaded or "new" for new macros. Thus you can see which macros are not saved.

Examples:
![grafik](https://user-images.githubusercontent.com/102688820/222938003-341c0f14-e270-46ba-b862-5cb6c1105283.png)

The 4<sup>th</sup> item is currently saved in the 11<sup>th</sup> file (start counting at 0). This happenes after dragging that item to this place. After closing the dialog renumbering to 3 will appear (and all macros below are renumbered also).

![grafik](https://user-images.githubusercontent.com/102688820/222938171-613f95c5-5458-4830-bd86-62bd7b352005.png)

Be aware that the tooltip information is not stored in the files. After closing and reopening the Edit Macros dialog all these files (downloaded or new) will show a pathname with an ordering number as a tooltip.