### PR TITLE
real cancel for insertRef dialog

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -5739,7 +5739,7 @@ void Texstudio::insertRef(const QString &refCmd)
 		foreach (const LatexDocument *doc, docs)
 			labels << doc->labelItems();
 	} else return;
-	QString listItemUseNoLabel = "<" + tr("use no label") + ">";	// of course we can't insert in the document a ref to this label
+	QString listItemUseNoLabel = "<" + tr("empty") + ">";	// of course we can't insert in the document a ref to this label
 	labels.sort();
 	labels.prepend(listItemUseNoLabel);
 	UniversalInputDialog dialog;

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -5739,14 +5739,18 @@ void Texstudio::insertRef(const QString &refCmd)
 		foreach (const LatexDocument *doc, docs)
 			labels << doc->labelItems();
 	} else return;
+	QString listItemUseNoLabel = "<" + tr("use no label") + ">";	// of course we can't insert in the document a ref to this label
 	labels.sort();
+	labels.prepend(listItemUseNoLabel);
 	UniversalInputDialog dialog;
 	dialog.addVariable(&labels, tr("Labels:"));
-	if (dialog.exec() && !labels.isEmpty()) {
-		QString tag = refCmd + "{" + labels.first() + "}";
+	if (dialog.exec()) {
+		QString cmdArgument = labels.first();
+		if (cmdArgument == listItemUseNoLabel)
+			cmdArgument = "";
+		QString tag = refCmd + "{" + cmdArgument + "}";
 		insertTag(tag, tag.length(), 0);
-	} else
-		insertTag(refCmd + "{}", refCmd.length() + 1, 0);
+	} // Cancel button inserts nothing
 }
 
 void Texstudio::insertRef()

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -1,8 +1,7 @@
 # CHANGELOG
 TeXstudio 4.6.3
 
-- 
-
+- Cancel button of dialog for inserting label references now inserts nothing, but you can still add an empty reference when needed ([#3230](https://github.com/texstudio-org/texstudio/issues/3230))
 
 ## TeXstudio 4.6.2
 


### PR DESCRIPTION
This PR resolves #3230. Cancel button now quits the dialog without any effect.
First entry in the list of labels is a surrogate that allows inserting `\ref{}` (empty command argument) into the document.

Note: When the dialog is presented you can immediately (at least on windows)

- scroll through the list with the up/down arrow keys
- open the list with Alt+down arrow key (image to the right)
- insert `\ref{}` by pressing Enter or clicking OK button

![image](https://github.com/texstudio-org/texstudio/assets/102688820/53958e14-3b01-46e8-bb0f-ab7af556cdca)
