### PR TITLE
show preview with document's preamble (option)

### DIFF
--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -4050,6 +4050,19 @@ them here.</string>
                    </widget>
                   </item>
                   <item row="7" column="0" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxShrinkPreviewPage">
+                    <property name="text">
+                     <string>Shrink Preview Page</string>
+                    </property>
+                    <property name="toolTip">
+                     <string>With this option, the preview uses the smallest possible page to display the preview data within a minipage.</string>
+                    </property>
+                    <property name="checked">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="8" column="0" colspan="2">
                    <widget class="QCheckBox" name="checkBoxToolTipPreview">
                     <property name="text">
                      <string>Show preview as tooltip on formulas in editor</string>

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -730,6 +730,7 @@ ConfigManager::ConfigManager(QObject *parent): QObject (parent),
     registerOption("Preview/Auto Preview", reinterpret_cast<int *>(&autoPreview), 1, &pseudoDialog->comboBoxAutoPreview);
 	registerOption("Preview/Auto Preview Delay", &autoPreviewDelay, 300, &pseudoDialog->spinBoxAutoPreviewDelay);
 	registerOption("Preview/SegmentPreviewScalePercent", &segmentPreviewScalePercent, 150, &pseudoDialog->spinBoxSegmentPreviewScalePercent);
+	registerOption("Preview/Shrink Preview Page", &shrinkPreviewPage, true, &pseudoDialog->checkBoxShrinkPreviewPage);
 
 	//pdf preview
 	QRect screen = QGuiApplication::primaryScreen()->availableGeometry();

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -173,6 +173,7 @@ public:
 	AutoPreviewMode autoPreview;
 	int autoPreviewDelay;
 	int segmentPreviewScalePercent;
+	bool shrinkPreviewPage;
 
 	// embedded viewer
 	bool viewerEnlarged;

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -1125,6 +1125,11 @@ void Texstudio::setupMenus()
 
 	setCheckedPreviewModeAction();
 
+	act = newManagedAction(menu, "shrinkPreviewPage", tr("&Shrink Preview Page"), SLOT(setShrinkPreviewPage()));
+	act->setCheckable(true);
+	act->setChecked(configManager.getOption("Preview/Shrink Preview Page").toBool());
+	setCheckedShrinkPreviewPageAction();
+
 	menu->addSeparator();
     newManagedEditorAction(menu, "togglecomment", tr("Toggle &Comment"), "toggleCommentSelection", Qt::CTRL | Qt::Key_T);
 	newManagedEditorAction(menu, "comment", tr("&Comment"), "commentSelection");
@@ -1495,7 +1500,7 @@ void Texstudio::setupMenus()
 	configManager.modifyManagedShortcuts();
 }
 /*! \brief slot for actions from Menu Preview Display Mode
-*/
+ */
 void Texstudio::setPreviewMode()
 {
 	QAction *act = qobject_cast<QAction *>(sender());
@@ -1504,7 +1509,7 @@ void Texstudio::setPreviewMode()
 	}
 }
 /*! \brief set action for Menu Preview Display Mode
-*/
+ */
 void Texstudio::setCheckedPreviewModeAction()
 {
 	ConfigManager::PreviewMode pm = configManager.previewMode;
@@ -1529,6 +1534,22 @@ void Texstudio::setCheckedPreviewModeAction()
 		default:	// PM_INLINE
 			getManagedAction("main/edit2/previewMode/PM_INLINE")->setChecked(true);
 	}
+}
+/*! \brief slot sets option Shrink Preview Page in config dialog to the value the option has in menu
+ */
+void Texstudio::setShrinkPreviewPage()
+{
+	QAction *act = qobject_cast<QAction *>(sender());
+	if (act) {
+		configManager.shrinkPreviewPage = act->isChecked();
+	}
+}
+/*! \brief sets Menu Option Idefix/Shrink Preview Page to the value the option has in config dialog
+ */
+void Texstudio::setCheckedShrinkPreviewPageAction()
+{
+	bool checked = configManager.shrinkPreviewPage;
+	getManagedAction("main/edit2/shrinkPreviewPage")->setChecked(checked);
 }
 /*! \brief set-up all tool-bars
  */
@@ -6926,6 +6947,8 @@ void Texstudio::generalOptions()
         changeSecondaryIconSize(configManager.guiSecondaryToolbarIconSize);
         changePDFIconSize(configManager.guiPDFToolbarIconSize);
         changeSymbolGridIconSize(configManager.guiSymbolGridIconSize, false);
+        // update Menu Option Idefix/Shrink Preview Page
+        setCheckedShrinkPreviewPageAction();
         //custom toolbar
         setupToolBars();
         //completion
@@ -6968,8 +6991,8 @@ void Texstudio::generalOptions()
         delete pdfviewerWindow;
     }
 #endif
-    // update action from Menu Preview Display Mode
-	setCheckedPreviewModeAction();
+    // update Menu Idefix/Preview Display Mode
+    setCheckedPreviewModeAction();
 #ifdef INTERNAL_TERMINAL
     outputView->getTerminalWidget()->updateSettings();
 #endif
@@ -8887,12 +8910,14 @@ QStringList Texstudio::makePreviewHeader(const LatexDocument *rootDoc)
 			header << newLine;
 		}
 	}
-	if ((buildManager.dvi2pngMode == BuildManager::DPM_EMBEDDED_PDF || buildManager.dvi2pngMode == BuildManager::DPM_LUA_EMBEDDED_PDF)
-			&& configManager.previewMode != ConfigManager::PM_EMBEDDED) {
-		header << "\\usepackage[active,tightpage]{preview}"
-		       << "\\usepackage{varwidth}"
-		       << "\\AtBeginDocument{\\begin{preview}\\begin{varwidth}{\\linewidth}}"
-		       << "\\AtEndDocument{\\end{varwidth}\\end{preview}}";
+	if (configManager.shrinkPreviewPage) {
+		if ((buildManager.dvi2pngMode == BuildManager::DPM_EMBEDDED_PDF || buildManager.dvi2pngMode == BuildManager::DPM_LUA_EMBEDDED_PDF)
+				&& configManager.previewMode != ConfigManager::PM_EMBEDDED) {
+			header << "\\usepackage[active,tightpage]{preview}"
+				<< "\\usepackage{varwidth}"
+				<< "\\AtBeginDocument{\\begin{preview}\\begin{varwidth}{\\linewidth}}"
+				<< "\\AtEndDocument{\\end{varwidth}\\end{preview}}";
+		}
 	}
 	header << "\\pagestyle{empty}";// << "\\begin{document}";
 	return header;

--- a/src/texstudio.h
+++ b/src/texstudio.h
@@ -137,6 +137,8 @@ private:
     void setStructureSectionIcons();
     void updateStatusBarIcons();
     void updatePDFIcons();
+	void setCheckedPreviewModeAction();
+	void setCheckedShrinkPreviewPageAction();
 
 	void updateUserMacros(bool updateMenu = true);
 
@@ -376,7 +378,7 @@ protected slots:
 	void editThesaurus(int line = -1, int col = -1);
 	void editChangeLineEnding();
 	void setPreviewMode();
-	void setCheckedPreviewModeAction();
+	void setShrinkPreviewPage();
 	void editSetupEncoding();
 	void editInsertUnicode(); ///< open dialog to insert a unicode character
 	void editInsertRefToNextLabel(const QString &refCmd = "\\ref", bool backward = false);


### PR DESCRIPTION
This PR gives the user the option to decide whether preview uses the documents preamble as is or with some additions (the current way). For details s. #3166.