### PR TITLE
enhance usage of units in the Quick Start wizard (Geometry tab)

### DIFF
--- a/src/quickdocumentdialog.cpp
+++ b/src/quickdocumentdialog.cpp
@@ -62,12 +62,12 @@ QuickDocumentDialog::QuickDocumentDialog(QWidget *parent, const QString &name)
 	connect(ui.tabWidget, SIGNAL(tabBarClicked(int)), SLOT(setPkgTabToolTip(int)));
 
 	//Geometry package
-	connect(ui.comboBoxUnitGeometryPageWidth, SIGNAL(currentTextChanged()), SLOT(geometryUnitsChanged()));
-	connect(ui.comboBoxUnitGeometryPageHeight, SIGNAL(currentTextChanged()), SLOT(geometryUnitsChanged()));
-	connect(ui.comboBoxUnitGeometryMarginLeft, SIGNAL(currentTextChanged()), SLOT(geometryUnitsChanged()));
-	connect(ui.comboBoxUnitGeometryMarginRight, SIGNAL(currentTextChanged()), SLOT(geometryUnitsChanged()));
-	connect(ui.comboBoxUnitGeometryMarginTop, SIGNAL(currentTextChanged()), SLOT(geometryUnitsChanged()));
-	connect(ui.comboBoxUnitGeometryMarginBottom, SIGNAL(currentTextChanged()), SLOT(geometryUnitsChanged()));
+	connect(ui.comboBoxUnitGeometryPageWidth, SIGNAL(currentTextChanged(QString)), SLOT(geometryUnitsChanged(QString)));
+	connect(ui.comboBoxUnitGeometryPageHeight, SIGNAL(currentTextChanged(QString)), SLOT(geometryUnitsChanged(QString)));
+	connect(ui.comboBoxUnitGeometryMarginLeft, SIGNAL(currentTextChanged(QString)), SLOT(geometryUnitsChanged(QString)));
+	connect(ui.comboBoxUnitGeometryMarginRight, SIGNAL(currentTextChanged(QString)), SLOT(geometryUnitsChanged(QString)));
+	connect(ui.comboBoxUnitGeometryMarginTop, SIGNAL(currentTextChanged(QString)), SLOT(geometryUnitsChanged(QString)));
+	connect(ui.comboBoxUnitGeometryMarginBottom, SIGNAL(currentTextChanged(QString)), SLOT(geometryUnitsChanged(QString)));
 
 	connect(ui.spinBoxGeometryPageWidth, SIGNAL(valueChanged(double)), SLOT(geometryValuesChanged()));
 	connect(ui.spinBoxGeometryPageHeight, SIGNAL(valueChanged(double)), SLOT(geometryValuesChanged()));
@@ -371,22 +371,15 @@ void QuickDocumentDialog::accept()
 	QDialog::accept();
 }
 
-void QuickDocumentDialog::geometryUnitsChanged()
+void QuickDocumentDialog::geometryUnitsChanged(QString newUnit)
 {
 	//update all units (easier than just the changed one, slower, but need probably less memory)
-	ui.spinBoxGeometryPageWidth->setSuffix(ui.comboBoxUnitGeometryPageWidth->currentText());
-	ui.spinBoxGeometryPageHeight->setSuffix(ui.comboBoxUnitGeometryPageHeight->currentText());
-	ui.spinBoxGeometryMarginLeft->setSuffix(ui.comboBoxUnitGeometryMarginLeft->currentText());
-	ui.spinBoxGeometryMarginRight->setSuffix(ui.comboBoxUnitGeometryMarginRight->currentText());
-	ui.spinBoxGeometryMarginTop->setSuffix(ui.comboBoxUnitGeometryMarginTop->currentText());
-	ui.spinBoxGeometryMarginBottom->setSuffix(ui.comboBoxUnitGeometryMarginBottom->currentText());
-
-	if (sender() == ui.comboBoxUnitGeometryPageWidth) ui.checkBoxGeometryPageWidth->setChecked(true);
-	else if (sender() == ui.comboBoxUnitGeometryPageHeight) ui.checkBoxGeometryPageHeight->setChecked(true);
-	else if (sender() == ui.comboBoxUnitGeometryMarginLeft) ui.checkBoxGeometryMarginLeft->setChecked(true);
-	else if (sender() == ui.comboBoxUnitGeometryMarginRight) ui.checkBoxGeometryMarginRight->setChecked(true);
-	else if (sender() == ui.comboBoxUnitGeometryMarginTop) ui.checkBoxGeometryMarginTop->setChecked(true);
-	else if (sender() == ui.comboBoxUnitGeometryMarginBottom) ui.checkBoxGeometryMarginBottom->setChecked(true);
+	ui.spinBoxGeometryPageWidth->setSuffix(newUnit);
+	ui.spinBoxGeometryPageHeight->setSuffix(newUnit);
+	ui.spinBoxGeometryMarginLeft->setSuffix(newUnit);
+	ui.spinBoxGeometryMarginRight->setSuffix(newUnit);
+	ui.spinBoxGeometryMarginTop->setSuffix(newUnit);
+	ui.spinBoxGeometryMarginBottom->setSuffix(newUnit);
 }
 
 void calculatePaperLength(qreal paper, qreal &left, qreal &body, qreal &right, qreal defaultLeftRatio)

--- a/src/quickdocumentdialog.cpp
+++ b/src/quickdocumentdialog.cpp
@@ -14,7 +14,7 @@
 #include "configmanagerinterface.h"
 #include "utilsUI.h"
 
-qreal convertLatexLengthToMetre(const qreal &length, const QString &unit)
+qreal unit2Metre(const qreal &length, const QString &unit)
 {
 	static const qreal inchInMetre = 0.0254;
 	static const qreal pointInMetre = inchInMetre / 72.27;
@@ -62,12 +62,12 @@ QuickDocumentDialog::QuickDocumentDialog(QWidget *parent, const QString &name)
 	connect(ui.tabWidget, SIGNAL(tabBarClicked(int)), SLOT(setPkgTabToolTip(int)));
 
 	//Geometry package
-	connect(ui.spinBoxUnitGeometryPageWidth, SIGNAL(editTextChanged(QString)), SLOT(geometryUnitsChanged()));
-	connect(ui.spinBoxUnitGeometryPageHeight, SIGNAL(editTextChanged(QString)), SLOT(geometryUnitsChanged()));
-	connect(ui.spinBoxUnitGeometryMarginLeft, SIGNAL(editTextChanged(QString)), SLOT(geometryUnitsChanged()));
-	connect(ui.spinBoxUnitGeometryMarginRight, SIGNAL(editTextChanged(QString)), SLOT(geometryUnitsChanged()));
-	connect(ui.spinBoxUnitGeometryMarginTop, SIGNAL(editTextChanged(QString)), SLOT(geometryUnitsChanged()));
-	connect(ui.spinBoxUnitGeometryMarginBottom, SIGNAL(editTextChanged(QString)), SLOT(geometryUnitsChanged()));
+	connect(ui.comboBoxUnitGeometryPageWidth, SIGNAL(currentTextChanged()), SLOT(geometryUnitsChanged()));
+	connect(ui.comboBoxUnitGeometryPageHeight, SIGNAL(currentTextChanged()), SLOT(geometryUnitsChanged()));
+	connect(ui.comboBoxUnitGeometryMarginLeft, SIGNAL(currentTextChanged()), SLOT(geometryUnitsChanged()));
+	connect(ui.comboBoxUnitGeometryMarginRight, SIGNAL(currentTextChanged()), SLOT(geometryUnitsChanged()));
+	connect(ui.comboBoxUnitGeometryMarginTop, SIGNAL(currentTextChanged()), SLOT(geometryUnitsChanged()));
+	connect(ui.comboBoxUnitGeometryMarginBottom, SIGNAL(currentTextChanged()), SLOT(geometryUnitsChanged()));
 
 	connect(ui.spinBoxGeometryPageWidth, SIGNAL(valueChanged(double)), SLOT(geometryValuesChanged()));
 	connect(ui.spinBoxGeometryPageHeight, SIGNAL(valueChanged(double)), SLOT(geometryValuesChanged()));
@@ -351,12 +351,12 @@ void QuickDocumentDialog::Init()
 	configManagerInterface->linkOptionToDialogWidget(&geometryMarginTop, ui.spinBoxGeometryMarginTop);
 	configManagerInterface->linkOptionToDialogWidget(&geometryMarginBottom, ui.spinBoxGeometryMarginBottom);
 
-	configManagerInterface->linkOptionToDialogWidget(&geometryPageWidthUnit, ui.spinBoxUnitGeometryPageWidth);
-	configManagerInterface->linkOptionToDialogWidget(&geometryPageHeightUnit, ui.spinBoxUnitGeometryPageHeight);
-	configManagerInterface->linkOptionToDialogWidget(&geometryMarginLeftUnit, ui.spinBoxUnitGeometryMarginLeft);
-	configManagerInterface->linkOptionToDialogWidget(&geometryMarginRightUnit, ui.spinBoxUnitGeometryMarginRight);
-	configManagerInterface->linkOptionToDialogWidget(&geometryMarginTopUnit, ui.spinBoxUnitGeometryMarginTop);
-	configManagerInterface->linkOptionToDialogWidget(&geometryMarginBottomUnit, ui.spinBoxUnitGeometryMarginBottom);
+	configManagerInterface->linkOptionToDialogWidget(&geometryPageWidthUnit, ui.comboBoxUnitGeometryPageWidth);
+	configManagerInterface->linkOptionToDialogWidget(&geometryPageHeightUnit, ui.comboBoxUnitGeometryPageHeight);
+	configManagerInterface->linkOptionToDialogWidget(&geometryMarginLeftUnit, ui.comboBoxUnitGeometryMarginLeft);
+	configManagerInterface->linkOptionToDialogWidget(&geometryMarginRightUnit, ui.comboBoxUnitGeometryMarginRight);
+	configManagerInterface->linkOptionToDialogWidget(&geometryMarginTopUnit, ui.comboBoxUnitGeometryMarginTop);
+	configManagerInterface->linkOptionToDialogWidget(&geometryMarginBottomUnit, ui.comboBoxUnitGeometryMarginBottom);
 
 	configManagerInterface->linkOptionToDialogWidget(&geometryPageWidthEnabled, ui.checkBoxGeometryPageWidth);
 	configManagerInterface->linkOptionToDialogWidget(&geometryPageHeightEnabled, ui.checkBoxGeometryPageHeight);
@@ -374,19 +374,19 @@ void QuickDocumentDialog::accept()
 void QuickDocumentDialog::geometryUnitsChanged()
 {
 	//update all units (easier than just the changed one, slower, but need probably less memory)
-	ui.spinBoxGeometryPageWidth->setSuffix(ui.spinBoxUnitGeometryPageWidth->currentText());
-	ui.spinBoxGeometryPageHeight->setSuffix(ui.spinBoxUnitGeometryPageHeight->currentText());
-	ui.spinBoxGeometryMarginLeft->setSuffix(ui.spinBoxUnitGeometryMarginLeft->currentText());
-	ui.spinBoxGeometryMarginRight->setSuffix(ui.spinBoxUnitGeometryMarginRight->currentText());
-	ui.spinBoxGeometryMarginTop->setSuffix(ui.spinBoxUnitGeometryMarginTop->currentText());
-	ui.spinBoxGeometryMarginBottom->setSuffix(ui.spinBoxUnitGeometryMarginBottom->currentText());
+	ui.spinBoxGeometryPageWidth->setSuffix(ui.comboBoxUnitGeometryPageWidth->currentText());
+	ui.spinBoxGeometryPageHeight->setSuffix(ui.comboBoxUnitGeometryPageHeight->currentText());
+	ui.spinBoxGeometryMarginLeft->setSuffix(ui.comboBoxUnitGeometryMarginLeft->currentText());
+	ui.spinBoxGeometryMarginRight->setSuffix(ui.comboBoxUnitGeometryMarginRight->currentText());
+	ui.spinBoxGeometryMarginTop->setSuffix(ui.comboBoxUnitGeometryMarginTop->currentText());
+	ui.spinBoxGeometryMarginBottom->setSuffix(ui.comboBoxUnitGeometryMarginBottom->currentText());
 
-	if (sender() == ui.spinBoxUnitGeometryPageWidth) ui.checkBoxGeometryPageWidth->setChecked(true);
-	else if (sender() == ui.spinBoxUnitGeometryPageHeight) ui.checkBoxGeometryPageHeight->setChecked(true);
-	else if (sender() == ui.spinBoxUnitGeometryMarginLeft) ui.checkBoxGeometryMarginLeft->setChecked(true);
-	else if (sender() == ui.spinBoxUnitGeometryMarginRight) ui.checkBoxGeometryMarginRight->setChecked(true);
-	else if (sender() == ui.spinBoxUnitGeometryMarginTop) ui.checkBoxGeometryMarginTop->setChecked(true);
-	else if (sender() == ui.spinBoxUnitGeometryMarginBottom) ui.checkBoxGeometryMarginBottom->setChecked(true);
+	if (sender() == ui.comboBoxUnitGeometryPageWidth) ui.checkBoxGeometryPageWidth->setChecked(true);
+	else if (sender() == ui.comboBoxUnitGeometryPageHeight) ui.checkBoxGeometryPageHeight->setChecked(true);
+	else if (sender() == ui.comboBoxUnitGeometryMarginLeft) ui.checkBoxGeometryMarginLeft->setChecked(true);
+	else if (sender() == ui.comboBoxUnitGeometryMarginRight) ui.checkBoxGeometryMarginRight->setChecked(true);
+	else if (sender() == ui.comboBoxUnitGeometryMarginTop) ui.checkBoxGeometryMarginTop->setChecked(true);
+	else if (sender() == ui.comboBoxUnitGeometryMarginBottom) ui.checkBoxGeometryMarginBottom->setChecked(true);
 }
 
 void calculatePaperLength(qreal paper, qreal &left, qreal &body, qreal &right, qreal defaultLeftRatio)
@@ -454,16 +454,16 @@ void QuickDocumentDialog::geometryValuesChanged()
 		ui.geometryPreviewLabel->setText("unknown paper format");
 		return;
 	}
-	qreal physicalPaperWidth = convertLatexLengthToMetre(paperFormats[paperFormat + 1].toDouble(), paperFormats[paperFormat + 3]);
-	qreal physicalPaperHeight = convertLatexLengthToMetre(paperFormats[paperFormat + 2].toDouble(), paperFormats[paperFormat + 3]);
+	qreal physicalPaperWidth = unit2Metre(paperFormats[paperFormat + 1].toDouble(), paperFormats[paperFormat + 3]);
+	qreal physicalPaperHeight = unit2Metre(paperFormats[paperFormat + 2].toDouble(), paperFormats[paperFormat + 3]);
 
-	qreal textWidth = (ui.checkBoxGeometryPageWidth->isChecked() ? convertLatexLengthToMetre(ui.spinBoxGeometryPageWidth->value(), ui.spinBoxGeometryPageWidth->suffix()) : -1);
-	qreal textHeight = (ui.checkBoxGeometryPageWidth->isChecked() ? convertLatexLengthToMetre(ui.spinBoxGeometryPageHeight->value(), ui.spinBoxGeometryPageHeight->suffix()) : -1);
+	qreal textWidth = (ui.checkBoxGeometryPageWidth->isChecked() ? unit2Metre(ui.spinBoxGeometryPageWidth->value(), ui.spinBoxGeometryPageWidth->suffix()) : -1);
+	qreal textHeight = (ui.checkBoxGeometryPageWidth->isChecked() ? unit2Metre(ui.spinBoxGeometryPageHeight->value(), ui.spinBoxGeometryPageHeight->suffix()) : -1);
 
-	qreal marginLeft = (ui.checkBoxGeometryMarginLeft->isChecked() ? convertLatexLengthToMetre(ui.spinBoxGeometryMarginLeft->value(), ui.spinBoxGeometryMarginLeft->suffix()) : -1);
-	qreal marginRight = (ui.checkBoxGeometryMarginRight->isChecked() ? convertLatexLengthToMetre(ui.spinBoxGeometryMarginRight->value(), ui.spinBoxGeometryMarginRight->suffix()) : -1);
-	qreal marginTop = (ui.checkBoxGeometryMarginTop->isChecked() ? convertLatexLengthToMetre(ui.spinBoxGeometryMarginTop->value(), ui.spinBoxGeometryMarginTop->suffix()) : -1);
-	qreal marginBottom = (ui.checkBoxGeometryMarginBottom->isChecked() ? convertLatexLengthToMetre(ui.spinBoxGeometryMarginBottom->value(), ui.spinBoxGeometryMarginBottom->suffix()) : -1);
+	qreal marginLeft = (ui.checkBoxGeometryMarginLeft->isChecked() ? unit2Metre(ui.spinBoxGeometryMarginLeft->value(), ui.spinBoxGeometryMarginLeft->suffix()) : -1);
+	qreal marginRight = (ui.checkBoxGeometryMarginRight->isChecked() ? unit2Metre(ui.spinBoxGeometryMarginRight->value(), ui.spinBoxGeometryMarginRight->suffix()) : -1);
+	qreal marginTop = (ui.checkBoxGeometryMarginTop->isChecked() ? unit2Metre(ui.spinBoxGeometryMarginTop->value(), ui.spinBoxGeometryMarginTop->suffix()) : -1);
+	qreal marginBottom = (ui.checkBoxGeometryMarginBottom->isChecked() ? unit2Metre(ui.spinBoxGeometryMarginBottom->value(), ui.spinBoxGeometryMarginBottom->suffix()) : -1);
 
     bool twoSide = ui.listWidgetOptions->findItems("twoside", Qt::MatchExactly).constFirst()->checkState() == Qt::Checked;
     bool landscape = ui.listWidgetOptions->findItems("landscape", Qt::MatchExactly).constFirst()->checkState() == Qt::Checked;

--- a/src/quickdocumentdialog.cpp
+++ b/src/quickdocumentdialog.cpp
@@ -14,18 +14,18 @@
 #include "configmanagerinterface.h"
 #include "utilsUI.h"
 
-qreal unit2Metre(const qreal &length, const QString &unit)
+qreal unit2Metre(const qreal &length, const QString &unit, const bool &inverse = false)
 {
 	static const qreal inchInMetre = 0.0254;
 	static const qreal pointInMetre = inchInMetre / 72.27;
 	static const qreal bigPointInMetre = inchInMetre / 72;
 	QString lunit = unit.toLower();
-	if (lunit == "pt") return length * pointInMetre;
-	if (lunit == "bp") return length * bigPointInMetre;
-	if (lunit == "cm") return length * 0.01;
-	if (lunit == "dm") return length * 0.1;
-	if (lunit == "in") return length * inchInMetre;
-	/*if (unit == "mm")*/ return length * 0.001;
+	if (lunit == "pt")    if (!inverse) return length * pointInMetre;      else  return length / pointInMetre;   
+	if (lunit == "bp")    if (!inverse) return length * bigPointInMetre;   else  return length / bigPointInMetre;
+	if (lunit == "cm")    if (!inverse) return length * 0.01;              else  return length * 100.;           
+	if (lunit == "dm")    if (!inverse) return length * 0.1;               else  return length * 10.;            
+	if (lunit == "in")    if (!inverse) return length * inchInMetre;       else  return length / inchInMetre;    
+	/*if (unit == "mm")*/ if (!inverse) return length * 0.001;             else  return length * 1000.;          
 }
 
 //options for the configmanager
@@ -374,12 +374,36 @@ void QuickDocumentDialog::accept()
 void QuickDocumentDialog::geometryUnitsChanged(QString newUnit)
 {
 	//update all units (easier than just the changed one, slower, but need probably less memory)
-	ui.spinBoxGeometryPageWidth->setSuffix(newUnit);
-	ui.spinBoxGeometryPageHeight->setSuffix(newUnit);
-	ui.spinBoxGeometryMarginLeft->setSuffix(newUnit);
-	ui.spinBoxGeometryMarginRight->setSuffix(newUnit);
-	ui.spinBoxGeometryMarginTop->setSuffix(newUnit);
-	ui.spinBoxGeometryMarginBottom->setSuffix(newUnit);
+	if (sender() == ui.comboBoxUnitGeometryPageWidth) {
+		qreal newValue = unit2Metre( unit2Metre(ui.spinBoxGeometryPageWidth->value(), ui.spinBoxGeometryPageWidth->suffix()), newUnit, true);
+		ui.spinBoxGeometryPageWidth->setSuffix(newUnit);
+		ui.spinBoxGeometryPageWidth->setValue(newValue);
+	} else
+	if (sender() == ui.comboBoxUnitGeometryPageHeight) {
+		qreal newValue = unit2Metre( unit2Metre(ui.spinBoxGeometryPageHeight->value(), ui.spinBoxGeometryPageHeight->suffix()), newUnit, true);
+		ui.spinBoxGeometryPageHeight->setSuffix(newUnit);
+		ui.spinBoxGeometryPageHeight->setValue(newValue);
+	} else
+	if (sender() == ui.comboBoxUnitGeometryMarginLeft) {
+		qreal newValue = unit2Metre( unit2Metre(ui.spinBoxGeometryMarginLeft->value(), ui.spinBoxGeometryMarginLeft->suffix()), newUnit, true);
+		ui.spinBoxGeometryMarginLeft->setSuffix(newUnit);
+		ui.spinBoxGeometryMarginLeft->setValue(newValue);
+	} else
+	if (sender() == ui.comboBoxUnitGeometryMarginRight) {
+		qreal newValue = unit2Metre( unit2Metre(ui.spinBoxGeometryMarginRight->value(), ui.spinBoxGeometryMarginRight->suffix()), newUnit, true);
+		ui.spinBoxGeometryMarginRight->setSuffix(newUnit);
+		ui.spinBoxGeometryMarginRight->setValue(newValue);
+	} else
+	if (sender() == ui.comboBoxUnitGeometryMarginTop) {
+		qreal newValue = unit2Metre( unit2Metre(ui.spinBoxGeometryMarginTop->value(), ui.spinBoxGeometryMarginTop->suffix()), newUnit, true);
+		ui.spinBoxGeometryMarginTop->setSuffix(newUnit);
+		ui.spinBoxGeometryMarginTop->setValue(newValue);
+	} else
+	if (sender() == ui.comboBoxUnitGeometryMarginBottom) {
+		qreal newValue = unit2Metre( unit2Metre(ui.spinBoxGeometryMarginBottom->value(), ui.spinBoxGeometryMarginBottom->suffix()), newUnit, true);
+		ui.spinBoxGeometryMarginBottom->setSuffix(newUnit);
+		ui.spinBoxGeometryMarginBottom->setValue(newValue);
+	}
 }
 
 void calculatePaperLength(qreal paper, qreal &left, qreal &body, qreal &right, qreal defaultLeftRatio)

--- a/src/quickdocumentdialog.cpp
+++ b/src/quickdocumentdialog.cpp
@@ -344,19 +344,19 @@ void QuickDocumentDialog::Init()
 	configManagerInterface->linkOptionToDialogWidget(&babel_language, ui.comboBoxBabel);
 	configManagerInterface->linkOptionToDialogWidget(&author, ui.lineEditAuthor);
 
-	configManagerInterface->linkOptionToDialogWidget(&geometryPageWidth, ui.spinBoxGeometryPageWidth);
-	configManagerInterface->linkOptionToDialogWidget(&geometryPageHeight, ui.spinBoxGeometryPageHeight);
-	configManagerInterface->linkOptionToDialogWidget(&geometryMarginLeft, ui.spinBoxGeometryMarginLeft);
-	configManagerInterface->linkOptionToDialogWidget(&geometryMarginRight, ui.spinBoxGeometryMarginRight);
-	configManagerInterface->linkOptionToDialogWidget(&geometryMarginTop, ui.spinBoxGeometryMarginTop);
-	configManagerInterface->linkOptionToDialogWidget(&geometryMarginBottom, ui.spinBoxGeometryMarginBottom);
-
 	configManagerInterface->linkOptionToDialogWidget(&geometryPageWidthUnit, ui.comboBoxUnitGeometryPageWidth);
 	configManagerInterface->linkOptionToDialogWidget(&geometryPageHeightUnit, ui.comboBoxUnitGeometryPageHeight);
 	configManagerInterface->linkOptionToDialogWidget(&geometryMarginLeftUnit, ui.comboBoxUnitGeometryMarginLeft);
 	configManagerInterface->linkOptionToDialogWidget(&geometryMarginRightUnit, ui.comboBoxUnitGeometryMarginRight);
 	configManagerInterface->linkOptionToDialogWidget(&geometryMarginTopUnit, ui.comboBoxUnitGeometryMarginTop);
 	configManagerInterface->linkOptionToDialogWidget(&geometryMarginBottomUnit, ui.comboBoxUnitGeometryMarginBottom);
+
+	configManagerInterface->linkOptionToDialogWidget(&geometryPageWidth, ui.spinBoxGeometryPageWidth);
+	configManagerInterface->linkOptionToDialogWidget(&geometryPageHeight, ui.spinBoxGeometryPageHeight);
+	configManagerInterface->linkOptionToDialogWidget(&geometryMarginLeft, ui.spinBoxGeometryMarginLeft);
+	configManagerInterface->linkOptionToDialogWidget(&geometryMarginRight, ui.spinBoxGeometryMarginRight);
+	configManagerInterface->linkOptionToDialogWidget(&geometryMarginTop, ui.spinBoxGeometryMarginTop);
+	configManagerInterface->linkOptionToDialogWidget(&geometryMarginBottom, ui.spinBoxGeometryMarginBottom);
 
 	configManagerInterface->linkOptionToDialogWidget(&geometryPageWidthEnabled, ui.checkBoxGeometryPageWidth);
 	configManagerInterface->linkOptionToDialogWidget(&geometryPageHeightEnabled, ui.checkBoxGeometryPageHeight);

--- a/src/quickdocumentdialog.h
+++ b/src/quickdocumentdialog.h
@@ -43,7 +43,7 @@ public slots:
 	void Init();
 	virtual void accept();
 
-	void geometryUnitsChanged();
+	void geometryUnitsChanged(QString newUnit);
 	void geometryValuesChanged();
 
 private slots:

--- a/src/quickdocumentdialog.ui
+++ b/src/quickdocumentdialog.ui
@@ -330,9 +330,9 @@
            </widget>
           </item>
           <item row="0" column="2">
-           <widget class="QComboBox" name="spinBoxUnitGeometryPageWidth">
+           <widget class="QComboBox" name="comboBoxUnitGeometryPageWidth">
             <property name="editable">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <item>
              <property name="text">
@@ -362,9 +362,9 @@
            </widget>
           </item>
           <item row="1" column="2" rowspan="2">
-           <widget class="QComboBox" name="spinBoxUnitGeometryPageHeight">
+           <widget class="QComboBox" name="comboBoxUnitGeometryPageHeight">
             <property name="editable">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <item>
              <property name="text">
@@ -446,9 +446,9 @@
            </widget>
           </item>
           <item row="0" column="2">
-           <widget class="QComboBox" name="spinBoxUnitGeometryMarginLeft">
+           <widget class="QComboBox" name="comboBoxUnitGeometryMarginLeft">
             <property name="editable">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <item>
              <property name="text">
@@ -501,9 +501,9 @@
            </widget>
           </item>
           <item row="1" column="2">
-           <widget class="QComboBox" name="spinBoxUnitGeometryMarginRight">
+           <widget class="QComboBox" name="comboBoxUnitGeometryMarginRight">
             <property name="editable">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <item>
              <property name="text">
@@ -549,9 +549,9 @@
            </widget>
           </item>
           <item row="2" column="2" rowspan="2">
-           <widget class="QComboBox" name="spinBoxUnitGeometryMarginTop">
+           <widget class="QComboBox" name="comboBoxUnitGeometryMarginTop">
             <property name="editable">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <item>
              <property name="text">
@@ -611,9 +611,9 @@
            </widget>
           </item>
           <item row="4" column="2">
-           <widget class="QComboBox" name="spinBoxUnitGeometryMarginBottom">
+           <widget class="QComboBox" name="comboBoxUnitGeometryMarginBottom">
             <property name="editable">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <item>
              <property name="text">
@@ -763,7 +763,7 @@
   <connection>
    <sender>checkBoxGeometryPageWidth</sender>
    <signal>toggled(bool)</signal>
-   <receiver>spinBoxUnitGeometryPageWidth</receiver>
+   <receiver>comboBoxUnitGeometryPageWidth</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -795,7 +795,7 @@
   <connection>
    <sender>checkBoxGeometryPageHeight</sender>
    <signal>toggled(bool)</signal>
-   <receiver>spinBoxUnitGeometryPageHeight</receiver>
+   <receiver>comboBoxUnitGeometryPageHeight</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -827,7 +827,7 @@
   <connection>
    <sender>checkBoxGeometryMarginLeft</sender>
    <signal>toggled(bool)</signal>
-   <receiver>spinBoxUnitGeometryMarginLeft</receiver>
+   <receiver>comboBoxUnitGeometryMarginLeft</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -859,7 +859,7 @@
   <connection>
    <sender>checkBoxGeometryMarginRight</sender>
    <signal>toggled(bool)</signal>
-   <receiver>spinBoxUnitGeometryMarginRight</receiver>
+   <receiver>comboBoxUnitGeometryMarginRight</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -891,7 +891,7 @@
   <connection>
    <sender>checkBoxGeometryMarginTop</sender>
    <signal>toggled(bool)</signal>
-   <receiver>spinBoxUnitGeometryMarginTop</receiver>
+   <receiver>comboBoxUnitGeometryMarginTop</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -923,7 +923,7 @@
   <connection>
    <sender>checkBoxGeometryMarginBottom</sender>
    <signal>toggled(bool)</signal>
-   <receiver>spinBoxUnitGeometryMarginBottom</receiver>
+   <receiver>comboBoxUnitGeometryMarginBottom</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -7,7 +7,7 @@
 - add support for alignedat environment in QuickArray Wizard ([#2921](https://github.com/texstudio-org/texstudio/issues/2921))
 - add a Lorem Ipsum generator to the Random Text Generator dialog ([#3102](https://github.com/texstudio-org/texstudio/pull/3102))
 - change default windows style for new installs to Fusion instead of modern-dark, in case system darkmode is detected ([ad0fc44](https://github.com/texstudio-org/texstudio/commit/ad0fc4485f2f7643b3b7b44318e29f54efe2132f))
-- improve some details and fix an issue of the Quick Start wizard ([#2901](https://github.com/texstudio-org/texstudio/issues/2901), [#3153](https://github.com/texstudio-org/texstudio/pull/3153), [#3150](https://github.com/texstudio-org/texstudio/pull/3150))
+- improve some details and fix an issue of the Quick Start wizard ([#2901](https://github.com/texstudio-org/texstudio/issues/2901), [#3153](https://github.com/texstudio-org/texstudio/pull/3153), [#3156](https://github.com/texstudio-org/texstudio/pull/3156), [#3150](https://github.com/texstudio-org/texstudio/pull/3150))
 - improve some details of the Edit Macros dialog ([#3130](https://github.com/texstudio-org/texstudio/pull/3130))
 - The link to the TeXstudio homepage is now at the top of the About dialog (Help menu) and the number of the latest stable version is also displayed ([#3146](https://github.com/texstudio-org/texstudio/pull/3146))
 - option Disable horizontal scrolling for "Fit to Text Width" now affects horizontal scrolling with mousepad and scroll wheel ([#1526](https://github.com/texstudio-org/texstudio/issues/1526))


### PR DESCRIPTION
This PR enhances the page geometry configuration that is part of the Quick Start wizard. It addresses following observations.

1. Lengths are given with a number combined with a unit. When you change the unit from cm to mm the number is not adjusted (image). Simply changing the unit means that the length shrinks to one tenth of the original length in this case. Even so the image doesn't change (workaround: change temp. the number with up/down buttons). In fact the image should not change but the number should increase by a factor of 10. This is implemented by the PR.

   ![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/17a5bdfc-dfc5-447a-a194-1e3f5af81f1d)

2. You can enter unknown units (like pico meters pm or nano meters nm) or even any text. In this case dialog uses mm internally. Unit dm is not in the list of the combo boxes, but is recognized when you enter it manually. But dm is not known to LaTeX. In fact there is no reason why one should enter units manually (in general necessary unit conversion formulae would miss). The PR therefore sets attribute editable to false for those combo boxes.

### Test
Changing units: 127mm = 12.7cm = 5in (since 25.4*5=125+2=127):

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/35f4e4b4-335e-4f28-91f5-6e43be5ce62d)

These values are correctly saved in and loaded from the ini file. The LaTeX code looks fine:
```
Quick\Geometry%20Page%20Width=127
Quick\Geometry%20Page%20Width%20Unit=mm
```
```latex
\usepackage[width=127.00mm, top=5.00cm, bottom=5.00cm]{geometry}
```
```
Quick\Geometry%20Page%20Width=12.7
Quick\Geometry%20Page%20Width%20Unit=cm
```
```latex
\usepackage[width=12.70cm, top=5.00cm, bottom=5.00cm]{geometry}
```
```
Quick\Geometry%20Page%20Width=5
Quick\Geometry%20Page%20Width%20Unit=in
```
```latex
\usepackage[width=5.00in, top=5.00cm, bottom=5.00cm]{geometry}
```