### PR TITLE
add \maketitle to quickStart document

### DIFF
--- a/src/quickdocumentdialog.cpp
+++ b/src/quickdocumentdialog.cpp
@@ -140,12 +140,16 @@ QString QuickDocumentDialog::getNewDocumentText()
 		}
 	}
 
-	if (ui.lineEditTitle->text() != "")
+	bool titleEmpty = ui.lineEditTitle->text() == "";
+	QString makeTitle;
+	if (!titleEmpty) {
+		makeTitle = "\\maketitle\n";
 		tag += "\\title{" + ui.lineEditTitle->text() + "}\n";
-	if (ui.lineEditAuthor->text() != "")
-      tag += "\\author{" + ui.lineEditAuthor->text() + "}\n";
+		if (ui.lineEditAuthor->text() != "")
+			tag += "\\author{" + ui.lineEditAuthor->text() + "}\n";
+	}
 
-	tag += QString("\\begin{document}\n%|\n\\end{document}");
+	tag += "\\begin{document}\n" + makeTitle + "%|\n\\end{document}";
 	return tag;
 }
 

--- a/src/quickdocumentdialog.cpp
+++ b/src/quickdocumentdialog.cpp
@@ -140,9 +140,8 @@ QString QuickDocumentDialog::getNewDocumentText()
 		}
 	}
 
-	bool titleEmpty = ui.lineEditTitle->text() == "";
 	QString makeTitle;
-	if (!titleEmpty) {
+	if (ui.lineEditTitle->text() != "") {
 		makeTitle = "\\maketitle\n";
 		tag += "\\title{" + ui.lineEditTitle->text() + "}\n";
 		if (ui.lineEditAuthor->text() != "")


### PR DESCRIPTION
To take advantage of the user given data for title and author a \maketitle is necessary in the LaTeX document.
The command is added only if a title is given (otherwise maketitle complains).