### PR TITLE
slightly resize Quick Letter dialog

### DIFF
--- a/src/letterdialog.cpp
+++ b/src/letterdialog.cpp
@@ -18,7 +18,7 @@ LetterDialog::LetterDialog(QWidget *parent, const char *name)
 	setWindowTitle(name);
 	setModal(true);
 	ui.setupUi(this);
-	UtilsUi::resizeInFontHeight(this, 28, 14);
+	UtilsUi::resizeInFontHeight(this, 24, 7);
 
 	ui.comboBoxPt->insertItem(0, "10pt");
 	ui.comboBoxPt->insertItem(1, "11pt");

--- a/src/letterdialog.ui
+++ b/src/letterdialog.ui
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0" >
  <class>LetterDialog</class>
  <widget class="QDialog" name="LetterDialog" >
@@ -17,7 +18,7 @@
     <number>6</number>
    </property>
    <item row="0" column="0" >
-    <layout class="QGridLayout" >
+    <layout class="QGridLayout" columnstretch="0,1">
      <property name="margin" >
       <number>0</number>
      </property>


### PR DESCRIPTION
This PR changes strechfactors such that the gap between label text and combobox is reduced. This improves visual connection of label information and value to select.

![image](https://user-images.githubusercontent.com/102688820/225433778-93503e98-204d-4473-8203-c5a585845af3.png)

More: add xml tag in ui file as it is in other ui files