### PR TITLE
preview colors only when imageToolTip option is set

### DIFF
--- a/src/latexeditorview.cpp
+++ b/src/latexeditorview.cpp
@@ -2704,7 +2704,7 @@ void LatexEditorView::mouseHovered(QPoint pos)
 				QToolTip::showText(editor->mapToGlobal(editor->mapFromFrame(pos)), text);
 			}
 		}
-		if (tk.subtype == Token::color) {
+		if (config->imageToolTip && tk.subtype == Token::color) {
 			QString text;
 			if (ts.size() > 1) {
 				ts.pop();


### PR DESCRIPTION
This PR introduces the possibility to disable editor previews for colors (a square of size 1cm filled with the color) like in `\textcolor{red}{some text}` when the mouse pointer hovers over the color name. For this, existing option _Show image tooltip on image files_ is used. It can be found in the Adv. Editor setup of the config dialog.
c.f. https://github.com/texstudio-org/texstudio/issues/3193#issuecomment-1621594805
from my side, no changelog entry necessary