### PR TITLE
Fix search field in macOS menu bar

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -205,6 +205,7 @@ jobs:
         cd build
         mkdir -p texstudio.app/Contents/Frameworks
         cp /usr/local/lib/libbrotlicommon.1.dylib texstudio.app/Contents/Frameworks
+        touch texstudio.app/Contents/Resources/empty.lproj
 
     - name: Package
       id: package

--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -2956,11 +2956,7 @@ void PDFDocument::setupMenus(bool embedded)
     menuGrid=configManager->newManagedMenu(menuView,nullptr,"pdf/view/grid",QApplication::translate("PDFDocument", "Grid"));
     menuWindow=configManager->newManagedMenu(menuroot,menubar,"pdf/window",QApplication::translate("PDFDocument", "&Window"));
     menuEdit=configManager->newManagedMenu(menuroot,menubar,"pdf/config",QApplication::translate("PDFDocument", "&Configure"));
-#ifdef Q_OS_MAC // enable search field in help menu in macOS
-    menuHelp=configManager->newManagedMenu(menuroot,menubar,"pdf/help",QApplication::translate("PDFDocument", "Help"));
-#else
     menuHelp=configManager->newManagedMenu(menuroot,menubar,"pdf/help",QApplication::translate("PDFDocument", "&Help"));
-#endif
     menus<<menuFile<<menuEdit<<menuEdit_2<<menuGrid<<menuHelp<<menuWindow<<menuView; // housekeeping for later removal
 
     if(!embedded)


### PR DESCRIPTION
#2981 was supposed to add a search field to the macOS menu bar. However, the fix in #2981 was only tested with an old version of Qt and the `BUILD.sh` script, and didn't work with the CD workflow. Sorry about that.

This PR adds the creation of an empty file called `empty.lproj` to the CD workflow, which fixes the search field in the macOS menu bar. The changes introduced in #2981 are no longer needed, and are reverted.