### PR TITLE
cleanup code in quickDocumentDialog.cpp

### DIFF
--- a/src/quickdocumentdialog.cpp
+++ b/src/quickdocumentdialog.cpp
@@ -364,6 +364,19 @@ void QuickDocumentDialog::Init()
 	configManagerInterface->linkOptionToDialogWidget(&geometryMarginRightEnabled, ui.checkBoxGeometryMarginRight);
 	configManagerInterface->linkOptionToDialogWidget(&geometryMarginTopEnabled, ui.checkBoxGeometryMarginTop);
 	configManagerInterface->linkOptionToDialogWidget(&geometryMarginBottomEnabled, ui.checkBoxGeometryMarginBottom);
+
+	ui.spinBoxGeometryPageWidth->setEnabled(ui.checkBoxGeometryPageWidth->isChecked());
+	ui.comboBoxUnitGeometryPageWidth->setEnabled(ui.checkBoxGeometryPageWidth->isChecked());
+	ui.spinBoxGeometryPageHeight->setEnabled(ui.checkBoxGeometryPageHeight->isChecked());
+	ui.comboBoxUnitGeometryPageHeight->setEnabled(ui.checkBoxGeometryPageHeight->isChecked());
+	ui.spinBoxGeometryMarginLeft->setEnabled(ui.checkBoxGeometryMarginLeft->isChecked());
+	ui.comboBoxUnitGeometryMarginLeft->setEnabled(ui.checkBoxGeometryMarginLeft->isChecked());
+	ui.spinBoxGeometryMarginRight->setEnabled(ui.checkBoxGeometryMarginRight->isChecked());
+	ui.comboBoxUnitGeometryMarginRight->setEnabled(ui.checkBoxGeometryMarginRight->isChecked());
+	ui.spinBoxGeometryMarginTop->setEnabled(ui.checkBoxGeometryMarginTop->isChecked());
+	ui.comboBoxUnitGeometryMarginTop->setEnabled(ui.checkBoxGeometryMarginTop->isChecked());
+	ui.spinBoxGeometryMarginBottom->setEnabled(ui.checkBoxGeometryMarginBottom->isChecked());
+	ui.comboBoxUnitGeometryMarginBottom->setEnabled(ui.checkBoxGeometryMarginBottom->isChecked());
 }
 
 void QuickDocumentDialog::accept()
@@ -373,14 +386,7 @@ void QuickDocumentDialog::accept()
 
 void QuickDocumentDialog::geometryUnitsChanged()
 {
-	//update all units (easier than just the changed one, slower, but need probably less memory)
 	// it was decided not to recalculate number part (s. https://github.com/texstudio-org/texstudio/pull/3156) and to not use suffix in spinBoxGeometry...
-	if (sender() == ui.comboBoxUnitGeometryPageWidth) ui.checkBoxGeometryPageWidth->setChecked(true);
-	else if (sender() == ui.comboBoxUnitGeometryPageHeight) ui.checkBoxGeometryPageHeight->setChecked(true);
-	else if (sender() == ui.comboBoxUnitGeometryMarginRight) ui.checkBoxGeometryMarginRight->setChecked(true);
-	else if (sender() == ui.comboBoxUnitGeometryMarginLeft) ui.checkBoxGeometryMarginLeft->setChecked(true);
-	else if (sender() == ui.comboBoxUnitGeometryMarginTop) ui.checkBoxGeometryMarginTop->setChecked(true);
-	else if (sender() == ui.comboBoxUnitGeometryMarginBottom) ui.checkBoxGeometryMarginBottom->setChecked(true);
 	geometryValuesChanged();
 }
 
@@ -404,14 +410,6 @@ void calculatePaperLength(qreal paper, qreal &left, qreal &body, qreal &right, q
 
 void QuickDocumentDialog::geometryValuesChanged()
 {
-	//if a value is changed, enable it (I just don't like to create 12 slots for this, where are you lambda?)
-	if (sender() == ui.spinBoxGeometryPageWidth) ui.checkBoxGeometryPageWidth->setChecked(true);
-	else if (sender() == ui.spinBoxGeometryPageHeight) ui.checkBoxGeometryPageHeight->setChecked(true);
-	else if (sender() == ui.spinBoxGeometryMarginLeft) ui.checkBoxGeometryMarginLeft->setChecked(true);
-	else if (sender() == ui.spinBoxGeometryMarginRight) ui.checkBoxGeometryMarginRight->setChecked(true);
-	else if (sender() == ui.spinBoxGeometryMarginTop) ui.checkBoxGeometryMarginTop->setChecked(true);
-	else if (sender() == ui.spinBoxGeometryMarginBottom) ui.checkBoxGeometryMarginBottom->setChecked(true);
-
 	static const QStringList paperFormats = QStringList()
 	                                        << "a0paper" << "841" << "1189" << "mm"
 	                                        << "a1paper" << "594" << "841" << "mm"


### PR DESCRIPTION
Code only needed at start of Quick Start wizard is moved to init method.