### PR TITLE
no horizontal touchpad scroll when fit to text width in pdf viewer

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -1685,7 +1685,10 @@ void PDFWidget::wheelEvent(QWheelEvent *event)
         double numDegrees = event->angleDelta().x() / 8.0;
         const int degreesPerStep = 15; // for a typical mouse (some may have finer resolution, but that's k with the co
         QScrollBar *scrollBar = getScrollArea()->horizontalScrollBar();
-        if (scrollBar->minimum() < scrollBar->maximum() && !globalConfig->disableHorizontalScrollingForFitToTextWidth) { //if scrollbar visible
+
+        if ( scrollBar->minimum() < scrollBar->maximum() &&
+//            !(PDFDocument::isCheckedFitToTextWidth() && globalConfig->disableHorizontalScrollingForFitToTextWidth) ) { //if scrollbar visible
+            !(actionFit_to_Text_Width->isChecked() && globalConfig->disableHorizontalScrollingForFitToTextWidth) ) { //if scrollbar visible
             scrollBar->setValue(scrollBar->value() - qRound(scrollBar->singleStep() * QApplication::wheelScrollLines() * numDegrees / degreesPerStep));
         }
     }
@@ -3074,6 +3077,10 @@ void PDFDocument::shortcutOnlyIfFocused(const QList<QAction *> &actions)
         act->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     }
 }
+
+//bool PDFDocument::isCheckedFitToTextWidth() {
+//	return actionFit_to_Text_Width->isChecked();
+//}
 
 /*!
  * \brief load Sync Icons

--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -1685,7 +1685,7 @@ void PDFWidget::wheelEvent(QWheelEvent *event)
         double numDegrees = event->angleDelta().x() / 8.0;
         const int degreesPerStep = 15; // for a typical mouse (some may have finer resolution, but that's k with the co
         QScrollBar *scrollBar = getScrollArea()->horizontalScrollBar();
-        if (scrollBar->minimum() < scrollBar->maximum()) { //if scrollbar visible
+        if (scrollBar->minimum() < scrollBar->maximum() && !globalConfig->disableHorizontalScrollingForFitToTextWidth) { //if scrollbar visible
             scrollBar->setValue(scrollBar->value() - qRound(scrollBar->singleStep() * QApplication::wheelScrollLines() * numDegrees / degreesPerStep));
         }
     }
@@ -4429,8 +4429,14 @@ void PDFDocument::adjustScaleActions(autoScaleOption scaleOption)
 		if (scrollArea->verticalScrollBarPolicy() != Qt::ScrollBarAlwaysOff)
 			scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 	} else {
-		if (scrollArea->horizontalScrollBarPolicy() != Qt::ScrollBarAsNeeded)
-			scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+		if (scaleOption == kFitTextWidth && globalConfig->disableHorizontalScrollingForFitToTextWidth) {
+			if (scrollArea->horizontalScrollBarPolicy() != Qt::ScrollBarAlwaysOff)
+				scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+		}
+		else {
+			if (scrollArea->horizontalScrollBarPolicy() != Qt::ScrollBarAsNeeded)
+				scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+		}
 		if (scrollArea->verticalScrollBarPolicy() != Qt::ScrollBarAsNeeded)
 			scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
 	}

--- a/src/pdfviewer/PDFDocument.h
+++ b/src/pdfviewer/PDFDocument.h
@@ -45,6 +45,7 @@
 
 
 const int kPDFWindowStateVersion = 1;
+static QAction *actionFit_to_Text_Width;
 
 class QAction;
 class QMenu;
@@ -458,6 +459,8 @@ public:
 
 	void setStateEnlarged(bool state);
     void updateIcons();
+//	bool isCheckedFitToTextWidth();
+
 
 protected:
 	virtual void changeEvent(QEvent *event);
@@ -664,7 +667,7 @@ private:
 	QAction *actionAutoHideToolbars;
     QAction *actionInvertColors;
     QAction *actionFocus_Editor;
-    QAction *actionFit_to_Text_Width;
+//    QAction *actionFit_to_Text_Width;
     QAction *actionGrayscale;
     QAction *actionSplitMerge;
     QActionGroup *actionGroupGrid;

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -6,6 +6,7 @@
 - cache structure/labels/usercommands/packages for faster reload of large projects (optional)
 - add support for alignedat environment in QuickArray Wizard ([#2921](https://github.com/texstudio-org/texstudio/issues/2921))
 - add a Lorem Ipsum generator to the Random Text Generator dialog ([#3102](https://github.com/texstudio-org/texstudio/pull/3102))
+- option Disable horizontal scrolling for "Fit to Text Width" now affects horizontal scrolling with mousepad and scroll wheel ([#1526](https://github.com/texstudio-org/texstudio/issues/1526))
 - change default windows style for new installs to Fusion instead of moden-dark, in case system darkmode is detected.
 - fix some icon issues on OSX ([#3100](https://github.com/texstudio-org/texstudio/issues/2921),[#3104](https://github.com/texstudio-org/texstudio/issues/3104))
 


### PR DESCRIPTION
This PR resolves #1526. So when scale option of the pdf viewer is set to _fit to text width_ and option _Disable horizontal scrolling for "Fit to Text Width"_ is set then horizontal scrolling is not possible neither with the touchpad nor with tilting the scroll wheel. The horizontal scrollbar is removed in this case, but you can still scroll horizontally with left/right arrow keys if needed.

![image](https://github.com/texstudio-org/texstudio/assets/102688820/78692cd8-857d-443a-9178-6174a9bac9be)
