### PR TITLE
fix issues with units in the Quick Start wizard (Geometry tab)

### DIFF
--- a/src/quickdocumentdialog.cpp
+++ b/src/quickdocumentdialog.cpp
@@ -375,6 +375,12 @@ void QuickDocumentDialog::geometryUnitsChanged()
 {
 	//update all units (easier than just the changed one, slower, but need probably less memory)
 	// it was decided not to recalculate number part (s. https://github.com/texstudio-org/texstudio/pull/3156) and to not use suffix in spinBoxGeometry...
+	if (sender() == ui.comboBoxUnitGeometryPageWidth) ui.checkBoxGeometryPageWidth->setChecked(true);
+	else if (sender() == ui.comboBoxUnitGeometryPageHeight) ui.checkBoxGeometryPageHeight->setChecked(true);
+	else if (sender() == ui.comboBoxUnitGeometryMarginRight) ui.checkBoxGeometryMarginRight->setChecked(true);
+	else if (sender() == ui.comboBoxUnitGeometryMarginLeft) ui.checkBoxGeometryMarginLeft->setChecked(true);
+	else if (sender() == ui.comboBoxUnitGeometryMarginTop) ui.checkBoxGeometryMarginTop->setChecked(true);
+	else if (sender() == ui.comboBoxUnitGeometryMarginBottom) ui.checkBoxGeometryMarginBottom->setChecked(true);
 	geometryValuesChanged();
 }
 
@@ -398,6 +404,14 @@ void calculatePaperLength(qreal paper, qreal &left, qreal &body, qreal &right, q
 
 void QuickDocumentDialog::geometryValuesChanged()
 {
+	//if a value is changed, enable it (I just don't like to create 12 slots for this, where are you lambda?)
+	if (sender() == ui.spinBoxGeometryPageWidth) ui.checkBoxGeometryPageWidth->setChecked(true);
+	else if (sender() == ui.spinBoxGeometryPageHeight) ui.checkBoxGeometryPageHeight->setChecked(true);
+	else if (sender() == ui.spinBoxGeometryMarginLeft) ui.checkBoxGeometryMarginLeft->setChecked(true);
+	else if (sender() == ui.spinBoxGeometryMarginRight) ui.checkBoxGeometryMarginRight->setChecked(true);
+	else if (sender() == ui.spinBoxGeometryMarginTop) ui.checkBoxGeometryMarginTop->setChecked(true);
+	else if (sender() == ui.spinBoxGeometryMarginBottom) ui.checkBoxGeometryMarginBottom->setChecked(true);
+
 	static const QStringList paperFormats = QStringList()
 	                                        << "a0paper" << "841" << "1189" << "mm"
 	                                        << "a1paper" << "594" << "841" << "mm"

--- a/src/quickdocumentdialog.cpp
+++ b/src/quickdocumentdialog.cpp
@@ -14,18 +14,18 @@
 #include "configmanagerinterface.h"
 #include "utilsUI.h"
 
-qreal convertLatexLengthToMetre(const qreal &length, const QString &unit)
+qreal unit2Metre(const qreal &length, const QString &unit, const bool &inverse = false)
 {
 	static const qreal inchInMetre = 0.0254;
 	static const qreal pointInMetre = inchInMetre / 72.27;
 	static const qreal bigPointInMetre = inchInMetre / 72;
 	QString lunit = unit.toLower();
-	if (lunit == "pt") return length * pointInMetre;
-	if (lunit == "bp") return length * bigPointInMetre;
-	if (lunit == "cm") return length * 0.01;
-	if (lunit == "dm") return length * 0.1;
-	if (lunit == "in") return length * inchInMetre;
-	/*if (unit == "mm")*/ return length * 0.001;
+	if (lunit == "pt")    if (!inverse) return length * pointInMetre;      else  return length / pointInMetre;   
+	if (lunit == "bp")    if (!inverse) return length * bigPointInMetre;   else  return length / bigPointInMetre;
+	if (lunit == "cm")    if (!inverse) return length * 0.01;              else  return length * 100.;           
+	if (lunit == "dm")    if (!inverse) return length * 0.1;               else  return length * 10.;            
+	if (lunit == "in")    if (!inverse) return length * inchInMetre;       else  return length / inchInMetre;    
+	/*if (unit == "mm")*/ if (!inverse) return length * 0.001;             else  return length * 1000.;          
 }
 
 //options for the configmanager
@@ -62,12 +62,12 @@ QuickDocumentDialog::QuickDocumentDialog(QWidget *parent, const QString &name)
 	connect(ui.tabWidget, SIGNAL(tabBarClicked(int)), SLOT(setPkgTabToolTip(int)));
 
 	//Geometry package
-	connect(ui.spinBoxUnitGeometryPageWidth, SIGNAL(editTextChanged(QString)), SLOT(geometryUnitsChanged()));
-	connect(ui.spinBoxUnitGeometryPageHeight, SIGNAL(editTextChanged(QString)), SLOT(geometryUnitsChanged()));
-	connect(ui.spinBoxUnitGeometryMarginLeft, SIGNAL(editTextChanged(QString)), SLOT(geometryUnitsChanged()));
-	connect(ui.spinBoxUnitGeometryMarginRight, SIGNAL(editTextChanged(QString)), SLOT(geometryUnitsChanged()));
-	connect(ui.spinBoxUnitGeometryMarginTop, SIGNAL(editTextChanged(QString)), SLOT(geometryUnitsChanged()));
-	connect(ui.spinBoxUnitGeometryMarginBottom, SIGNAL(editTextChanged(QString)), SLOT(geometryUnitsChanged()));
+	connect(ui.comboBoxUnitGeometryPageWidth, SIGNAL(currentTextChanged(QString)), SLOT(geometryUnitsChanged()));
+	connect(ui.comboBoxUnitGeometryPageHeight, SIGNAL(currentTextChanged(QString)), SLOT(geometryUnitsChanged()));
+	connect(ui.comboBoxUnitGeometryMarginLeft, SIGNAL(currentTextChanged(QString)), SLOT(geometryUnitsChanged()));
+	connect(ui.comboBoxUnitGeometryMarginRight, SIGNAL(currentTextChanged(QString)), SLOT(geometryUnitsChanged()));
+	connect(ui.comboBoxUnitGeometryMarginTop, SIGNAL(currentTextChanged(QString)), SLOT(geometryUnitsChanged()));
+	connect(ui.comboBoxUnitGeometryMarginBottom, SIGNAL(currentTextChanged(QString)), SLOT(geometryUnitsChanged()));
 
 	connect(ui.spinBoxGeometryPageWidth, SIGNAL(valueChanged(double)), SLOT(geometryValuesChanged()));
 	connect(ui.spinBoxGeometryPageHeight, SIGNAL(valueChanged(double)), SLOT(geometryValuesChanged()));
@@ -116,12 +116,12 @@ QString QuickDocumentDialog::getNewDocumentText()
 	        ui.checkBoxGeometryMarginBottom->isChecked() ||
 	        ui.checkBoxGeometryMarginTop->isChecked()) {
 		QString geometryOptions;
-		if (ui.checkBoxGeometryPageWidth->isChecked()) geometryOptions += ", width=" + ui.spinBoxGeometryPageWidth->text();
-		if (ui.checkBoxGeometryPageHeight->isChecked()) geometryOptions += ", height=" + ui.spinBoxGeometryPageHeight->text();
-		if (ui.checkBoxGeometryMarginLeft->isChecked()) geometryOptions += ", left=" + ui.spinBoxGeometryMarginLeft->text();
-		if (ui.checkBoxGeometryMarginRight->isChecked()) geometryOptions += ", right=" + ui.spinBoxGeometryMarginRight->text();
-		if (ui.checkBoxGeometryMarginTop->isChecked()) geometryOptions += ", top=" + ui.spinBoxGeometryMarginTop->text();
-		if (ui.checkBoxGeometryMarginBottom->isChecked()) geometryOptions += ", bottom=" + ui.spinBoxGeometryMarginBottom->text();
+		if (ui.checkBoxGeometryPageWidth->isChecked()) geometryOptions += QString(", width=%1").arg(ui.spinBoxGeometryPageWidth->value()) + ui.comboBoxUnitGeometryPageWidth->currentText();
+		if (ui.checkBoxGeometryPageHeight->isChecked()) geometryOptions += QString(", height=%1").arg(ui.spinBoxGeometryPageHeight->value()) + ui.comboBoxUnitGeometryPageHeight->currentText();
+		if (ui.checkBoxGeometryMarginLeft->isChecked()) geometryOptions += QString(", left=%1").arg(ui.spinBoxGeometryMarginLeft->value()) + ui.comboBoxUnitGeometryMarginLeft->currentText();
+		if (ui.checkBoxGeometryMarginRight->isChecked()) geometryOptions += QString(", right=%1").arg(ui.spinBoxGeometryMarginRight->value()) + ui.comboBoxUnitGeometryMarginRight->currentText();
+		if (ui.checkBoxGeometryMarginTop->isChecked()) geometryOptions += QString(", top=%1").arg(ui.spinBoxGeometryMarginTop->value()) + ui.comboBoxUnitGeometryMarginTop->currentText();
+		if (ui.checkBoxGeometryMarginBottom->isChecked()) geometryOptions += QString(", bottom=%1").arg(ui.spinBoxGeometryMarginBottom->value()) + ui.comboBoxUnitGeometryMarginBottom->currentText();
 		geometryOptions.remove(0, 2);
 		geometry = QString("\\usepackage[%1]{geometry}\n").arg(geometryOptions);
 	}
@@ -351,12 +351,12 @@ void QuickDocumentDialog::Init()
 	configManagerInterface->linkOptionToDialogWidget(&geometryMarginTop, ui.spinBoxGeometryMarginTop);
 	configManagerInterface->linkOptionToDialogWidget(&geometryMarginBottom, ui.spinBoxGeometryMarginBottom);
 
-	configManagerInterface->linkOptionToDialogWidget(&geometryPageWidthUnit, ui.spinBoxUnitGeometryPageWidth);
-	configManagerInterface->linkOptionToDialogWidget(&geometryPageHeightUnit, ui.spinBoxUnitGeometryPageHeight);
-	configManagerInterface->linkOptionToDialogWidget(&geometryMarginLeftUnit, ui.spinBoxUnitGeometryMarginLeft);
-	configManagerInterface->linkOptionToDialogWidget(&geometryMarginRightUnit, ui.spinBoxUnitGeometryMarginRight);
-	configManagerInterface->linkOptionToDialogWidget(&geometryMarginTopUnit, ui.spinBoxUnitGeometryMarginTop);
-	configManagerInterface->linkOptionToDialogWidget(&geometryMarginBottomUnit, ui.spinBoxUnitGeometryMarginBottom);
+	configManagerInterface->linkOptionToDialogWidget(&geometryPageWidthUnit, ui.comboBoxUnitGeometryPageWidth);
+	configManagerInterface->linkOptionToDialogWidget(&geometryPageHeightUnit, ui.comboBoxUnitGeometryPageHeight);
+	configManagerInterface->linkOptionToDialogWidget(&geometryMarginLeftUnit, ui.comboBoxUnitGeometryMarginLeft);
+	configManagerInterface->linkOptionToDialogWidget(&geometryMarginRightUnit, ui.comboBoxUnitGeometryMarginRight);
+	configManagerInterface->linkOptionToDialogWidget(&geometryMarginTopUnit, ui.comboBoxUnitGeometryMarginTop);
+	configManagerInterface->linkOptionToDialogWidget(&geometryMarginBottomUnit, ui.comboBoxUnitGeometryMarginBottom);
 
 	configManagerInterface->linkOptionToDialogWidget(&geometryPageWidthEnabled, ui.checkBoxGeometryPageWidth);
 	configManagerInterface->linkOptionToDialogWidget(&geometryPageHeightEnabled, ui.checkBoxGeometryPageHeight);
@@ -374,19 +374,8 @@ void QuickDocumentDialog::accept()
 void QuickDocumentDialog::geometryUnitsChanged()
 {
 	//update all units (easier than just the changed one, slower, but need probably less memory)
-	ui.spinBoxGeometryPageWidth->setSuffix(ui.spinBoxUnitGeometryPageWidth->currentText());
-	ui.spinBoxGeometryPageHeight->setSuffix(ui.spinBoxUnitGeometryPageHeight->currentText());
-	ui.spinBoxGeometryMarginLeft->setSuffix(ui.spinBoxUnitGeometryMarginLeft->currentText());
-	ui.spinBoxGeometryMarginRight->setSuffix(ui.spinBoxUnitGeometryMarginRight->currentText());
-	ui.spinBoxGeometryMarginTop->setSuffix(ui.spinBoxUnitGeometryMarginTop->currentText());
-	ui.spinBoxGeometryMarginBottom->setSuffix(ui.spinBoxUnitGeometryMarginBottom->currentText());
-
-	if (sender() == ui.spinBoxUnitGeometryPageWidth) ui.checkBoxGeometryPageWidth->setChecked(true);
-	else if (sender() == ui.spinBoxUnitGeometryPageHeight) ui.checkBoxGeometryPageHeight->setChecked(true);
-	else if (sender() == ui.spinBoxUnitGeometryMarginLeft) ui.checkBoxGeometryMarginLeft->setChecked(true);
-	else if (sender() == ui.spinBoxUnitGeometryMarginRight) ui.checkBoxGeometryMarginRight->setChecked(true);
-	else if (sender() == ui.spinBoxUnitGeometryMarginTop) ui.checkBoxGeometryMarginTop->setChecked(true);
-	else if (sender() == ui.spinBoxUnitGeometryMarginBottom) ui.checkBoxGeometryMarginBottom->setChecked(true);
+	// it was decided not to recalculate number part (s. https://github.com/texstudio-org/texstudio/pull/3156) and to not use suffix in spinBoxGeometry...
+	geometryValuesChanged();
 }
 
 void calculatePaperLength(qreal paper, qreal &left, qreal &body, qreal &right, qreal defaultLeftRatio)
@@ -409,14 +398,6 @@ void calculatePaperLength(qreal paper, qreal &left, qreal &body, qreal &right, q
 
 void QuickDocumentDialog::geometryValuesChanged()
 {
-	//if a value is changed, enable it (I just don't like to create 12 slots for this, where are you lambda?)
-	if (sender() == ui.spinBoxGeometryPageWidth) ui.checkBoxGeometryPageWidth->setChecked(true);
-	else if (sender() == ui.spinBoxGeometryPageHeight) ui.checkBoxGeometryPageHeight->setChecked(true);
-	else if (sender() == ui.spinBoxGeometryMarginLeft) ui.checkBoxGeometryMarginLeft->setChecked(true);
-	else if (sender() == ui.spinBoxGeometryMarginRight) ui.checkBoxGeometryMarginRight->setChecked(true);
-	else if (sender() == ui.spinBoxGeometryMarginTop) ui.checkBoxGeometryMarginTop->setChecked(true);
-	else if (sender() == ui.spinBoxGeometryMarginBottom) ui.checkBoxGeometryMarginBottom->setChecked(true);
-
 	static const QStringList paperFormats = QStringList()
 	                                        << "a0paper" << "841" << "1189" << "mm"
 	                                        << "a1paper" << "594" << "841" << "mm"
@@ -454,16 +435,16 @@ void QuickDocumentDialog::geometryValuesChanged()
 		ui.geometryPreviewLabel->setText("unknown paper format");
 		return;
 	}
-	qreal physicalPaperWidth = convertLatexLengthToMetre(paperFormats[paperFormat + 1].toDouble(), paperFormats[paperFormat + 3]);
-	qreal physicalPaperHeight = convertLatexLengthToMetre(paperFormats[paperFormat + 2].toDouble(), paperFormats[paperFormat + 3]);
+	qreal physicalPaperWidth = unit2Metre(paperFormats[paperFormat + 1].toDouble(), paperFormats[paperFormat + 3]);
+	qreal physicalPaperHeight = unit2Metre(paperFormats[paperFormat + 2].toDouble(), paperFormats[paperFormat + 3]);
 
-	qreal textWidth = (ui.checkBoxGeometryPageWidth->isChecked() ? convertLatexLengthToMetre(ui.spinBoxGeometryPageWidth->value(), ui.spinBoxGeometryPageWidth->suffix()) : -1);
-	qreal textHeight = (ui.checkBoxGeometryPageWidth->isChecked() ? convertLatexLengthToMetre(ui.spinBoxGeometryPageHeight->value(), ui.spinBoxGeometryPageHeight->suffix()) : -1);
+	qreal textWidth = (ui.checkBoxGeometryPageWidth->isChecked() ? unit2Metre(ui.spinBoxGeometryPageWidth->value(), ui.comboBoxUnitGeometryPageWidth->currentText()) : -1);
+	qreal textHeight = (ui.checkBoxGeometryPageWidth->isChecked() ? unit2Metre(ui.spinBoxGeometryPageHeight->value(), ui.comboBoxUnitGeometryPageHeight->currentText()) : -1);
 
-	qreal marginLeft = (ui.checkBoxGeometryMarginLeft->isChecked() ? convertLatexLengthToMetre(ui.spinBoxGeometryMarginLeft->value(), ui.spinBoxGeometryMarginLeft->suffix()) : -1);
-	qreal marginRight = (ui.checkBoxGeometryMarginRight->isChecked() ? convertLatexLengthToMetre(ui.spinBoxGeometryMarginRight->value(), ui.spinBoxGeometryMarginRight->suffix()) : -1);
-	qreal marginTop = (ui.checkBoxGeometryMarginTop->isChecked() ? convertLatexLengthToMetre(ui.spinBoxGeometryMarginTop->value(), ui.spinBoxGeometryMarginTop->suffix()) : -1);
-	qreal marginBottom = (ui.checkBoxGeometryMarginBottom->isChecked() ? convertLatexLengthToMetre(ui.spinBoxGeometryMarginBottom->value(), ui.spinBoxGeometryMarginBottom->suffix()) : -1);
+	qreal marginLeft = (ui.checkBoxGeometryMarginLeft->isChecked() ? unit2Metre(ui.spinBoxGeometryMarginLeft->value(), ui.comboBoxUnitGeometryMarginLeft->currentText()) : -1);
+	qreal marginRight = (ui.checkBoxGeometryMarginRight->isChecked() ? unit2Metre(ui.spinBoxGeometryMarginRight->value(), ui.comboBoxUnitGeometryMarginRight->currentText()) : -1);
+	qreal marginTop = (ui.checkBoxGeometryMarginTop->isChecked() ? unit2Metre(ui.spinBoxGeometryMarginTop->value(), ui.comboBoxUnitGeometryMarginTop->currentText()) : -1);
+	qreal marginBottom = (ui.checkBoxGeometryMarginBottom->isChecked() ? unit2Metre(ui.spinBoxGeometryMarginBottom->value(), ui.comboBoxUnitGeometryMarginBottom->currentText()) : -1);
 
     bool twoSide = ui.listWidgetOptions->findItems("twoside", Qt::MatchExactly).constFirst()->checkState() == Qt::Checked;
     bool landscape = ui.listWidgetOptions->findItems("landscape", Qt::MatchExactly).constFirst()->checkState() == Qt::Checked;

--- a/src/quickdocumentdialog.ui
+++ b/src/quickdocumentdialog.ui
@@ -321,18 +321,15 @@
             <property name="locale">
              <locale language="English" country="UnitedStates"/>
             </property>
-            <property name="suffix">
-             <string>mm</string>
-            </property>
             <property name="maximum">
              <double>99999.990000000005239</double>
             </property>
            </widget>
           </item>
           <item row="0" column="2">
-           <widget class="QComboBox" name="spinBoxUnitGeometryPageWidth">
+           <widget class="QComboBox" name="comboBoxUnitGeometryPageWidth">
             <property name="editable">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <item>
              <property name="text">
@@ -362,9 +359,9 @@
            </widget>
           </item>
           <item row="1" column="2" rowspan="2">
-           <widget class="QComboBox" name="spinBoxUnitGeometryPageHeight">
+           <widget class="QComboBox" name="comboBoxUnitGeometryPageHeight">
             <property name="editable">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <item>
              <property name="text">
@@ -397,9 +394,6 @@
            <widget class="QDoubleSpinBox" name="spinBoxGeometryPageHeight">
             <property name="locale">
              <locale language="English" country="UnitedStates"/>
-            </property>
-            <property name="suffix">
-             <string>mm</string>
             </property>
             <property name="maximum">
              <double>99999.990000000005239</double>
@@ -434,9 +428,6 @@
             <property name="locale">
              <locale language="English" country="UnitedStates"/>
             </property>
-            <property name="suffix">
-             <string>mm</string>
-            </property>
             <property name="maximum">
              <double>99999.990000000005239</double>
             </property>
@@ -446,9 +437,9 @@
            </widget>
           </item>
           <item row="0" column="2">
-           <widget class="QComboBox" name="spinBoxUnitGeometryMarginLeft">
+           <widget class="QComboBox" name="comboBoxUnitGeometryMarginLeft">
             <property name="editable">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <item>
              <property name="text">
@@ -489,9 +480,6 @@
             <property name="locale">
              <locale language="English" country="UnitedStates"/>
             </property>
-            <property name="suffix">
-             <string>mm</string>
-            </property>
             <property name="maximum">
              <double>99999.990000000005239</double>
             </property>
@@ -501,9 +489,9 @@
            </widget>
           </item>
           <item row="1" column="2">
-           <widget class="QComboBox" name="spinBoxUnitGeometryMarginRight">
+           <widget class="QComboBox" name="comboBoxUnitGeometryMarginRight">
             <property name="editable">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <item>
              <property name="text">
@@ -537,9 +525,6 @@
             <property name="locale">
              <locale language="English" country="UnitedStates"/>
             </property>
-            <property name="suffix">
-             <string>mm</string>
-            </property>
             <property name="maximum">
              <double>99999.990000000005239</double>
             </property>
@@ -549,9 +534,9 @@
            </widget>
           </item>
           <item row="2" column="2" rowspan="2">
-           <widget class="QComboBox" name="spinBoxUnitGeometryMarginTop">
+           <widget class="QComboBox" name="comboBoxUnitGeometryMarginTop">
             <property name="editable">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <item>
              <property name="text">
@@ -599,9 +584,6 @@
             <property name="locale">
              <locale language="English" country="UnitedStates"/>
             </property>
-            <property name="suffix">
-             <string>mm</string>
-            </property>
             <property name="maximum">
              <double>99999.990000000005239</double>
             </property>
@@ -611,9 +593,9 @@
            </widget>
           </item>
           <item row="4" column="2">
-           <widget class="QComboBox" name="spinBoxUnitGeometryMarginBottom">
+           <widget class="QComboBox" name="comboBoxUnitGeometryMarginBottom">
             <property name="editable">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <item>
              <property name="text">
@@ -763,7 +745,7 @@
   <connection>
    <sender>checkBoxGeometryPageWidth</sender>
    <signal>toggled(bool)</signal>
-   <receiver>spinBoxUnitGeometryPageWidth</receiver>
+   <receiver>comboBoxUnitGeometryPageWidth</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -795,7 +777,7 @@
   <connection>
    <sender>checkBoxGeometryPageHeight</sender>
    <signal>toggled(bool)</signal>
-   <receiver>spinBoxUnitGeometryPageHeight</receiver>
+   <receiver>comboBoxUnitGeometryPageHeight</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -827,7 +809,7 @@
   <connection>
    <sender>checkBoxGeometryMarginLeft</sender>
    <signal>toggled(bool)</signal>
-   <receiver>spinBoxUnitGeometryMarginLeft</receiver>
+   <receiver>comboBoxUnitGeometryMarginLeft</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -859,7 +841,7 @@
   <connection>
    <sender>checkBoxGeometryMarginRight</sender>
    <signal>toggled(bool)</signal>
-   <receiver>spinBoxUnitGeometryMarginRight</receiver>
+   <receiver>comboBoxUnitGeometryMarginRight</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -891,7 +873,7 @@
   <connection>
    <sender>checkBoxGeometryMarginTop</sender>
    <signal>toggled(bool)</signal>
-   <receiver>spinBoxUnitGeometryMarginTop</receiver>
+   <receiver>comboBoxUnitGeometryMarginTop</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -923,7 +905,7 @@
   <connection>
    <sender>checkBoxGeometryMarginBottom</sender>
    <signal>toggled(bool)</signal>
-   <receiver>spinBoxUnitGeometryMarginBottom</receiver>
+   <receiver>comboBoxUnitGeometryMarginBottom</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -7,7 +7,7 @@
 - add support for alignedat environment in QuickArray Wizard ([#2921](https://github.com/texstudio-org/texstudio/issues/2921))
 - add a Lorem Ipsum generator to the Random Text Generator dialog ([#3102](https://github.com/texstudio-org/texstudio/pull/3102))
 - change default windows style for new installs to Fusion instead of modern-dark, in case system darkmode is detected ([ad0fc44](https://github.com/texstudio-org/texstudio/commit/ad0fc4485f2f7643b3b7b44318e29f54efe2132f))
-- improve some details and fix an issue of the Quick Start wizard ([#2901](https://github.com/texstudio-org/texstudio/issues/2901), [#3153](https://github.com/texstudio-org/texstudio/pull/3153), [#3150](https://github.com/texstudio-org/texstudio/pull/3150))
+- improve some details and fix issues of the Quick Start wizard ([#2901](https://github.com/texstudio-org/texstudio/issues/2901), [#3153](https://github.com/texstudio-org/texstudio/pull/3153), [#3150](https://github.com/texstudio-org/texstudio/pull/3150), [#3157](https://github.com/texstudio-org/texstudio/pull/3157))
 - improve some details of the Edit Macros dialog ([#3130](https://github.com/texstudio-org/texstudio/pull/3130))
 - The link to the TeXstudio homepage is now at the top of the About dialog (Help menu) and the number of the latest stable version is also displayed ([#3146](https://github.com/texstudio-org/texstudio/pull/3146))
 - option Disable horizontal scrolling for "Fit to Text Width" now affects horizontal scrolling with mousepad and scroll wheel ([#1526](https://github.com/texstudio-org/texstudio/issues/1526))


### PR DESCRIPTION
This PR enhances the page geometry configuration that is part of the Quick Start wizard.

**Note:** This PR is a cut down of #3156. A detailed discussion can be found there.

The PR addresses following observations:

1. Lengths are given with a number combined with a unit. This unit is also mirrored as a suffix to the number in the spin box. When you alter a unit then the number is not adjusted (s. image below). This means that the length changes. But the picture visualizing the settings doesn't change (workaround: change temp. the number with up/down buttons). This is fixed.

2. The mirrored units are removed by the PR (s. Test below).

   ![QuickDialogChangingUnitsIssue](https://github.com/texstudio-org/texstudio/assets/102688820/f7489039-0eea-49a3-a443-3390ec5e5e60)
   Fig,: Visualization doesn't reflect change of width when altering unit in combo box. Unit is editable (s. cursor mark).

3. You can enter unknown units (like pico meters pm or nano meters nm) or even any text. In this case dialog falls back to mm. Unit dm is not in the list of the combo boxes, but is recognized when you enter it manually. But dm is not known to LaTeX. The PR therefore sets attribute editable to false for those combo boxes. As side effects signal `editTextChanged()` is replaced by `currentTextChanged()` and the names for the unit combo boxes are corrected from `spinBoxUnitGeometryPageWidth` to `comboBoxUnitGeometryPageWidth`, and so on.

4. Code setting checkBoxes without effect is removed. **Update:** Since not totally correct this part is reverted.

### Test
![QuickDialogChangingUnits](https://github.com/texstudio-org/texstudio/assets/102688820/9bbe8dfc-dfb2-47d1-821a-7d3c8a41487e)
Fig.: Visualization now reflects change of width when altering unit in combo box (not editable). Suffix units are not present.

These values are correctly saved in and loaded from the ini file. The LaTeX code looks fine:
```
Quick\Geometry%20Page%20Width=15
Quick\Geometry%20Page%20Width%20Unit=mm
```
```latex
\usepackage[width=15mm, height=23cm]{geometry}
```
```
Quick\Geometry%20Page%20Width=15
Quick\Geometry%20Page%20Width%20Unit=cm
```
```latex
\usepackage[width=15cm, height=23cm]{geometry}
```
