### PR TITLE
copy icons+separators from submenu to toolbar combobox drop-down list

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -820,6 +820,11 @@ void Texstudio::updateToolBarMenu(const QString &menuName)
 								defaultIndex = actionTexts.length() - 1;
 							}
 						}
+						else {
+							actionTexts.append("");
+							actionInfos.append("");
+							actionIcons.append(QIcon());
+						}
 					}
 					UtilsUi::createComboToolButton(tb.toolbar, actionTexts, actionInfos, actionIcons, -1, this, SLOT(callToolButtonAction()), defaultIndex, combo);
 
@@ -1588,6 +1593,11 @@ void Texstudio::setupToolBars()
 							list.append(act->text());
 							infos.append(act->toolTip());
 							icons.append(act->icon());
+						}
+						else {
+							list.append("");
+							infos.append("");
+							icons.append(QIcon());
 						}
 					//TODO: Is the callToolButtonAction()-slot really needed? Can't we just add the menu itself as the menu of the qtoolbutton, without creating a copy? (should be much faster)
 					QToolButton *combo = UtilsUi::createComboToolButton(mtb.toolbar, list, infos, icons, 0, this, SLOT(callToolButtonAction()));

--- a/src/utilsUI.cpp
+++ b/src/utilsUI.cpp
@@ -148,13 +148,18 @@ QToolButton *createComboToolButton(QWidget *parent, const QStringList &list, con
 	bool defaultSet = false;
 	for (int i = 0; i < list.length(); i++) {
 		QString text = list[i];
-		//QIcon icon = (i<icons.length()) ? icons[i] : QIcon();
-		QAction *mAction = mMenu->addAction(text, receiver, member);
-		if (infos.count()>0) mAction->setToolTip(infos[i]);
-		max = qMax(max, getFmWidth(fm, text + "        "));
-		if (i == defaultIndex) {
-			combo->setDefaultAction(mAction);
-			defaultSet = true;
+		if (text!="") {
+			QAction *mAction = mMenu->addAction(text, receiver, member);
+			if (infos.count()>i) mAction->setToolTip(infos[i]);
+			if (icons.count()>i) mAction->setIcon(icons[i]);
+			max = qMax(max, getFmWidth(fm, text + "        "));
+			if (i == defaultIndex) {
+				combo->setDefaultAction(mAction);
+				defaultSet = true;
+			}
+		}
+		else {
+			QAction *mAction = mMenu->addSeparator();
 		}
 	}
 	if (!defaultSet) {


### PR DESCRIPTION
This PR enhances copying data from main (sub)menus when the menu is added to a combobox in a toolbar (s. config dialog->Toolbars), and solves #3025.
Now icons for actions and separators from the menu are copied as well.

#### Example
Add menu main/tools/commands to the custom toolbar in the config dialog. Now compare the main menu (in the middle) with the added menu as in txs version 4.5.1 (to the left) and in txs build with this PR (to the right):

![grafik](https://user-images.githubusercontent.com/102688820/226178999-1b960b0f-3835-4d1c-9ade-074ff559279a.png)
