### PR TITLE
fix issue in changeLog

### DIFF
--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -9,7 +9,7 @@
 - add Min/Max/Close buttons to Macro Editor dialog ([#2987](https://github.com/texstudio-org/texstudio/pull/2987))
 - fix text in status bar of Macro Editor wiggling around after 10s and 50s ([#3001](https://github.com/texstudio-org/texstudio/pull/3001))
 - Show changelog in about dialog and [manual](https://texstudio-org.github.io/CHANGELOG.html)
-- pasting from LibreOffice Calc uses '&' and '\\' as delimiters. If pasted where no table is defined, the table wizard is called.
+- pasting from LibreOffice Calc uses '&' and '\\\\' as delimiters. If pasted where no table is defined, the table wizard is called.
 - change Adv. Editor option "Vertical Overscroll" to scroll last line to top ([#2944](https://github.com/texstudio-org/texstudio/issues/2944))
 - when the mouse cursor hovers over a spin/combo box, the wheel scrolls through the configuration page instead of changing values ([#2977](https://github.com/texstudio-org/texstudio/issues/2977))
 - copy some details (icons, separators) to menu item list in combo box ([#3025](https://github.com/texstudio-org/texstudio/issues/3025))


### PR DESCRIPTION
escape each of the two backslashes

@sunderme Please check [https://texstudio-org.github.io/CHANGELOG.html](https://texstudio-org.github.io/CHANGELOG.html) because there is no backslash present. But current source of two backslashes should show one backslash.
Thanks