### PR TITLE
add cleveref, move hyperref

### DIFF
--- a/src/quickdocumentdialog.cpp
+++ b/src/quickdocumentdialog.cpp
@@ -93,7 +93,7 @@ QuickDocumentDialog::~QuickDocumentDialog()
 QString QuickDocumentDialog::getNewDocumentText()
 {
 	QString amssymb, amsthm, babel, fontenc, geometry, graphicx, hyperref, mathtools, nameref, thmtools, xcolor;  // packages initially available in the dialog to be sorted
-	QString  inputenc, userPackages;  // packages added by user, special case inputenc needs to be sorted
+	QString  cleveref, inputenc, userPackages;  // packages added by user, special cases cleveref, inputenc need to be sorted
 
 	QString classOpt;
 	if (ui.comboBoxBabel->currentText() != "NONE") {
@@ -136,6 +136,7 @@ QString QuickDocumentDialog::getNewDocumentText()
 			// packages initially available from Packages tab
 			if (text=="amssymb"  ) amssymb   = QString("\\usepackage{amssymb}\n"); else
 			if (text=="amsthm"   ) amsthm    = QString("\\usepackage{amsthm}\n"); else
+			if (text=="cleveref" ) cleveref  = QString("\\usepackage{cleveref}\n"); else   // special case for user (s. definition of cleveref)
 			if (text=="graphicx" ) graphicx  = QString("\\usepackage{graphicx}\n"); else
 			if (text=="hyperref" ) hyperref  = QString("\\usepackage{hyperref}\n"); else
 			if (text=="inputenc" ) inputenc  = QString("\\usepackage{inputenc}\n"); else   // special case for user (s. definition of inputenc)
@@ -147,7 +148,7 @@ QString QuickDocumentDialog::getNewDocumentText()
 		}
 	}
 // LaTeX code for all packages used
-	tag += inputenc + fontenc + geometry + graphicx + mathtools + amssymb + amsthm + thmtools + xcolor + nameref + babel + hyperref + userPackages;
+	tag += inputenc + fontenc + geometry + graphicx + mathtools + amssymb + amsthm + thmtools + xcolor + nameref + babel + userPackages + hyperref + cleveref;
 
 	QString makeTitle;
 	if (ui.lineEditTitle->text() != "") {


### PR DESCRIPTION
This PR resolves #3164, s. previous IS/PR: #2901/#3151

Now order looks like
``inputenc + fontenc + geometry + graphicx + mathtools + amssymb + amsthm + thmtools + xcolor + nameref + babel + userPackages + hyperref + cleveref``

### Test
![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/00e15541-6448-4292-9d07-9378a1470cb3)

results in

```latex
\documentclass[ngerman,10pt,a4paper]{article}
\usepackage{inputenc}
\usepackage[T1]{fontenc}
\usepackage[width=15cm, height=24cm]{geometry}
\usepackage{graphicx}
\usepackage{mathtools}
\usepackage{amssymb}
\usepackage{amsthm}
\usepackage{thmtools}
\usepackage{xcolor}
\usepackage{nameref}
\usepackage{babel}
\usepackage{tikz}
\usepackage{calc}
\usepackage{hyperref}
\usepackage{cleveref}
\begin{document}

\end{document}
```