### PR TITLE
don't add duplicate packages in QuickStart wizard

### DIFF
--- a/src/quickdocumentdialog.cpp
+++ b/src/quickdocumentdialog.cpp
@@ -556,12 +556,26 @@ void QuickDocumentDialog::addUserOptions()
 
 void QuickDocumentDialog::addUserPackages()
 {
+	QStringList packagesList;
+	QTableWidget *table = ui.tableWidgetPackages;
+	for (int i=0; i < table->rowCount(); ++i) {
+		QTableWidgetItem *itemPkgName = table->item(i,0);
+		packagesList << itemPkgName->text();
+	}
+	packagesList << "inputenc" << "fontenc" << "geometry" << "babel"; // additional packages you shouldn't add
+
 	QString newoption;
 	UniversalInputDialog dialog;
 	dialog.addVariable(&newoption, tr("New:"));
-	if (dialog.exec() && !newoption.isEmpty()) {
-		otherPackagesList.append(newoption);
-		Init();
+
+	if (dialog.exec() == QDialog::Accepted) {
+		if (packagesList.contains(newoption)) {
+			QMessageBox::information(this, tr("Hint"), tr("Package %1 already in use.").arg(newoption));
+		}
+		else if (!newoption.isEmpty()) {
+			otherPackagesList.append(newoption);
+			Init();
+		}
 	}
 }
 


### PR DESCRIPTION
With this PR it is not possible to add packages already available in the Packages tab of the Quick Start wizard. Furthermore adding any of "inputenc", "fontenc", "geometry", or "babel" is not accepted. Note: "inputenc" is not used by the dialog and should not be used by the user.

### Test
Package tikz is user added, babel is used on first tab by line edit field language.
![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/f9ee08ce-7a0a-49a3-8a67-026717eab341)
