### PR TITLE
Detect LaTeX3 and LuaLaTeX module warnings

### DIFF
--- a/src/latexoutputfilter.cpp
+++ b/src/latexoutputfilter.cpp
@@ -825,7 +825,7 @@ bool LatexOutputFilter::detectWarning(const QString &strLine, short &dwCookie)
 
 bool LatexOutputFilter::detectLaTeXLineNumber(QString &warning, short &dwCookie, int len)
 {
-	static QRegExp reLaTeXLineNumber("(.*) on(?: input)? line ([0-9]+)\\.$", Qt::CaseInsensitive);
+	static QRegExp reLaTeXLineNumber("(.*) on(?: input)? line ([0-9]+)\\.?$", Qt::CaseInsensitive);
 	static QRegExp reInternationalLaTeXLineNumber("(.*)([0-9]+)\\.$", Qt::CaseInsensitive);
 	if ((reLaTeXLineNumber.indexIn(warning) != -1) || (reInternationalLaTeXLineNumber.indexIn(warning) != -1)) {
 		m_currentItem.oldline = (reLaTeXLineNumber.cap(2).toInt());

--- a/src/latexoutputfilter.cpp
+++ b/src/latexoutputfilter.cpp
@@ -735,7 +735,7 @@ bool LatexOutputFilter::detectWarning(const QString &strLine, short &dwCookie)
 	bool found = false, flush = false;
 	QString warning;
 
-	static QRegExp reLaTeXWarning("^(((! )?(La|pdf|Lua)TeX)|Package|Class) .*Warning.*:(.*)", Qt::CaseInsensitive);
+	static QRegExp reLaTeXWarning("^(((! )?(La|pdf|Lua)TeX)|Package|Class|Module) .*Warning.*:(.*)", Qt::CaseInsensitive);
 	static QRegExp reLatex3Warning("^\\*\\s+(\\S.*)");
 	static QRegExp reLatex3WarningHeader("^\\*\\s*(.*warning:\\s*.*)", Qt::CaseInsensitive);
 	static QRegExp reNoFile("^No file (.*)");
@@ -825,7 +825,7 @@ bool LatexOutputFilter::detectWarning(const QString &strLine, short &dwCookie)
 
 bool LatexOutputFilter::detectLaTeXLineNumber(QString &warning, short &dwCookie, int len)
 {
-	static QRegExp reLaTeXLineNumber("(.*) on input[ ]?line ([0-9]+)\\.$", Qt::CaseInsensitive);
+	static QRegExp reLaTeXLineNumber("(.*) on(?: input)? line ([0-9]+)\\.$", Qt::CaseInsensitive);
 	static QRegExp reInternationalLaTeXLineNumber("(.*)([0-9]+)\\.$", Qt::CaseInsensitive);
 	if ((reLaTeXLineNumber.indexIn(warning) != -1) || (reInternationalLaTeXLineNumber.indexIn(warning) != -1)) {
 		m_currentItem.oldline = (reLaTeXLineNumber.cap(2).toInt());


### PR DESCRIPTION
This PR extended (regex) patterns used for filtering warnings from log.  It's basically the same as James-Yu/LaTeX-Workshop#3815 plus James-Yu/LaTeX-Workshop#3872.

- LaTeX3 warnings may end with `on line <number>.` instead of `on input line <number>.` in LaTeX2e warnings.
- LuaLaTeX module warnings start with `Module <modname> Warning: `.

LaTeX example that generates both:
```tex
% !TeX TS-program = lualatex
\documentclass{article}

\ExplSyntaxOn
\msg_new:nnn { mypkg } { msg-name }
  { Warning~ text~ \msg_line_context:. }

% writes
%   Package mypkg Warning: Warning text on line 9.
% to log
\msg_warning:nn { mypkg } { msg-name }
\ExplSyntaxOff

% writes
%   Module mymod Warning: Another warning text on input line 20
% to log
\directlua{
  % https://tex.stackexchange.com/a/641044
  luatexbase.module_warning('mymod', "Another warning text")
}

\begin{document}
content
\end{document}
```

Before
![image](https://github.com/texstudio-org/texstudio/assets/6376638/e78bb991-97ac-43f3-88ba-1deb58751157)

After
![image](https://github.com/texstudio-org/texstudio/assets/6376638/3afe3415-6107-4dff-8081-2519ecf9650c)
