### PR TITLE
wrong height display in QuickWizard/Geometry

### DIFF
--- a/src/quickdocumentdialog.cpp
+++ b/src/quickdocumentdialog.cpp
@@ -485,7 +485,7 @@ void QuickDocumentDialog::geometryValuesChanged()
 	painter.drawLine(QPointF(marginLeft, 0), QPointF(marginLeft, physicalPaperHeight));
 	painter.drawLine(QPointF(0, marginTop), QPointF(physicalPaperWidth, marginTop));
 	painter.drawLine(QPointF(physicalPaperWidth - marginRight, 0), QPointF(physicalPaperWidth - marginRight, physicalPaperHeight));
-	painter.drawLine(QPointF(0, physicalPaperHeight -  marginTop), QPointF(physicalPaperWidth, physicalPaperHeight - marginTop));
+	painter.drawLine(QPointF(0, physicalPaperHeight -  marginBottom), QPointF(physicalPaperWidth, physicalPaperHeight - marginBottom));
 
 	ui.geometryPreviewLabel->setPixmap(preview);
 }


### PR DESCRIPTION
drawing lower margin line is not correct (uses value from top margin), so top and bottom lines are not the same even so height equals 0.

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/924749db-9db2-4421-a633-c6126ca5536a)

after fix:

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/8089fdc0-38e8-4935-ab43-b8776ad245a4)

Hint: The horizontal line is not in the middle of the page because there is a default ratio of 40% for the top margin.