### PR TITLE
add tabstops to Quick Start dialog

### DIFF
--- a/src/quickdocumentdialog.cpp
+++ b/src/quickdocumentdialog.cpp
@@ -59,8 +59,7 @@ QuickDocumentDialog::QuickDocumentDialog(QWidget *parent, const QString &name)
 	setWindowTitle(tr("Quick Start"));
 
 	//Package Tab
-	ui.pushButtonPackages->setFocusPolicy(Qt::NoFocus);
-	connect(ui.tabWidget, SIGNAL(tabBarClicked(int)), SLOT(setFocusToTable(int)));
+	connect(ui.tabWidget, SIGNAL(tabBarClicked(int)), SLOT(setPkgTabToolTip(int)));
 
 	//Geometry package
 	connect(ui.spinBoxUnitGeometryPageWidth, SIGNAL(editTextChanged(QString)), SLOT(geometryUnitsChanged()));
@@ -212,6 +211,7 @@ QStringList babelLanguages = QStringList()
 
 void QuickDocumentDialog::Init()
 {
+	ui.lineEditTitle->setFocus();
 	ui.comboBoxClass->clear();
 	ui.comboBoxClass->addItem("article");
 	ui.comboBoxClass->addItem("report");
@@ -287,7 +287,6 @@ void QuickDocumentDialog::Init()
 	table->clearContents();
 	table->horizontalHeader()->setStretchLastSection(true);
 	table->setSelectionMode(QAbstractItemView::NoSelection);
-//	table->setSelectionBehavior(QAbstractItemView::SelectRows);
 	table->verticalHeader()->hide();
 
 	//each QStringList holds 2 items: the name of the package, and a short package description. These constitute a row of the table of the packages tab
@@ -554,11 +553,10 @@ void QuickDocumentDialog::addUserPackages()
 	}
 }
 
-void QuickDocumentDialog::setFocusToTable(int idx)
+void QuickDocumentDialog::setPkgTabToolTip(int idx)
 {
 	int tabPos = ui.tabWidget->indexOf(ui.tabPackages);
 	if (idx == tabPos) {
-		ui.tableWidgetPackages->setFocus();
 		ui.tabWidget->setTabToolTip(tabPos, tr("All packages that have the checkbox checked will appear in a new document within \\usepackage commands after pressing OK."));
 	}
 	else ui.tabWidget->setTabToolTip(tabPos, "");

--- a/src/quickdocumentdialog.h
+++ b/src/quickdocumentdialog.h
@@ -53,7 +53,7 @@ private slots:
 	void addBabelOption();
 	void addUserOptions();
 	void addUserPackages();
-	void setFocusToTable(int idx);
+	void setPkgTabToolTip(int idx);
 };
 
 

--- a/src/quickdocumentdialog.ui
+++ b/src/quickdocumentdialog.ui
@@ -31,7 +31,7 @@
      <property name="currentIndex">
       <number>0</number>
      </property>
-     <widget class="QWidget" name="tab">
+     <widget class="QWidget" name="tabClass">
       <attribute name="title">
        <string>&amp;Class Options</string>
       </attribute>
@@ -680,16 +680,12 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="okButton">
-       <property name="text">
-        <string>OK</string>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="cancelButton">
-       <property name="text">
-        <string>Cancel</string>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
        </property>
       </widget>
      </item>
@@ -698,16 +694,27 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>okButton</tabstop>
-  <tabstop>cancelButton</tabstop>
+  <tabstop>comboBoxClass</tabstop>
+  <tabstop>pushButtonClass</tabstop>
+  <tabstop>comboBoxSize</tabstop>
+  <tabstop>comboBoxPaper</tabstop>
+  <tabstop>pushButtonPaper</tabstop>
+  <tabstop>comboBoxFontEncoding</tabstop>
+  <tabstop>pushButtonFontEncoding</tabstop>
+  <tabstop>comboBoxBabel</tabstop>
+  <tabstop>pushButtonBabel</tabstop>
+  <tabstop>lineEditTitle</tabstop>
+  <tabstop>lineEditAuthor</tabstop>
+  <tabstop>listWidgetOptions</tabstop>
+  <tabstop>pushButtonOptions</tabstop>
  </tabstops>
  <resources>
   <include location="../images.qrc"/>
  </resources>
  <connections>
   <connection>
-   <sender>okButton</sender>
-   <signal>clicked()</signal>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
    <receiver>QuickDocumentDialog</receiver>
    <slot>accept()</slot>
    <hints>
@@ -722,8 +729,8 @@
    </hints>
   </connection>
   <connection>
-   <sender>cancelButton</sender>
-   <signal>clicked()</signal>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
    <receiver>QuickDocumentDialog</receiver>
    <slot>reject()</slot>
    <hints>


### PR DESCRIPTION
This PR improves usage of the tab key and allows pressing the ok button if you just want to accept current settings.
The focus now is set to the title field because you likely use same settings for most of your documents created with the QuickStart wizard. So you can just enter title and author, and then confirm anything else by pressing enter key.

The tab key now walks line by line from left to right, touches ok and cancel, and finally the tabwidget item (where you can switch tabs with the left and right arrow keys). Thus it's easy having quick access to any of the fields you want to change.

### Comparison to previous builds
In **4.5.1** and **current master** the Class tabwidget item has focus. It's _not_ possible to confirm all settings by just pressing ok key because the add Class dialog catches this key (note blue framed widget). Tab key cycles to the Author field, then to Doc Class, then it's add button, then to add button for Language, to Size combo, and so on in a random walk.

![image](https://user-images.githubusercontent.com/102688820/225167060-c6d820e0-bd61-4ac7-bb4f-4f41d0e14c70.png)

More: One method and one widget were renamed to more suitable names, a comment and an almost useless focus policy were removed. Ok/Cancel button are now constructed in the same way as in the QuickBeamer ui file.