### PR TITLE
add alignedat env to QuickArray wizard

### DIFF
--- a/src/arraydialog.cpp
+++ b/src/arraydialog.cpp
@@ -134,7 +134,7 @@ QStringList ArrayDialog::getEnvBeginEndStatements() {
 	else if (env == "alignedat") {
 		begin += QString("{%1}").arg((ncols + 1) / 2);
 	}
-	else if (env.last(1) == "*") {   // mathtools
+	else if (env.endsWith("*")) {   // mathtools
 		int idx = ui.comboAlignment->currentIndex();
 		begin += "[" + QString(ui.comboAlignment->itemData(idx).toChar()) + "]";
 	}
@@ -202,7 +202,7 @@ int ArrayDialog::currentColAlignIndex(int col) {
 			ix = alignList.indexOf(Qt::AlignLeft);
 		}
 	}
-	else if (env.last(1) == "*") {  // mathtools
+	else if (env.endsWith("*")) {  // mathtools
 		ix = ui.comboAlignment->currentIndex();
 	}
 	else {  // amsmath
@@ -219,7 +219,7 @@ void ArrayDialog::slotAlignmentChanged(int ix) {
 		Qt::AlignmentFlag align = alignList[ix];
 		setColAlignment(col, align);
 	}
-	else if (env.last(1) != "*" || env == "alignedat") {}
+	else if (!env.endsWith("*") || env == "alignedat") {}
 	else
 		setColAlignments();
 	setTitle();

--- a/src/arraydialog.cpp
+++ b/src/arraydialog.cpp
@@ -178,7 +178,6 @@ void ArrayDialog::slotPackageChanged() {
 	QString package = ui.comboPackage->currentText();
 	QString currentEnv = ui.comboEnvironment->currentText();
 	int currentEnvIx = ui.comboEnvironment->currentIndex();
-	int currentAlignIx = ui.comboAlignment->currentIndex();
 	setComboEnv(package);
 
 	if (package == "amsmath" || package == "mathtools") {
@@ -291,7 +290,6 @@ void ArrayDialog::newRows(int rows) {
 	int rowsOld = ui.tableWidget->rowCount();
 	int cols = ui.tableWidget->columnCount();
 	ui.tableWidget->setRowCount(rows);
-	int colds = ui.tableWidget->columnCount();
 	if (rows > rowsOld) {
 		for (int col = 0; col < cols; col++) {
 			int ix = currentColAlignIndex(col);

--- a/src/arraydialog.cpp
+++ b/src/arraydialog.cpp
@@ -485,7 +485,6 @@ void ArrayDialog::keyPressEvent(QKeyEvent *event)
         {
             if (cur_row >= ui.tableWidget->rowCount())
             {
-//                ui.tableWidget->setRowCount(ui.tableWidget->rowCount() + 1);
                 ui.spinBoxRows->setValue(ui.spinBoxRows->value() + 1);
             }
 
@@ -494,7 +493,6 @@ void ArrayDialog::keyPressEvent(QKeyEvent *event)
             {
                 if (cur_col >= ui.tableWidget->columnCount())
                 {
-//                    ui.tableWidget->setColumnCount(ui.tableWidget->columnCount() + 1);
                     ui.spinBoxColumns->setValue(ui.spinBoxColumns->value() + 1);
                 }
 
@@ -504,13 +502,6 @@ void ArrayDialog::keyPressEvent(QKeyEvent *event)
                     item->setText(col);
                     ++cur_col;
                 }
-//                else
-//                {
-//                    // Creates new item if item doesn't exist.
-//                    QTableWidgetItem *newItem = new QTableWidgetItem();
-//                    newItem->setText(col);
-//                    ui.tableWidget->setItem(cur_row, cur_col, newItem);
-//                }
             }
             ++cur_row;
             cur_col = starting_col;

--- a/src/arraydialog.h
+++ b/src/arraydialog.h
@@ -25,10 +25,31 @@ public:
 	Ui::ArrayDialog ui;
 	QString getLatexText();
 
+private:
+	QStringList packageList = {"latex", "amsmath", "mathtools"};
+	QStringList environmentList = {"array", "alignedat", "matrix", "pmatrix", "bmatrix", "Bmatrix", "vmatrix", "Vmatrix"};
+	QList<Qt::AlignmentFlag> alignList = {Qt::AlignHCenter, Qt::AlignLeft, Qt::AlignRight};
+	QStringList alignTextList = {tr("Center"), tr("Left"), tr("Right")};
+	QList<int> arrayAligns;
+	void addEmptyTableItems();
+	void addEmptyColumnItems(int col);
+	void setComboEnv(QString package);
+	void setColAlignments();
+	void setColAlignment(int col, Qt::AlignmentFlag align);
+	int currentColAlignIndex(int col);
+	QStringList getEnvBeginEndStatements();
+	QString getFactoredAlignments();
+	QString squash(QString part, QString align);
+
 protected slots:
 	void newRows(int num);
 	void newColumns(int num);
     void keyPressEvent(QKeyEvent *event);
+	void setTitle();
+	void slotEnvironmentChanged();
+	void slotCurrentCellChanged(int row, int col);
+	void slotAlignmentChanged(int ix);
+	void slotPackageChanged();
 };
 
 #endif

--- a/src/arraydialog.h
+++ b/src/arraydialog.h
@@ -26,30 +26,32 @@ public:
 	QString getLatexText();
 
 private:
-	QStringList packageList = {"latex", "amsmath", "mathtools"};
-	QStringList environmentList = {"array", "alignedat", "matrix", "pmatrix", "bmatrix", "Bmatrix", "vmatrix", "Vmatrix"};
+	QStringList environmentList = { "array", "alignedat",
+									"", /* separator */
+									"matrix",  "pmatrix",  "bmatrix",  "Bmatrix",  "vmatrix",  "Vmatrix",		// amsmath
+									"", /* separator */
+									"matrix*", "pmatrix*", "bmatrix*", "Bmatrix*", "vmatrix*", "Vmatrix*" };	// mathtools
 	QList<Qt::AlignmentFlag> alignList = {Qt::AlignHCenter, Qt::AlignLeft, Qt::AlignRight};
 	QStringList alignTextList = {tr("Center"), tr("Left"), tr("Right")};
 	QList<int> arrayAligns;
 	void addEmptyTableItems();
 	void addEmptyColumnItems(int col);
-	void setComboEnv(QString package);
+	void setComboEnv();
 	void setColAlignments();
 	void setColAlignment(int col, Qt::AlignmentFlag align);
 	int currentColAlignIndex(int col);
 	QStringList getEnvBeginEndStatements();
-	QString getFactoredAlignments();
-	QString squash(QString part, QString align);
+	QString getArrayAlignments();
 
 protected slots:
 	void newRows(int num);
 	void newColumns(int num);
     void keyPressEvent(QKeyEvent *event);
 	void setTitle();
+	void setTableHeader();
 	void slotEnvironmentChanged();
-	void slotCurrentCellChanged(int row, int col);
 	void slotAlignmentChanged(int ix);
-	void slotPackageChanged();
+	void slotCurrentCellChanged(int row, int col);
 };
 
 #endif

--- a/src/arraydialog.ui
+++ b/src/arraydialog.ui
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0" >
  <class>ArrayDialog</class>
  <widget class="QDialog" name="ArrayDialog" >
@@ -17,7 +18,7 @@
     <number>6</number>
    </property>
    <item row="0" column="0" >
-    <layout class="QGridLayout" >
+    <layout class="QGridLayout"  columnstretch="0,1">
      <property name="margin" >
       <number>0</number>
      </property>
@@ -41,7 +42,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0" >
+     <item row="5" column="0" >
       <widget class="QLabel" name="label_2" >
        <property name="text" >
         <string>Columns Alignment</string>
@@ -62,13 +63,31 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1" >
+     <item row="5" column="1" >
       <widget class="QComboBox" name="comboAlignment" >
        <property name="currentIndex" >
         <number>-1</number>
        </property>
        <property name="maxVisibleItems" >
         <number>11</number>
+       </property>
+       <property name="toolTip" >
+        <string>In case of an array environment sets the alignment for the column of the currently selected cell.
+For matrix* and the like (package mathtools) sets the alignment for all columns at once.</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0" colspan="2" >
+      <widget class="QCheckBox" name="checkBoxFactorAlignments" >
+       <property name="text" >
+        <string>Squash column definitions</string>
+       </property>
+       <property name="toolTip" >
+        <string>When the column specifiers of an array environment contain a sequence of n > 6 equal alignment
+characters "c" then they are replaced by *{n}{c}.</string>
+       </property>
+       <property name="checked" >
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -83,7 +102,26 @@
       </widget>
      </item>
      <item row="4" column="1" >
-      <widget class="QComboBox" name="comboEnvironment" />
+      <widget class="QComboBox" name="comboEnvironment" >
+       <property name="toolTip" >
+        <string>Choose environment to be created (s. window title).</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0" >
+       <widget class="QLabel" name="packageLabel" >
+       <property name="text" >
+        <string>Package Support</string>
+       </property>
+       </widget>
+     </item>
+     <item row="3" column="1" >
+      <widget class="QComboBox" name="comboPackage" >
+       <property name="toolTip" >
+        <string>When you choose latex then array is the only environment you can choose from in the next combo box. Choose
+amsmath or mathtools when the document loads the package selected to have more environments available.</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/src/arraydialog.ui
+++ b/src/arraydialog.ui
@@ -77,20 +77,6 @@ For matrix* and the like (package mathtools) sets the alignment for all columns 
        </property>
       </widget>
      </item>
-     <item row="6" column="0" colspan="2" >
-      <widget class="QCheckBox" name="checkBoxFactorAlignments" >
-       <property name="text" >
-        <string>Squash column definitions</string>
-       </property>
-       <property name="toolTip" >
-        <string>When the column specifiers of an array environment contain a sequence of n > 6 equal alignment
-characters "c" then they are replaced by *{n}{c}.</string>
-       </property>
-       <property name="checked" >
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="1" >
       <widget class="QSpinBox" name="spinBoxRows" />
      </item>
@@ -103,23 +89,13 @@ characters "c" then they are replaced by *{n}{c}.</string>
      </item>
      <item row="4" column="1" >
       <widget class="QComboBox" name="comboEnvironment" >
-       <property name="toolTip" >
-        <string>Choose environment to be created (s. window title).</string>
+       <property name="maxVisibleItems" >
+        <number>16</number>
        </property>
-      </widget>
-     </item>
-     <item row="3" column="0" >
-       <widget class="QLabel" name="packageLabel" >
-       <property name="text" >
-        <string>Package Support</string>
-       </property>
-       </widget>
-     </item>
-     <item row="3" column="1" >
-      <widget class="QComboBox" name="comboPackage" >
        <property name="toolTip" >
-        <string>When you choose latex then array is the only environment you can choose from in the next combo box. Choose
-amsmath or mathtools when the document loads the package selected to have more environments available.</string>
+        <string>Choose environment to be created (s. window title).
+Package amsmath supports alignedat, matrix, pmatrix, bmatrix, Bmatrix, vmatrix, Vmatrix.
+Package mathtools supports alignedat, matrix*, pmatrix*, bmatrix*, Bmatrix*, vmatrix*, Vmatrix*.</string>
        </property>
       </widget>
      </item>

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -14,6 +14,7 @@
 - don't show pointing hand cursor over hyperlinks when magnifier is activ ([#2982](https://github.com/texstudio-org/texstudio/pull/2982))
 - improve usage of tab key and enter key in QuickStart Wizard ([#3014](https://github.com/texstudio-org/texstudio/pull/3014))
 - add \maketitle to the document created by QuickStart Wizard if appropriate ([#3015](https://github.com/texstudio-org/texstudio/pull/3015))
+- add support for alignedat environment in QuickArray Wizard ([#2921](https://github.com/texstudio-org/texstudio/issues/2921))
 - pos1 (home) key now sets cursor to start or to first non-blank character of editor lines ([#3012](https://github.com/texstudio-org/texstudio/issues/3012))
 - fix a crash in a special case ([#2985](https://github.com/texstudio-org/texstudio/issues/2985))
 - updated LaTeX2e manual (help menu) and added missing image


### PR DESCRIPTION
This PR resolves #2921. Key information:

- add alignedat environment for QuickArray Wizard (1)
- align table text accordingly to alignment settings given or set by the environment
- in case of array env choose alignment for each column separately
- for array env replace sequences of the same alignment character by *{n}{c} expressions (checkbox)
- show short preview of env statement in window title

(1) since all currently supported envs need math mode I added alignedat, not alignat or alignat*.