### PR TITLE
Fix cwl typo

### DIFF
--- a/completion/diagbox.cwl
+++ b/completion/diagbox.cwl
@@ -12,19 +12,19 @@
 \diagbox{left%text}{middle%text}{right%text}#t
 
 #keyvals:\diagbox
-width=##l
-height=##l
+width=##L
+height=##L
 dir=#NW,NE,SW,SE
-innerwidth=##l
-innerleftsep=##l
-innerrightsep=##l
-outerleftsep=##l
-outerrightsep=##l
-leftsep=##l
-rightsep=##l
+innerwidth=##L
+innerleftsep=##L
+innerrightsep=##L
+outerleftsep=##L
+outerrightsep=##L
+leftsep=##L
+rightsep=##L
 trim=#l,r,lr,rl
 font=%<font commands%>
-linewidth=##l
+linewidth=##L
 linecolor=#%color
 #endkeyvals
 

--- a/completion/luatodonotes.cwl
+++ b/completion/luatodonotes.cwl
@@ -95,8 +95,8 @@ author=
 \missingfigure[options%keyvals]{text%todo}#D
 
 #keyvals:\missingfigure
-figwidth=##l
-figheight=##l
+figwidth=##L
+figheight=##L
 figcolor=#%color
 #endkeyvals
 

--- a/completion/tabularraylibrarydiagbox.cwl
+++ b/completion/tabularraylibrarydiagbox.cwl
@@ -7,18 +7,18 @@
 \diagboxthree[options%keyvals]{lower}{middle}{upper}
 
 #keyvals:\diagboxthree
-width=##l
-height=##l
+width=##L
+height=##L
 dir=#NW,NE,SW,SE
-innerwidth=##l
-innerleftsep=##l
-innerrightsep=##l
-outerleftsep=##l
-outerrightsep=##l
-leftsep=##l
-rightsep=##l
+innerwidth=##L
+innerleftsep=##L
+innerrightsep=##L
+outerleftsep=##L
+outerrightsep=##L
+leftsep=##L
+rightsep=##L
 trim=#l,r,lr,rl
 font=%<font commands%>
-linewidth=##l
+linewidth=##L
 linecolor=#%color
 #endkeyvals


### PR DESCRIPTION
To specify a key expects a length, `##L` is the right one to use.  Lowercase `##l` specifies the key argument is used to define a new label.

https://github.com/texstudio-org/texstudio/blob/9d387d4b7c06c0aac9ce44522e7f9ca4d659f93f/utilities/manual/source/background.md?plain=1#L128-L130