### PR TITLE
remove \address and \signature from scrlttr2 template

### DIFF
--- a/templates/template_Scrlttr2.tex
+++ b/templates/template_Scrlttr2.tex
@@ -5,15 +5,9 @@
 % remove the ``%'' on the next line:
 % \pagestyle{headings}
 
-\begin{letter}{TO_ADDRESS}
-\address{}
+\begin{letter}{TO ADDRESS}
 
 \opening{}
-
-
-
-
-\signature{}
 
 \closing{}
 


### PR DESCRIPTION
`\address` and `\signature` are not defined by this class