### PR TITLE
fix status bar of Macro Editor behaves weird

### DIFF
--- a/src/usermenudialog.cpp
+++ b/src/usermenudialog.cpp
@@ -58,6 +58,7 @@ UserMenuDialog::UserMenuDialog(QWidget *parent,  QString name, QLanguageFactory 
 	ui.tagEdit->setLayout(new QVBoxLayout());
 	codeedit = new QCodeEdit(ui.tagEdit);
 	codeedit->editor()->setFlag(QEditor::AdjustIndent, false);
+	codeedit->editor()->setDisplayModifyTime(false);
 	codeedit->editor()->document()->setCenterDocumentInEditor(false);
 	languages->setLanguage(codeedit->editor(), "");
 	//QLineMarkPanel* lineMarkPanel=new QLineMarkPanel;


### PR DESCRIPTION
This shows the status bar of the latex editor:
![grafik](https://user-images.githubusercontent.com/102688820/223305711-68087b4a-37f0-4036-abbc-5377e2f45f01.png)

Open the Macro Editor and observe the surprising large distance between column number and mode indicator INSERT in the status bar compared to the latex editor:
![grafik](https://user-images.githubusercontent.com/102688820/223306052-eeb26a2f-bbbb-45e4-ade6-d9eb39ce2637.png)

After 10s the indicator is shifted 6pix to the right, then after another 50s shifted back 6px. This behavior is quite distracting (image not in real time):
![usermacroStatusbar](https://user-images.githubusercontent.com/102688820/223306495-6a39aa3b-e494-40ef-a8af-df72497c43a4.gif)
Notes: If you open the Macro Editor again you need to edit the macro to restart the timer. Every time something is edited the timer turns back to zero and a shift of the indicator may appear.

Reason is a not visible timer positioned left to the mode indicator that is counting minutes and seconds. After 10 seconds one digit more is needed, after another 50 seconds one digit is removed because the seconds turn back to 0. If you have time to wait 10min, 100min and so on you will even observe larger translations of the indicator to the left.