### PR TITLE
fix typo in `babel.cwl`

### DIFF
--- a/completion/babel.cwl
+++ b/completion/babel.cwl
@@ -3131,7 +3131,7 @@ SuppressWarning#true,false
 reset=#none,section,chapter,page,page-resume,page-cont
 resume
 indent=#article-nosp,article-sp,hulist
-ruler=#none,one-line,fourth,choose
+rule=#none,one-line,fourth,choose
 marksize=max-normal
 mark=#arabic,stars,stars-max
 mpmark=#arabic,stars,stars-max
@@ -3221,7 +3221,7 @@ editor
 reset=#none,section,chapter,page,page-resume,page-cont
 resume
 indent=#article-nosp,article-sp,hulist
-ruler=#none,one-line,fourth,choose
+rule=#none,one-line,fourth,choose
 marksize=max-normal
 mark=#arabic,stars,stars-max
 mpmark=#arabic,stars,stars-max


### PR DESCRIPTION
Info to support that it's indeed `rule=#none,one-line,fourth,choose`, not `ruler=...`: `magyar.ldf` (1.5c 2019-01-14) provided by `babel-hungarian` package, [lines 4443--4456](https://www.tug.org/svn/texlive/trunk/Master/texmf-dist/tex/generic/babel-hungarian/magyar.ldf?view=markup&pathrev=49701#l4443)
```tex
  \@namedef{fos@rule=choose}{% ripped from footmisc.sty
    \ifx\footnoterule\magyar@fo@chooserule
      \let\footnoterule\magyar@fo@defaultrule
    \fi
    \expandafter\ifx\csname  pagefootnoterule\endcsname\relax \let \pagefootnoterule\footnoterule\fi
    \expandafter\ifx\csname    mpfootnoterule\endcsname\relax \let   \mpfootnoterule\footnoterule\fi
    \expandafter\ifx\csname splitfootnoterule\endcsname\relax \let\splitfootnoterule\magyar@fo@fourthrule\fi
    \expandafter\ifx\csname split@prev\endcsname\relax \gdef\split@prev{0}\fi
    % ^^^ Dat: \split@prev is named the same in footmisc.sty
    \let\footnoterule\magyar@fo@chooserule
  }
  \@namedef{fos@rule=none}{\let\footnoterule\@empty}%
  \@namedef{fos@rule=fourth}{\let\footnoterule\magyar@fo@fourthrule}%
  \@namedef{fos@rule=one-line}{\let\footnoterule\magyar@fo@onelinerule}%
```

Fixes #3018