### PR TITLE
show current stable version in About Dialog

### DIFF
--- a/src/aboutdialog.cpp
+++ b/src/aboutdialog.cpp
@@ -20,7 +20,7 @@ AboutDialog::AboutDialog(QWidget *parent)
 	ui.setupUi(this);
 	setText();
 	connect(UpdateChecker::instance(), SIGNAL(dataParsed(QString)), SLOT(setText(QString)));
-	UpdateChecker::instance()->check();
+	UpdateChecker::instance()->check(true, -2);  // comboBoxUpdateLevel = -2 is used to suppress Update dialog
 	QAction *act = new QAction("large", this);
 	connect(act, SIGNAL(triggered()), SLOT(largeLogo()));
 	ui.label->addAction(act);

--- a/src/aboutdialog.cpp
+++ b/src/aboutdialog.cpp
@@ -12,43 +12,15 @@
 #include "aboutdialog.h"
 #include "utilsVersion.h"
 #include "utilsSystem.h"
+#include "updatechecker.h"
 
 AboutDialog::AboutDialog(QWidget *parent)
 	: QDialog(parent)
 {
 	ui.setupUi(this);
-    QString changelogPath = findResourceFile("CHANGELOG.md");
-    if(changelogPath.isEmpty()){
-        changelogPath="https://texstudio-org.github.io/CHANGELOG.html";
-    }else{
-        if(!changelogPath.startsWith("/")){
-            changelogPath="/"+changelogPath;
-        }
-        changelogPath="file://"+changelogPath;
-    }
-	ui.textBrowser->setOpenExternalLinks(true);
-    ui.textBrowser->setHtml(QString("<b>%1 %2</b> (git %3)").arg(TEXSTUDIO,TXSVERSION,TEXSTUDIO_GIT_REVISION ? TEXSTUDIO_GIT_REVISION : "n/a") + "<br>" +
-                            tr("Using Qt Version %1, compiled with Qt %2 %3").arg(qVersion(),QT_VERSION_STR,COMPILED_DEBUG_OR_RELEASE) + "<br>" +
-                            "<a href=\""+changelogPath+"\">"+tr("Changelog")+"</a><br><br>" +
-	                        "Copyright (c)<br>" +
-	                        TEXSTUDIO + ": Benito van der Zander, Jan Sundermeyer, Daniel Braun, Tim Hoffmann<br>" +
-	                        "Texmaker: Pascal Brachet<br>" +
-	                        "QCodeEdit: Luc Bruant<br>" +
-	                        tr("html conversion: ") + QString::fromUtf8("Joël Amblard</i><br>") +
-	                        tr("TeXstudio contains code from Hunspell (GPL), QtCreator (GPL, Copyright (C) Nokia), KILE (GPL) and SyncTeX (by Jerome Laurens).") + "<br>" +
-	                        tr("TeXstudio uses the PDF viewer of TeXworks.") + "<br>" +
-	                        tr("TeXstudio uses the DSingleApplication class (Author: Dima Fedorov Levit - Copyright (C) BioImage Informatics - Licence: GPL).") + "<br>" +
-	                        tr("TeXstudio uses TexTablet (MIT License, Copyright (c) 2012 Steven Lovegrove).") + "<br>" +
-	                        tr("TeXstudio uses QuaZip (LGPL, Copyright (C) 2005-2012 Sergey A. Tachenov and contributors).") + "<br>" +
-	                        tr("TeXstudio uses To Title Case (MIT License, Copyright (c) 2008-2013 David Gouch).") + "<br>" +
-	                        tr("TeXstudio contains an image by Alexander Klink.") + "<br>" +
-	                        tr("TeXstudio uses icons from the Crystal Project (LGPL), the Oxygen icon theme (CC-BY-SA 3.0) and the Colibre icon theme (CC0) of LibreOffice.") + "<br>" +
-	                        tr("TeXstudio uses flowlayout from Qt5.6 examples.") + "<br>" +
-                            tr("TeXstudio uses adwaita-qt (GPL2) from ") + "<a href=\"https://github.com/FedoraQt/adwaita-qt\">https://github.com/FedoraQt/adwaita-qt</a><br>" +
-	                        "<br>" +
-                            tr("Thanks to ") + QString::fromUtf8("Frédéric Devernay, Denis Bitouzé, Vesselin Atanasov, Yukai Chou, Jean-Côme Charpentier, Luis Silvestre, Enrico Vittorini, Aleksandr Zolotarev, David Sichau, Grigory Mozhaev, mattgk, A. Weder, Pavel Fric, András Somogyi, István Blahota, Edson Henriques, Grant McLean, Tom Jampen, Kostas Oikinimou, Lion Guillaume, ranks.nl, AI Corleone, Diego Andrés Jarrín, Matthias Pospiech, Zulkifli Hidayat, Christian Spieß, Robert Diaz, Kirill Müller, Atsushi Nakajima Yuriy Kolerov, Victor Kozyakin, Mattia Meneguzzo, Andriy Bandura, Carlos Eduardo Valencia Urbina, Koutheir Attouchi, Stefan Kraus, Bjoern Menke, Charles Brunet, François Gannaz, Marek Kurdej, Paulo Silva, Thiago de Melo, YoungFrog, Klaus Schneider-Zapp, Jakob Nixdorf, Thomas Leitz, Quoc Ho, Matthew Bertucci, geolta.<br><br>") +
-                            tr("Project home site:") + " <a href=\"https://texstudio.org/\">https://texstudio.org/</a><br><br>" +
-	                        tr("This program is licensed to you under the terms of the GNU General Public License Version 2 as published by the Free Software Foundation."));
+	setText();
+	connect(UpdateChecker::instance(), SIGNAL(dataParsed(QString)), SLOT(setText(QString)));
+	UpdateChecker::instance()->check();
 	QAction *act = new QAction("large", this);
 	connect(act, SIGNAL(triggered()), SLOT(largeLogo()));
 	ui.label->addAction(act);
@@ -69,4 +41,41 @@ void AboutDialog::largeLogo()
 	dlg->layout()->addWidget(label);
 	dlg->setWindowTitle("TeXstudio");
 	dlg->exec();
+}
+
+void AboutDialog::setText(QString latestVersion) {
+    QString changelogPath = findResourceFile("CHANGELOG.md");
+    if(changelogPath.isEmpty()){
+        changelogPath="https://texstudio-org.github.io/CHANGELOG.html";
+    }else{
+        if(!changelogPath.startsWith("/")){
+            changelogPath="/"+changelogPath;
+        }
+        changelogPath="file://"+changelogPath;
+    }
+    if (latestVersion=="") latestVersion = tr("couldn't retrieve data");
+    ui.textBrowser->setOpenExternalLinks(true);
+    ui.textBrowser->setHtml(QString("<b>%1 %2</b> (git %3)").arg(TEXSTUDIO,TXSVERSION,TEXSTUDIO_GIT_REVISION ? TEXSTUDIO_GIT_REVISION : "n/a") + "<br>" +
+                            tr("Using Qt Version %1, compiled with Qt %2 %3").arg(qVersion(),QT_VERSION_STR,COMPILED_DEBUG_OR_RELEASE) + "<br><br>" +
+                            tr("Project home site:") + " <a href=\"https://texstudio.org/\">https://texstudio.org/</a><br>" +
+                            tr("Latest stable version: %1").arg(latestVersion)+"<br>" +
+                            "<a href=\""+changelogPath+"\">"+tr("Changelog")+"</a><br><br>"+
+	                        "Copyright (c)<br>" +
+	                        TEXSTUDIO + ": Benito van der Zander, Jan Sundermeyer, Daniel Braun, Tim Hoffmann<br>" +
+	                        "Texmaker: Pascal Brachet<br>" +
+	                        "QCodeEdit: Luc Bruant<br>" +
+	                        tr("html conversion: ") + QString::fromUtf8("Joël Amblard</i><br>") +
+	                        tr("TeXstudio contains code from Hunspell (GPL), QtCreator (GPL, Copyright (C) Nokia), KILE (GPL) and SyncTeX (by Jerome Laurens).") + "<br>" +
+	                        tr("TeXstudio uses the PDF viewer of TeXworks.") + "<br>" +
+	                        tr("TeXstudio uses the DSingleApplication class (Author: Dima Fedorov Levit - Copyright (C) BioImage Informatics - Licence: GPL).") + "<br>" +
+	                        tr("TeXstudio uses TexTablet (MIT License, Copyright (c) 2012 Steven Lovegrove).") + "<br>" +
+	                        tr("TeXstudio uses QuaZip (LGPL, Copyright (C) 2005-2012 Sergey A. Tachenov and contributors).") + "<br>" +
+	                        tr("TeXstudio uses To Title Case (MIT License, Copyright (c) 2008-2013 David Gouch).") + "<br>" +
+	                        tr("TeXstudio contains an image by Alexander Klink.") + "<br>" +
+	                        tr("TeXstudio uses icons from the Crystal Project (LGPL), the Oxygen icon theme (CC-BY-SA 3.0) and the Colibre icon theme (CC0) of LibreOffice.") + "<br>" +
+	                        tr("TeXstudio uses flowlayout from Qt5.6 examples.") + "<br>" +
+                            tr("TeXstudio uses adwaita-qt (GPL2) from ") + "<a href=\"https://github.com/FedoraQt/adwaita-qt\">https://github.com/FedoraQt/adwaita-qt</a><br>" +
+	                        "<br>" +
+                            tr("Thanks to ") + QString::fromUtf8("Frédéric Devernay, Denis Bitouzé, Vesselin Atanasov, Yukai Chou, Jean-Côme Charpentier, Luis Silvestre, Enrico Vittorini, Aleksandr Zolotarev, David Sichau, Grigory Mozhaev, mattgk, A. Weder, Pavel Fric, András Somogyi, István Blahota, Edson Henriques, Grant McLean, Tom Jampen, Kostas Oikinimou, Lion Guillaume, ranks.nl, AI Corleone, Diego Andrés Jarrín, Matthias Pospiech, Zulkifli Hidayat, Christian Spieß, Robert Diaz, Kirill Müller, Atsushi Nakajima Yuriy Kolerov, Victor Kozyakin, Mattia Meneguzzo, Andriy Bandura, Carlos Eduardo Valencia Urbina, Koutheir Attouchi, Stefan Kraus, Bjoern Menke, Charles Brunet, François Gannaz, Marek Kurdej, Paulo Silva, Thiago de Melo, YoungFrog, Klaus Schneider-Zapp, Jakob Nixdorf, Thomas Leitz, Quoc Ho, Matthew Bertucci, geolta.<br><br>") +
+	                        tr("This program is licensed to you under the terms of the GNU General Public License Version 2 as published by the Free Software Foundation."));
 }

--- a/src/aboutdialog.h
+++ b/src/aboutdialog.h
@@ -25,6 +25,7 @@ public:
 	~AboutDialog();
 	Ui::AboutDialog ui;
 private slots:
+	void setText(QString latestVersion = "");
 	void largeLogo(); ///< show enlarged logo, triggered via context menu on image in about-dialog
 };
 

--- a/src/updatechecker.cpp
+++ b/src/updatechecker.cpp
@@ -123,6 +123,8 @@ void UpdateChecker::parseData(const QByteArray &data)
             if (type.isEmpty() || type.toLower() == "stable"){
                 Version v( ver, "stable", revision);
                 latestStableVersion = v;
+                if (latestStableVersion.isValid())
+                    emit dataParsed(latestStableVersion.versionNumber);
                 if (!latestDevVersion.isValid())
                     latestDevVersion = v;
                 if (!latestReleaseCandidateVersion.isValid())

--- a/src/updatechecker.cpp
+++ b/src/updatechecker.cpp
@@ -80,7 +80,8 @@ void UpdateChecker::onRequestCompleted()
 	QByteArray ba = reply->readAll();
 
 	parseData(ba);
-	checkForNewVersion();
+	if (comboBoxUpdateLevel > -2)  // if not About dialog
+		checkForNewVersion();
 
     networkManager->deleteLater();
     networkManager=nullptr;
@@ -139,12 +140,13 @@ void UpdateChecker::checkForNewVersion()
 {
 	// updateLevel values from comboBoxUpdateLevel indices:
 	// 0: stable, 1: release candidate, 2: development (alpha, beta)
-	// config dialog (check button) passes correct current index from dialog, so user can check with different settings without closing dialog
-	// auto check uses -1, since we do not have the current gui value. in this case we can stay with config value.
+	// Config dialog (check button) passes correct current index from dialog, so user can check with different settings without closing dialog
+	// Auto check uses -1, since we do not have the current gui value. in this case we can stay with config value.
+	// About dialog uses -2, so we can suppress Update dialog. But in this case this function isn't called.
 	int updateLevel;
 	if (comboBoxUpdateLevel > -1)
 		updateLevel = comboBoxUpdateLevel;
-	else
+	else // comboBoxUpdateLevel = -1
 		updateLevel = ConfigManager::getInstance()->getOption("Update/UpdateLevel").toInt();
 
 	bool checkReleaseCandidate = updateLevel >= 1;
@@ -230,7 +232,7 @@ void UpdateChecker::notify(QString message)
 	msgBox.setTextFormat(Qt::RichText);
 	msgBox.setText(message);
 	msgBox.setStandardButtons(QMessageBox::Ok);
-	msgBox.setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::LinksAccessibleByMouse);
+	msgBox.setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::LinksAccessibleByMouse | Qt::LinksAccessibleByKeyboard);
 	msgBox.exec();
 }
 

--- a/src/updatechecker.h
+++ b/src/updatechecker.h
@@ -22,6 +22,7 @@ public:
 	void check(bool m_silent = true, int currentComboBoxUpdateLevel = -1);
 
 signals:
+	void dataParsed(QString versionNumber);
 	void checkCompleted();
 
 public slots:

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -8,6 +8,7 @@
 - add a Lorem Ipsum generator to the Random Text Generator dialog ([#3102](https://github.com/texstudio-org/texstudio/pull/3102))
 - change default windows style for new installs to Fusion instead of modern-dark, in case system darkmode is detected ([ad0fc44](https://github.com/texstudio-org/texstudio/commit/ad0fc4485f2f7643b3b7b44318e29f54efe2132f))
 - improve some details of the Edit Macros dialog ([#3130](https://github.com/texstudio-org/texstudio/pull/3130))
+- The link to the TeXstudio homepage is now at the top of the About dialog (Help menu) and the number of the latest stable version is also displayed ([#3146](https://github.com/texstudio-org/texstudio/pull/3146))
 - option Disable horizontal scrolling for "Fit to Text Width" now affects horizontal scrolling with mousepad and scroll wheel ([#1526](https://github.com/texstudio-org/texstudio/issues/1526))
 - fix editor moving last line of a selection when selection ends at start of a line ([#3131](https://github.com/texstudio-org/texstudio/issues/3131))
 - fix some icon issues on OSX ([#3100](https://github.com/texstudio-org/texstudio/issues/2921),[#3104](https://github.com/texstudio-org/texstudio/issues/3104))


### PR DESCRIPTION
It's quite common to use About Dialog to figure out whether your version is up to date, or to visit the home page. Starting About Dialog is much faster than starting Config Dialog. Also, moving the link to the home page to the beginning of the text makes it much easier to access.

![image](https://github.com/texstudio-org/texstudio/assets/102688820/dc9faaa1-4e8c-476c-aaff-7cd1f2292a1e)
