### PR TITLE
Display error for directory arguments

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -7006,12 +7006,15 @@ void Texstudio::executeCommandLine(const QStringList &args, bool realCmdLine)
 	}
 #endif
 
-	// execute command line
+    	// execute command line
 	foreach (const QString &fileToLoad, filesToLoad) {
 		QFileInfo ftl(fileToLoad);
 		if (fileToLoad != "") {
-			if (ftl.exists()) {
-                if (ftl.suffix() == Session::fileExtension() || ftl.suffix() == "txss") {
+			if (ftl.isDir()) {
+				QMessageBox::warning(this, "", tr("%1 is an invalid TeX project directory.").arg(ftl.absoluteFilePath()));
+				exit(1);
+			} else if (ftl.exists()) {
+				if (ftl.suffix() == Session::fileExtension() || ftl.suffix() == "txss") {
 					loadSession(ftl.filePath());
 				} else {
 					load(fileToLoad, hasExplicitRoot);


### PR DESCRIPTION
When running `$ texstudio DIRECTORY_CONTAINING_TEX_FILES`, I get the following error from TeXstudio: 

```
You do not have read permission to the file $DIRECTORY_CONTAINING_TEX_FILES.
```

This PR makes TeXstudio open valid `.tex` files if a directory is passed as an argument, or display an appropriate error if there are none.

![image](https://user-images.githubusercontent.com/20600565/234765033-e8a30364-2c3c-4c5b-9f8f-02b2c848b85c.png)

![image](https://user-images.githubusercontent.com/20600565/234765175-297fd695-487b-4f33-80fe-705cda7c7b95.png)


Building + Testing:

```bash
$ cd texstudio
$ mkdir build && cd build
$ cmake .. && cmake --build . --parallel && ./texstudio $ARGUMENTS

```