### PR TITLE
Avoid reserved word "class"

### DIFF
--- a/completion/xeCJK.cwl
+++ b/completion/xeCJK.cwl
@@ -131,8 +131,8 @@ LoadFandol#true,false
 \xeCJKRestoreSubCJKBlock*{blocks}#*
 
 ## 3.4
-\xeCJKDeclareCharClass{class}{class range}#*
-\xeCJKDeclareCharClass*{class}{class range}#*
+\xeCJKDeclareCharClass{char class}{class range}#*
+\xeCJKDeclareCharClass*{char class}{class range}#*
 
 \xeCJKResetCharClass#*
 \xeCJKResetPunctClass#*


### PR DESCRIPTION
Argument name "class" represents a document class.
see https://texstudio-org.github.io/background.html#argument-names