### PR TITLE
fix editor moving one more line

### DIFF
--- a/src/latexeditorview.cpp
+++ b/src/latexeditorview.cpp
@@ -928,7 +928,9 @@ QList<QPair<int, int> > LatexEditorView::getSelectedLineBlocks()
 	for (int i=0;i<cursors.length();i++) {
 		if (cursors[i].hasSelection()) {
 			QDocumentSelection sel = cursors[i].selection();
-			for (int l=sel.startLine;l<=sel.endLine;l++)
+			int lastLineOfBlock = sel.endLine;
+			if (cursors[i].selectionEnd().columnNumber()==0) lastLineOfBlock -= 1;
+			for (int l=sel.startLine;l<=lastLineOfBlock;l++)
 				lines << l;
 		} else lines << cursors[i].lineNumber();
 	}

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -3,10 +3,12 @@
 
 - use subfiles root for compilation if the current document is a child
 - load the complete subfile project to provide proper syntax checking, also when just opening a subfile root
-- cache structure/labels/usercommands/packages for faster reload of large projects (optional)
+- cache structure/labels/usercommands/packages for faster reload of large projects (optional) ([ef0ab75](https://github.com/texstudio-org/texstudio/commit/ef0ab75e00a4f785d199089060553a53ba23bb7e))
 - add support for alignedat environment in QuickArray Wizard ([#2921](https://github.com/texstudio-org/texstudio/issues/2921))
 - add a Lorem Ipsum generator to the Random Text Generator dialog ([#3102](https://github.com/texstudio-org/texstudio/pull/3102))
-- change default windows style for new installs to Fusion instead of moden-dark, in case system darkmode is detected.
+- change default windows style for new installs to Fusion instead of modern-dark, in case system darkmode is detected ([ad0fc44](https://github.com/texstudio-org/texstudio/commit/ad0fc4485f2f7643b3b7b44318e29f54efe2132f))
+- improve some details of the Edit Macros dialog ([#3130](https://github.com/texstudio-org/texstudio/pull/3130))
+- fix editor moving last line of a selection when selection ends at start of a line ([#3131](https://github.com/texstudio-org/texstudio/issues/3131))
 - fix some icon issues on OSX ([#3100](https://github.com/texstudio-org/texstudio/issues/2921),[#3104](https://github.com/texstudio-org/texstudio/issues/3104))
 
 ## TeXstudio 4.5.2


### PR DESCRIPTION
This PR fixes #3131.

When a cursor is found with a selection then the indices of all lines from selection.startLine to selection.endLine are added to a list of lines being moved. But the last line should only be added if the selection doesn't end in column 0.