### PR TITLE
scale tooltip preview to keep the image width and height (physical length) constant

### DIFF
--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -546,6 +546,7 @@ ConfigManager::ConfigManager(QObject *parent): QObject (parent),
 	registerOption("Editor/ToolTip Help", &editorConfig->toolTipHelp, true, &pseudoDialog->checkBoxToolTipHelp2);
 	registerOption("Editor/ToolTip Preview", &editorConfig->toolTipPreview, true, &pseudoDialog->checkBoxToolTipPreview);
 	registerOption("Editor/ImageToolTip", &editorConfig->imageToolTip, true, &pseudoDialog->checkBoxImageToolTip);
+	registerOption("Editor/ImageToolTipLoadMaxPixels", &editorConfig->imageToolTipLoadMaxPixels, 30);
 	registerOption("Editor/MaxImageTooltipWidth", &editorConfig->maxImageTooltipWidth, 400);
 	registerOption("Editor/ContextMenuKeyboardModifiers", &editorConfig->contextMenuKeyboardModifiers, Qt::ShiftModifier);
 	registerOption("Editor/ContextMenuSpellcheckingEntryLocation", &editorConfig->contextMenuSpellcheckingEntryLocation, 0, &pseudoDialog->comboBoxContextMenuSpellcheckingEntryLocation);

--- a/src/latexeditorview_config.h
+++ b/src/latexeditorview_config.h
@@ -43,6 +43,7 @@ public:
 	bool toolTipPreview;
 	bool toolTipHelp;
 	bool imageToolTip;
+	int imageToolTipLoadMaxPixels;
 	int maxImageTooltipWidth;
 	bool texdocHelpInInternalViewer;
 	bool monitorFilesForExternalChanges;

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -9,6 +9,7 @@
 - change default windows style for new installs to Fusion instead of modern-dark, in case system darkmode is detected ([ad0fc44](https://github.com/texstudio-org/texstudio/commit/ad0fc4485f2f7643b3b7b44318e29f54efe2132f))
 - improve some details and fix issues of the Quick Start wizard ([#2901](https://github.com/texstudio-org/texstudio/issues/2901), [#3153](https://github.com/texstudio-org/texstudio/pull/3153), [#3150](https://github.com/texstudio-org/texstudio/pull/3150), [#3157](https://github.com/texstudio-org/texstudio/pull/3157))
 - improve some details of the Edit Macros dialog ([#3130](https://github.com/texstudio-org/texstudio/pull/3130))
+- improve some details when previewing image files in tooltips, includes a new image size option ([#3197](https://github.com/texstudio-org/texstudio/issues/3197))
 - The link to the TeXstudio homepage is now at the top of the About dialog (Help menu) and the number of the latest stable version is also displayed ([#3146](https://github.com/texstudio-org/texstudio/pull/3146))
 - option Disable horizontal scrolling for "Fit to Text Width" now affects horizontal scrolling with mousepad and scroll wheel ([#1526](https://github.com/texstudio-org/texstudio/issues/1526))
 - fix editor moving last line of a selection when selection ends at start of a line ([#3131](https://github.com/texstudio-org/texstudio/issues/3131))


### PR DESCRIPTION
This PR resolves #3197. Tooltips for images show when you hover (with the mouse pointer) over a file name or complete a file name with the completer. With this PR the image is scaled proportional to the quotient of both the pixel densities (resolutions) of the screen and the value given in the image data. By this the quotient of width in pixels divided by resolution, i.e. the physical width (and also height) keeps constant.

From version 6 on, Qt offers a [function](https://doc.qt.io/qt-6/qimagereader.html#setAllocationLimit) that can change the amount of storage a loaded image may use. Larger images will not be loaded as a precaution. This is addressed by a new option in the ini file (not in the config dialog), so the user can change the limit. The options name is `Editor\ImageToolTipLoadMaxPixels` with a default value of $30$. This means that the storage calculated for the image, with 4 bytes per pixel, is $30 \cdot 4\text{MiBytes}=30 \cdot 1024^2 \cdot 4\text{Bytes}$. It follows that the number of pixels the image can have, could be a little bit larger than $30\text{Mpixels}$ (where M means $1000^2$). A value of $0$ means no limit.

Let me note that there is another limit in txs that affects image tooltips: The width can't be larger than 400pix, otherwise the image is scaled to this limit, that is stored in option `Editor\MaxImageTooltipWidth`.