### PR TITLE
Enhance TeXdoc dialog

### DIFF
--- a/src/texdocdialog.h
+++ b/src/texdocdialog.h
@@ -23,14 +23,15 @@ public:
 	~TexdocDialog();
 
 private slots:
-	void searchTermChanged(const QString &text);
+	void tableSearchTermChanged(QString term);
+	void itemChanged(QTableWidgetItem* item);
 	void delayedCheckDocAvailable(const QString &package);
 	void checkDockAvailable();
 	void updateDocAvailableInfo(const QString &package, bool available, QString customWarning = QString());
+	void openCtanUrl();
 
 private:
 	Ui::TexdocDialog *ui;
-    QRegularExpressionValidator packageNameValidator;
 	QAbstractButton *openButton;
 	QTimer checkTimer;
 	QString lastDocRequest;

--- a/src/texdocdialog.ui
+++ b/src/texdocdialog.ui
@@ -14,106 +14,105 @@
    <string>Packages Help (Texdoc)</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="1">
-    <widget class="QLabel" name="lbWarnIcon">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16</width>
-       <height>16</height>
-      </size>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="pixmap">
-      <pixmap resource="images.qrc">:/images-ng/warning.svgz</pixmap>
-     </property>
-     <property name="scaledContents">
-      <bool>true</bool>
+   <item row="0" column="0" colspan="3">
+    <widget class="QLineEdit" name="lineEditSearch">
+     <property name="toolTip">
+      <string>Enter Package Name to search, or a regular expression</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1" colspan="2">
-    <widget class="QLabel" name="lbShortDescription">
-     <property name="text">
-      <string>description text</string>
+   <item row="1" column="0" colspan="3">
+    <widget class="QTableWidget" name="tbPackages">
+     <property name="columnCount" >
+      <number>2</number>
      </property>
-     <property name="textFormat">
-      <enum>Qt::PlainText</enum>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
+     <column>
+      <property name="text">
+       <string>Package</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Caption</string>
+      </property>
+     </column>
     </widget>
    </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QComboBox" name="cbPackages">
-     <property name="editable">
-      <bool>true</bool>
-     </property>
-     <property name="insertPolicy">
-      <enum>QComboBox::NoInsert</enum>
-     </property>
+   <item row="2" column="1" colspan="2">
+    <layout class="QHBoxLayout" name="hboxWarning">
+     <item>
+      <spacer name="horizontalSpacerHboxWarning">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="lbWarnIcon">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16</width>
+         <height>16</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="pixmap">
+        <pixmap resource="images.qrc">:/images-ng/warning.svgz</pixmap>
+       </property>
+       <property name="scaledContents">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lbInfo">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>16</height>
+        </size>
+       </property>
+       <property name="text">
+        <string notr="true">Warning message</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="3" column="0">
+    <widget class="QPushButton" name="buttonCTAN">
+      <property name="text">
+       <string>open CTAN</string>
+      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Package:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <widget class="QLabel" name="lbInfo">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>16</height>
-      </size>
-     </property>
-     <property name="text">
-      <string notr="true">Warning message</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="3">
+   <item row="3" column="1" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Open</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Description:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
      </property>
     </widget>
    </item>

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -6770,9 +6770,6 @@ void Texstudio::texdocHelp()
 	if (currentEditorView()) {
 		selection = currentEditorView()->editor->cursor().selectedText();
 		foreach (const QString &key, currentEditorView()->document->parent->cachedPackages.keys()) {
-			if (currentEditorView()->document->parent->cachedPackages[key].completionWords.isEmpty())
-				// remove empty packages which probably do not exist
-				continue;
 			packages << LatexPackage::keyToPackageName(key);
 		}
 

--- a/utilities/packages.xml
+++ b/utilities/packages.xml
@@ -1,0 +1,6488 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE packages SYSTEM 'http://www.ctan.org/xml/2.0/catalogue.dtd'>
+<packages>
+  <package key="a0poster" name="a0poster" caption="Support for designing posters on large paper" />
+  <package key="a2ac" name="a2ac" caption="AFM to AFM plus Composites" />
+  <package key="a2ping" name="a2ping" caption="Advanced PS, PDF, EPS converter" />
+  <package key="a4" name="a4" caption="Support for A4 paper sizes" />
+  <package key="a4wide" name="a4wide" caption="&quot;Wide&quot; a4 layout" />
+  <package key="a5comb" name="a5comb" caption="Support for a5 paper sizes" />
+  <package key="aaai" name="aaai" caption="AAAI style" />
+  <package key="aaai-named" name="aaai-named" caption="BibTeX style for AAAI" />
+  <package key="aalok" name="Aalok" caption="LaTeX class file for the Marathi journal &#8216;Aalok&#8217;" />
+  <package key="aastex" name="aastex" caption="Macros for Manuscript Preparation for AAS Journals" />
+  <package key="abbr" name="abbr" caption="Simple macros supporting abreviations for Plain and LaTeX" />
+  <package key="abbrevs" name="abbrevs" caption="Text abbreviations in LaTeX" />
+  <package key="abc" name="abc" caption="Support ABC music notation in LaTeX" />
+  <package key="abc2mtex" name="abc2mtex" caption="Notate tunes stored in ABC notation" />
+  <package key="abnt" name="abnt" caption="Typesetting academic works according to ABNT rules" />
+  <package key="abntex2" name="abntex2" caption="Typeset technical and scientific Brazilian documents based on ABNT rules" />
+  <package key="abntexto" name="abntexto" caption="LaTeX class for formatting academic papers in ABNT standards" />
+  <package key="aboensis" name="Aboensis" caption="A late medieval OpenType cursive font" />
+  <package key="abraces" name="abraces" caption="Asymmetric over-/underbraces in maths" />
+  <package key="abspos" name="abspos" caption="Absolute placement with coffins" />
+  <package key="abstbook" name="abstbook" caption="Books of abstracts" />
+  <package key="abstr-collect" name="abstr-collect" caption="Print a collection of abstracts" />
+  <package key="abstract" name="abstract" caption="Control the typesetting of the abstract environment" />
+  <package key="abstyles-babel" name="abstyles-babel" caption="Adaptable styles for use with Babel" />
+  <package key="abstyles-orig" name="abstyles-orig" caption="Adaptable BibTeX styles" />
+  <package key="academicons" name="academicons" caption="Font containing high quality icons of online academic profiles" />
+  <package key="accanthis" name="accanthis" caption="Accanthis fonts, with LaTeX support" />
+  <package key="accenti" name="accenti" caption="Extra accented character macros, designed for Italian" />
+  <package key="accents" name="accents" caption="Multiple mathematical accents" />
+  <package key="accents-cs" name="accents-cs" caption="Create a VF for the accents used in Czech/Slovak" />
+  <package key="accessibility" name="accessibility" caption="Create tagged and structured PDF files" />
+  <package key="accfonts" name="accfonts" caption="Utilities to derive new fonts from existing ones" />
+  <package key="accsupp" name="accsupp" caption="Better accessibility support for PDF files" />
+  <package key="achemso" name="achemso" caption="Support for American Chemical Society journal submissions" />
+  <package key="achicago" name="achicago" caption="Chicago Manual citations in LaTeX" />
+  <package key="achicago-bst" name="achicago-bst" caption="Chicago Manual BibTeX style" />
+  <package key="acm" name="acm" caption="ACM document style" />
+  <package key="acmart" name="acmart" caption="Class for typesetting publications of ACM" />
+  <package key="acmconf" name="acmconf" caption="Class for ACM conference proceedings" />
+  <package key="acmproc" name="acmproc" caption="Style option for ACM proceedings" />
+  <package key="acmtrans" name="acmtrans" caption="Class and BibTeX style for ACM Transactions" />
+  <package key="acro" name="acro" caption="Typeset acronyms" />
+  <package key="acroflex" name="acroflex" caption="Create a graphing widget in a PDF file" />
+  <package key="acromake" name="acromake" caption="Make commands for acronyms" />
+  <package key="acromemory" name="AcroMemory" caption="Memory games in LaTeX" />
+  <package key="acronym" name="acronym" caption="Expand acronyms at least once" />
+  <package key="acronym209" name="acronym209" caption="An algorithm package developed for LaTeX 2.09" />
+  <package key="acroreloadpdf" name="acroreloadpdf" caption="Reload-the-current-PDF utility for Adobe Reader on Unix systems" />
+  <package key="acrosort" name="AcroSort" caption="Sort sliced image into order" />
+  <package key="acroterm" name="acroterm" caption="Manage and index acronyms and terms" />
+  <package key="acrotex" name="acrotex" caption="The AcroTeX education bundle" />
+  <package key="acrotex-js" name="acrotex-js" caption="JavaScript files used by acrotex and other packages" />
+  <package key="acrotex-web" name="acrotex-web" caption="Establish a page layout for an on-screen (PDF) document" />
+  <package key="acroweb" name="acroweb" caption="Scripts to create interactive tests from a database" />
+  <package key="acs" name="acs" caption="LaTeX 2.09 support for Advances in Control Systems" />
+  <package key="active-conf" name="active-conf" caption="Class for typesetting ACTIVE conference papers" />
+  <package key="actuarialangle" name="actuarialangle" caption="Angle symbol denoting a duration in actuarial and financial notation" />
+  <package key="actuarialsymbol" name="actuarialsymbol" caption="Actuarial symbols of life contingencies and financial mathematics" />
+  <package key="adami" name="adami" caption="A DOS system for working with Tamil" />
+  <package key="add-wes" name="add-wes" caption="A &quot;book&quot; style for Addison-Wesley house style" />
+  <package key="addfont" name="addfont" caption="Easier use of fonts without LaTeX support" />
+  <package key="addindex" name="addindex" caption="Add index entries to LaTeX document" />
+  <package key="addliga" name="addliga" caption="Access basic ligatures in legacy TrueType fonts" />
+  <package key="addlines" name="addlines" caption="A user-friendly wrapper around \enlargethispage" />
+  <package key="address" name="address" caption="Generate form letters and address labels" />
+  <package key="addtex2eps" name="AddTeX2Eps" caption="Use LaTeX syntax on EPS figures, within Mathematica" />
+  <package key="addtoluatexpath" name="addtoluatexpath" caption="Add paths to Lua packages and input TeX files" />
+  <package key="adfathesis" name="adfathesis" caption="Australian Defence Force Academy thesis format" />
+  <package key="adforn" name="adforn" caption="OrnementsADF font with TeX/LaTeX support" />
+  <package key="adfsymbols" name="adfsymbols" caption="SymbolsADF with TeX/LaTeX support" />
+  <package key="adhocfilelist" name="adhocfilelist" caption="&#8216;\listfiles&#8217; entries from the command line" />
+  <package key="adigraph" name="adigraph" caption="Augmenting directed graphs" />
+  <package key="adjmulticol" name="adjmulticol" caption="Adjusting margins for multicolumn and single column output" />
+  <package key="adjustbox" name="adjustbox" caption="Graphics package-alike macros for &#8220;general&#8221; boxes" />
+  <package key="adobe-euro" name="adobe-euro" caption="Metric and map files for the Adobe Euro fonts" />
+  <package key="adobecaslon" name="adobecaslon" caption="Adobe Caslon font in LaTeX" />
+  <package key="adobemapping" name="adobemapping" caption="Adobe cmap and pdfmapping files" />
+  <package key="adobeornaments" name="adobeornaments" caption="Using ornaments in Adobe Fonts with LuaLaTeX or XeLaTeX" />
+  <package key="adrconv" name="adrconv" caption="BibTeX styles to implement an address database" />
+  <package key="adrlist" name="adrlist" caption="Using address lists in LaTeX" />
+  <package key="adtrees" name="adtrees" caption="Macros for drawing adpositional trees" />
+  <package key="advdate" name="advdate" caption="Print a date relative to &quot;today&quot;" />
+  <package key="ae" name="ae" caption="Virtual fonts for T1 encoded CMR-fonts" />
+  <package key="aeb-minitoc" name="aeb-minitoc" caption="Create mini-tocs" />
+  <package key="aeb-mlink" name="aeb-mlink" caption="Multi-line links with hyperref" />
+  <package key="aeb-mobile" name="aeb-mobile" caption="Format PDF files for use on a smartphone" />
+  <package key="aeb-pro" name="AeB Pro" caption="Items from the AeB Pro Family of Software" />
+  <package key="aeb-tilebg" name="aeb-tilebg" caption="AeB Tiling Backgrounds" />
+  <package key="aeb_dad" name="aeb_dad" caption="A drag-and-drop matching game with PDF files" />
+  <package key="aebenvelope" name="aebenvelope" caption="The AeB Pro eEnvelope System" />
+  <package key="aebslicing" name="AeB slicing" caption="An image slicer" />
+  <package key="aebxmp" name="aebXMP" caption="Add advanced metadata to PDF files" />
+  <package key="aecc" name="aecc" caption="Almost European Concrete Roman virtual fonts" />
+  <package key="aeguill" name="aeguill" caption="Add several kinds of guillemets to the ae fonts" />
+  <package key="aesupp" name="aesupp" caption="Special support for the &#230; character" />
+  <package key="afmtopl-clark" name="AFMtoPL (Clark)" caption="Convert AFM files to PLs for use with dvitops" />
+  <package key="afmtopl-elwell" name="AFMtoPL (Elwell)" caption="An early converter from AFM to PL" />
+  <package key="afmtopl-wolczko" name="AFMtopl (Wolczko)" caption="Unix utilities for translating AFM files to PL" />
+  <package key="afparticle" name="afparticle" caption="Typesetting articles for Archives of Forensic Psychology" />
+  <package key="afterpackage" name="afterpackage" caption="Add commands to package after it&apos;s loaded" />
+  <package key="afterpage" name="afterpage" caption="Execute command after the next page break" />
+  <package key="afthesis" name="afthesis" caption="Air Force Institute of Technology thesis class" />
+  <package key="aguplus" name="aguplus" caption="Styles for American Geophysical Union" />
+  <package key="aiaa" name="aiaa" caption="Typeset AIAA conference papers" />
+  <package key="aichej" name="aichej" caption="Bibliography style file for the AIChE Journal" />
+  <package key="aifont" name="aifont" caption="Remap Computer Modern fonts" />
+  <package key="ajl" name="ajl" caption="BibTeX style for AJL" />
+  <package key="akktex" name="AkkTeX" caption="A collection of packages and classes" />
+  <package key="akletter" name="akletter" caption="Comprehensive letter support" />
+  <package key="akshar" name="akshar" caption="Support for syllables in the Devanagari script" />
+  <package key="alatex" name="alatex" caption="Abstract LaTeX" />
+  <package key="albatross" name="albatross" caption="Find fonts that contain a given glyph" />
+  <package key="alchemist" name="alchemist" caption="Typeset alchemist and astrological symbols" />
+  <package key="alegreya" name="alegreya" caption="Alegreya fonts with LaTeX support" />
+  <package key="aleph" name="aleph" caption="Extended TeX" />
+  <package key="alertmessage" name="alertmessage" caption="Alert messages for LaTeX" />
+  <package key="alfaslabone" name="AlfaSlabOne" caption="The Alfa Slab One font face with support for LaTeX and pdfLaTeX" />
+  <package key="alg" name="alg" caption="LaTeX environments for typesetting algorithms" />
+  <package key="algobox" name="algobox" caption="Typeset Algobox programs" />
+  <package key="algolrevived" name="algolrevived" caption="A revival of Frutiger&apos;s Algol alphabet" />
+  <package key="algorithm2e" name="algorithm2e" caption="Floating algorithm environment with algorithmic keywords" />
+  <package key="algorithmicx" name="algorithmicx" caption="The algorithmic style you always wanted" />
+  <package key="algorithms" name="algorithms" caption="A suite of tools for typesetting algorithms in pseudo-code" />
+  <package key="algpseudocodex" name="algpseudocodex" caption="Package for typesetting pseudocode" />
+  <package key="algxpar" name="algxpar" caption="Support multiple lines of pseudocode" />
+  <package key="aliascnt" name="aliascnt" caption="Alias counters" />
+  <package key="aligned-overset" name="aligned-overset" caption="Fix alignment at \overset or \underset" />
+  <package key="alkalami" name="alkalami" caption="A font for Arabic-based writing systems in Nigeria and Niger" />
+  <package key="alleqno" name="alleqno" caption="Automatic numbering of all equations" />
+  <package key="allrunes" name="allrunes" caption="Fonts and LaTeX package for almost all runes" />
+  <package key="alltt" name="alltt" caption="Everything in tt font, but obey commands and line endings" />
+  <package key="alltt2" name="alltt2" caption="Indented version of alltt" />
+  <package key="almendra" name="almendra" caption="Almendra fonts with LaTeX support" />
+  <package key="almfixed" name="almfixed" caption="Arabic-Latin Modern Fixed extends TeX-Gyre Latin Modern Mono 10 Regular to full Arabic Unicode support" />
+  <package key="alnumsec" name="alnumsec" caption="Alphanumeric section numbering" />
+  <package key="alpha" name="alpha" caption="Editor for the Macintosh with good TeX support" />
+  <package key="alpha-persian" name="alpha-persian" caption="Persian version of alpha.bst" />
+  <package key="alphabib" name="alphabib" caption="Add alphabetical headers into citations" />
+  <package key="alphalph" name="alphalph" caption="Convert numbers to letters" />
+  <package key="alphanum" name="alphanum" caption="Sectioning commands for jura" />
+  <package key="alphanum-bst" name="alphanum-bst" caption="Modified alpha BibTeX style" />
+  <package key="alphanumb" name="alphanumb" caption="A modification of alpha.bst" />
+  <package key="alterqcm" name="alterqcm" caption="Multiple choice questionnaires in two column tables" />
+  <package key="altfont" name="altfont" caption="Alternative font handling in LaTeX" />
+  <package key="altnline" name="altnline" caption="Line numbering in LaTeX 2.09" />
+  <package key="altsubsup" name="altsubsup" caption="Subscripts and superscripts with square brackets" />
+  <package key="altverse" name="altverse" caption="Typesetting verse" />
+  <package key="ama" name="ama" caption="AMA manual of style citations" />
+  <package key="ametsoc" name="ametsoc" caption="Official American Meteorological Society LaTeX Template" />
+  <package key="amiri" name="amiri" caption="A classical Arabic typeface, Naskh style" />
+  <package key="amiweb2c" name="amiweb2c" caption="An Amiga port of web2C" />
+  <package key="amiweb2c-guide" name="amiweb2c-guide" caption="How to install AmiWeb2c" />
+  <package key="ams-cd" name="ams-cd" caption="AMSTeX Commutative Diagrams for LaTeX" />
+  <package key="ams2bib" name="ams2bib" caption="Convert AMS-TeX style bibliography entries to BibTeX" />
+  <package key="amsaddr" name="amsaddr" caption="Alter the position of affiliations in amsart" />
+  <package key="amsart" name="amsart" caption="LaTeX document class for AMS math journal articles" />
+  <package key="amsbook" name="amsbook" caption="LaTeX document class for AMS books" />
+  <package key="amsbsy" name="amsbsy" caption="Produce bold math symbols (AMS-LaTeX)" />
+  <package key="amscd" name="amscd" caption="AMS-LaTeX commutative diagrams" />
+  <package key="amscdx" name="amscdx" caption="Enhanced commutative diagrams" />
+  <package key="amscls" name="amscls" caption="AMS document classes for LaTeX" />
+  <package key="amscls-doc" name="amscls-doc" caption="User documentation for AMS document classes" />
+  <package key="amsfonts" name="amsfonts" caption="TeX fonts from the American Mathematical Society" />
+  <package key="amslatex" name="amslatex" caption="Mathematical enhancements for LaTeX" />
+  <package key="amslatex-primer" name="amslatex-primer" caption="Getting up and running with AMS-LaTeX" />
+  <package key="amslatexdoc-vietnamese" name="amslatexdoc-vietnamese" caption="Vietnamese translation of AMSLaTeX documentation" />
+  <package key="amsltx11" name="amsltx11" caption="AMS-LaTeX, original version (obsolete)" />
+  <package key="amsmath" name="amsmath" caption="AMS mathematical facilities for LaTeX" />
+  <package key="amsmath-it" name="amsmath-it" caption="Italian translations of some old amsmath documents" />
+  <package key="amsmidx" name="amsmidx" caption="Support for multiple indexes in AMS Classes" />
+  <package key="amsopn" name="amsopn" caption="Typeset mathematical operator names" />
+  <package key="amspell" name="amspell" caption="ASCII and LaTeX spell checker" />
+  <package key="amsppt" name="amsppt" caption="AMS-TeX article preprint document style" />
+  <package key="amsppt1" name="amsppt1" caption="AMS-TeX v.2 compatibility for amsppt.sty v.1" />
+  <package key="amsproc" name="amsproc" caption="LaTeX document class for AMS conference proceedings" />
+  <package key="amsrefs" name="amsrefs" caption="A LaTeX-based replacement for BibTeX" />
+  <package key="amstex" name="amstex" caption="American Mathematical Society plain TeX macros" />
+  <package key="amstext" name="amstext" caption="Typeset text fragments in mathematics" />
+  <package key="amsthm" name="amsthm" caption="Typesetting theorems (AMS style)" />
+  <package key="analogclock" name="analogclock" caption="An analog ticking clock package for PDF output" />
+  <package key="andika" name="andika" caption="andika fonts with support for all LaTeX engines" />
+  <package key="animate" name="animate" caption="Create PDF and SVG animations from graphics files and inline graphics" />
+  <package key="anleitung" name="anleitung" caption="Using LaTeX with MikTeX, including TrueType fonts" />
+  <package key="annee-scolaire" name="annee-scolaire" caption="Automatically typeset the academic year (French way)" />
+  <package key="annot-pro" name="annot-pro" caption="Create text, stamp and file attachment annotations" />
+  <package key="annotate" name="annotate" caption="A bibliography style with annotations" />
+  <package key="annotate-equations" name="annotate-equations" caption="Easily annotate math equations using TikZ" />
+  <package key="annotation" name="annotation" caption="A BibTeX style that processes annotations" />
+  <package key="annotation-pkg" name="annotation-pkg" caption="Suppress or permit annotations to a document" />
+  <package key="anonchap" name="anonchap" caption="Make chapters be typeset like sections" />
+  <package key="anonymous-acm" name="anonymous-acm" caption="Typeset anonymous versions for ACM articles" />
+  <package key="anonymouspro" name="AnonymousPro" caption="Use AnonymousPro fonts with LaTeX" />
+  <package key="ans" name="ans" caption="Answers and solutions, for LaTeX 2.09" />
+  <package key="answers" name="answers" caption="Setting questions (or exercises) and answers" />
+  <package key="ant" name="ant" caption="A typesetting system inspired by TeX" />
+  <package key="ant-worker-tasks" name="ant-worker-tasks" caption="Apache ANT Tasks for TeX and PDF" />
+  <package key="antanilipsum" name="antanilipsum" caption="Generate sentences in the style of &#8220;Amici miei&#8221;" />
+  <package key="anti" name="anti" caption="Typeset an anti-particle in maths mode" />
+  <package key="antique-spanish-units" name="antique-spanish-units" caption="A short document about antique spanish units" />
+  <package key="antomega" name="antomega" caption="Alternative language support for Omega/Lambda" />
+  <package key="antp" name="antp" caption="Antykwa P&#243;&#322;tawskiego: a Type 1 family of Polish traditional type" />
+  <package key="antt" name="antt" caption="Antykwa Toru&#324;ska: a Type 1 family of a Polish traditional type" />
+  <package key="anttvf" name="anttvf" caption="Virtual fonts for PostScript Antykwa Toru&#324;ska font" />
+  <package key="anufinalexam" name="ANUfinalexam" caption="LaTeX document shell for ANU final exam" />
+  <package key="anyfontsize" name="anyfontsize" caption="Select any font size in LaTeX" />
+  <package key="anysize" name="anysize" caption="A simple package to set up document margins" />
+  <package key="aobs-tikz" name="aobs-tikz" caption="TikZ styles for creating overlaid pictures in beamer" />
+  <package key="aomart" name="aomart" caption="Typeset articles for the Annals of Mathematics" />
+  <package key="apa" name="apa" caption="American Psychological Association format" />
+  <package key="apa6" name="apa6" caption="Format documents in APA style (6th edition)" />
+  <package key="apa6e" name="apa6e" caption="Format manuscripts to APA 6th edition guidelines" />
+  <package key="apa7" name="apa7" caption="Format documents in APA style (7th edition)" />
+  <package key="apabst" name="apabst" caption="Early APA BibTeX style" />
+  <package key="apacite" name="apacite" caption="Citation style following the rules of the APA" />
+  <package key="apalike-ejor" name="apalike-ejor" caption="A BibTeX style file for the European Journal of Operational Research" />
+  <package key="apalike-german" name="apalike-german" caption="A copy of apalike.bst with German localization" />
+  <package key="apalike2" name="apalike2" caption="Bibliography style that approaches APA requirements" />
+  <package key="apasoft" name="apasoft" caption="An APA-like style for BibTeX" />
+  <package key="apeqnum" name="apeqnum" caption="Number equations by appendix" />
+  <package key="apl" name="apl" caption="Fonts for typesetting APL programs" />
+  <package key="aplweb" name="aplweb" caption="Literate programming in APL" />
+  <package key="apnum" name="apnum" caption="Arbitrary precision numbers implemented by TeX macros" />
+  <package key="appelt-chess" name="appelt-chess" caption="Chess board macros using standard fonts" />
+  <package key="appendix" name="appendix" caption="Extra control of appendices" />
+  <package key="appendixnumberbeamer" name="appendixnumberbeamer" caption="Manage frame numbering in appendixes in beamer" />
+  <package key="apprendre-a-programmer-en-tex" name="apprendre-a-programmer-en-tex" caption="The book &#8220;Apprendre &#224; programmer en TeX&#8221;" />
+  <package key="apprends-latex" name="apprends-latex" caption="Apprends LaTeX!" />
+  <package key="apptools" name="apptools" caption="Tools for customising appendices" />
+  <package key="apxproof" name="apxproof" caption="Proofs in appendix" />
+  <package key="ar" name="ar" caption="Capital A and capital R ligature for Aspect Ratio" />
+  <package key="arabi" name="arabi" caption="(La)TeX support for Arabic and Farsi, compliant with Babel" />
+  <package key="arabi-add" name="arabi-add" caption="Using hyperref and bookmark packages with arabic and farsi languages" />
+  <package key="arabic" name="arabic" caption="Read a lower-case roman number" />
+  <package key="arabic-book" name="arabic-book" caption="An Arabic book class" />
+  <package key="arabicfront" name="arabicfront" caption="Frontmatter with arabic page numbers" />
+  <package key="arabluatex" name="arabluatex" caption="ArabTeX for LuaLaTeX" />
+  <package key="arabtex" name="arabtex" caption="Macros and fonts for typesetting Arabic" />
+  <package key="arabxetex" name="arabxetex" caption="An ArabTeX-like interface for XeLaTeX" />
+  <package key="aramaic" name="aramaic" caption="Fonts for Aramaic script" />
+  <package key="aramaic-serto" name="aramaic-serto" caption="Fonts and LaTeX for Syriac written in Serto" />
+  <package key="arara" name="arara" caption="Automation of LaTeX compilation" />
+  <package key="arbeit" name="arbeit" caption="Typeset classwork exercises" />
+  <package key="archaeologie" name="archaeologie" caption="A citation-style which covers rules of the German Archaeological Institute" />
+  <package key="archaic" name="archaic" caption="A collection of archaic fonts" />
+  <package key="archivo" name="Archivo" caption="The Archivo font face with support for LaTeX and pdfLaTeX" />
+  <package key="arcs" name="arcs" caption="Draw arcs over and under text" />
+  <package key="arev" name="arev" caption="Fonts and LaTeX support files for Arev Sans" />
+  <package key="arimo" name="arimo" caption="Arimo sans serif fonts with LaTeX support" />
+  <package key="arlatex" name="arlatex" caption="A LaTeX-based archiver" />
+  <package key="armtex" name="armtex" caption="A system for writing in Armenian with TeX and LaTeX" />
+  <package key="armymemo" name="armymemo" caption="A document class for Army memorandums in accordance with AR 25-50" />
+  <package key="aro-bend" name="aro-bend" caption="Exercises in TeX, with answers" />
+  <package key="arosgn" name="arosgn" caption="Support for the Bengali language" />
+  <package key="around-the-bend" name="around-the-bend" caption="Typeset exercises in TeX, with answers" />
+  <package key="arphic" name="arphic" caption="Arphic (Chinese) font packages" />
+  <package key="arphic-ttf" name="arphic-ttf" caption="TrueType version of Chinese Arphic fonts" />
+  <package key="array" name="array" caption="Extending the array and tabular environments" />
+  <package key="arraycols" name="arraycols" caption="New column types for array and tabular environments" />
+  <package key="arrayjob" name="arrayjob" caption="Array data structures for (La)TeX" />
+  <package key="arrayjobx" name="arrayjobx" caption="Array data structures for (La)TeX" />
+  <package key="arraymaker" name="Array Maker" caption="A program for making LaTeX and xypic arrays" />
+  <package key="arraysort" name="arraysort" caption="Sort arrays (or portions of them)" />
+  <package key="arrow" name="arrow" caption="Eplain macros for commutative diagrams" />
+  <package key="arsclassica" name="ArsClassica" caption="A different view of the ClassicThesis package" />
+  <package key="artex" name="artex" caption="Make filecontents environments of non-standard files or packages" />
+  <package key="article" name="article" caption="Default class for composing an article" />
+  <package key="articleingud" name="articleingud" caption="LaTeX class for articles published in INGENIERIA review" />
+  <package key="artthreads" name="artthreads" caption="Support for article threads" />
+  <package key="arvo" name="Arvo" caption="The Arvo font face with support for LaTeX and pdfLaTeX" />
+  <package key="arxivbib" name="arXivBib" caption="Get bibliography entries from arXiv.org" />
+  <package key="arydshln" name="arydshln" caption="Draw dash-lines in array/tabular" />
+  <package key="asaetr" name="asaetr" caption="Transactions of the ASAE" />
+  <package key="asana-math" name="asana-math" caption="A font to typeset maths in Xe(La)TeX and Lua(La)TeX" />
+  <package key="asapsym" name="asapsym" caption="Using the free ASAP Symbol font with LaTeX and Plain TeX" />
+  <package key="asc2tex" name="asc2tex" caption="Retrieve text from screenshots" />
+  <package key="ascelike" name="ascelike" caption="Bibliography style for the ASCE" />
+  <package key="ascii-chart" name="ascii-chart" caption="An ASCII wall chart" />
+  <package key="ascii-cyrillic" name="ascii-cyrillic" caption="A Latin alphabet representation of Cyrillic" />
+  <package key="ascii-font" name="ascii-font" caption="Use the ASCII &#8220;font&#8221; in LaTeX" />
+  <package key="asciilist" name="asciilist" caption="Environments AsciiList and AsciiDocList for prototyping nested lists in LaTeX" />
+  <package key="ascmac" name="ascmac" caption="Boxes and picture macros with Japanese vertical writing support" />
+  <package key="askinclude" name="askinclude" caption="Interactive use of \includeonly" />
+  <package key="askmaps" name="askmaps" caption="Typeset American style Karnaugh maps" />
+  <package key="asmeconf" name="asmeconf" caption=" A LaTeX template for ASME conference papers " />
+  <package key="asmejour" name="asmejour" caption="A template for ASME journal papers" />
+  <package key="aspectratio" name="aspectratio" caption="Capital A and capital R ligature for Aspect Ratio" />
+  <package key="aspell" name="aspell" caption="Spell checker" />
+  <package key="assignment" name="assignment" caption="A class file for typesetting homework and lab assignments" />
+  <package key="assoccnt" name="assoccnt" caption="Associate counters, making them step when a master steps" />
+  <package key="association-matrix" name="association-matrix" caption="LaTeX support for creating association matrices" />
+  <package key="asternote" name="asternote" caption="Annotation symbols enclosed in square brackets and marked with an asterisk" />
+  <package key="astro" name="astro" caption="Astronomical (planetary) symbols" />
+  <package key="astron" name="astron" caption="BibTeX style for astronomical journals" />
+  <package key="astyped" name="astyped" caption="Verbatim environment, with rather few escapes" />
+  <package key="asyfig" name="asyfig" caption="Commands for using Asymptote figures" />
+  <package key="asymptote" name="asymptote" caption="2D and 3D TeX-Aware Vector Graphics Language" />
+  <package key="asymptote-by-example-zh-cn" name="asymptote-by-example-zh-cn" caption="Asymptote by example" />
+  <package key="asymptote-faq-zh-cn" name="asymptote-faq-zh-cn" caption="Asymptote FAQ (Chinese translation)" />
+  <package key="asymptote-manual-zh-cn" name="asymptote-manual-zh-cn" caption="A Chinese translation of the asymptote manual" />
+  <package key="asypictureb" name="asypictureB" caption="User-friendly integration of Asymptote into LaTeX" />
+  <package key="at" name="at" caption="Short commands starting &apos;@&apos;" />
+  <package key="atari-cstex" name="atari-cstex" caption="TeX for Atari machines" />
+  <package key="atbegshi" name="atbegshi" caption="Execute stuff at \shipout time" />
+  <package key="atenddvi" name="atenddvi" caption="Provides the \AtEndDvi command" />
+  <package key="atendofenv" name="atendofenv" caption=" Add a custom symbol at the end of an environment" />
+  <package key="atkinson" name="atkinson" caption="Support for the Atkinson Hyperlegible family of fonts" />
+  <package key="attachfile" name="attachfile" caption="Attach arbitrary files to a PDF document" />
+  <package key="attachfile2" name="attachfile2" caption="Attach files into PDF" />
+  <package key="attrib" name="attrib" caption="Attribution of block quotations in LaTeX" />
+  <package key="atveryend" name="atveryend" caption="Hooks at the very end of a document" />
+  <package key="aucklandthesis" name="aucklandthesis" caption="Memoir-based class for formatting University of Auckland masters&apos; and doctors&apos; theses" />
+  <package key="auctex" name="auctex" caption="Emacs support files for TeX" />
+  <package key="augie" name="augie" caption="Calligraphic font for typesetting handwriting" />
+  <package key="auncial" name="auncial" caption="Artificial Uncial manuscript book-hand font" />
+  <package key="auncial-new" name="auncial-new" caption="Artificial Uncial font and LaTeX support macros" />
+  <package key="aurical" name="aurical" caption="Calligraphic fonts for use with LaTeX in T1 encoding" />
+  <package key="aurl" name="aurl" caption="Extends the hyperref package with a mechanism for hyperlinked URLs abbreviated with prefixes" />
+  <package key="aurora" name="aurora" caption="Header files for dvips to make colour separations" />
+  <package key="authblk" name="authblk" caption="Support for footnote style author/affiliation" />
+  <package key="authoraftertitle" name="authoraftertitle" caption="Make author, etc., available after \maketitle" />
+  <package key="authorarchive" name="authorarchive" caption="Adds self-archiving information to scientific papers" />
+  <package key="authordate" name="authordate" caption="Author/date style citation styles" />
+  <package key="authorindex" name="authorindex" caption="Index citations by author names" />
+  <package key="auto-pst-pdf" name="auto-pst-pdf" caption="Wrapper for pst-pdf (with some psfrag features)" />
+  <package key="auto-pst-pdf-lua" name="auto-pst-pdf-lua" caption="Using LuaLaTeX together with PostScript code" />
+  <package key="auto1" name="auto1" caption="LaTeX support for Underware Auto 1 fonts" />
+  <package key="autoaligne" name="autoaligne" caption="Align terms and members in math expressions" />
+  <package key="autobreak" name="autobreak" caption="Simple line breaking of long formulae" />
+  <package key="autoconf" name="autoconf" caption="Autoconf macros to test for the presence of LaTeX" />
+  <package key="autofancyhdr" name="autofancyhdr" caption="Automatically compute headlength for fancyhdr package" />
+  <package key="autolatex" name="AutoLaTeX" caption="Automate compilation of large scale LaTeX projects" />
+  <package key="autolist" name="autolist" caption="More lists" />
+  <package key="automagic" name="automagic" caption="Automagic numbering in Plain TeX" />
+  <package key="automata" name="automata" caption="Finite state machines, graphs and trees in MetaPost" />
+  <package key="automatica" name="automatica" caption="A harvard-family BibTeX style" />
+  <package key="autonum" name="autonum" caption="Automatic equation references" />
+  <package key="autopdf" name="autopdf" caption="Conversion of graphics to pdfLaTeX-compatible formats" />
+  <package key="autopict" name="autopict" caption="The LaTeX picture mode, for use with Plain TeX" />
+  <package key="autopuncitems" name="autopuncitems" caption="Automatically punctuate lists" />
+  <package key="autosp" name="autosp" caption="A Preprocessor that generates note-spacing commands for MusiXTeX scores" />
+  <package key="autotab" name="autotab" caption="Generating tabulars from input data" />
+  <package key="autotoc" name="autotoc" caption="Table of contents in Plain TeX" />
+  <package key="autoview" name="autoview" caption="Maintain a Ghostscript view of emacs buffer" />
+  <package key="auxhook" name="auxhook" caption="Hooks for auxiliary files" />
+  <package key="avremu" name="avremu" caption="An 8-Bit Microcontroller Simulator written in LaTeX" />
+  <package key="aweb" name="aweb" caption="Web system for programs written in Ada" />
+  <package key="awesomebox" name="awesomebox" caption="Draw admonition blocks in your documents, illustrated with FontAwesome icons" />
+  <package key="axessibility" name="axessibility" caption="Access to formulas in PDF files by assistive technologies" />
+  <package key="axodraw" name="axodraw" caption="Feynman diagrams in a LaTeX document" />
+  <package key="axodraw2" name="axodraw2" caption="Feynman diagrams in a LaTeX document" />
+  <package key="b1encoding" name="b1encoding" caption="LaTeX encoding tools for Bookhands fonts" />
+  <package key="babel" name="babel" caption="Multilingual support for LaTeX, LuaLaTeX, XeLaTeX, and Plain TeX" />
+  <package key="babel-albanian" name="babel-albanian" caption="Support for Albanian within babel" />
+  <package key="babel-azerbaijani" name="babel-azerbaijani" caption="Support for Azerbaijani within babel" />
+  <package key="babel-bahasa" name="babel-bahasa" caption="Support for Bahasa within babel" />
+  <package key="babel-basque" name="babel-basque" caption="Babel contributed support for Basque" />
+  <package key="babel-belarusian" name="babel-belarusian" caption="Babel support for Belarusian" />
+  <package key="babel-bosnian" name="babel-bosnian" caption="Babel contrib support for Bosnian" />
+  <package key="babel-breton" name="babel-breton" caption="Babel contributed support for Breton" />
+  <package key="babel-bulgarian" name="babel-bulgarian" caption="Babel contributed support for Bulgarian" />
+  <package key="babel-catalan" name="babel-catalan" caption="Babel contributed support for Catalan" />
+  <package key="babel-contrib" name="babel-contrib" caption="Contributed language-support files for Babel" />
+  <package key="babel-croatian" name="babel-croatian" caption="Babel contributed support for Croatian" />
+  <package key="babel-czech" name="babel-czech" caption="Babel support for Czech" />
+  <package key="babel-danish" name="babel-danish" caption="Babel contributed support for Danish" />
+  <package key="babel-dutch" name="babel-dutch" caption="Babel contributed support for Dutch" />
+  <package key="babel-english" name="babel-english" caption="Babel support for English" />
+  <package key="babel-esperanto" name="babel-esperanto" caption="Babel support for Esperanto" />
+  <package key="babel-estonian" name="babel-estonian" caption="Babel support for Estonian" />
+  <package key="babel-finnish" name="babel-finnish" caption="Babel support for Finnish" />
+  <package key="babel-french" name="babel-french" caption="Babel contributed support for French" />
+  <package key="babel-friulan" name="babel-friulan" caption="Babel/Polyglossia support for Friulan(Furlan)" />
+  <package key="babel-galician" name="babel-galician" caption="Babel/Polyglossia support for Galician" />
+  <package key="babel-georgian" name="babel-georgian" caption="Babel support for Georgian" />
+  <package key="babel-german" name="babel-german" caption="Babel support for documents written in German" />
+  <package key="babel-greek" name="babel-greek" caption="Babel support for the Greek language and script" />
+  <package key="babel-hebrew" name="babel-hebrew" caption="Babel support for Hebrew" />
+  <package key="babel-hungarian" name="babel-hungarian" caption="Babel support for Hungarian (Magyar)" />
+  <package key="babel-icelandic" name="babel-icelandic" caption="Babel support for Icelandic" />
+  <package key="babel-indonesian" name="babel-indonesian" caption="Support for Indonesian within babel" />
+  <package key="babel-interlingua" name="babel-interlingua" caption="Babel support for Interlingua" />
+  <package key="babel-irish" name="babel-irish" caption="Babel support for Irish" />
+  <package key="babel-italian" name="babel-italian" caption="Babel support for Italian text" />
+  <package key="babel-japanese" name="babel-japanese" caption="Babel support for Japanese" />
+  <package key="babel-kurmanji" name="babel-kurmanji" caption="Babel support for Kurmanji" />
+  <package key="babel-latin" name="babel-latin" caption="Babel support for Latin" />
+  <package key="babel-latvian" name="babel-latvian" caption="Babel support for Latvian" />
+  <package key="babel-lithuanian" name="babel-lithuanian" caption="Babel support for documents written in Lithuanian" />
+  <package key="babel-macedonian" name="babel-macedonian" caption="Babel module to support Macedonian Cyrillic" />
+  <package key="babel-malay" name="babel-malay" caption="Support for Malay within babel" />
+  <package key="babel-norsk" name="babel-norsk" caption="Babel support for Norwegian" />
+  <package key="babel-occitan" name="babel-occitan" caption="Babel support for Occitan" />
+  <package key="babel-piedmontese" name="babel-piedmontese" caption="Babel support for Piedmontese" />
+  <package key="babel-polish" name="babel-polish" caption="Babel support for Polish" />
+  <package key="babel-portuges" name="babel-portuges" caption="Babel support for Portuges" />
+  <package key="babel-romanian" name="babel-romanian" caption="Babel support for Romanian" />
+  <package key="babel-romansh" name="babel-romansh" caption="Babel/Polyglossia support for the Romansh language" />
+  <package key="babel-russian" name="babel-russian" caption="Russian language module for Babel" />
+  <package key="babel-samin" name="babel-samin" caption="Babel support for Samin" />
+  <package key="babel-scottish" name="babel-scottish" caption="Babel support for Scottish Gaelic" />
+  <package key="babel-serbian" name="babel-serbian" caption="Babel/Polyglossia support for Serbian" />
+  <package key="babel-serbianc" name="babel-serbianc" caption="Babel module to support Serbian Cyrillic" />
+  <package key="babel-slovak" name="babel-slovak" caption="Babel support for typesetting Slovak" />
+  <package key="babel-slovenian" name="babel-slovenian" caption="Babel support for typesetting Slovenian" />
+  <package key="babel-sorbian" name="babel-sorbian" caption="Babel support for Upper and Lower Sorbian" />
+  <package key="babel-spanglish" name="babel-spanglish" caption="Simplified Spanish support for Babel" />
+  <package key="babel-spanish" name="babel-spanish" caption="Babel support for Spanish" />
+  <package key="babel-swedish" name="babel-swedish" caption="Babel support for typesetting Swedish" />
+  <package key="babel-thai" name="babel-thai" caption="Support for Thai within babel" />
+  <package key="babel-turkish" name="babel-turkish" caption="Babel support for Turkish documents" />
+  <package key="babel-ukrainian" name="babel-ukrainian" caption="Babel support for Ukrainian" />
+  <package key="babel-vietnamese" name="babel-vietnamese" caption="Babel support for typesetting Vietnamese" />
+  <package key="babel-welsh" name="babel-welsh" caption="Babel support for Welsh" />
+  <package key="babelbib" name="babelbib" caption="Multilingual bibliographies" />
+  <package key="babeltools" name="babeltools" caption="Tools for dealing with Babel annoyances" />
+  <package key="babyloniannum" name="babyloniannum" caption="Typeset Babylonian numerals with XeTeX" />
+  <package key="backgrnd" name="backgrnd" caption="Mark text with grey background or change bar" />
+  <package key="background" name="background" caption="Placement of background material on pages of a document" />
+  <package key="backnaur" name="backnaur" caption="Typeset Backus Naur Form definitions" />
+  <package key="backref" name="backref" caption="Make hyper-references back from bibliography to citation" />
+  <package key="backrefx" name="backrefx" caption="Bibliographical back referencing" />
+  <package key="badge" name="badge" caption="Print badge labels" />
+  <package key="baekmuk" name="baekmuk" caption="Baekmuk Korean TrueType fonts" />
+  <package key="bagpipe" name="bagpipe" caption="Support for typesetting bagpipe music" />
+  <package key="bahyph" name="bahyph" caption="Hyphenation for Basque" />
+  <package key="bakoma" name="bakoma" caption="A TeX distribution for MS-Windows VISTA/XP/2000" />
+  <package key="bakoma-fonts" name="bakoma-fonts" caption="Computer Modern and AMS fonts in outline form" />
+  <package key="bakoma-games" name="bakoma-games" caption="BaKoMa modules for music and games" />
+  <package key="bakoma-mac" name="bakoma-mac" caption="A BaKoMa system for the Macintosh" />
+  <package key="balance" name="balance" caption="Balanced two-column mode" />
+  <package key="balanced" name="balanced" caption="Balance double-column sections in LaTeX" />
+  <package key="balancedquotes" name="balancedquotes" caption="Code balanced quotes according to document language" />
+  <package key="bangla" name="bangla" caption="A comprehensive Bangla LaTeX package" />
+  <package key="bangorcsthesis" name="bangorcsthesis" caption="Typeset a thesis at Bangor University" />
+  <package key="bangorexam" name="bangorexam" caption="Typeset an examination at Bangor University" />
+  <package key="bangtex" name="bangtex" caption="Writing Bangla and Assamese with LaTeX" />
+  <package key="bankstatement" name="bankstatement" caption="A LaTeX class for bank statements based on csv data" />
+  <package key="bar" name="bar" caption="A patched version of bar.sty" />
+  <package key="barcodes" name="barcodes" caption="Fonts for making barcodes" />
+  <package key="barcodes-vulis" name="barcodes-vulis" caption="A font for making barcodes" />
+  <package key="bard" name="bard" caption="Celtic bardic runes font" />
+  <package key="bardi" name="bardi" caption="Hyphenation and babel support for Bardi" />
+  <package key="bardiag" name="bardiag" caption="LaTeX package for drawing bar diagrams" />
+  <package key="bargraph-js" name="bargraph-js" caption="Create bar graphs using form fields and JavaScript" />
+  <package key="barkom" name="barkom" caption="A package for bar charts in LaTeX" />
+  <package key="barracuda" name="barracuda" caption="Draw barcodes with Lua" />
+  <package key="bartel-chess-fonts" name="bartel-chess-fonts" caption="A set of fonts supporting chess diagrams" />
+  <package key="base" name="base" caption="Definitive source of Plain TeX on CTAN" />
+  <package key="bashful" name="bashful" caption="Invoke bash commands from within LaTeX" />
+  <package key="bashkirian" name="bashkirian" caption="Bashkirian extension to OT2 fonts" />
+  <package key="basicarith" name="basicarith" caption="Macros for typesetting basic arithmetic" />
+  <package key="basiclatex-ru" name="BasicLaTeX-ru" caption="An introduction to LaTeX, in Russian" />
+  <package key="basix" name="basix" caption="A BASIC interpreter written in TeX" />
+  <package key="baskervaldadf" name="baskervaldadf" caption="Baskervald ADF fonts collection with TeX/LaTeX support" />
+  <package key="baskervaldx" name="baskervaldx" caption="Extension and modification of BaskervaldADF with LaTeX support" />
+  <package key="baskervillef" name="baskervillef" caption="Fry&#8217;s Baskerville look-alike, with math support" />
+  <package key="basque-book" name="basque-book" caption="Class for book-type documents written in Basque" />
+  <package key="basque-date" name="basque-date" caption="Print the date in Basque" />
+  <package key="bath-bst" name="bath-bst" caption="Harvard referencing style as recommended by the University of Bath Library" />
+  <package key="battleship" name="battleship" caption="A LaTeX style file for typesetting Battleship logic puzzles" />
+  <package key="baum" name="baum" caption="Trees, using PicTeX" />
+  <package key="bbcard" name="bbcard" caption="Bullshit bingo, calendar and baseball-score cards" />
+  <package key="bbding" name="bbding" caption="A symbol (dingbat) font and LaTeX macros for its use" />
+  <package key="bbfig" name="bbfig" caption="Calculate and print bounding box" />
+  <package key="bbl2html" name="bbl2html" caption="Convert a LaTeX .bbl file to formatted html code" />
+  <package key="bbm" name="bbm" caption="&quot;Blackboard-style&quot; cm fonts" />
+  <package key="bbm-macros" name="bbm-macros" caption="LaTeX support for &quot;blackboard-style&quot; cm fonts" />
+  <package key="bbold" name="bbold" caption="Sans serif blackboard bold" />
+  <package key="bbold-type1" name="bbold-type1" caption="An Adobe Type 1 format version of the bbold font" />
+  <package key="bboldx" name="bboldx" caption="Extension of the bbold package with a Blackboard Bold alphabet" />
+  <package key="bbs" name="bbs" caption="Bibliography style for Behavioral and Brain Sciences" />
+  <package key="bchart" name="bchart" caption="Draw simple bar charts in LaTeX" />
+  <package key="bclogo" name="bclogo" caption="Creating colourful boxes with logos" />
+  <package key="bdfchess" name="bdfchess" caption="Typeset correspondence chess games" />
+  <package key="beamer" name="beamer" caption="A LaTeX class for producing presentations and slides" />
+  <package key="beamer-fuberlin" name="beamer-fuberlin" caption="Beamer, using the style of FU Berlin" />
+  <package key="beamer-rl" name="beamer-rl" caption="Right to left presentation with beamer and babel" />
+  <package key="beamer-tut-pt" name="beamer-tut-pt" caption="An introduction to the Beamer class, in Portuguese" />
+  <package key="beamer-verona" name="beamer-verona" caption="A theme for the beamer class" />
+  <package key="beamer2thesis" name="beamer2thesis" caption="Thesis presentations using beamer" />
+  <package key="beamerappendixnote" name="beamerappendixnote" caption="Create notes on appendix frames in beamer" />
+  <package key="beameraudience" name="beameraudience" caption="Assembling beamer frames according to audience" />
+  <package key="beamerauxtheme" name="beamerauxtheme" caption="Supplementary outer and inner themes for beamer" />
+  <package key="beamercolorthemeowl" name="beamercolorthemeowl" caption="A flexible beamer color theme to maximize visibility" />
+  <package key="beamerdarkthemes" name="beamerdarkthemes" caption="Dark color themes for beamer" />
+  <package key="beamerposter" name="beamerposter" caption="Extend beamer and a0poster for custom sized posters" />
+  <package key="beamersubframe" name="beamersubframe" caption="Reorder frames in the PDF file" />
+  <package key="beamerswitch" name="beamerswitch" caption="Convenient mode selection in Beamer documents" />
+  <package key="beamertheme-arguelles" name="beamertheme-arguelles" caption="Simple, typographic beamer theme" />
+  <package key="beamertheme-cuerna" name="beamertheme-cuerna" caption="A beamer theme with 4 colour palettes" />
+  <package key="beamertheme-detlevcm" name="beamertheme-detlevcm" caption="A beamer theme designed for use in the University of Leeds" />
+  <package key="beamertheme-epyt" name="beamertheme-epyt" caption="A simple and clean theme for LaTeX beamer class" />
+  <package key="beamertheme-focus" name="beamertheme-focus" caption="A minimalist presentation theme for LaTeX Beamer" />
+  <package key="beamertheme-light" name="beamertheme-light" caption="A minimal beamer style" />
+  <package key="beamertheme-metropolis" name="beamertheme-metropolis" caption="A modern LaTeX beamer theme" />
+  <package key="beamertheme-npbt" name="beamertheme-npbt" caption="A collection of LaTeX beamer themes" />
+  <package key="beamertheme-phnompenh" name="beamertheme-phnompenh" caption="A simple beamer theme" />
+  <package key="beamertheme-pure-minimalistic" name="beamertheme-pure-minimalistic" caption="A minimalistic presentation theme for LaTeX Beamer" />
+  <package key="beamertheme-rainbow" name="beamertheme-rainbow" caption="A beamer colour theme which alternates theme colours on every frame" />
+  <package key="beamertheme-saintpetersburg" name="beamertheme-saintpetersburg" caption="A beamer theme that incorporates colours and fonts of Saint Petersburg State University" />
+  <package key="beamertheme-simpledarkblue" name="Beamertheme-SimpleDarkBlue" caption="Template for a simple presentation" />
+  <package key="beamertheme-simpleplus" name="beamertheme-SimplePlus" caption="A simple and clean theme for LaTeX beamer" />
+  <package key="beamertheme-tcolorbox" name="beamertheme-tcolorbox" caption="A beamer inner theme which reproduces standard beamer blocks using tcolorboxes" />
+  <package key="beamertheme-trigon" name="beamertheme-trigon" caption="A modern, elegant, and versatile theme for Beamer" />
+  <package key="beamertheme-upenn-bc" name="beamertheme-upenn-bc" caption="Beamer themes for Boston College and the University of Pennsylvania" />
+  <package key="beamerthemeamurmaple" name="beamerthemeAmurmaple" caption="A new modern beamer theme" />
+  <package key="beamerthemejltree" name="beamerthemeJLTree" caption="Contributed beamer theme" />
+  <package key="beamerthemelalic" name="beamerthemelalic" caption="A beamer theme for LALIC" />
+  <package key="beamerthemenirma" name="beamerthemenirma" caption="A Beamer theme for academic presentations" />
+  <package key="beamerthemenord" name="beamerthemeNord" caption="A simple beamer theme using the &#8220;Nord&#8221; color theme" />
+  <package key="beamerthemetamu" name="beamerthemetamu" caption="A beamer theme for Texas A&amp;M University" />
+  <package key="bearwear" name="bearwear" caption="Shirts to dress TikZbears" />
+  <package key="beaulivre" name="beaulivre" caption="Write your books in a colorful way" />
+  <package key="beautybook" name="beautybook" caption="A beautiful book template for maths and science" />
+  <package key="beebe-dvi" name="Beebe-DVI" caption="A modular collection of DVI processors" />
+  <package key="begingreek" name="begingreek" caption="Greek environment to be used with pdfLaTeX only" />
+  <package key="beginlatex" name="beginlatex" caption="A beginner&apos;s guide to LaTeX" />
+  <package key="begriff" name="begriff" caption="Typeset Begriffschrift" />
+  <package key="beilstein" name="beilstein" caption="Support for submissions to the &#8220;Beilstein Journal of Nanotechnology&#8221;" />
+  <package key="beletter" name="beletter" caption="Typeset Belgian letters" />
+  <package key="belleek" name="belleek" caption="Free replacement for basic MathTime fonts" />
+  <package key="bellmac" name="bellmac" caption="Outline scheme for form letter production" />
+  <package key="bengali-omega" name="Bengali Omega" caption="Bengali in Velthuis transliteration or in UTF-8" />
+  <package key="bengali-pandey" name="bengali-pandey" caption="Support for the Bengali language" />
+  <package key="bera" name="bera" caption="Bera fonts" />
+  <package key="berenisadf" name="berenisadf" caption="Berenis ADF fonts and TeX/LaTeX support" />
+  <package key="besjournals-bst" name="besjournals-bst" caption="Bibliographies suitable for British Ecological Society journals" />
+  <package key="bestpapers" name="bestpapers" caption="A BibTeX package to produce lists of authors&#8217; best papers" />
+  <package key="betababel" name="betababel" caption="Insert ancient greek text coded in Beta Code" />
+  <package key="beton" name="beton" caption="Use Concrete fonts" />
+  <package key="beuron" name="beuron" caption="The script of the Beuronese art school" />
+  <package key="bewerbung" name="bewerbung" caption="Typesetting job applications" />
+  <package key="bez123" name="bez123" caption="Support for Bezier curves" />
+  <package key="bezierplot" name="bezierplot" caption="Approximate smooth function graphs with cubic bezier splines for use with TikZ or MetaPost" />
+  <package key="bfh-ci" name="bfh-ci" caption="Corporate Design for Bern University of Applied Sciences" />
+  <package key="bfsymb" name="bfsymb" caption="Generate bold symbols in Plain TeX mathematics" />
+  <package key="bg" name="bg" caption="Annotate backgammon matches and positions" />
+  <package key="bghyphen" name="bghyphen" caption="Hyphenation patterns for Bulgarian" />
+  <package key="bgreek" name="bgreek" caption="Using Beccari&#8217;s fonts in betacode for classical Greek" />
+  <package key="bgteubner" name="bgteubner" caption="Class for producing books for the publisher &#8220;Teubner Verlag&#8221;" />
+  <package key="bguq" name="bguq" caption="Improved quantifier stroke for Begriffsschrift packages" />
+  <package key="bhcexam" name="BHCexam" caption="An exam class for mathematics teachers in China" />
+  <package key="bib-fr" name="bib-fr" caption="French translation of classical BibTeX styles" />
+  <package key="bib-greek" name="bib-greek" caption="A BibTeX style for Greek documents" />
+  <package key="bib2dvi" name="bib2dvi" caption="Generate a DVI file from a Bibliography file" />
+  <package key="bib2gls" name="bib2gls" caption="Command line application to convert .bib files to glossaries-extra.sty resource files" />
+  <package key="bib2ml" name="bib2ml" caption="BibTeX to HTML/SQL/XML translator" />
+  <package key="bib2xhtml" name="bib2xhtml" caption="Convert BibTeX Files into XHTML" />
+  <package key="bibarts" name="BibArts" caption="&#8220;Arts&#8221;-style bibliographical information" />
+  <package key="bibbuild" name="bibbuild" caption="A bibliography builder for FileMaker Pro 7" />
+  <package key="bibcard" name="bibcard" caption="An XView based interface for BibTeX databases" />
+  <package key="bibcheck" name="bibcheck" caption="Check on references to items in thebibliography" />
+  <package key="bibclean" name="bibclean" caption="A BibTeX prettyprinter, verifier, etc" />
+  <package key="bibcop" name="bibcop" caption="Style checker for .bib files" />
+  <package key="bibdb" name="bibdb" caption="BibTeX bibliography manager for MS-Windows and MS-DOS" />
+  <package key="bibentry" name="bibentry" caption="Full bibliography entries in the main text of a document" />
+  <package key="biber" name="biber" caption="A BibTeX replacement for users of BibLaTeX" />
+  <package key="biber-cygwin" name="biber-cygwin" caption="Biber binaries for Cygwin on Windows" />
+  <package key="biber-freebsd" name="biber-freebsd" caption="Biber binaries for FreeBSD" />
+  <package key="biber-linux" name="biber-linux" caption="Biber binaries for Linux" />
+  <package key="biber-linux-musl" name="biber-linux-musl" caption="Biber binaries for Linux-MUSL" />
+  <package key="biber-macos" name="biber-macos" caption="Biber binaries for MacOS" />
+  <package key="biber-ms" name="biber-ms" caption="A BibTeX replacement for users of BibLaTeX (multiscript version)" />
+  <package key="biber-ms-linux" name="biber-ms-linux" caption="Biber (multiscript) binaries for Linux" />
+  <package key="biber-ms-macos" name="biber-ms-macos" caption="Biber (multiscript) binaries for MacOS" />
+  <package key="biber-ms-windows" name="biber-ms-windows" caption="Biber (multiscript) binaries for Windows" />
+  <package key="biber-solaris" name="biber-solaris" caption="Biber binaries for Solaris" />
+  <package key="biber-windows" name="biber-windows" caption="Biber binaries for Windows" />
+  <package key="bibex" name="Bibex" caption="Automatic extraction of references from BibTeX databases" />
+  <package key="bibexport" name="bibexport" caption="Extract a BibTeX file based on a .aux file" />
+  <package key="bibextract" name="bibextract" caption="Utilities to extract BibTeX data" />
+  <package key="bibfile-reformat-pages" name="bibfile-reformat-pages" caption="Puts .bib file page ranges into uniform format" />
+  <package key="bibfilex" name="bibfilex" caption="A free bibliographic manager for BibLaTeX" />
+  <package key="bibfind" name="bibfind" caption="Prints entries in your bib file that match search string" />
+  <package key="bibhtml" name="bibhtml" caption="BibTeX support for HTML files" />
+  <package key="bibindex" name="bibindex" caption="Index BibTeX files for fast searching" />
+  <package key="biblatex" name="BibLaTeX" caption="Sophisticated Bibliographies in LaTeX" />
+  <package key="biblatex-abnt" name="biblatex-abnt" caption="BibLaTeX style for Brazil&apos;s ABNT rules" />
+  <package key="biblatex-ajc2020unofficial" name="biblatex-ajc2020unofficial" caption="BibLaTeX style for the Australasian Journal of Combinatorics" />
+  <package key="biblatex-anonymous" name="biblatex-anonymous" caption="A tool to manage anonymous work with BibLaTeX" />
+  <package key="biblatex-apa" name="biblatex-apa" caption="BibLaTeX citation and reference style for APA" />
+  <package key="biblatex-apa6" name="biblatex-apa6" caption="BibLaTeX citation and reference style for APA 6th Edition" />
+  <package key="biblatex-archaeology" name="biblatex-archaeology" caption="A collection of BibLaTeX styles for German prehistory" />
+  <package key="biblatex-arthistory-bonn" name="biblatex-arthistory-bonn" caption="BibLaTeX citation style covers the citation and bibliography guidelines for art historians" />
+  <package key="biblatex-authoryear-icomp-tt" name="biblatex-authoryear-icomp-tt" caption="Author-year style with compact multiple-reference-citations and ibidem mechanism for BibLaTeX" />
+  <package key="biblatex-bath" name="biblatex-bath" caption="Harvard referencing style as recommended by the University of Bath Library" />
+  <package key="biblatex-bookinarticle" name="biblatex-bookinarticle" caption="Manage book edited in article" />
+  <package key="biblatex-bookinother" name="biblatex-bookinother" caption="Manage book edited in other entry type" />
+  <package key="biblatex-bwl" name="biblatex-bwl" caption="BibLaTeX citations for FU Berlin" />
+  <package key="biblatex-caspervector" name="biblatex-caspervector" caption="A simple citation style for Chinese users" />
+  <package key="biblatex-cheatsheet" name="biblatex-cheatsheet" caption="BibLaTeX/Biber &#8216;cheat sheet&#8217;" />
+  <package key="biblatex-chem" name="biblatex-chem" caption="A set of BibLaTeX implementations of chemistry-related bibliography styles" />
+  <package key="biblatex-chicago" name="biblatex-chicago" caption="Chicago style files for BibLaTeX" />
+  <package key="biblatex-claves" name="biblatex-claves" caption="A tool to manage claves of old litterature with BibLaTeX" />
+  <package key="biblatex-cv" name="biblatex-cv" caption="Create a CV from BibTeX files" />
+  <package key="biblatex-dw" name="biblatex-dw" caption="Humanities styles for BibLaTeX" />
+  <package key="biblatex-enc" name="biblatex-enc" caption="BibLaTeX style for the &#201;cole nationale des chartes (Paris)" />
+  <package key="biblatex-ext" name="biblatex-ext" caption="Extended BibLaTeX standard styles" />
+  <package key="biblatex-fiwi" name="biblatex-fiwi" caption="BibLaTeX styles for use in German humanities" />
+  <package key="biblatex-gb7714-2015" name="biblatex-gb7714-2015" caption="A BibLaTeX implementation of the GBT7714-2015 bibliography style for Chinese users" />
+  <package key="biblatex-german-legal" name="biblatex-german-legal" caption="Comprehensive citation style for German legal texts" />
+  <package key="biblatex-gost" name="biblatex-gost" caption="BibLaTeX support for GOST standard bibliographies" />
+  <package key="biblatex-historian" name="biblatex-historian" caption="A BibLaTeX style" />
+  <package key="biblatex-ieee" name="biblatex-ieee" caption="IEEE style files for BibLaTeX" />
+  <package key="biblatex-ijsra" name="biblatex-ijsra" caption="BibLaTeX style for the International Journal of Student Research in Archaeology" />
+  <package key="biblatex-iso690" name="biblatex-iso690" caption="BibLaTeX style for ISO 690 standard" />
+  <package key="biblatex-jura" name="biblatex-jura" caption="BibLaTeX stylefiles for German legal literature" />
+  <package key="biblatex-jura2" name="biblatex-jura2" caption="Citation style for the German legal profession" />
+  <package key="biblatex-juradiss" name="biblatex-juradiss" caption="BibLaTeX stylefiles for German law theses" />
+  <package key="biblatex-license" name="biblatex-license" caption="Add license data to the bibliography" />
+  <package key="biblatex-lncs" name="biblatex-lncs" caption="BibLaTeX style for Springer Lecture Notes in Computer Science" />
+  <package key="biblatex-lni" name="biblatex-lni" caption="LNI style for BibLaTeX" />
+  <package key="biblatex-luh-ipw" name="biblatex-luh-ipw" caption="BibLaTeX styles for social sciences" />
+  <package key="biblatex-manuscripts-philology" name="biblatex-manuscripts-philology" caption="Manage classical manuscripts with BibLaTeX" />
+  <package key="biblatex-mla" name="biblatex-mla" caption="MLA style files for BibLaTeX" />
+  <package key="biblatex-morenames" name="biblatex-morenames" caption="New names for standard BibLaTeX entry type" />
+  <package key="biblatex-ms" name="biblatex-ms" caption="Sophisticated Bibliographies in LaTeX (multiscript version)" />
+  <package key="biblatex-multiple-dm" name="biblatex-multiple-dm" caption="Load multiple datamodels in BibLaTeX" />
+  <package key="biblatex-musuos" name="biblatex-musuos" caption="A BibLaTeX style for citations in musuos.cls" />
+  <package key="biblatex-nature" name="biblatex-nature" caption="BibLaTeX support for Nature" />
+  <package key="biblatex-nejm" name="biblatex-nejm" caption="BibLaTeX style for the New England Journal of Medicine (NEJM)" />
+  <package key="biblatex-nottsclassic" name="biblatex-nottsclassic" caption="Citation style for the University of Nottingham" />
+  <package key="biblatex-opcit-booktitle" name="biblatex-opcit-booktitle" caption="Use op. cit. for the booktitle of a subentry" />
+  <package key="biblatex-oxref" name="biblatex-oxref" caption="BibLaTeX styles inspired by the Oxford Guide to Style" />
+  <package key="biblatex-philosophy" name="biblatex-philosophy" caption="Styles for using BibLaTeX for work in philosophy" />
+  <package key="biblatex-phys" name="biblatex-phys" caption="A BibLaTeX implementation of the AIP and APS bibliography style" />
+  <package key="biblatex-publist" name="biblatex-publist" caption="BibLaTeX bibliography support for publication lists" />
+  <package key="biblatex-readbbl" name="biblatex-readbbl" caption="Read a .bbl file created by biber" />
+  <package key="biblatex-realauthor" name="biblatex-realauthor" caption="Indicate the real author of a work" />
+  <package key="biblatex-sbl" name="biblatex-sbl" caption="Society of Biblical Literature (SBL) style files for BibLaTeX" />
+  <package key="biblatex-science" name="biblatex-science" caption="BibLaTeX implementation of the Science bibliography style" />
+  <package key="biblatex-shortfields" name="biblatex-shortfields" caption="Use short forms of fields with BibLaTeX" />
+  <package key="biblatex-socialscienceshuberlin" name="biblatex-socialscienceshuberlin" caption="BibLaTeX-style for the social sciences at HU Berlin" />
+  <package key="biblatex-software" name="biblatex-software" caption="BibLaTeX stylefiles for software products" />
+  <package key="biblatex-source-division" name="biblatex-source-division" caption="References by &#8220;division&#8221; in classical sources" />
+  <package key="biblatex-spbasic" name="biblatex-spbasic" caption="A BibLaTeX style emulating Springer&#8217;s old spbasic.bst" />
+  <package key="biblatex-subseries" name="biblatex-subseries" caption="Manages subseries with BibLaTeX" />
+  <package key="biblatex-swiss-legal" name="biblatex-swiss-legal" caption="Bibliography and citation styles following Swiss legal practice" />
+  <package key="biblatex-trad" name="biblatex-trad" caption="&#8220;Traditional&#8221; BibTeX styles with BibLaTeX" />
+  <package key="biblatex-true-citepages-omit" name="biblatex-true-citepages-omit" caption="Correction of some limitation of the citepages=omit option of BibLaTeX styles" />
+  <package key="biblatex-unified" name="biblatex-unified" caption=" BibLaTeX implementation of the unified stylesheet for linguistics journals" />
+  <package key="biblatex-vancouver" name="biblatex-vancouver" caption="Vancouver style for BibLaTeX" />
+  <package key="biblatex2bibitem" name="biblatex2bibitem" caption="Convert BibLaTeX-generated bibliography to bibitems" />
+  <package key="bible" name="BiBLE" caption="A BibTeX library editor" />
+  <package key="bibleref" name="bibleref" caption="Format bible citations" />
+  <package key="bibleref-french" name="bibleref-french" caption="French translations for bibleref" />
+  <package key="bibleref-german" name="bibleref-german" caption="German adaptation of bibleref" />
+  <package key="bibleref-lds" name="bibleref-lds" caption="Bible references, including those to the scriptures of the Church of Jesus Christ of Latter Day Saints" />
+  <package key="bibleref-mouth" name="bibleref-mouth" caption="Consistent formatting of Bible references" />
+  <package key="bibleref-parse" name="bibleref-parse" caption="Specify Bible passages in human-readable format" />
+  <package key="bibletext" name="bibletext" caption="Insert Bible passages by their reference" />
+  <package key="biblio" name="biblio" caption="A collection of bibliographies" />
+  <package key="biblio-perl" name="biblio-perl" caption="System for maintaining and presenting bibliographies" />
+  <package key="biblist" name="biblist" caption="Print a BibTeX database" />
+  <package key="biblook" name="biblook" caption="Fast searching of BibTeX files" />
+  <package key="biblos" name="biblos" caption="CGI interface to BibTeX files" />
+  <package key="bibmods" name="bibmods" caption="Tighter tolerances for bibliographies" />
+  <package key="bibplain" name="bibplain" caption="Simple macros for using BibTeX with Plain TeX" />
+  <package key="bibsort" name="bibsort" caption="Sort a BibTeX bibliography file" />
+  <package key="bibtex" name="bibtex" caption="Process bibliographies (bib files) for LaTeX or other formats" />
+  <package key="bibtex-examples" name="BibTeX-examples" caption="Examples of BibTeX usage" />
+  <package key="bibtex-gen" name="BibTeX Database Generator" caption="A simple interactive script to generate BibTeX Files" />
+  <package key="bibtex-help" name="BibTeX-help" caption="VMS help file for BibTeX" />
+  <package key="bibtex-test" name="bibtex-test" caption="BibTeX testing files" />
+  <package key="bibtex8" name="bibtex8" caption="A fully 8-bit adaptation of BibTeX 0.99" />
+  <package key="bibtexmng" name="BibTexMng" caption="Manipulate BibTeX database files" />
+  <package key="bibtexperllibs" name="bibtexperllibs" caption="BibTeX Perl Libraries" />
+  <package key="bibtexu" name="bibtexu" caption="An adaptation of BibTeX 0.99 that supports Unicode via ICU" />
+  <package key="bibtool" name="BibTool" caption="A tool for manipulating BibTeX files" />
+  <package key="bibtools" name="bibtools" caption="Bib management tools" />
+  <package key="bibtopic" name="bibtopic" caption="Include multiple bibliographies in a document" />
+  <package key="bibtopicprefix" name="bibtopicprefix" caption="Prefix references to bibliographies produced by bibtopic" />
+  <package key="bibunits" name="bibunits" caption="Multiple bibliographies in one document" />
+  <package key="bibutils" name="bibutils" caption="A collection of bibliography format convertors" />
+  <package key="bibview" name="bibview" caption="View BibTeX files" />
+  <package key="bibview-x" name="bibview-x" caption="A visual manager for BibTeX files" />
+  <package key="bibweb" name="bibweb" caption="Automatically retrieve bibliography from MathSciNet" />
+  <package key="bicaption" name="bicaption" caption="Support for bilingual captions" />
+  <package key="bickham" name="bickham" caption="Virtual fonts for Adobe Bickham Script Pro" />
+  <package key="bidi" name="bidi" caption="Bidirectional typesetting in plain TeX and LaTeX, using XeTeX" />
+  <package key="bidi-atbegshi" name="bidi-atbegshi" caption="Bidi-aware shipout macros" />
+  <package key="bidicontour" name="bidicontour" caption="Bidi-aware coloured contour around text" />
+  <package key="bidihl" name="bidihl" caption="Experimental bidi-aware text highlighting" />
+  <package key="bidipagegrid" name="bidipagegrid" caption="Bidi-aware page grid in background" />
+  <package key="bidipresentation" name="bidipresentation" caption="Experimental bidi presentation" />
+  <package key="bidishadowtext" name="bidishadowtext" caption="Bidi-aware shadow text" />
+  <package key="bidstobibtex" name="bidstobibtex" caption="Convert BIDS returns to BibTeX" />
+  <package key="bigdelim" name="bigdelim" caption="Big delimiters in tabular or array" />
+  <package key="bigfoot" name="bigfoot" caption="Footnotes for critical editions" />
+  <package key="bigintcalc" name="bigintcalc" caption="Integer calculations on very large numbers" />
+  <package key="bigints" name="bigints" caption="Writing big integrals" />
+  <package key="bigsign" name="bigsign" caption="Making &quot;big signs&quot; (mini-posters)" />
+  <package key="bigstrut" name="bigstrut" caption="Struts for opening up tabular spacing" />
+  <package key="bigtable" name="bigtable" caption="Multi-page tables in Plain TeX" />
+  <package key="bigtabular" name="bigtabular" caption="Tabulars that can split at page boundaries" />
+  <package key="biihead" name="biihead" caption="Underlined page headings" />
+  <package key="bilingualpages" name="bilingualpages" caption="Typeset two columns in parallel" />
+  <package key="binarytree" name="binarytree" caption="Drawing binary trees using TikZ" />
+  <package key="binhex" name="binhex" caption="Convert numbers into binary, octal and hexadecimal" />
+  <package key="binomexp" name="binomexp" caption="Calculate Pascal&apos;s triangle" />
+  <package key="biochemistry-colors" name="biochemistry-colors" caption="Colors used to display amino acids, nucleotides, sugars or atoms in biochemistry" />
+  <package key="biocon" name="biocon" caption="Typesetting biological species names" />
+  <package key="biokey" name="biokey" caption="Flexible identification key tables in LaTeX" />
+  <package key="biolett-bst" name="biolett-bst" caption="A BibTeX style for the journal &#8220;Biology Letters&#8221;" />
+  <package key="biolinum-type1" name="biolinum-type1" caption="(pdf)LaTeX support for the Biolinum family of fonts" />
+  <package key="biolist" name="biolist" caption="List observed species" />
+  <package key="birkhaeuser" name="Birkhaeuser" caption="Style for Birkhaeuser books, conference proceedings, etc" />
+  <package key="bit2spr" name="bit2spr" caption="Convert bitmaps to &quot;sprites&quot;" />
+  <package key="bitelist" name="bitelist" caption="Split list, in TeX&#8217;s mouth" />
+  <package key="bitfield" name="bitfield" caption="Draw bit field data structure diagrams (obsolete)" />
+  <package key="bithesis" name="bithesis" caption="Templates for the Beijing Institute of Technology" />
+  <package key="bitpattern" name="bitpattern" caption="Typeset bit pattern diagrams" />
+  <package key="bits" name="bits" caption="Sub-document environments in LaTeX" />
+  <package key="bitset" name="bitset" caption="Handle bit-vector datatype" />
+  <package key="bitstrea" name="bitstrea" caption="Support for use of Bitstream fonts" />
+  <package key="bitter" name="bitter" caption="The Bitter family of fonts with LaTeX support" />
+  <package key="bizcard" name="bizcard" caption="Typeset business cards" />
+  <package key="bjfuthesis" name="bjfuthesis" caption="A thesis class for Beijing Forestry University" />
+  <package key="blackboard" name="blackboard" caption="Comparison of blackboard bold fonts" />
+  <package key="blackletter" name="blackletter" caption="A blackletter font" />
+  <package key="blacklettert1" name="blacklettert1" caption="T1-encoded versions of Haralambous old German fonts" />
+  <package key="blanks" name="blanks" caption="Macros for &quot;fill in the blanks&quot; forms" />
+  <package key="blindtext" name="blindtext" caption="Producing &apos;blind&apos; text for testing" />
+  <package key="blkarray" name="blkarray" caption="Extended array and tabular" />
+  <package key="blkcntrl" name="blkcntrl" caption="Block-element hooks in LaTeX" />
+  <package key="blochsphere" name="blochsphere" caption="Draw pseudo-3D diagrams of Bloch spheres" />
+  <package key="block" name="block" caption="A block letter style for the letter class" />
+  <package key="blockdraw_mp" name="blockdraw_mp" caption="Block diagrams and bond graphs, with MetaPost" />
+  <package key="blopentype" name="BLOpenType" caption="A basic LuaTeX OpenType handler" />
+  <package key="bloques" name="bloques" caption="Generate control diagrams" />
+  <package key="blowup" name="blowup" caption="Upscale or downscale all pages of a document" />
+  <package key="blox" name="blox" caption="Draw block diagrams, using TikZ" />
+  <package key="blue" name="blue" caption="A document preparation system" />
+  <package key="bm" name="bm" caption="Access bold symbols in maths mode" />
+  <package key="bm2font" name="bm2font" caption="Convert bitmaps to PK fonts" />
+  <package key="bm2ltx" name="bm2ltx" caption="Convert a bitmap image to LaTeX code" />
+  <package key="bmeps" name="bmeps" caption="Converter from PNG/JPEG/Tgb81AIFF/NetPBM to EPS" />
+  <package key="bmpp" name="bmpp" caption="Convert bitmap files to PS/EPS/PDF" />
+  <package key="bmpsize" name="bmpsize" caption="Extract size and resolution data from bitmap files" />
+  <package key="bmstu" name="bmstu" caption="A LaTeX class for Bauman Moscow State Technical University" />
+  <package key="bmstu-iu8" name="bmstu-iu8" caption="A class for IU8 reports" />
+  <package key="bnf-plain" name="bnf-plain" caption="Plain TeX macros for BNF grammars" />
+  <package key="bnumexpr" name="bnumexpr" caption="Extends eTeX&#8217;s \numexpr...\relax construct to big integers" />
+  <package key="bodegraph" name="bodegraph" caption="Draw Bode, Nyquist and Black plots with gnuplot and TikZ" />
+  <package key="bodeplot" name="bodeplot" caption="Draw Bode, Nyquist and Nichols plots with gnuplot or pgfplots" />
+  <package key="bohr" name="bohr" caption="Simple atom representation according to the Bohr model" />
+  <package key="boisik" name="boisik" caption="A font inspired by Baskerville design" />
+  <package key="boites" name="boites" caption="Boxes that may break across pages" />
+  <package key="bold-extra" name="bold-extra" caption="Use bold small caps and typewriter fonts" />
+  <package key="boldline" name="boldline" caption="Heavier lines in tables" />
+  <package key="boldtensors" name="boldtensors" caption="Bold latin and greek characters through simple prefix characters" />
+  <package key="bondgraph" name="bondgraph" caption="Create bond graph figures in LaTeX documents" />
+  <package key="bondgraphs" name="bondgraphs" caption="Draws bond graphs in LaTeX, using PGF/TikZ" />
+  <package key="book" name="book" caption="A class for typesetting books" />
+  <package key="book-examples" name="book-examples" caption="A collection of examples from published TeX-related books" />
+  <package key="book-of-common-prayer" name="book-of-common-prayer" caption="Typeset in the style of &#8220;Book of Common Prayer&#8221;" />
+  <package key="bookcover" name="bookcover" caption="A class for book covers and dust jackets" />
+  <package key="bookdb" name="bookdb" caption="A BibTeX style file for cataloguing a home library" />
+  <package key="bookest" name="bookest" caption="Extended book class" />
+  <package key="bookform" name="bookform" caption="LaTeX 2.08 style for MIL STD 490 documents" />
+  <package key="bookhands" name="bookhands" caption="A collection of book-hand fonts" />
+  <package key="booklet" name="booklet" caption="Aids for  printing simple booklets" />
+  <package key="bookmark" name="bookmark" caption="A new bookmark (outline) organization for hyperref" />
+  <package key="bookshelf" name="bookshelf" caption="Create a nice image from a BibTeX file" />
+  <package key="booktabs" name="booktabs" caption="Publication quality tables in LaTeX" />
+  <package key="booktabs-de" name="booktabs-de" caption="German version of booktabs" />
+  <package key="booktabs-fr" name="booktabs-fr" caption="French translation of booktabs documentation" />
+  <package key="boolexpr" name="boolexpr" caption="A boolean expression evaluator and a switch command" />
+  <package key="boondox" name="boondox" caption="Mathematical alphabets derived from the STIX fonts" />
+  <package key="bophook" name="bophook" caption="Provides an At-Begin-Page hook" />
+  <package key="borceux" name="borceux" caption="Diagram macros by Fran&#231;ois Borceux" />
+  <package key="border" name="border" caption="Draw a black border around a Plain TeX page" />
+  <package key="bosisio" name="bosisio" caption="A collection of packages by Francesco Bosisio" />
+  <package key="boxedart4mac" name="boxedart4mac" caption="Import graphics into Macintosh TeX" />
+  <package key="boxedeps" name="boxedeps" caption="Incorporate EPS files into TeX documents" />
+  <package key="boxedminipage" name="boxedminipage" caption="Framed minipages of a specified total width (text and frame combined)" />
+  <package key="boxhandler" name="boxhandler" caption="Flexible Captioning and Deferred Box/List Printing" />
+  <package key="boxit" name="boxit" caption="Draw a box around a text" />
+  <package key="boxit-ltx" name="boxit-ltx" caption="An environment for boxing things" />
+  <package key="bpchem" name="bpchem" caption="Typeset chemical names, formulae, etc" />
+  <package key="bpolynomial" name="bpolynomial" caption="Drawing polynomial functions of up to order 3" />
+  <package key="br-lex" name="br-lex" caption="A Class for Typesetting Brazilian legal texts" />
+  <package key="bracketkey" name="bracketkey" caption="Produce bracketed identification keys" />
+  <package key="braids" name="braids" caption="Draw braid diagrams with PGF/TikZ" />
+  <package key="braille" name="braille" caption="Support for braille" />
+  <package key="braket" name="braket" caption="Dirac bra-ket and set notations" />
+  <package key="brandeis-dissertation" name="brandeis-dissertation" caption="Class for Brandeis University dissertations" />
+  <package key="brandeis-problemset" name="brandeis-problemset" caption="Document class for COSI Problem sets at Brandeis University (Waltham, MA)" />
+  <package key="brandeis-thesis" name="brandeis-thesis" caption="A class for Brandeis University M.A. theses" />
+  <package key="brclc" name="brclc" caption="Support 16-bit (double) calculations in LaTeX" />
+  <package key="breakcites" name="breakcites" caption="Ensure that multiple citations may break at line end" />
+  <package key="breakurl" name="breakurl" caption="Line-breakable \url-like links in hyperref when compiling via dvips/ps2pdf" />
+  <package key="bredzenie" name="bredzenie" caption="A Polish version of &#8220;lorem ipsum&#8230;&#8221; in the form of a LaTeX package" />
+  <package key="breqn" name="breqn" caption="Automatic line breaking of displayed equations" />
+  <package key="bridge" name="bridge" caption="Typesetting bridge diagrams" />
+  <package key="bridge-pln" name="bridge-pln" caption="Plain TeX macros for writing about bridge" />
+  <package key="brief-t" name="brief-t" caption="LaTeX support for the brief editor" />
+  <package key="bropd" name="bropd" caption="Simplified brackets and differentials in LaTeX" />
+  <package key="brushscr" name="brushscr" caption="A handwriting script font" />
+  <package key="bsf" name="bsf" caption="Access bold computer modern sans in LaTeX 2.09" />
+  <package key="bsheaders" name="bsheaders" caption="Double-ruled chapter heading style" />
+  <package key="bsl" name="bsl" caption="Access bold computer modern slanted in LaTeX 2.09" />
+  <package key="bsr2dvi" name="BSR2dvi" caption="Convert a TeXtures working file to DVI" />
+  <package key="btable" name="btable" caption="Bordered tables" />
+  <package key="btool" name="btOOL" caption="Perl library for parsing and processing BibTeX files" />
+  <package key="bubblesort" name="bubblesort" caption=" Bubble sorts a list" />
+  <package key="buctthesis" name="BUCTthesis" caption="Beijing University of Chemical Technology Thesis Template" />
+  <package key="bullcntr" name="bullcntr" caption="Display list item counter as regular pattern of bullets" />
+  <package key="bundledoc" name="bundledoc" caption="Bundle together all the files needed to build a LaTeX document" />
+  <package key="burmese" name="burmese" caption="Basic Support for Writing Burmese" />
+  <package key="buscard" name="buscard" caption="A document style for business cards" />
+  <package key="business-research" name="business-research" caption="Markup for the journal Business Research" />
+  <package key="businesscard-qrcode" name="businesscard-qrcode" caption="Business cards with QR-Code" />
+  <package key="bussproofs" name="bussproofs" caption="Proof trees in the style of the sequent calculus" />
+  <package key="bussproofs-extra" name="bussproofs-extra" caption="Extra commands for bussproofs.sty" />
+  <package key="bxbase" name="BXbase" caption="BX bundle base components" />
+  <package key="bxcalc" name="bxcalc" caption="Extend the functionality of the calc package" />
+  <package key="bxcjkjatype" name="bxcjkjatype" caption="Typeset Japanese with pdfLaTeX and CJK" />
+  <package key="bxdpx-beamer" name="bxdpx-beamer" caption="Dvipdfmx extras for use with beamer" />
+  <package key="bxdvidriver" name="bxdvidriver" caption="Enables specifying a driver option effective only in DVI output" />
+  <package key="bxeepic" name="bxeepic" caption="Eepic facilities using pict2e" />
+  <package key="bxenclose" name="bxenclose" caption="Enclose the document body with some pieces of code" />
+  <package key="bxghost" name="BXghost" caption="Ghost insertion for proper xkanjiskip" />
+  <package key="bxjaholiday" name="BXjaholiday" caption="Support for Japanese holidays" />
+  <package key="bxjalipsum" name="BXjalipsum" caption="Dummy text in Japanese" />
+  <package key="bxjaprnind" name="BXjaprnind" caption="Adjust the position of parentheses at paragraph head" />
+  <package key="bxjatoucs" name="bxjatoucs" caption="Convert Japanese character code to Unicode" />
+  <package key="bxjscls" name="BXjscls" caption="Japanese document class collection for all major engines" />
+  <package key="bxnewfont" name="bxnewfont" caption="Enhanced \newfont command" />
+  <package key="bxorigcapt" name="bxorigcapt" caption="To retain the original caption names when using Babel" />
+  <package key="bxpapersize" name="bxpapersize" caption="Synchronize output paper size with layout paper size" />
+  <package key="bxpdfver" name="bxpdfver" caption="Specify version and compression level of output PDF files" />
+  <package key="bxtexlogo" name="bxtexlogo" caption="Additional TeX-family logos" />
+  <package key="bxwareki" name="bxwareki" caption="Convert dates from Gregorian to Japanese calender" />
+  <package key="byo-twemojis" name="byo-twemojis" caption="&#8220;Build Your Own Twemojis&#8221; with TikZ" />
+  <package key="byrne" name="byrne" caption="This package provides a set of tools to typeset geometric proofs in the style of Oliver Byrne&apos;s 1847 ed. of Euclid&apos;s &quot;Elements&quot;" />
+  <package key="bytefield" name="bytefield" caption="Create illustrations for network protocol specifications" />
+  <package key="byzantinemusic" name="byzantinemusic" caption="Facilitates writing byzantinemusic" />
+  <package key="byzfonts" name="byzfonts" caption="Byzantine Music Font" />
+  <package key="c-pascal" name="c-pascal" caption="Typeset Python, C and Pascal programs" />
+  <package key="c2cweb" name="c2cweb" caption="C language prettyprinter" />
+  <package key="c2latex" name="c2latex" caption="Simple conversion of C programs to LaTeX" />
+  <package key="cabin" name="cabin" caption="A humanist Sans Serif font, with LaTeX support" />
+  <package key="cachepic" name="cachepic" caption="Convert document fragments into graphics" />
+  <package key="caesarcm" name="caesarcm" caption="Hyphenation of inflected languages, using CM fonts" />
+  <package key="cahierprof" name="cahierprof" caption="Schedule and grade books for French teachers" />
+  <package key="cahyph" name="cahyph" caption="Hyphenation patterns for the Catalan language" />
+  <package key="caladea" name="caladea" caption="Support for the Caladea family of fonts" />
+  <package key="calc" name="calc" caption="Simple arithmetic in LaTeX commands" />
+  <package key="calcage" name="calcage" caption="Calculate the age of something, in years" />
+  <package key="calctab" name="calctab" caption="Language for numeric tables" />
+  <package key="calculation" name="calculation" caption="Typesetting reasoned calculations,  also called calculational proofs" />
+  <package key="calculator" name="calculator" caption="Use LaTeX as a scientific calculator" />
+  <package key="calendar" name="calendar" caption="A package for calendars and timetables" />
+  <package key="calendar-barr" name="calendar-Barr" caption="A calendar document" />
+  <package key="calendarweek" name="calendarweek" caption="Calculate the week number of a date" />
+  <package key="calligra" name="calligra" caption="Calligraphic font" />
+  <package key="calligra-type1" name="calligra-type1" caption="Type 1 version of Calligra" />
+  <package key="callouts" name="callouts" caption="Put simple annotations and notes inside a picture" />
+  <package key="calorie" name="calorie" caption="Calorie checking for dieters" />
+  <package key="calrsfs" name="calrsfs" caption="Copperplate calligraphic letters in LaTeX" />
+  <package key="cals" name="cals" caption="Multipage tables with wide range of features" />
+  <package key="calxxxx" name="calxxxx" caption="Prints a card-size calendar for any year" />
+  <package key="calxxxx-yyyy" name="calxxxx-yyyy" caption="Print a calendar for a group of years" />
+  <package key="camel" name="camel" caption="Prototype work on future citation engine" />
+  <package key="cancel" name="cancel" caption="Place lines through maths formulae" />
+  <package key="canoniclayout" name="canoniclayout" caption="Create canonical page layouts with memoir" />
+  <package key="cantarell" name="cantarell" caption="LaTeX support for the Cantarell font family" />
+  <package key="capbas" name="capbas" caption="Capital baseball &quot;matrix printer&quot; font collection" />
+  <package key="capparmode" name="capparmode" caption="Dropped capitals for Plain TeX" />
+  <package key="capt-of" name="capt-of" caption="Captions on more than floats" />
+  <package key="captcont" name="captcont" caption="Retain float number across several floats" />
+  <package key="captdef" name="captdef" caption="Declare free-standing \caption commands" />
+  <package key="caption" name="caption" caption="Customising captions in floating environments" />
+  <package key="caption2" name="caption2" caption="Superseded version of the caption package" />
+  <package key="carbohydrates" name="carbohydrates" caption="Carbohydrate molecules with chemfig" />
+  <package key="card" name="card" caption="Print visiting cards" />
+  <package key="card-set" name="card-set" caption="Typeset text for cardfile cards" />
+  <package key="carlisle" name="carlisle" caption="David Carlisle&#8217;s small packages" />
+  <package key="carlito" name="carlito" caption="Support for Carlito sans-serif fonts" />
+  <package key="carolmin" name="carolmin" caption="Carolingan Miniscule manuscript book-hand font" />
+  <package key="carolmin-t1" name="carolmin-t1" caption="Adobe Type 1 format of Carolingian Minuscule fonts" />
+  <package key="cartonaugh" name="cartonaugh" caption="A LuaLaTeX package for drawing karnaugh maps with up to 6 variables" />
+  <package key="cascade" name="cascade" caption=" Constructions with braces to present mathematical demonstrations" />
+  <package key="cascadia-code" name="CascadiaCode" caption="The Cascadia Code font with support for LaTeX and pdfLaTeX" />
+  <package key="cascadilla" name="cascadilla" caption="Typeset papers conforming to the stylesheet of the Cascadilla Proceedings Project" />
+  <package key="cascover" name="cascover" caption="Make cassette covers" />
+  <package key="cases" name="cases" caption="Numbered cases environment" />
+  <package key="casiofont" name="casiofont" caption="Support for the Casio ClassWiz font" />
+  <package key="cassette" name="cassette" caption="Typeset cassette box inserts" />
+  <package key="cassette-shipunov" name="cassette-shipunov" caption="Print labels for audio cassettes" />
+  <package key="cassette209" name="cassette209" caption="A LaTeX 209 document style for cassette inserts" />
+  <package key="casslbl" name="casslbl" caption="Typeset cassette labels" />
+  <package key="casyl" name="casyl" caption="Typeset Cree/Inuktitut in Canadian Aboriginal Syllabics" />
+  <package key="catalan" name="catalan" caption="Catalan hyphenation patterns" />
+  <package key="catalanbib" name="catalanbib" caption="Bibliographic styles for use in Catalan" />
+  <package key="catalogue" name="Catalogue" caption="A catalogue of what&#8217;s available on CTAN" />
+  <package key="catchfile" name="catchfile" caption="Catch an external file into a macro" />
+  <package key="catchfilebetweentags" name="catchfilebetweentags" caption="Catch text delimited by docstrip tags" />
+  <package key="catcodes" name="catcodes" caption="Generic handling of TeX category codes" />
+  <package key="catdoc" name="catdoc" caption="Text extractor for word files" />
+  <package key="catdvi" name="catdvi" caption="A DVI to plain text translator" />
+  <package key="catechis" name="catechis" caption="Macros for typesetting catechisms" />
+  <package key="catoptions" name="catoptions" caption="Preserving and recalling standard catcodes" />
+  <package key="causets" name="causets" caption="Draw causal set (Hasse) diagrams" />
+  <package key="cbcoptic" name="cbcoptic" caption="Coptic fonts and LaTeX macros for general usage and for philology" />
+  <package key="cbe" name="cbe" caption="Bibliography style for Council of Biology Editors format" />
+  <package key="cbfonts-fd" name="cbfonts-fd" caption="LaTeX font description files for the CB Greek fonts" />
+  <package key="cbgreek-complete" name="cbgreek-complete" caption="Complete set of Greek fonts" />
+  <package key="cc-pl" name="cc-pl" caption="Polish extension of Computer Concrete fonts" />
+  <package key="ccaption" name="ccaption" caption="Continuation headings and legends for floats" />
+  <package key="ccfonts" name="ccfonts" caption="Support for Concrete text and math fonts in LaTeX" />
+  <package key="cchess" name="cchess" caption="Chinese chess" />
+  <package key="ccicons" name="ccicons" caption="LaTeX support for Creative Commons icons" />
+  <package key="cclicenses" name="CClicenses" caption="Typeset Creative Commons licence logos" />
+  <package key="ccool" name="ccool" caption="A key-value document command parser" />
+  <package key="cd" name="cd" caption="Typeset CD covers" />
+  <package key="cdcmd" name="cdcmd" caption="Expandable conditional commands for LaTeX" />
+  <package key="cdcover" name="cdcover" caption="Typeset CD covers" />
+  <package key="cdlabeler" name="cdlabeler" caption="Take user text and typeset it to fit a CD label" />
+  <package key="cdpbundl" name="C.D.P. Bundle" caption="Business letters in the Italian style" />
+  <package key="cea" name="cea" caption="Produce papers for Computers and Electronics in Agriculture" />
+  <package key="cell" name="cell" caption="Bibliography style for Cell" />
+  <package key="cellprops" name="cellprops" caption="Accept CSS-like selectors in tabular, array, &#8230;" />
+  <package key="cellspace" name="cellspace" caption="Ensure minimal spacing of table cells" />
+  <package key="cellular" name="cellular" caption="Cellular table construction" />
+  <package key="cellwise" name="cellwise" caption="Building tables one cell at a time" />
+  <package key="celtic" name="celtic" caption="A TikZ library for drawing celtic knots" />
+  <package key="censor" name="censor" caption="Tools for producing redacted documents" />
+  <package key="centeredline" name="centeredline" caption="A macro for centering lines" />
+  <package key="centerlastline" name="centerlastline" caption="Paragraphs with last line centered, known as &#8220;Spanish&#8221; paragraphs" />
+  <package key="centernot" name="centernot" caption="Centred \not command" />
+  <package key="cep" name="cep" caption="Compression tools for PostScript" />
+  <package key="cesenaexam" name="cesenaexam" caption="A class file to typeset exams" />
+  <package key="cfgguide" name="cfgguide" caption="Documentation of LaTeX configuration options" />
+  <package key="cfr-initials" name="cfr-initials" caption="LaTeX packages for use of initials" />
+  <package key="cfr-lm" name="cfr-lm" caption="Enhanced support for the Latin Modern fonts" />
+  <package key="changebar" name="changebar" caption="Generate changebars in LaTeX documents" />
+  <package key="changelayout" name="changelayout" caption="Change the layout of individual pages and their text" />
+  <package key="changelog" name="changelog" caption="Typesetting keepachangelog.com style changelogs" />
+  <package key="changepage" name="changepage" caption="Margin adjustment and detection of odd/even pages" />
+  <package key="changes" name="changes" caption="Manual change markup" />
+  <package key="chappg" name="chappg" caption="Page numbering by chapter" />
+  <package key="chapref" name="chapref" caption="Bibliography details per chapter" />
+  <package key="chapterbib" name="chapterbib" caption="Multiple bibliographies in a document" />
+  <package key="chapterfolder" name="chapterfolder" caption="Package for working with complicated folder structures" />
+  <package key="charissil" name="CharisSIL" caption="CharisSIL fonts with support for all LaTeX engines" />
+  <package key="charter" name="charter" caption="Charter fonts" />
+  <package key="chbar" name="chbar" caption="Change bar marks in Plain TeX" />
+  <package key="chbibref" name="chbibref" caption="Change the Bibliography/References title" />
+  <package key="cheatsheet" name="cheatsheet" caption="A simple cheatsheet class" />
+  <package key="check" name="check" caption="A syntax checker and tidier" />
+  <package key="check-parens" name="check-parens" caption="Check parentheses in LaTeX" />
+  <package key="checkcites" name="checkcites" caption="Check citation commands in a document" />
+  <package key="checkend" name="checkend" caption="Extend &#8220;improperly closed environment&#8221; messages" />
+  <package key="checklab" name="checklab" caption="A patch for the label-checking code" />
+  <package key="checklistings" name="checklistings" caption="
+    Pass verbatim contents through a compiler
+    and reincorporate the resulting output 
+  " />
+  <package key="chem-journal" name="chem-journal" caption="Various BibTeX formats for journals in Chemistry" />
+  <package key="chemarr" name="chemarr" caption="Arrows for chemists" />
+  <package key="chemarrow" name="chemarrow" caption="Arrows for use in chemistry" />
+  <package key="chembst" name="chembst" caption="A collection of BibTeX files for chemistry journals" />
+  <package key="chemcompounds" name="chemcompounds" caption="Simple consecutive numbering of chemical compounds" />
+  <package key="chemcono" name="chemcono" caption="Support for compound numbers in chemistry documents" />
+  <package key="chemexec" name="chemexec" caption="Creating (chemical) exercise sheets" />
+  <package key="chemfig" name="chemfig" caption="Draw molecules with easy syntax" />
+  <package key="chemformula" name="chemformula" caption="Command for typesetting chemical formulas and reactions" />
+  <package key="chemgreek" name="chemgreek" caption="Upright Greek letters in chemistry" />
+  <package key="chemmacros" name="chemmacros" caption="A collection of macros to support typesetting chemistry documents" />
+  <package key="chemnum" name="chemnum" caption="A method for numbering chemical compounds" />
+  <package key="chemobabel" name="chemobabel" caption="Convert chemical structures from ChemDraw, MDL molfile or SMILES using Open Babel" />
+  <package key="chemplants" name="chemplants" caption="Symbology to draw chemical plants with TikZ" />
+  <package key="chemscheme" name="chemscheme" caption="Support for chemical schemes" />
+  <package key="chemschemex" name="chemschemex" caption="Typeset and cross-reference chemical schemes based on TikZ code" />
+  <package key="chemsec" name="chemsec" caption="Automated creation of numeric entity labels" />
+  <package key="chemstruct" name="chemstruct" caption="Structural organic chemistry" />
+  <package key="chemstyle" name="chemstyle" caption="Writing chemistry with style" />
+  <package key="chemsym" name="chemsym" caption="Macros for typing chemical symbols" />
+  <package key="chemtex" name="chemtex" caption="Structural chemistry" />
+  <package key="cheq" name="cheq" caption="Adobe chess font" />
+  <package key="cherokee" name="cherokee" caption="A font for the Cherokee script" />
+  <package key="chess" name="chess" caption="Fonts for typesetting chess boards" />
+  <package key="chess-problem-diagrams" name="chess-problem-diagrams" caption="A package for typesetting chess problem diagrams" />
+  <package key="chessboard" name="chessboard" caption="Print chess boards" />
+  <package key="chessfss" name="chessfss" caption="A package to handle chess fonts" />
+  <package key="chessmin" name="chessmin" caption="Minimal chess diagrams" />
+  <package key="chet" name="chet" caption="LaTeX layout inspired by harvmac" />
+  <package key="chextras" name="chextras" caption="A companion package for the Swiss typesetter" />
+  <package key="chgbar" name="chgbar" caption="Draw change bars in the margin" />
+  <package key="chhaya" name="chhaya" caption="Linguistic glossing in Marathi language" />
+  <package key="chicago" name="chicago" caption="A &quot;Chicago&quot; bibliography style" />
+  <package key="chicago-annote" name="chicago-annote" caption="Chicago-based annotated BibTeX style" />
+  <package key="chicagoa" name="chicagoa" caption="&quot;Chicago&quot; bibliography style with annotations" />
+  <package key="chickenize" name="chickenize" caption="Use lua callbacks for &#8220;interesting&#8221; textual effects" />
+  <package key="chifoot" name="chifoot" caption="Chicago-style footnote formatting" />
+  <package key="childdoc" name="childdoc" caption="Directly compile \include&#8217;d child documents" />
+  <package key="china2e" name="china2e" caption="Font and macros for Chinese calendar" />
+  <package key="chinese-jfm" name="ChineseJFM" caption="Luatexja-jfm files for Chinese typesetting" />
+  <package key="chinesechess" name="chinesechess" caption="Typeset Chinese chess with l3draw" />
+  <package key="chitex" name="chitex" caption="A Chinese TeX system" />
+  <package key="chivo" name="Chivo" caption="Using the free Chivo fonts with LaTeX" />
+  <package key="chkfloat" name="chkfloat" caption="Warn whenever a float is placed &#8220;to far away&#8221;" />
+  <package key="chklref" name="chklref" caption="Check for problems with labels in LaTeX" />
+  <package key="chktex" name="chktex" caption="Check for errors in LaTeX documents" />
+  <package key="chletter" name="chletter" caption="Class for typesetting letters to Swiss rules" />
+  <package key="chngcntr" name="chngcntr" caption="Change the resetting of counters" />
+  <package key="chngpage" name="chngpage" caption="Change the page layout in the middle of a document" />
+  <package key="chomsky" name="chomsky" caption="Macros to typeset parsing trees" />
+  <package key="chordbars" name="chordbars" caption="Print chord grids for pop/jazz tunes" />
+  <package key="chordbox" name="chordbox" caption="Draw chord diagrams" />
+  <package key="chroma" name="chroma" caption="Chroma: a reference book of LaTeX colours" />
+  <package key="chronology" name="chronology" caption="Provides a horizontal timeline" />
+  <package key="chronosys" name="chronosys" caption="Drawing time-line diagrams" />
+  <package key="chs-physics-report" name="chs-physics-report" caption="Physics lab reports for Carmel High School" />
+  <package key="chscite" name="chscite" caption="Bibliography style for Chalmers University of Technology" />
+  <package key="churchslavonic" name="churchslavonic" caption="Typeset documents in Church Slavonic language using Unicode" />
+  <package key="cinzel" name="cinzel" caption="LaTeX support for Cinzel and Cinzel Decorative fonts" />
+  <package key="circ" name="circ" caption="Macros for typesetting circuit diagrams" />
+  <package key="circle" name="circle" caption="Maths mode circles for temporal logic" />
+  <package key="circledsteps" name="circledsteps" caption="Typeset circled numbers" />
+  <package key="circledtext" name="circledtext" caption="Create circled text" />
+  <package key="circuit-macros" name="circuit-macros" caption="M4 macros for electric circuit diagrams" />
+  <package key="circuitikz" name="CircuiTikZ" caption="Draw electrical networks with TikZ" />
+  <package key="cirth" name="cirth" caption="Fonts for Cirth" />
+  <package key="citation-style-language" name="citation-style-language" caption="Bibliography formatting with Citation Style Language" />
+  <package key="cite" name="cite" caption="Improved citation handling in LaTeX" />
+  <package key="cite-bundle" name="cite-bundle" caption="Citation management bundle" />
+  <package key="citeall" name="citeall" caption="Cite all entries of a bbl created with BibLaTeX" />
+  <package key="citeref" name="citeref" caption=" Add reference-page-list to bibliography-items" />
+  <package key="citesidx" name="citesidx" caption="Produce a citation list for the bibliography" />
+  <package key="cj" name="CJ" caption="BibTeX style for Computer Journal" />
+  <package key="cje" name="cje" caption="LaTeX document class for CJE articles" />
+  <package key="cjhebrew" name="CJHebrew" caption="Typeset Hebrew with LaTeX" />
+  <package key="cjk" name="cjk" caption="CJK language support" />
+  <package key="cjk-fonts" name="cjk-fonts" caption="Chinese/Japanese/Korean bitmap fonts" />
+  <package key="cjk-gs-integrate" name="cjk-gs-integrate" caption="Tools to integrate CJK fonts into Ghostscript" />
+  <package key="cjk-ko" name="cjk-ko" caption="Extension of the CJK package for Korean typesetting" />
+  <package key="cjkpunct" name="cjkpunct" caption="Adjust locations and kerning of CJK punctuation marks" />
+  <package key="cjw" name="cjw" caption="A bundle of packages and classes" />
+  <package key="clara" name="clara" caption=" A serif font family" />
+  <package key="classes" name="classes" caption="The source of LaTeX&#8217;s standard classes" />
+  <package key="classico" name="classico" caption="URW Classico fonts" />
+  <package key="classics" name="classics" caption="Cite classic works" />
+  <package key="classicthesis" name="ClassicThesis" caption="A &#8220;classically styled&#8221; thesis package" />
+  <package key="classif2" name="classif2" caption="Biological classification tables" />
+  <package key="classlist" name="classlist" caption="Record classes used in a document" />
+  <package key="classpack" name="classpack" caption="XML mastering for LaTeX classes and packages" />
+  <package key="cleanthesis" name="cleanthesis" caption="A clean LaTeX style for thesis documents" />
+  <package key="clearsans" name="clearsans" caption="Clear Sans fonts with LaTeX support" />
+  <package key="clefval" name="clefval" caption="Key/value support with a hash" />
+  <package key="cleveref" name="cleveref" caption="Intelligent cross-referencing" />
+  <package key="cleveref-usedon" name="cleveref-usedon" caption="Adds forward-referencing functionality to the cleveref package" />
+  <package key="clicks" name="clicks" caption="Slide Deck Animation" />
+  <package key="clip" name="clip" caption="A language-independent literate programming tool" />
+  <package key="clipboard" name="clipboard" caption="Copy and paste into and across documents" />
+  <package key="clistmap" name="clistmap" caption="Map and iterate over LaTeX3 clists" />
+  <package key="clock" name="clock" caption="Graphical and textual clocks for TeX and LaTeX" />
+  <package key="clojure-pamphlet" name="clojure-pamphlet" caption="A simple literate programming tool based on clojure&apos;s pamphlet system" />
+  <package key="closefrm" name="closefrm" caption="Tidy up after reading a MetaPost file" />
+  <package key="cloze" name="cloze" caption="A LuaLaTeX package for creating cloze texts" />
+  <package key="clrdblpg" name="clrdblpg" caption="Control pagestyle of pages left blank by \cleardoublepage" />
+  <package key="clrscode" name="clrscode" caption="Typesets pseudocode as in Introduction to Algorithms" />
+  <package key="clrscode3e" name="clrscode3e" caption="Typesets pseudocode as in Introduction to Algorithms" />
+  <package key="clrstrip" name="clrstrip" caption="Place contents into a full width colour strip" />
+  <package key="clsguide" name="clsguide" caption="Documentation of LaTeX class and package writing" />
+  <package key="cluttex" name="cluttex" caption="An automation tool for running LaTeX" />
+  <package key="cm" name="cm" caption="Computer Modern fonts" />
+  <package key="cm-afm" name="cm-afm" caption="Adobe Font Metrics for the CM fonts" />
+  <package key="cm-gf" name="cm-gf" caption="Generate GF format for CM" />
+  <package key="cm-lgc" name="cm-lgc" caption="Type 1 CM-based fonts for Latin, Greek and Cyrillic" />
+  <package key="cm-mf" name="cm-mf" caption="Sources of the Computer Modern fonts" />
+  <package key="cm-mf-extra-bold" name="cm-mf-extra-bold" caption="Extra Metafont files for CM" />
+  <package key="cm-mf-opt-kern" name="cm-mf-opt-kern" caption="Improve the kerning of CM fonts" />
+  <package key="cm-pk" name="cm-pk" caption="PK bitmaps of the Computer Modern fonts" />
+  <package key="cm-super" name="cm-super" caption="CM-Super family of fonts" />
+  <package key="cm-tfm" name="cm-tfm" caption="Metric files for the Computer Modern fonts" />
+  <package key="cm-unicode" name="cm-unicode" caption="Computer Modern Unicode font family" />
+  <package key="cmactex" name="cmactex" caption="TeX for the Macintosh" />
+  <package key="cmap" name="cmap" caption="Make PDF files searchable and copyable" />
+  <package key="cmarrows" name="cmarrows" caption="MetaPost arrows and braces in the Computer Modern style" />
+  <package key="cmastro" name="cmastro" caption="Font for planetary symbols" />
+  <package key="cmathbb" name="cmathbb" caption="Computer modern mathematical blackboard bold font" />
+  <package key="cmbright" name="cmbright" caption="Computer Modern Bright fonts" />
+  <package key="cmcyr" name="cmcyr" caption="Computer Modern fonts with cyrillic extensions" />
+  <package key="cmcyr-patch" name="cmcyr-patch" caption="A set of Type 1 Cyrillic fonts" />
+  <package key="cmcyralt-fonts" name="cmcyralt-fonts" caption="Russian fonts in &quot;alternative&quot; encoding" />
+  <package key="cmcyralt-ltx" name="cmcyralt-ltx" caption="LaTeX support for the cmcyralt fonts" />
+  <package key="cmdstring" name="cmdstring" caption="Get command name reliably" />
+  <package key="cmdtrack" name="cmdtrack" caption="Check used commands" />
+  <package key="cmextra-latex" name="cmextra-latex" caption="Install macros for &#8220;standard&#8221; fonts not used by LaTeX itself" />
+  <package key="cmfrak" name="cmfrak" caption="Reencoded versions of Haralambous fraktur fonts" />
+  <package key="cmll" name="cmll" caption="Symbols for linear logic" />
+  <package key="cmoefont" name="cmoefont" caption="Old English glyphs to go with Computer Modern" />
+  <package key="cmolddig" name="cmolddig" caption="Virtual fount setup for using old style digits" />
+  <package key="cmoutlines" name="cmoutlines" caption="Outline versions of the Computer Modern fonts" />
+  <package key="cmpica" name="cmpica" caption="A Computer Modern Pica variant" />
+  <package key="cmpj" name="cmpj" caption="Style for the journal Condensed Matter Physics" />
+  <package key="cms4talks" name="cms4talks" caption="Content Management System for Talks" />
+  <package key="cmsd" name="cmsd" caption="Interfaces to the CM Sans Serif Bold fonts" />
+  <package key="cmslup" name="cmslup" caption="Upright punctuation with CM slanted" />
+  <package key="cmsrb" name="cmsrb" caption="Computer Modern for Serbian and Macedonian" />
+  <package key="cmtest" name="cmtest" caption="CM fonts test sources" />
+  <package key="cmtiup" name="cmtiup" caption="Upright punctuation with CM italic" />
+  <package key="cmtt" name="cmtt" caption="A package for handling the cmtt font better" />
+  <package key="cmtype3" name="CM Type3" caption="Type 3 outline versions of the CM fonts" />
+  <package key="cmupint" name="cmupint" caption="Upright integral symbols for Computer Modern" />
+  <package key="cmyk-hax" name="cmyk-hax" caption="A TeX macro package for colour manipulation (using PostScript)" />
+  <package key="cnbwp" name="cnbwp" caption="Typeset working papers of the Czech National Bank" />
+  <package key="cnltx" name="cnltx" caption="LaTeX tools and documenting facilities" />
+  <package key="cnoweb" name="cnoweb" caption="Simple &quot;quality&quot; printing of C sources" />
+  <package key="cntdwn" name="cntdwn" caption="Support for countdowns, and for clocks in any timezone" />
+  <package key="cntformats" name="cntformats" caption="A different way to read counters" />
+  <package key="cntperchap" name="cntperchap" caption="Store counter values per chapter" />
+  <package key="cochineal" name="cochineal" caption="Cochineal fonts with LaTeX support" />
+  <package key="code" name="code" caption="Typeset &quot;code&quot; in verbatim" />
+  <package key="code128" name="code128" caption="Barcode macros for the Code 128 standard" />
+  <package key="codeanatomy" name="codeanatomy" caption="Typeset code with annotations" />
+  <package key="codebox" name="codebox" caption="Highlighted source code in a fancy box" />
+  <package key="codedescribe" name="codedescribe" caption="A minimalist set of commands (expl3 based) to describe
+    Document and Class level commands/functions" />
+  <package key="codedoc" name="codedoc" caption="LaTeX code and documentation in LaTeX-format file" />
+  <package key="codehigh" name="codehigh" caption="Highlight code and demos with l3regex and lpeg" />
+  <package key="codepage" name="codepage" caption="Support for variant code pages" />
+  <package key="codesection" name="codesection" caption="Provides an environment that may be conditionally included" />
+  <package key="codicefiscaleitaliano" name="codicefiscaleitaliano" caption="Test the consistency of the Italian personal Fiscal Code" />
+  <package key="coelacanth" name="coelacanth" caption="Coelacanth fonts with LaTeX support" />
+  <package key="coffeestains" name="coffeestains" caption="Add coffee stains to documents" />
+  <package key="collcell" name="collcell" caption="Collect contents of a tabular cell as argument to a macro" />
+  <package key="collect" name="collect" caption="Collect text for later re-use" />
+  <package key="collectbox" name="collectbox" caption="Collect and process macro arguments as boxes" />
+  <package key="collref" name="collref" caption="Collect blocks of references into a single reference" />
+  <package key="colonequals" name="colonequals" caption="Colon equals symbols" />
+  <package key="colophon" name="colophon" caption="Provides commands for producing a colophon" />
+  <package key="color" name="color" caption="Colour control for LaTeX documents" />
+  <package key="color-edits" name="color-edits" caption="Colorful edits for multiple authors of a shared document" />
+  <package key="colordoc" name="colordoc" caption="Coloured syntax highlights in documentation" />
+  <package key="colordvi" name="colordvi" caption="Simple colour use in Plain TeX" />
+  <package key="coloremoji" name="coloremoji" caption=" Style package for directly including color emojis in LaTeX documents" />
+  <package key="colorframed" name="colorframed" caption="Fix color problems with the package &#8220;framed&#8221;" />
+  <package key="colorinfo" name="colorinfo" caption="Retrieve colour model and values for defined colours" />
+  <package key="coloring" name="coloring" caption="Define missing colors by their names" />
+  <package key="colorist" name="colorist" caption="Write your articles or books in a colorful way" />
+  <package key="colorprofiles" name="colorprofiles" caption="Collection of free ICC profiles" />
+  <package key="colors" name="colors" caption="Simple colour-selection commands" />
+  <package key="colorsep" name="colorsep" caption="Color separation" />
+  <package key="colorspace" name="colorspace" caption="Provides PDF color spaces" />
+  <package key="colortab" name="colortab" caption="Shade cells of tables and halign" />
+  <package key="colortbl" name="colortbl" caption="Add colour to LaTeX tables" />
+  <package key="colortex" name="colortex" caption="Colour facilities for use with TeX" />
+  <package key="colorwav" name="colorwav" caption="Colours by wavelength of visible light" />
+  <package key="colorweb" name="colorweb" caption="Extend the color package colour space" />
+  <package key="colourchange" name="colourchange" caption="Colourchange" />
+  <package key="combelow" name="combelow" caption="Typeset &quot;comma-below&quot; letters, as in Romanian" />
+  <package key="combine" name="combine" caption="Bundle individual documents into a single document" />
+  <package key="combinedgraphics" name="combinedgraphics" caption="Include graphic (EPS or PDF)/LaTeX combinations" />
+  <package key="combofont" name="combofont" caption="Add NFSS-declarations of combo fonts to LuaLaTeX documents" />
+  <package key="comfortaa" name="comfortaa" caption="Sans serif font, with LaTeX support" />
+  <package key="comicneue" name="comicneue" caption="Use Comic Neue with TeX(-alike) systems" />
+  <package key="comicsans" name="comicsans" caption="Use Microsoft Comic Sans font" />
+  <package key="comma" name="comma" caption="Formats a number by inserting commas" />
+  <package key="commado" name="commado" caption="Expandable iteration on comma-separated and filename lists" />
+  <package key="commath" name="commath" caption="Mathematics typesetting support" />
+  <package key="commedit" name="commedit" caption="Commented editions with LaTeX" />
+  <package key="comment" name="comment" caption="Selectively include/exclude portions of text" />
+  <package key="comment-pln" name="comment-pln" caption="Comment macros for use in Plain TeX" />
+  <package key="comment_io" name="comment_io" caption="A Python script to comment and uncomment lines" />
+  <package key="committee-font" name="committee-font" caption="A font designed by a committee" />
+  <package key="commonunicode" name="commonunicode" caption="Convert common unicode symbols to LaTeX code" />
+  <package key="commutative-diagrams" name="commutative-diagrams" caption="CoDi: Commutative Diagrams for TeX" />
+  <package key="comp-fonts-faq" name="comp-fonts-FAQ" caption="Frequently Asked Questions from comp.fonts" />
+  <package key="compact-symbols" name="compact-symbols" caption="Compact lists of symbols" />
+  <package key="compactbib" name="compactbib" caption="Multiple thebibliography environments" />
+  <package key="compare" name="compare" caption="Compare two strings" />
+  <package key="competences" name="competences" caption="Track skills of classroom checks" />
+  <package key="complexity" name="complexity" caption="Computational complexity class names" />
+  <package key="components" name="components" caption="Components of TeX" />
+  <package key="comprehensive" name="The Comprehensive LaTeX Symbol List" caption="Symbols accessible from LaTeX" />
+  <package key="compsci" name="compsci" caption="Document (LaTeX) programming with LaTeX" />
+  <package key="computational-complexity" name="computational-complexity" caption="Class for the journal Computational Complexity" />
+  <package key="computer-typesetting-using-latex" name="computer-typesetting-using-latex" caption="Content of the book Computer Typesetting Using LaTeX" />
+  <package key="concepts" name="concepts" caption="Keeping track of formal &#8216;concepts&#8217; for a particular field" />
+  <package key="concmath" name="concmath" caption="Concrete Math fonts" />
+  <package key="concmath-fonts" name="concmath-fonts" caption="Concrete mathematics fonts" />
+  <package key="concmath-otf" name="concmath-otf" caption="Concrete based OpenType Math font" />
+  <package key="concprog" name="concprog" caption="Concert programmes" />
+  <package key="concrete" name="concrete" caption="Concrete Roman fonts" />
+  <package key="concrete-macros" name="concrete-macros" caption="Consistent text and maths using concrete fonts" />
+  <package key="conditext" name="CondiTeXt" caption="Define and manage conditional content" />
+  <package key="confproc" name="confproc" caption="A set of tools for generating conference proceedings" />
+  <package key="consdiag" name="consdiag" caption="A utility for OO programming documentation" />
+  <package key="constants" name="constants" caption="Automatic numbering of constants" />
+  <package key="conteq" name="conteq" caption="Typeset multiline continued equalities" />
+  <package key="context" name="context" caption="The ConTeXt macro package" />
+  <package key="context-account" name="context-account" caption="A simple accounting package" />
+  <package key="context-algorithmic" name="context-algorithmic" caption="Algorithm handling in ConTeXt" />
+  <package key="context-animation" name="context-animation" caption="Generate fieldstack based animation with ConTeXt" />
+  <package key="context-annotation" name="context-annotation" caption="Annotate text blocks" />
+  <package key="context-bnf" name="context-bnf" caption="A BNF module for ConTeXt" />
+  <package key="context-calendar-examples" name="context-calendar-examples" caption="Collection of calendars based on the PocketDiary-module" />
+  <package key="context-chromato" name="context-chromato" caption="ConTeXt macros for chromatograms" />
+  <package key="context-cmscbf" name="context-cmscbf" caption="Use Computer Modern bold Caps and Small-caps in ConTeXt" />
+  <package key="context-cmttbf" name="ConTeXt-cmttbf" caption="Use Computer Modern Typewriter bold font in ConTeXt" />
+  <package key="context-collatingmarks" name="context-collatingmarks" caption="Environment to place collating marks on the spine of a section" />
+  <package key="context-construction-plan" name="context-construction-plan" caption="Construction plans in ConTeXt" />
+  <package key="context-cyrillicnumbers" name="context-cyrillicnumbers" caption="Write numbers as cyrillic glyphs" />
+  <package key="context-degrade" name="context-degrade" caption="Degrading JPEG images in ConTeXt" />
+  <package key="context-fancybreak" name="context-fancybreak" caption="Overfull pages with ConTeXt" />
+  <package key="context-filter" name="context-filter" caption="Run external programs on the contents of a start-stop environment" />
+  <package key="context-fixme" name="context-fixme" caption="Make editorial marks on a document" />
+  <package key="context-french" name="context-french" caption="Support for writing French in ConTeXt" />
+  <package key="context-fullpage" name="context-fullpage" caption="Overfull pages with ConTeXt" />
+  <package key="context-gantt" name="context-gantt" caption="GANTT module for ConTeXt" />
+  <package key="context-gnuplot" name="ConTeXt-gnuplot" caption="Inclusion of Gnuplot graphs in ConTeXt" />
+  <package key="context-handlecsv" name="context-handlecsv" caption="Data merging for automatic document creation" />
+  <package key="context-inifile" name="context-inifile" caption="An ini-file pretty-printer, using ConTeXt" />
+  <package key="context-interval-calendar" name="context-interval-calendar" caption="Date driven lists or lists driven by date-intervals" />
+  <package key="context-layout" name="context-layout" caption="Show ConTeXt layouts" />
+  <package key="context-letter" name="context-letter" caption="ConTeXt package for writing letters" />
+  <package key="context-lettrine" name="context-lettrine" caption="A ConTeXt implementation of lettrines" />
+  <package key="context-lilypond" name="context-lilypond" caption="Lilypond code in ConTeXt" />
+  <package key="context-mathsets" name="context-mathsets" caption="Set notation in ConTeXt" />
+  <package key="context-notes-zh-cn" name="context-notes-zh-cn" caption="Notes on using ConTeXt MkIV" />
+  <package key="context-pocketdiary" name="context-pocketdiary" caption="A personal organiser" />
+  <package key="context-rst" name="context-rst" caption="Process reStructuredText with ConTeXt" />
+  <package key="context-ruby" name="context-ruby" caption="Ruby annotations in ConTeXt" />
+  <package key="context-sgf" name="context-sgf" caption="A Go system in ConTeXt" />
+  <package key="context-simplefonts" name="context-simplefonts" caption="Simplified font usage for ConTeXt" />
+  <package key="context-simpleslides" name="context-simpleslides" caption="A module for preparing presentations" />
+  <package key="context-sudoku" name="context-sudoku" caption="Sudokus for ConTeXt" />
+  <package key="context-taspresent" name="context-taspresent" caption="Simple presentations using ConTeXt" />
+  <package key="context-title" name="context-title" caption="Place document titles" />
+  <package key="context-top-ten" name="context-top-ten" caption="The &quot;top ten&quot; ConTeXt commands" />
+  <package key="context-transliterator" name="context-transliterator" caption="Transliterate text from &#8216;other&#8217; alphabets" />
+  <package key="context-typearea" name="context-typearea" caption="Something like Koma-Script typearea" />
+  <package key="context-typescripts" name="context-typescripts" caption="Small modules to load various fonts for use in ConTeXt" />
+  <package key="context-urwgaramond" name="context-URWGaramond" caption="ConTeXt support for URW Garamond font" />
+  <package key="context-urwgothic" name="context-URWGothic" caption="ConTeXt support for URW Gothic" />
+  <package key="context-vim" name="context-vim" caption="Generate ConTeXt syntax highlighting code from vim" />
+  <package key="context-visualcounter" name="context-visualcounter" caption="Visual display of ConTeXt counters" />
+  <package key="continue" name="continue" caption="Prints &#8216;continuation&#8217; marks on pages of multipage documents" />
+  <package key="contour" name="contour" caption="Print a coloured contour around text" />
+  <package key="contracard" name="contracard" caption="Generate calling cards for dances" />
+  <package key="conv-xkv" name="conv-xkv" caption="Create new key-value syntax" />
+  <package key="convbkmk" name="convbkmk" caption="Correct platex/uplatex bookmarks in PDF created with hyperref" />
+  <package key="convert" name="convert" caption="Generate Knuthian encoding for text files" />
+  <package key="cooking" name="cooking" caption="Typeset recipes" />
+  <package key="cooking-units" name="cooking-units" caption="Typeset and convert units for cookery books and recipes" />
+  <package key="cookingsymbols" name="cookingsymbols" caption="Symbols for recipes" />
+  <package key="cookybooky" name="cookybooky" caption="A LaTeX based package to easily typeset some professional looking cooking recipes" />
+  <package key="cool" name="cool" caption="COntent-Oriented LaTeX" />
+  <package key="coolfn" name="coolfn" caption="Typeset long legal footnotes" />
+  <package key="coollist" name="coollist" caption="Manipulate COntent Oriented LaTeX Lists" />
+  <package key="coolstr" name="coolstr" caption="String manipulation in LaTeX" />
+  <package key="coolthms" name="coolthms" caption="Reference items in a theorem environment" />
+  <package key="cooltooltips" name="cooltooltips" caption="Associate a pop-up window and tooltip with PDF hyperlinks" />
+  <package key="coop-writing" name="coop-writing" caption="Support for Cooperative Writing and editorial comments" />
+  <package key="cooperhewitt" name="cooperhewitt" caption=" LaTeX, pdfLaTeX, XeLaTeX and LuaLaTeX support for the Cooper Hewitt family of sans serif fonts" />
+  <package key="coordsys" name="coordsys" caption="Draw cartesian coordinate systems" />
+  <package key="copac-clean" name="copac-clean" caption="Automatic editing of Copac/BibTeX records" />
+  <package key="coptic" name="coptic" caption="Coptic Fonts" />
+  <package key="copyedit" name="copyedit" caption="Copyediting support for LaTeX documents" />
+  <package key="copypaste" name="copypaste" caption="Copy and paste into and across documents" />
+  <package key="copyrightbox" name="copyrightbox" caption="Provide copyright notices for images in a document" />
+  <package key="corelfonts" name="corelfonts" caption="An installation script for Corel Ventura fonts" />
+  <package key="corelpak" name="corelpak" caption="Metrics, etc., for fonts distributed with Corel products" />
+  <package key="corelpak-contrib" name="corelpak-contrib" caption="Manage Corel-distributed fonts" />
+  <package key="cormorantgaramond" name="CormorantGaramond" caption="Cormorant Garamond family of fonts" />
+  <package key="correctmathalign" name="correctmathalign" caption="Correct spacing of the alignment in expressions" />
+  <package key="corrects" name="corrects" caption="Macros for marking correction sheets" />
+  <package key="corridx-latex" name="corridx-latex" caption="Correct index entries for chemical compounds" />
+  <package key="corridx-obsolete" name="corridx-obsolete" caption="Add index entries to LaTeX document" />
+  <package key="coseoul" name="coseoul" caption="Context sensitive outline elements" />
+  <package key="couleurs-fr" name="couleurs-fr" caption="French version of colour definitions from xcolor" />
+  <package key="count1to" name="count1to" caption="Make use of count1 to count9" />
+  <package key="counterz" name="counterz" caption="Additional tools for counters" />
+  <package key="countriesofeurope" name="countriesofeurope" caption="A font with the images of the countries of Europe" />
+  <package key="counttexruns" name="counttexruns" caption="Count compilations of a document" />
+  <package key="courier" name="Courier" caption="Adobe Type 1 &#8220;free&#8221; copies of Courier" />
+  <package key="courier-scaled" name="courier scaled" caption="Provides a scaled Courier font" />
+  <package key="courierten" name="courierten" caption="Courier 10 Pitch BT with LaTeX support" />
+  <package key="courseoutline" name="courseoutline" caption="Prepare university course outlines" />
+  <package key="coursepaper" name="coursepaper" caption="Prepare university course papers" />
+  <package key="coverpage" name="coverpage" caption="Automatic cover page creation for scientific papers" />
+  <package key="covfonts" name="covfonts" caption="Make Apostrophic Laboratories&apos;s Covington fonts available to TeX and LaTeX" />
+  <package key="covington" name="covington" caption="LaTeX macros for Linguistics" />
+  <package key="cprog" name="cprog" caption="Typeset C programs" />
+  <package key="cprotect" name="cprotect" caption="Allow verbatim, etc., in macro arguments" />
+  <package key="cprotectinside" name="cprotectinside" caption="Use cprotect arbitrarily nested" />
+  <package key="cpssp" name="cpssp" caption="Draw protein secondary structures" />
+  <package key="cptex" name="cptex" caption="Use different code pages for TeX input" />
+  <package key="cqubeamer" name="CQUBeamer" caption="LaTeX Beamer Template for Chongqing University" />
+  <package key="cquthesis" name="CQUThesis" caption="LaTeX Thesis Template for Chongqing University" />
+  <package key="crbox" name="crbox" caption="Boxes with crossed corners" />
+  <package key="create-struktex" name="create-struktex" caption="Create struktex code" />
+  <package key="create-theorem" name="create-theorem" caption="Initializing and configuring theorem-like environments, with multilingual support" />
+  <package key="crefthe" name="crefthe" caption="Cross referencing with proper definite articles" />
+  <package key="crimson" name="crimson" caption="Crimson fonts with LaTeX support" />
+  <package key="crimsonpro" name="CrimsonPro" caption="CrimsonPro fonts with LaTeX support" />
+  <package key="croatian" name="croatian" caption="Fonts for Croatian Glagolitic and other Croatian scripts" />
+  <package key="crop" name="crop" caption="Support for cropmarks" />
+  <package key="cropmark" name="cropmark" caption="Crop marks on \shipout" />
+  <package key="cropmark-pu" name="cropmark-pu" caption="Cropmark macros for Plain TeX" />
+  <package key="cropmarks-pt" name="cropmarks-pt" caption="Philip Taylor&apos;s cropmarks macros" />
+  <package key="cropmrks" name="cropmrks" caption="Add crop marks to a Plain TeX document" />
+  <package key="crossrefenum" name="crossrefenum" caption="Smart typesetting of enumerated cross-references for various TeX formats" />
+  <package key="crossreference" name="crossreference" caption="Crossreferences within documents" />
+  <package key="crossreftools" name="crossreftools" caption="Expandable extraction of cleveref data" />
+  <package key="crossrefware" name="crossrefware" caption="Scripts for working with crossref.org" />
+  <package key="crosstex" name="crosstex" caption="Bibliography management tool" />
+  <package key="crossword" name="crossword" caption="Typeset crossword puzzles" />
+  <package key="crosswrd" name="crosswrd" caption="Macros for typesetting crossword puzzles" />
+  <package key="crudetype" name="crudetype" caption="Line printer output from DVI files" />
+  <package key="crumbs" name="crumbs" caption="Add a Navigation Path to the page header" />
+  <package key="crw" name="crw" caption="Crossword macros for Plain TeX" />
+  <package key="cryptocode" name="cryptocode" caption="Typesetting pseudocode, protocols, game-based proofs and black-box reductions in cryptography" />
+  <package key="cryst" name="cryst" caption="Font for graphical symbols used in crystallography" />
+  <package key="csassignments" name="csassignments" caption="A wrapper for article with macros and customizations for computer science assignments" />
+  <package key="csbulletin" name="csbulletin" caption="LaTeX class for articles submitted to the CSTUG Bulletin (Zpravodaj)" />
+  <package key="csfonts" name="csfonts" caption="Czech/Slovak-tuned Computer Modern fonts" />
+  <package key="csfonts-t1" name="csfonts-t1" caption="Czech/Slovak tuned CM fonts in Type 1 format" />
+  <package key="csindex" name="csindex" caption="Czech/Slovak version of MakeIndex" />
+  <package key="cslatex" name="cslatex" caption="LaTeX support for Czech/Slovak typesetting" />
+  <package key="csname-doc" name="csname-doc" caption="A list of plain.tex cs names" />
+  <package key="csplain" name="csplain" caption="Plain TeX multilanguage support" />
+  <package key="cspsfonts" name="cspsfonts" caption="Czech/Slovakian PostScript font support" />
+  <package key="csquotes" name="csquotes" caption="Context sensitive quotation facilities" />
+  <package key="csquotes-de" name="csquotes-de" caption="German translation of csquotes documentation" />
+  <package key="css-colors" name="css-colors" caption="Named colors for web-safe design" />
+  <package key="cstex" name="CSTeX" caption="Support for Czech/Slovak languages" />
+  <package key="cstypo" name="cstypo" caption="Czech typography rules enforced through LuaTeX hooks" />
+  <package key="csv2latex" name="csv2latex" caption="Convert spreadsheet table cells into LaTeX source" />
+  <package key="csvmerge" name="csvmerge" caption="Merge TeX code with csv data" />
+  <package key="csvsimple" name="csvsimple" caption="Simple CSV file processing" />
+  <package key="csvtolatex" name="csvtolatex" caption="Link spread sheets to LaTeX" />
+  <package key="csvtools" name="csvtools" caption="Reading data from CSV files" />
+  <package key="csx" name="csx" caption="Computer Sanskrit(/Extended) coding support on MS-DOS" />
+  <package key="ctable" name="ctable" caption="Flexible typesetting of table and figure floats using key/value directives" />
+  <package key="ctablestack" name="ctablestack" caption="Catcode table stable support" />
+  <package key="ctan-bibdata" name="ctan-bibdata" caption="Bibliography data for all CTAN packages" />
+  <package key="ctan-o-mat" name="ctan-o-mat" caption="Upload or validate a package for CTAN" />
+  <package key="ctan_chk" name="ctan_chk" caption="CTAN guidelines verifier and corrector for uploading projects" />
+  <package key="ctanbib" name="ctanbib" caption="Export CTAN entries to bib format" />
+  <package key="ctanify" name="ctanify" caption="Prepare a package for upload to CTAN" />
+  <package key="ctantools" name="CTAN tools" caption="A jiffy to search CTAN file list" />
+  <package key="ctanupload" name="ctanupload" caption="Support for users uploading to CTAN" />
+  <package key="ctex" name="ctex" caption="LaTeX classes and packages for Chinese typesetting" />
+  <package key="ctex-faq" name="ctex-faq" caption="LaTeX FAQ by the Chinese TeX Society (ctex.org)" />
+  <package key="ctib4tex" name="ctib4tex" caption="Tibetan for TeX and LaTeX2e" />
+  <package key="ctie" name="ctie" caption="C version of tie (merging Web change files)" />
+  <package key="cuisine" name="cuisine" caption="Typeset recipes" />
+  <package key="cun" name="cun" caption="A cuneiform font" />
+  <package key="cuprum" name="cuprum" caption="Cuprum font family support for LaTeX" />
+  <package key="currency" name="currency" caption="Format currencies in a consistent way" />
+  <package key="currfile" name="currfile" caption="Provide file name and path of input files" />
+  <package key="currvita" name="currvita" caption="Typeset a curriculum vitae" />
+  <package key="cursolatex" name="cursolatex" caption="A LaTeX tutorial" />
+  <package key="cursor" name="cursor" caption="Draw a cursor in an equation" />
+  <package key="curve" name="CurVe" caption="A class for making curriculum vitae" />
+  <package key="curve2e" name="curve2e" caption="Extensions for package pict2e" />
+  <package key="curves" name="curves" caption="Curves for LaTeX picture environment" />
+  <package key="custom-bib" name="custom-bib" caption="Customised BibTeX styles" />
+  <package key="customdice" name="customdice" caption="Simple commands for drawing customisable dice" />
+  <package key="cuted" name="cuted" caption="Mixing onecolumn and twocolumn modes" />
+  <package key="cutwin" name="cutwin" caption="Cut a window in a paragraph, typeset material in it" />
+  <package key="cv" name="cv" caption="A package for creating a curriculum vitae" />
+  <package key="cv4tw" name="cv4tw" caption="LaTeX CV class, with extended details" />
+  <package key="cvss" name="cvss" caption="Compute and display CVSS base scores" />
+  <package key="cvsty" name="CVsty" caption="Yet another style for easy CV pagination" />
+  <package key="cweb" name="cweb" caption="A Web system in C" />
+  <package key="cweb-latex" name="cweb-latex" caption="A LaTeX version of CWEB" />
+  <package key="cwebbin" name="cwebbin" caption="CWEB for ANSI-C/C++ compilers" />
+  <package key="cwebhy" name="cweb-hy" caption="Insert hyperlinks for included files" />
+  <package key="cwebx" name="cwebx" caption="A system for Structured Software Documentation in C" />
+  <package key="cyber" name="cyber" caption="Annotate compliance with cybersecurity requirements" />
+  <package key="cybercic" name="cybercic" caption="&#8220;Controls in Contents&#8221; for the cyber package" />
+  <package key="cyklop" name="cyklop" caption="The Cyclop typeface" />
+  <package key="cypriot" name="cypriot" caption="A script which was used on Cyprus for writing Greek" />
+  <package key="cypriote" name="cypriote" caption="A font for ancient Cypriot Greek inscriptions" />
+  <package key="cyrguide" name="cyrguide" caption="Documentation of LaTeX Cyrillic-alphabet features" />
+  <package key="cyrillic209" name="cyrillic209" caption="Provides basic LaTeX 2.09 font access to the Washington cyrillic fonts" />
+  <package key="cyrmemo" name="cyrmemo" caption="Details of using the AMS Cyrillic fonts" />
+  <package key="cyrtug" name="cyrtug" caption="EmTeX as distributed by CyrTUG" />
+  <package key="czhyph" name="czhyph" caption="Hyphenation patterns for Czech" />
+  <package key="czhyph2e" name="czhyph2e" caption="Convert Czech hyphenation patterns to standard encoding" />
+  <package key="dad" name="dad" caption="Simple typesetting system for mixed Arabic/Latin documents" />
+  <package key="dancers" name="dancers" caption="Font for Conan Doyle&#8217;s &#8220;The Dancing Men&#8221;" />
+  <package key="dante-book-reviews" name="dante-book-reviews" caption="Book reviews published in DANTE&apos;s journal" />
+  <package key="dantelogo" name="dantelogo" caption="A font for DANTE&apos;s logo" />
+  <package key="darkmode" name="darkmode" caption="General Dark Mode Support for LaTeX-Documents" />
+  <package key="dashbox" name="dashbox" caption="Draw dashed boxes" />
+  <package key="dashrule" name="dashrule" caption="Draw dashed rules" />
+  <package key="dashundergaps" name="dashundergaps" caption="Produce gaps that are underlined, dotted or dashed" />
+  <package key="dataref" name="dataref" caption="Manage references to experimental data" />
+  <package key="datatool" name="datatool" caption="Tools to load and manipulate data" />
+  <package key="datatooltk" name="datatooltk" caption="A Java GUI for preparing datatool input" />
+  <package key="datax" name="datax" caption="Import individual data from script files" />
+  <package key="dateiliste" name="dateiliste" caption="Extensions of the \listfiles concept" />
+  <package key="datenumber" name="datenumber" caption="Convert a date into a number and vice versa" />
+  <package key="datepicker-pro" name="datepicker-pro" caption="Create a popup datepicker using SWF" />
+  <package key="dates" name="dates" caption="Macros for parsing date strings" />
+  <package key="dates209" name="dates209" caption="Flexible date macros" />
+  <package key="datestamp" name="datestamp" caption="Fixed date-stamps with LuaLaTeX" />
+  <package key="datetime" name="datetime" caption="Change format of \today with commands for current time" />
+  <package key="datetime2" name="datetime2" caption="Formats for dates, times and time zones" />
+  <package key="datetime2-bahasai" name="datetime2-bahasai" caption="Bahasai language module for the datetime2 package" />
+  <package key="datetime2-basque" name="datetime2-basque" caption="Basque language module for the datetime2 package" />
+  <package key="datetime2-breton" name="datetime2-breton" caption="Breton language module for the datetime2 package" />
+  <package key="datetime2-bulgarian" name="datetime2-bulgarian" caption="Bulgarian language module for the datetime2 package" />
+  <package key="datetime2-catalan" name="datetime2-catalan" caption="Catalan language module for the datetime2 package" />
+  <package key="datetime2-croatian" name="datetime2-croatian" caption="Croatian language module for the datetime2 package" />
+  <package key="datetime2-czech" name="datetime2-czech" caption="Czech language module for the datetime2 package" />
+  <package key="datetime2-danish" name="datetime2-danish" caption="Danish language module for the datetime2 package" />
+  <package key="datetime2-dutch" name="datetime2-dutch" caption="Dutch language module for the datetime2 package" />
+  <package key="datetime2-en-fulltext" name="datetime2-en-fulltext" caption="English Full Text styles for the datetime2 package" />
+  <package key="datetime2-english" name="datetime2-english" caption="English language module for the datetime2 package" />
+  <package key="datetime2-esperanto" name="datetime2-esperanto" caption="Esperanto language module for the datetime2 package" />
+  <package key="datetime2-estonian" name="datetime2-estonian" caption="Estonian language module for the datetime2 package" />
+  <package key="datetime2-finnish" name="datetime2-finnish" caption="Finnish language module for the datetime2 package" />
+  <package key="datetime2-french" name="datetime2-french" caption="French language module for the datetime2 package" />
+  <package key="datetime2-galician" name="datetime2-galician" caption="Galician language module for the datetime2 package" />
+  <package key="datetime2-german" name="datetime2-german" caption="German language module for the datetime2 package" />
+  <package key="datetime2-greek" name="datetime2-greek" caption="Greek language module for the datetime2 package" />
+  <package key="datetime2-hebrew" name="datetime2-hebrew" caption="Hebrew language module for the datetime2 package" />
+  <package key="datetime2-icelandic" name="datetime2-icelandic" caption="Icelandic language module for the datetime2 package" />
+  <package key="datetime2-irish" name="datetime2-irish" caption="Irish Gaelic Language Module for the datetime2 Package" />
+  <package key="datetime2-it-fulltext" name="datetime2-it-fulltext" caption="Italian full text styles for the datetime2 package" />
+  <package key="datetime2-italian" name="datetime2-italian" caption="Italian language module for the datetime2 package" />
+  <package key="datetime2-latin" name="datetime2-latin" caption="Latin language module for the datetime2 package" />
+  <package key="datetime2-lsorbian" name="datetime2-lsorbian" caption="Lower Sorbian language module for the datetime2 package" />
+  <package key="datetime2-magyar" name="datetime2-magyar" caption="Magyar language module for the datetime2 package" />
+  <package key="datetime2-norsk" name="datetime2-norsk" caption="Norsk language module for the datetime2 package" />
+  <package key="datetime2-polish" name="datetime2-polish" caption="Polish language module for the datetime2 package" />
+  <package key="datetime2-portuges" name="datetime2-portuges" caption="Portuguese language module for the datetime2 package" />
+  <package key="datetime2-romanian" name="datetime2-romanian" caption="Romanian language module for the datetime2 package" />
+  <package key="datetime2-russian" name="datetime2-russian" caption="Russian language module for the datetime2 package" />
+  <package key="datetime2-samin" name="datetime2-samin" caption="Northern Sami language module for the datetime2 package" />
+  <package key="datetime2-scottish" name="datetime2-scottish" caption="Scottish Gaelic Language Module for the datetime2 Package" />
+  <package key="datetime2-serbian" name="datetime2-serbian" caption="Serbian language module for the datetime2 package" />
+  <package key="datetime2-slovak" name="datetime2-slovak" caption="Slovak language module for the datetime2 package" />
+  <package key="datetime2-slovene" name="datetime2-slovene" caption="Slovene language module for the datetime2 package" />
+  <package key="datetime2-spanish" name="datetime2-spanish" caption="Spanish language module for the datetime2 package" />
+  <package key="datetime2-swedish" name="datetime2-swedish" caption="Swedish language module for the datetime2 package" />
+  <package key="datetime2-turkish" name="datetime2-turkish" caption="Turkish language module for the datetime2 package" />
+  <package key="datetime2-ukrainian" name="datetime2-ukrainian" caption="Ukrainian language module for the datetime2 package" />
+  <package key="datetime2-usorbian" name="datetime2-usorbian" caption="Upper Sorbian language module for the datetime2 package" />
+  <package key="datetime2-welsh" name="datetime2-welsh" caption="Welsh language module for the datetime2 package" />
+  <package key="dayofweek" name="dayofweek" caption="Calculate day of week, phase of moon" />
+  <package key="dayroman" name="DayRoman" caption="The Day Roman typeface" />
+  <package key="daytime" name="daytime" caption="Print time of day" />
+  <package key="db" name="db" caption="Process simple databases inside LaTeX" />
+  <package key="dblfloatfix" name="dblfloatfix" caption="Fixes for twocolumn floats" />
+  <package key="dblfnote" name="dblfnote" caption="Double-column footnotes" />
+  <package key="dblfont" name="dblfont" caption="Blackboard bold font package" />
+  <package key="dbprocess" name="DB_process" caption="Process database output" />
+  <package key="dbshow" name="dbshow" caption="A package to store and display data with custom filters, orders, and styles" />
+  <package key="dccpaper" name="dccpaper" caption="Typeset papers for the International Journal of Digital Curation" />
+  <package key="dco" name="dco" caption="Use the DC fonts with old-style numerals" />
+  <package key="dcolumn" name="dcolumn" caption="Align on the decimal point of numbers in tabular columns" />
+  <package key="dcounter" name="dcounter" caption="Support dynamic counters" />
+  <package key="dcpic" name="DCpic" caption="Commutative diagrams in a LaTeX and TeX documents" />
+  <package key="ddphonism" name="ddphonism" caption="Dodecaphonic diagrams: twelve-tone matrices, clock diagrams, etc" />
+  <package key="de-macro" name="de-macro" caption="Expand private macros in a document" />
+  <package key="debate" name="debate" caption="Debates between reviewers" />
+  <package key="decimal" name="decimal" caption="LaTeX package for the English raised decimal point" />
+  <package key="decision-table" name="decision-table" caption="An easy way to create Decision Model and Notation decision tables" />
+  <package key="declare" name="declare" caption="Declare register names locally" />
+  <package key="decorule" name="decorule" caption="Decorative swelled rule using font character" />
+  <package key="decsci" name="decsci" caption="BibTeX style for the journal Decision Sciences" />
+  <package key="dectab" name="dectab" caption="Align columns on a decimal point" />
+  <package key="default" name="default" caption="Provide default parameters for TeX macros" />
+  <package key="deflist" name="deflist" caption="A variation on the description environment" />
+  <package key="defoldfonts" name="defoldfonts" caption="Define old font commands" />
+  <package key="defstring" name="defstring" caption="Define macros as verbatim macros" />
+  <package key="degrade" name="degrade" caption="Degrade JPEG images on the fly, prior to inclusion" />
+  <package key="dehyph" name="dehyph" caption="German hyphenation patterns for traditional orthography" />
+  <package key="dehyph-exptl" name="dehyph-exptl" caption="Experimental hyphenation patterns for the German language" />
+  <package key="dejavu" name="dejavu" caption="LaTeX support for the DejaVu fonts" />
+  <package key="dejavu-otf" name="dejavu-otf" caption="Support for the ttf and otf DejaVu fonts" />
+  <package key="delarray" name="delarray" caption="Delimiters for arrays" />
+  <package key="deleq" name="deleq" caption="Flexible numbering of equations" />
+  <package key="delig" name="delig" caption="Disable misplaced ligatures in LaTeX documents" />
+  <package key="delim" name="delim" caption="Simplify typesetting mathematical delimiters" />
+  <package key="delimseasy" name="delimseasy" caption="Delimiter commands that are easy to use and resize" />
+  <package key="delimset" name="delimset" caption="Typeset and declare sets of delimiters with convenient size control" />
+  <package key="delimtxt" name="delimtxt" caption="Read and parse text tables" />
+  <package key="democodetools" name="democodetools" caption="Package for LaTeX code documentation" />
+  <package key="denisbdoc" name="denisbdoc" caption="A personal dirty package for documenting packages" />
+  <package key="deproc" name="deproc" caption="Macros for DECUS proceedings articles" />
+  <package key="derivative" name="derivative" caption="Nice and easy derivatives" />
+  <package key="desclist" name="desclist" caption="Extended &#8220;description&#8221; lists" />
+  <package key="designcon" name="designcon" caption="Develop DesignCon papers" />
+  <package key="detex" name="detex" caption="Strip TeX from a source file" />
+  <package key="detexfaq" name="detexfaq" caption="German TeX FAQ" />
+  <package key="devanagari" name="devanagari" caption="Typeset Devanagari" />
+  <package key="devanagari-omega" name="devanagari-omega" caption="Typeset Devanagari with Omega" />
+  <package key="development" name="development" caption="BibTeX style file for the journal Development" />
+  <package key="dfgproposal" name="dfgproposal" caption="Support for writing proposals to the DFG" />
+  <package key="dhua" name="dhua" caption="German abbreviations using thin space" />
+  <package key="diabetes-logbook" name="diabetes-logbook" caption="A logbook for people with type one diabetes" />
+  <package key="diadia" name="diadia" caption="Package to keep a diabetes diary" />
+  <package key="diagbox" name="diagbox" caption="Table heads with diagonal lines" />
+  <package key="diagmac" name="diagmac" caption="A diagram drawing package" />
+  <package key="diagmac2" name="diagmac2" caption="Diagram macros, using pict2e" />
+  <package key="diagnose" name="diagnose" caption="A diagnostic tool for a TeX installation" />
+  <package key="diagramf" name="diagramf" caption="Labelled diagrams in Metafont" />
+  <package key="diagrams" name="diagrams" caption="A CTAN collection of diagram macro packages" />
+  <package key="diagxy" name="diagxy" caption="Diagram macros by Michael Barr" />
+  <package key="dialogl" name="dialogl" caption="Macros for constructing interactive LaTeX scripts" />
+  <package key="dialogue" name="dialogue" caption="Quote short scripted dialogue in LaTeX" />
+  <package key="dice" name="dice" caption="A font for die faces" />
+  <package key="dichokey" name="dichokey" caption="Construct dichotomous identification keys" />
+  <package key="dickimaw" name="dickimaw" caption="Books and tutorials from the &#8220;Dickimaw LaTeX Series&#8221;" />
+  <package key="dictsym" name="dictsym" caption="DictSym font and macro package" />
+  <package key="diffcoeff" name="diffcoeff" caption="Write differential coefficients easily and consistently" />
+  <package key="digestif" name="digestif" caption="Editor plugin for LaTeX, ConTeXt etc" />
+  <package key="digicap-pro" name="digicap-pro" caption="Creates captions to digital photos" />
+  <package key="digiconfigs" name="digiconfigs" caption="Writing &quot;configurations&quot;" />
+  <package key="dijkstra" name="dijkstra" caption="Dijkstra algorithm for LaTeX" />
+  <package key="dimnum" name="dimnum" caption="Commands for dimensionless numbers" />
+  <package key="din1505" name="din1505" caption="Bibliography styles for German texts" />
+  <package key="dinat" name="dinat" caption="Bibliography style for German texts" />
+  <package key="dinbrief" name="dinbrief" caption="German letter DIN style" />
+  <package key="dinbrief-gui" name="dinbrief-gui" caption="GUI for LaTeX package dinbrief" />
+  <package key="dingbat" name="dingbat" caption="Two dingbat symbol fonts" />
+  <package key="directory" name="directory" caption="An address book using BibTeX" />
+  <package key="directtex" name="directtex" caption="TeX for the Macintosh" />
+  <package key="dirtree" name="dirtree" caption="Display trees in the style of windows explorer" />
+  <package key="dirtytalk" name="dirtytalk" caption="A package to typeset quotations easier" />
+  <package key="disser" name="disser" caption="Class and templates for typesetting dissertations in Russian" />
+  <package key="ditaa" name="ditaa" caption="Use ditaa diagrams within LaTeX documents" />
+  <package key="dithesis" name="dithesis" caption="A class for undergraduate theses at the University of Athens" />
+  <package key="divine" name="divine" caption="LaTeX support for the divine font" />
+  <package key="djgpp" name="djgpp" caption="DJGPP-based version of TeX for MS-DOS" />
+  <package key="dk-bib" name="dk-bib" caption="Danish variants of standard BibTeX styles" />
+  <package key="dkhyphen" name="dkhyphen" caption="Danish hyphenation patterns" />
+  <package key="dktools" name="dktools" caption="Tools and libraries by Dirk Krause" />
+  <package key="dlfltxb" name="dlfltxb" caption="Macros related to &quot;Introdktion til LaTeX&quot;" />
+  <package key="dmfonts" name="dmfonts" caption="Virtual fonts to provide T1 encoding" />
+  <package key="dmhgener" name="dmhgener" caption="Equation, figure (etc.) numbering and referencing" />
+  <package key="dnaseq" name="dnaseq" caption="Format DNA base sequences" />
+  <package key="do-it-yourself-tex" name="do-it-yourself-tex" caption="Back to Plain XeTeX" />
+  <package key="doafter" name="doafter" caption="Do things after a group" />
+  <package key="doc" name="doc" caption="Format LaTeX documentation" />
+  <package key="doc-pictex" name="doc-pictex" caption="A summary list of PicTeX documentation" />
+  <package key="docarc" name="docarc" caption="Multi-user distributed bibliographic database system" />
+  <package key="docassembly" name="docassembly" caption="Use the Acrobat JavaScript API" />
+  <package key="docbytex" name="docbytex" caption="Creating documentation from source code" />
+  <package key="doclicense" name="doclicense" caption="Support for putting documents under a license" />
+  <package key="docmfp" name="docmfp" caption="Document non-LaTeX code" />
+  <package key="docmute" name="docmute" caption="Input files ignoring LaTeX preamble, etc" />
+  <package key="docshots" name="docshots" caption="TeX samples next to their PDF Snapshots" />
+  <package key="docstrip" name="docstrip" caption="Remove comments from file" />
+  <package key="docsurvey" name="docsurvey" caption="A survey of LaTeX documentation" />
+  <package key="doctools" name="doctools" caption="Tools for the documentation of LaTeX code" />
+  <package key="documentation" name="documentation" caption="Documentation support for C, Java and assembler code" />
+  <package key="docutils" name="docutils" caption="Helper commands and element definitions for Docutils LaTeX output" />
+  <package key="dogma" name="dogma" caption="Metrics and LaTeX support for Dogma Font From Emigre Graphics" />
+  <package key="doi" name="doi" caption="Create correct hyperlinks for DOI numbers" />
+  <package key="doipubmed" name="doipubmed" caption="Special commands for use in bibliographies" />
+  <package key="domitian" name="domitian" caption="Drop-in replacement for Palatino" />
+  <package key="dos-dc" name="dos-dc" caption="A distribution of the DC fonts for emTeX" />
+  <package key="dosepsbin" name="dosepsbin" caption="Deal with DOS binary EPS files" />
+  <package key="dot2tex" name="dot2tex" caption="Convert graphs generated by Graphviz to LaTeX friendly formats" />
+  <package key="dot2texi" name="dot2texi" caption="Create graphs within LaTeX using the dot2tex tool" />
+  <package key="dotarrow" name="dotarrow" caption="Extendable dotted arrows" />
+  <package key="dotlessi" name="dotlessi" caption="Provides dotless i&#8217;s and j&#8217;s for use in any math font" />
+  <package key="dotlessj" name="dotlessj" caption="Generates a dot-less j" />
+  <package key="dotseqn" name="dotseqn" caption="Flush left equations with dotted leaders to the numbers" />
+  <package key="dottex" name="dottex" caption="Use dot code in LaTeX" />
+  <package key="doublecol" name="doublecol" caption="Double-column page macros for Plain TeX" />
+  <package key="doublespace" name="doublespace" caption="Double space environment" />
+  <package key="doublestroke" name="doublestroke" caption="Typeset mathematical double stroke symbols" />
+  <package key="doulossil" name="doulossil" caption="A font for typesetting the International Phonetic Alphabet (IPA)" />
+  <package key="dow" name="dow" caption="Calculate day of week from a numeric date" />
+  <package key="dowith" name="dowith" caption="Apply a command to a list of items" />
+  <package key="download" name="download" caption="Allow LaTeX to download files using an external process" />
+  <package key="dox" name="dox" caption="Extend the doc package" />
+  <package key="dozenal" name="dozenal" caption="Typeset documents using base twelve numbering (also called &#8220;dozenal&#8221;)" />
+  <package key="dpcircling" name="DPcircling" caption="Decorated text boxes using TikZ" />
+  <package key="dpfloat" name="dpfloat" caption="Support for double-page floats" />
+  <package key="dprogress" name="dprogress" caption="LaTeX-relevant log information for debugging" />
+  <package key="dps" name="dps" caption="Create a &quot;matching&quot; game with a hidden message" />
+  <package key="drac" name="drac" caption="Declare active character substitution, robustly" />
+  <package key="draft" name="draft" caption="A LaTeX 2.09 style for supporting work on drafts" />
+  <package key="draftcopy" name="draftcopy" caption="Identify draft copies" />
+  <package key="draftfigure" name="draftfigure" caption="Replace figures with a white box and additional features" />
+  <package key="drafthead" name="drafthead" caption="Mark &quot;DRAFT&quot; in page headers" />
+  <package key="draftmark" name="draftmark" caption="Put draft marks on selected pages" />
+  <package key="draftwatermark" name="draftwatermark" caption="Put a grey textual watermark on document pages" />
+  <package key="drama" name="drama" caption="Production-style stage script in LaTeX" />
+  <package key="dramatist" name="dramatist" caption="Typeset dramas, both in verse and in prose" />
+  <package key="dratex" name="dratex" caption="General drawing macros" />
+  <package key="drawing" name="drawing" caption="Simple drawings with Metafont" />
+  <package key="drawing-with-metapost" name="Drawing-with-Metapost" caption="How to draw technical diagrams with MetaPost" />
+  <package key="drawmatrix" name="drawmatrix" caption="Draw visual representations of matrices in LaTeX" />
+  <package key="drawstack" name="drawstack" caption="Draw execution stacks" />
+  <package key="drcaps" name="drcaps" caption="Simple dropped capitals" />
+  <package key="drftcite" name="drftcite" caption="Print the bibliography in &quot;draft&quot; mode" />
+  <package key="drm" name="drm" caption="A complete family of fonts written in Metafont" />
+  <package key="droid" name="droid" caption="LaTeX support for the Droid font families" />
+  <package key="droit-fr" name="droit-fr" caption="Document class and bibliographic style for French law" />
+  <package key="drop" name="drop" caption="Dropped capitals at the start of a paragraph (LaTeX 2.09)" />
+  <package key="dropcaps" name="dropcaps" caption="Use dropped capitals to start a paragraph" />
+  <package key="dropping" name="dropping" caption="Drop first letter of paragraphs" />
+  <package key="drs" name="drs" caption="Typeset Discourse Representation Structures (DRS)" />
+  <package key="drv" name="drv" caption="Derivation trees with MetaPost" />
+  <package key="dsptricks" name="dsptricks" caption="Macros for Digital Signal Processing plots" />
+  <package key="dsserif" name="DSSerif" caption="A double-struck serifed font for mathematical use" />
+  <package key="dtk" name="dtk" caption="Document class for the journal of DANTE" />
+  <package key="dtk-1.32" name="dtk-1.32" caption="Document class for the journal of DANTE" />
+  <package key="dtk-bibliography" name="dtk-bibliography" caption="Bibliography of &#8220;Die TeXnische Kom&#246;die&#8221;" />
+  <package key="dtl" name="dtl" caption="Tools to dis-assemble and re-assemble DVI files" />
+  <package key="dtxdescribe" name="dtxdescribe" caption="Describe additional object types in dtx source files" />
+  <package key="dtxgallery" name="DTX gallery" caption="A small collection of minimal DTX examples" />
+  <package key="dtxgen" name="dtxgen" caption="Creates a template for a self-extracting .dtx file" />
+  <package key="dtxtut" name="dtxtut" caption="Tutorial on writing .dtx and .ins files" />
+  <package key="ducksay" name="ducksay" caption="Draw ASCII art of animals saying a specified message" />
+  <package key="duckuments" name="duckuments" caption="Create duckified dummy content" />
+  <package key="duerer" name="duerer" caption="Computer Duerer fonts" />
+  <package key="duerer-latex" name="duerer-LaTeX" caption="LaTeX support for the Duerer fonts" />
+  <package key="duotenzor" name="duotenzor" caption="Drawing package for circuit and duotensor diagrams" />
+  <package key="duplicat" name="duplicat" caption="Make duplicate page numbers distinct" />
+  <package key="dutchcal" name="dutchcal" caption="A reworking of ESSTIX13, adding a bold version" />
+  <package key="dvdcoll" name="dvdcoll" caption="A class for typesetting DVD archives" />
+  <package key="dvgloss" name="dvgloss" caption="Facilities for setting interlinear glossed text" />
+  <package key="dvgt" name="dvgt" caption="Previewer for use on graphic and character-cell terminals" />
+  <package key="dvgtk" name="dvgtk" caption="Tektronix 401x DVI previewer" />
+  <package key="dvi-economic" name="dvi-economic" caption="Save paper while printing" />
+  <package key="dvi2bitmap" name="dvi2bitmap" caption="Utility to convert TeX DVI files directly to bitmaps" />
+  <package key="dvi2ln3" name="dvi2ln3" caption="LN03 driver based on DVItype" />
+  <package key="dvi2tty" name="dvi2tty" caption="Produce ASCII from DVI" />
+  <package key="dvi2xx" name="dvi2xx" caption="A general-purpose DVI output for Hewlett-Packard printers" />
+  <package key="dviasm" name="DVIasm" caption="A utility for editing DVI files" />
+  <package key="dvibit" name="dvibit" caption="DVI driver for BBN bitgraph terminal" />
+  <package key="dvibook" name="dvibook" caption="Utilities for manipulating DVI files" />
+  <package key="dvichk" name="dvichk" caption="List the page numbers in a DVI file" />
+  <package key="dviconcat" name="dviconcat" caption="Concatenates DVI files" />
+  <package key="dvicopy" name="dvicopy" caption="Copy DVI files, flattening VFs" />
+  <package key="dvidvi" name="dvidvi" caption="Convert one DVI file into another" />
+  <package key="dvii" name="dvii" caption="Extract information from a DVI file" />
+  <package key="dviincl" name="dviincl" caption="Include a DVI page into MetaPost output" />
+  <package key="dviinfox" name="dviinfox" caption="Perl script to print DVI meta information" />
+  <package key="dviljk" name="dviljk" caption="DVI to Laserjet output" />
+  <package key="dvimerge" name="dvimerge" caption="Merge two DVI files together" />
+  <package key="dviout" name="dviout" caption="TeX previewer and printer driver for MS-Windows" />
+  <package key="dvipaste" name="dvipaste" caption="DVI manipulation" />
+  <package key="dvipdfm" name="dvipdfm" caption="A DVI driver to produce PDF directly" />
+  <package key="dvipdfmx" name="dvipdfmx" caption="An extended version of dvipdfm" />
+  <package key="dvipdfmx-def" name="dvipdfmx-def" caption="Configuration file for dvipdfmx graphics" />
+  <package key="dvipng" name="dvipng" caption="A fast DVI to PNG/GIF converter" />
+  <package key="dvips" name="dvips" caption="A DVI to PostScript driver" />
+  <package key="dvips-os2" name="dvips-os2" caption="OS/2 dvips" />
+  <package key="dvips-shell" name="dvips-shell" caption="A dvips Shell for MS-Windows32" />
+  <package key="dvipscol" name="dvipscol" caption="Alter the usage of the dvips colour stack" />
+  <package key="dvipsconfig" name="dvipsconfig" caption="Collection of dvips PostScript headers" />
+  <package key="dvipsk" name="dvipsk" caption="Convert DVI to PostScript" />
+  <package key="dvisirule" name="dvisirule" caption="Superimpose the covered hline and vline in a LaTeX tabular/colortbl environment" />
+  <package key="dvistd" name="dvistd" caption="A standard for DVI drivers" />
+  <package key="dvisun" name="dvisun" caption="DVI viewer for Sun2 systems" />
+  <package key="dvisvgm" name="dvisvgm" caption="Convert DVI, EPS, and PDF files to Scalable Vector Graphics format (SVG)" />
+  <package key="dvisvgm-def" name="dvisvgm-def" caption="Colour and Graphics support for dvisvgm" />
+  <package key="dvitoln03" name="DVItoLN03" caption="DVI output to Digital LN03 printer" />
+  <package key="dvitops" name="dvitops" caption="A DVI driver for PostScript output" />
+  <package key="dvitty" name="dvitty" caption="A plain-text output DVI driver" />
+  <package key="dvitype" name="dvitype" caption="Type out the content of a DVI file" />
+  <package key="dvivue" name="DVIVue" caption="A DVI/PDF viewer for Windows" />
+  <package key="dviwin" name="dviwin" caption="MS-Windows DVI screen and printer driver" />
+  <package key="dynamicnumber" name="dynamicnumber" caption="
+    Dynamically typeset numbers and values in LaTeX through &#8220;symbolic links&#8221;
+  " />
+  <package key="dynblocks" name="dynblocks" caption="A simple way to create dynamic blocks for Beamer" />
+  <package key="dynbrackets" name="dynbrackets" caption="Commands to simplify the syntax of dynamic math brackets" />
+  <package key="dynkin-diagrams" name="dynkin-diagrams" caption="Draw Dynkin, Coxeter, and Satake diagrams using TikZ" />
+  <package key="dyntree" name="dyntree" caption="Construct Dynkin tree diagrams" />
+  <package key="e-french" name="e-french" caption="Comprehensive LaTeX support for French-language typesetting" />
+  <package key="ean" name="ean" caption="Macros for making EAN barcodes" />
+  <package key="ean13isbn" name="ean13isbn" caption="Print EAN13 for ISBN" />
+  <package key="easing" name="easing" caption=" easing functions for pgfmath" />
+  <package key="easy" name="easy" caption="A collection of easy-to-use macros" />
+  <package key="easy-todo" name="easy-todo" caption="To-do notes in a document" />
+  <package key="easybib" name="easybib" caption="Simple syntax for custom bibliographies" />
+  <package key="easybmat" name="easybmat" caption="Block matrices" />
+  <package key="easybook" name="easybook" caption="Easily typesetting Chinese theses or books" />
+  <package key="easyeqn" name="easyeqn" caption="A simple package for writing equations" />
+  <package key="easyfig" name="easyfig" caption="Simplifying the use of common figures" />
+  <package key="easyfloats" name="easyfloats" caption="An easier interface to insert figures, tables and other objects in LaTeX" />
+  <package key="easyformat" name="easyformat" caption="Easily add boldface, italics and smallcaps" />
+  <package key="easylatex" name="easyLaTeX" caption="Faster and simpler writing of LaTeX documents" />
+  <package key="easylist" name="easylist" caption="Lists using a single active character" />
+  <package key="easymat" name="easymat" caption="A simple package for writing matrices" />
+  <package key="easyreview" name="easyReview" caption="Package to  provide a way to review (or perform editorial process) in LaTeX" />
+  <package key="easytable" name="easytable" caption="A simple package for writing tables" />
+  <package key="easyvector" name="easyvector" caption="Write vectors in a C-like fashion" />
+  <package key="ebezier" name="ebezier" caption="Device independent picture environment enhancement" />
+  <package key="ebgaramond" name="ebgaramond" caption="LaTeX support for EBGaramond fonts" />
+  <package key="ebgaramond-maths" name="ebgaramond-maths" caption="LaTeX support for EBGaramond fonts in mathematics" />
+  <package key="ebib" name="ebib" caption="BibTeX database manager for GNU Emacs" />
+  <package key="ebnf" name="ebnf" caption="Simple package for EBNF productions" />
+  <package key="ebong" name="EBONG" caption="Utility for writing Bengali in Rapid Roman Format" />
+  <package key="ebook" name="ebook" caption="Helps creating an ebook by providing an ebook class" />
+  <package key="ebproof" name="ebproof" caption="Formal proofs in the style of sequent calculus" />
+  <package key="ebsthesis" name="ebsthesis" caption="Typesetting theses for economics" />
+  <package key="ec" name="ec" caption="Computer modern fonts in T1 and TS1 encodings" />
+  <package key="ec-plain" name="ec-plain" caption="Use EC fonts in Plain TeX" />
+  <package key="ecards" name="ecards" caption="Electronic flash cards" />
+  <package key="ecc" name="ecc" caption="Sources for the European Concrete fonts" />
+  <package key="ecclesiastic" name="ecclesiastic" caption="Typesetting Ecclesiastic Latin" />
+  <package key="ecgdraw" name="ecgdraw" caption="Draws electrocardiograms (ECG)" />
+  <package key="ecltree" name="ecltree" caption="Trees using epic and eepic macros" />
+  <package key="eco" name="eco" caption="Oldstyle numerals using EC fonts" />
+  <package key="ecobiblatex" name="ecobiblatex" caption="Global Ecology and Biogeography BibLaTeX styles for the Biber backend" />
+  <package key="econ-bst" name="econ-bst" caption="BibTeX style for economics papers" />
+  <package key="econlipsum" name="econlipsum" caption="Generate sentences from economic articles" />
+  <package key="econometrica" name="Econometrica" caption="BibTeX support for Econometrica" />
+  <package key="econometrics" name="econometrics" caption="Defines some commands that simplify mathematic notation in economic and econometric writing" />
+  <package key="economic" name="economic" caption="BibTeX support for submitting to Economics journals" />
+  <package key="ecothesis" name="ecothesis" caption="LaTeX thesis template for the Universidade Federal de Vi&#231;osa (UFV), Brazil" />
+  <package key="ecta" name="ecta" caption="Bibliography style for submission to Econometrica" />
+  <package key="ecv" name="ECV" caption="A fancy Curriculum Vitae class" />
+  <package key="eczar" name="eczar" caption="A font family supporting Devanagari and Latin script" />
+  <package key="ed" name="ed" caption="Editorial Notes for LaTeX documents" />
+  <package key="eddi4tex" name="eddi4tex" caption="Editor and shell for DOS and OS/2" />
+  <package key="edfnotes" name="edfnotes" caption="Critical annotations to footnotes with ednotes" />
+  <package key="edichokey" name="edichokey" caption="Typeset dichotomous identification keys" />
+  <package key="editbar" name="editbar" caption="Change bars for LaTeX 2.09" />
+  <package key="edmac" name="edmac" caption="Typeset critical editions" />
+  <package key="edmargin" name="edmargin" caption="Multiple series of endnotes for critical editions" />
+  <package key="ednotes" name="ednotes" caption="Typeset scholarly editions" />
+  <package key="eehyph" name="eehyph" caption="Hyphenation patterns for the Estonian language" />
+  <package key="eemeir" name="eemeir" caption="Adjust the gender of words in a document" />
+  <package key="eepic" name="eepic" caption="Extensions to epic and the LaTeX drawing tools" />
+  <package key="efbox" name="efbox" caption="Extension of \fbox, with controllable frames and colours" />
+  <package key="eforms" name="eforms" caption="eForm support for the AcroTeX bundle" />
+  <package key="ega2mf" name="ega2mf" caption="Generate Metafont code for EGA screen fonts" />
+  <package key="egameps" name="egameps" caption="LaTeX package for typesetting extensive games" />
+  <package key="egothic" name="egothic" caption="Early Gothic manuscript book-hand font" />
+  <package key="egpeirce" name="egpeirce" caption="Draw existential graphs invented by Charles S. Peirce" />
+  <package key="egplot" name="egplot" caption="Encapsulate Gnuplot sources in LaTeX documents" />
+  <package key="ehhline" name="ehhline" caption="Extend the \hhline command" />
+  <package key="eiad" name="eiad" caption="Traditional style Irish fonts" />
+  <package key="eiad-ltx" name="eiad-ltx" caption="LaTeX support for the eiad font" />
+  <package key="eijkhout" name="eijkhout" caption="Victor Eijkhout&apos;s packages" />
+  <package key="einfart" name="einfart" caption="Write your articles in a simple and clear way" />
+  <package key="einfuehrung" name="einfuehrung" caption="Examples from the book Einf&#252;hrung in LaTeX" />
+  <package key="einfuehrung2" name="einfuehrung2" caption="Examples from the book Einf&#252;hrung in LaTeX" />
+  <package key="eitl" name="eitl" caption="Easy install of TeX Live" />
+  <package key="ejpecp" name="ejpecp" caption="Class for EJP and ECP" />
+  <package key="ekaia" name="ekaia" caption="Article format for publishing the Basque Country Science and Technology Journal &quot;Ekaia&quot;" />
+  <package key="ekdosis" name="ekdosis" caption="Typesetting TEI-xml compliant Critical Editions" />
+  <package key="ektype-tanka" name="EkType-Tanka" caption="Devanagari fonts by EkType" />
+  <package key="elbioimp" name="elbioimp" caption="A LaTeX document class for the Journal of Electrical Bioimpedance" />
+  <package key="electrumadf" name="electrumadf" caption="Electrum ADF fonts collection" />
+  <package key="eledform" name="eledform" caption="Define textual variants" />
+  <package key="eledmac" name="eledmac" caption="Typeset scholarly editions" />
+  <package key="eledpar" name="eledpar" caption="Typeset scholarly editions in parallel texts" />
+  <package key="elegantbook" name="ElegantBook" caption="An Elegant LaTeX Template for Books" />
+  <package key="elegantnote" name="ElegantNote" caption="Elegant LaTeX Template for Notes" />
+  <package key="elegantpaper" name="ElegantPaper" caption="An Elegant LaTeX Template for Working Papers" />
+  <package key="elements" name="elements" caption="Provides properties of chemical elements" />
+  <package key="elhyphen" name="elhyphen" caption="Hyphenation for Greek text" />
+  <package key="ellipse" name="ellipse" caption="Draw ellipses and elliptical arcs using the standard LaTeX2e picture environment" />
+  <package key="ellipsis" name="ellipsis" caption="Fix uneven spacing around ellipses in LaTeX text mode" />
+  <package key="elmath" name="elmath" caption="Mathematics in Greek texts" />
+  <package key="elocalloc" name="elocalloc" caption="Local allocation macros for LaTeX 2015" />
+  <package key="elpres" name="elpres" caption="A simple class for electronic presentations" />
+  <package key="els-cas-templates" name="els-cas-templates" caption="Elsevier updated LaTeX templates" />
+  <package key="elsarticle" name="elsarticle" caption="Class for articles for submission to Elsevier journals" />
+  <package key="elteiktdk" name="elteiktdk" caption="TDK-thesis template for Hungarian TDK conferences, Section of Computer Science" />
+  <package key="elteikthesis" name="elteikthesis" caption="Thesis template for E&#246;tv&#246;s Lor&#225;nd University (Informatics)" />
+  <package key="eltex" name="eltex" caption="Simple circuit diagrams in LaTeX picture mode" />
+  <package key="elvish" name="elvish" caption="Fonts for typesetting Tolkien Elvish scripts" />
+  <package key="elzcards" name="elzcards" caption="Typeset business cards, index cards and flash cards easily" />
+  <package key="emarks" name="emarks" caption="Named mark registers with e-TeX" />
+  <package key="embedall" name="embedall" caption="Embed source files into the generated PDF" />
+  <package key="embedfile" name="embedfile" caption="Embed files into PDF" />
+  <package key="embrac" name="embrac" caption="Upright brackets in emphasised text" />
+  <package key="emerald" name="emerald" caption="Support for the free emerald city fontwerks fonts" />
+  <package key="emf" name="emf" caption="Support for the EMF symbol" />
+  <package key="emisa" name="emisa" caption="A LaTeX package for preparing manuscripts for the journal EMISA" />
+  <package key="emo" name="emo" caption="Emoji for all (LaTeX engines)" />
+  <package key="emoji" name="emoji" caption="Emoji support in (Lua)LaTeX" />
+  <package key="emojicite" name="emojicite" caption="Add emojis to citations" />
+  <package key="emp" name="emp" caption="&quot;Encapsulate&quot; MetaPost figures in a document" />
+  <package key="empheq" name="empheq" caption="EMPHasizing EQuations" />
+  <package key="emptypage" name="emptypage" caption="Make empty pages really empty" />
+  <package key="emtex" name="emtex" caption="A TeX system for MS-DOS and OS/2" />
+  <package key="emtexgi" name="emtexgi" caption="A MS-Windows shell for emTeX" />
+  <package key="emtrees" name="emtrees" caption="Draw labelled trees, using emTeX \specials" />
+  <package key="emulateapj" name="emulateapj" caption="Produce output similar to that of APJ" />
+  <package key="encguide" name="encguide" caption="Documentation of LaTeX font encodings" />
+  <package key="enctex" name="encTeX" caption="A TeX extension that translates input on its way into TeX" />
+  <package key="encxvlna" name="encxvlna" caption="Insert nonbreakable spaces, using encTeX" />
+  <package key="endfloat" name="endfloat" caption="Move floats to the end, leaving markers where they belong" />
+  <package key="endheads" name="endheads" caption="Running headers of the form &quot;Notes to pp.xx-yy&quot;" />
+  <package key="endiagram" name="endiagram" caption="Easy creation of potential energy curve diagrams" />
+  <package key="endnote" name="endnote" caption="Generic &quot;endnotes&quot; code" />
+  <package key="endnote2bib" name="EndNote2bib" caption="Convert EndNote files to BibTeX" />
+  <package key="endnotes" name="endnotes" caption="Place footnotes at the end" />
+  <package key="endnotes-hy" name="endnotes-hy" caption="Patches the endnotes package to create hypertext links to the correct anchors" />
+  <package key="endnotesj" name="endnotesj" caption="Japanese-style endnotes" />
+  <package key="endofproofwd" name="endofproofwd" caption="An &#8220;end of proof&#8221; sign" />
+  <package key="engord" name="engord" caption="Converts numbers to English ordinal numbers" />
+  <package key="engpron" name="engpron" caption="Helps to type the pronunciation of English words" />
+  <package key="engrec" name="engrec" caption="Enumerate with lower- or uppercase Greek letters" />
+  <package key="engtlc" name="engtlc" caption="Support for users in Telecommunications Engineering" />
+  <package key="engwar" name="engwar" caption="Font for typesetting Tolkien Engwar script" />
+  <package key="enigma" name="enigma" caption="Encrypt documents with a three rotor Enigma" />
+  <package key="enotez" name="enotez" caption="Support for end-notes" />
+  <package key="enparen" name="enparen" caption="Consistent nested brackets" />
+  <package key="enpassant" name="enpassant" caption="Enpassant chess font support" />
+  <package key="enumerate" name="enumerate" caption="Enumerate with redefinable labels" />
+  <package key="enumitem" name="enumitem" caption="Control layout of itemize, enumerate, description" />
+  <package key="enumitem-zref" name="enumitem-zref" caption="Extended references to items for enumitem package" />
+  <package key="enumspec" name="enumspec" caption="Enumerate with extra leading character for labels" />
+  <package key="envbig" name="envbig" caption="Printing addresses on envelopes" />
+  <package key="envelope" name="envelope" caption="Print envelopes" />
+  <package key="environ" name="environ" caption="A new interface for environments in LaTeX" />
+  <package key="envlab" name="envlab" caption="Addresses on envelopes or mailing labels" />
+  <package key="envmath" name="envmath" caption="Maths commands and environments" />
+  <package key="eolang" name="eolang" caption="Formulas and graphs for the EO programming language" />
+  <package key="eolgrab" name="eolgrab" caption="Catch arguments delimited by end of line" />
+  <package key="epic" name="epic" caption="Enhance LaTeX picture mode" />
+  <package key="epigrafica" name="Epigrafica" caption="A Greek and Latin font" />
+  <package key="epigram" name="epigram" caption="Display short quotations" />
+  <package key="epigraph" name="epigraph" caption="A package for typesetting epigraphs" />
+  <package key="epigraph-keys" name="epigraph-keys" caption="Epigraphs using key values" />
+  <package key="epiolmec" name="epiolmec" caption="Typesetting the Epi-Olmec Language" />
+  <package key="epix" name="ePiX" caption="Utility for mathematically accurate, camera quality plots and line figures" />
+  <package key="eplain" name="eplain" caption="Extended plain TeX macros" />
+  <package key="epmtfe" name="epmtfe" caption="TeX environment for OS/2" />
+  <package key="eppstein-trees" name="eppstein-trees" caption="Macros for producing trees" />
+  <package key="eps2pdf" name="eps2pdf" caption="A Win32 GUI EPS to PDF convertor" />
+  <package key="epsdice" name="epsdice" caption="A scalable dice &quot;font&quot;" />
+  <package key="epsf" name="epsf" caption="Simple macros for EPS inclusion" />
+  <package key="epsf-dvipdfmx" name="epsf-dvipdfmx" caption="Plain TeX file for using epsf.tex with (x)dvipdfmx" />
+  <package key="epsfig" name="epsfig" caption="Include Encapsulated PostScript in LaTeX documents" />
+  <package key="epsfig209" name="epsfig209" caption="Obsolete graphics inclusion macros" />
+  <package key="epsfview" name="epsfview" caption="Mac AppleScript tool for viewing figures generated with MetaPost" />
+  <package key="epsfx" name="epsfx" caption="A TeX macro package for including EPS graphics" />
+  <package key="epsincl" name="epsincl" caption="Include EPS in MetaPost figures" />
+  <package key="epslatex" name="epslatex" caption="Guide to using Encapsulated PostScript in LaTeX" />
+  <package key="epspdf" name="epspdf" caption="Converter for PostScript, EPS and PDF" />
+  <package key="epspdf-extra" name="epspdf-extra" caption="Platform-specific extras for epspdf" />
+  <package key="epspdf-setup" name="epspdf-setup" caption="epspdftk with GUI installer" />
+  <package key="epspdfconversion" name="epspdfconversion" caption="On-the-fly conversion of EPS to PDF" />
+  <package key="epstool" name="epstool" caption="Manipulate Encapsulated PostScript (EPS)" />
+  <package key="epstopdf" name="epstopdf" caption="Convert EPS to PDF using Ghostscript" />
+  <package key="epstopdf-pkg" name="epstopdf-pkg" caption="Call epstopdf &quot;on the fly&quot;" />
+  <package key="eq-fetchbbl" name="eq-fetchbbl" caption="Match Biblical passages with verse references in a quiz" />
+  <package key="eq-pin2corr" name="eq-pin2corr" caption="Add PIN security to the &#8220;Correct&#8221; button of a quiz created by exerquiz" />
+  <package key="eq-save" name="eq-save" caption="Save exerquiz quizzes and resume" />
+  <package key="eq2db" name="eq2db" caption="Convert a quiz to one submitted to a server-side script" />
+  <package key="eqell" name="eqell" caption="Sympathetically spaced ellipsis after punctuation" />
+  <package key="eqexam" name="eqexam" caption="A stand-alone exam package" />
+  <package key="eqexpl" name="eqexpl" caption="Align explanations for formulas" />
+  <package key="eqlist" name="eqlist" caption="Description lists with equal indentation" />
+  <package key="eqmark" name="eqmark" caption="Generalise facilities for marking equation arrays" />
+  <package key="eqmlite" name="Eqmlite/Free" caption="TeX system and PDF support for Linux and OS/2" />
+  <package key="eqnalign" name="eqnalign" caption="Make eqnarray behave like align" />
+  <package key="eqname" name="eqname" caption="Name tags for equations" />
+  <package key="eqnarray" name="eqnarray" caption="More generalised equation arrays with numbering" />
+  <package key="eqnarray209" name="eqnarray209" caption="A fix for LaTeX 2.09 eqnarray" />
+  <package key="eqnnumwarn" name="eqnnumwarn" caption="Modifies the amsmath equation environments to warn for a displaced equation number" />
+  <package key="eqparbox" name="eqparbox" caption="Create equal-widthed parboxes" />
+  <package key="equationauthor" name="equationauthor" caption="Visual equation editor" />
+  <package key="erdc" name="erdc" caption="Style for Reports by US Army Corps of Engineers" />
+  <package key="erewhon" name="erewhon" caption="Font package derived from Heuristica and Utopia" />
+  <package key="erewhon-math" name="erewhon-math" caption="Utopia based OpenType Math font" />
+  <package key="errata" name="errata" caption="Error markup for LaTeX documents" />
+  <package key="erw-l3" name="erw-l3" caption="Utilities based on LaTeX3" />
+  <package key="esami" name="esami" caption="Typeset exams with scrambled questions and answers" />
+  <package key="escapetext" name="escapeTeXt" caption="Make plain text safe for use in LaTeX" />
+  <package key="esdiff" name="esdiff" caption="Simplify typesetting of derivatives" />
+  <package key="esieecv" name="esieecv" caption="Curriculum vitae for French use" />
+  <package key="esindex" name="esindex" caption="Typset index entries in Spanish documents" />
+  <package key="esint" name="esint" caption="Extended set of integrals for Computer Modern" />
+  <package key="esint-type1" name="esint-type1" caption="Font esint10 in Type 1 format" />
+  <package key="esk" name="esk" caption="Package to encapsulate Sketch files in LaTeX sources" />
+  <package key="eskd" name="eskd" caption="Modern Russian typesetting" />
+  <package key="eskdx" name="eskdx" caption="Modern Russian typesetting" />
+  <package key="eslides" name="eslides" caption="An option for article style to make slides" />
+  <package key="eso-pic" name="eso-pic" caption="Add picture commands (or backgrounds) to every page" />
+  <package key="esperant" name="esperant" caption="Style option for writing Esperanto texts" />
+  <package key="espo" name="espo" caption="Customisation for Esperanto" />
+  <package key="esrelation" name="esrelation" caption="Provides a symbol set for describing relations between ordered pairs" />
+  <package key="esstix" name="esstix" caption="PostScript versions of the ESSTIX, with macro support" />
+  <package key="estcpmm" name="estcpmm" caption="Style for Munitions Management Project Reports" />
+  <package key="esvect" name="esvect" caption="Vector arrows" />
+  <package key="et" name="et" caption="TeX-compatible editor" />
+  <package key="etaremune" name="etaremune" caption="Reverse-counting enumerate environment" />
+  <package key="etbb" name="ETbb" caption="An expansion of Edward Tufte&#8217;s ET-Bembo family" />
+  <package key="etdipa" name="etdipa" caption="Simple, lightweight template for scientific documents" />
+  <package key="etex" name="e-TeX" caption="An extended version of TeX, from the NTS project" />
+  <package key="etex-pkg" name="etex-pkg" caption="E-TeX support package" />
+  <package key="etexcmds" name="etexcmds" caption="Avoid name clashes with e-TeX commands" />
+  <package key="etextools" name="etextools" caption="e-TeX tools for LaTeX users and package writers" />
+  <package key="ethiop" name="ethiop" caption="LaTeX macros and fonts for typesetting Amharic" />
+  <package key="ethiop-t1" name="ethiop-t1" caption="Type 1 versions of Amharic fonts" />
+  <package key="ethtex" name="ethtex" caption="Fonts and LaTeX support for typesetting Amharic" />
+  <package key="etl" name="etl" caption="Expandable token list operations" />
+  <package key="etoc" name="etoc" caption="Completely customisable TOCs" />
+  <package key="etoolbox" name="etoolbox" caption="e-TeX tools for LaTeX" />
+  <package key="etoolbox-de" name="etoolbox-de" caption="German translation of documentation of etoolbox" />
+  <package key="etruscan" name="etruscan" caption="Fonts for the Etruscan script" />
+  <package key="etsvthor" name="etsvthor" caption="Some useful abbreviations for members of e.t.s.v. Thor" />
+  <package key="euclideangeometry" name="euclideangeometry" caption="Draw geometrical constructions" />
+  <package key="euenc" name="EUenc" caption="Unicode font encoding definitions for XeTeX" />
+  <package key="euflag" name="euflag" caption="A command to reproduce the flag of the European Union" />
+  <package key="eukdate" name="eukdate" caption="UK format dates, with weekday" />
+  <package key="eukleides" name="eukleides" caption="A geometry drawing system" />
+  <package key="euler" name="euler" caption="Use AMS Euler fonts for math" />
+  <package key="euler-math" name="euler-math" caption="OpenType version of Hermann Zapf&#8217;s Euler maths font" />
+  <package key="eulerpx" name="eulerpx" caption="A modern interface for the Euler math fonts" />
+  <package key="eulervm" name="eulervm" caption="Euler virtual math fonts" />
+  <package key="euproposal" name="euproposal" caption="A class for preparing FP7 proposals" />
+  <package key="euro" name="euro" caption="Provide Euro values for national currency amounts" />
+  <package key="euro-ce" name="euro-ce" caption="Euro and CE sign font" />
+  <package key="eurofont" name="eurofont" caption="Provides a command that prints a euro symbol" />
+  <package key="euroitc" name="euroitc" caption="LaTeX interface for the ITC euro font symbols" />
+  <package key="europasscv" name="europasscv" caption="Unofficial class for the new version of the Europass curriculum vitae" />
+  <package key="europecv" name="EuropeCV" caption="Unofficial class for European curricula vitae" />
+  <package key="europs" name="europs" caption="Access to Adobe&#8217;s Euro currency symbol fonts" />
+  <package key="eurosans" name="eurosans" caption="Interface to Adobe&#8217;s sans-serif Euro font" />
+  <package key="eurosym" name="eurosym" caption="Metafont and macros for Euro sign" />
+  <package key="eurotex" name="eurotex" caption="Multilingual macros for Plain TeX" />
+  <package key="euxunicode" name="euxunicode" caption="Generate Unicode characters from accented glyphs" />
+  <package key="evangelion-jfm" name="Evangelion-JFM" caption="A Japanese font metric supporting many advanced features" />
+  <package key="evautofl" name="evautofl" caption="Pages with cut lines and punch marks" />
+  <package key="evenpage" name="evenpage" caption="Ensure that the total number of pages is even" />
+  <package key="everyhook" name="everyhook" caption="Hooks for standard TeX token lists" />
+  <package key="everypage" name="everypage" caption="Provide hooks to be run on every page of a document" />
+  <package key="everysel" name="everysel" caption="Provides hooks into \selectfont" />
+  <package key="everyshi" name="everyshi" caption="Take action at every \shipout" />
+  <package key="evweek" name="evweek" caption="Weekly calendar" />
+  <package key="exam" name="exam" caption="Package for typesetting exam scripts" />
+  <package key="exam-lite" name="exam-lite" caption="Quicker preparation of exams in LaTeX" />
+  <package key="exam-n" name="exam-n" caption="Exam class, focused on collaborative authoring" />
+  <package key="exam-randomizechoices" name="exam-randomizechoices" caption="Randomize mc choices using the exam class" />
+  <package key="exam-zh" name="exam-zh" caption="LaTeX template for Chinese exams" />
+  <package key="exam209" name="exam209" caption="Process exam questions and answers (LaTeX 2.09)" />
+  <package key="examdesign" name="Exam design" caption="LaTeX class for typesetting exams" />
+  <package key="example" name="example" caption="Typeset examples for TeX courses" />
+  <package key="examplep" name="examplep" caption="Verbatim phrases and listings in LaTeX" />
+  <package key="exams" name="exams" caption="Typeset exam questions" />
+  <package key="examz" name="examz" caption="Randomized exams with multiple versions" />
+  <package key="excalibur" name="excalibur" caption="Macintosh spell checker" />
+  <package key="excel2latex" name="Excel2LaTeX" caption="Convert Excel spreadsheets to LaTeX tables" />
+  <package key="exceltex" name="Exceltex" caption="Get data from Excel files into LaTeX" />
+  <package key="excludeonly" name="excludeonly" caption="Prevent files being \include-ed" />
+  <package key="exercise" name="exercise" caption="Typeset exercises, problems, etc. and their answers" />
+  <package key="exercisebank" name="exercisebank" caption="Creating and managing exercises, and reusing them as composed sets" />
+  <package key="exercisepoints" name="exercisepoints" caption="A LaTeX package to count exercises and points" />
+  <package key="exercises" name="exercises" caption="
+    Typeset exercises and solutions with automatic addition of points
+  " />
+  <package key="exerquiz" name="exerquiz" caption="Environments for defining exercises and quizzes" />
+  <package key="exesheet" name="exesheet" caption="Typesetting exercise or exam sheets" />
+  <package key="exframe" name="exframe" caption="Framework for exercise problems" />
+  <package key="exp-testopt" name="exp-testopt" caption="Expandable \@testopt (and related) macros" />
+  <package key="expdlist" name="expdlist" caption="Expanded description environments" />
+  <package key="expex" name="expex" caption="Linguistic examples and glosses, with reference capabilities" />
+  <package key="expex-acro" name="expex-acro" caption="Wrapper for the expex package" />
+  <package key="expkv" name="expkv" caption="An expandable key=val implementation" />
+  <package key="expkv-bundle" name="expkv-bundle" caption="An expandable key=val implementation and friends" />
+  <package key="expkv-cs" name="expkv-cs" caption="Define expandable key=val macros using expkv" />
+  <package key="expkv-def" name="expkv-def" caption="A key-defining frontend for expkv" />
+  <package key="expkv-opt" name="expkv-opt" caption="Parse class and package options with expkv" />
+  <package key="expl3" name="expl3" caption="Wrapper package for experimental LaTeX3" />
+  <package key="export" name="export" caption="Import and export values of LaTeX registers" />
+  <package key="expose-expl3-dunkerque-2019" name="expose-expl3-dunkerque-2019" caption="Using expl3 to implement some numerical algorithms" />
+  <package key="expressg" name="expressg" caption="Diagrams consisting of boxes, lines, and annotations" />
+  <package key="exscale" name="exscale" caption="Implements scaling of the &apos;cmex&apos; fonts" />
+  <package key="exsheets" name="exsheets" caption="Create exercise sheets and exams" />
+  <package key="exsol" name="exsol" caption="Exercises and solutions from the same source, into a book" />
+  <package key="extarrows" name="extarrows" caption="Extra Arrows beyond those provided in amsmath" />
+  <package key="extdash" name="extdash" caption="A range of dash commands for compound words" />
+  <package key="exteps" name="exteps" caption="Include EPS figures in MetaPost" />
+  <package key="extpfeil" name="extpfeil" caption="Extensible arrows in mathematics" />
+  <package key="extract" name="extract" caption="Extract parts of a document and write to another document" />
+  <package key="extractpdfmark" name="extractpdfmark" caption="Extract page mode and named destinations as PDFmark from PDF" />
+  <package key="extradefs" name="extradefs" caption="A miscellany of support macros" />
+  <package key="extsizes" name="extsizes" caption="Extend the standard classes&#8217; size options" />
+  <package key="fac" name="fac" caption="Macros for FAC journal" />
+  <package key="facsimile" name="facsimile" caption="Document class for preparing faxes" />
+  <package key="factura" name="factura" caption="Typeset and calculate invoices according to Venezuelan law" />
+  <package key="facture" name="facture" caption="Generate an invoice" />
+  <package key="facture-belge-simple-sans-tva" name="facture-belge-simple-sans-tva" caption="Simple Belgian invoice without VAT" />
+  <package key="fahyph" name="fahyph" caption="Hyphenation patterns for Persian (in Unicode)" />
+  <package key="fail-fast" name="fail-fast" caption="Turn warnings into errors" />
+  <package key="fakebold" name="fakebold" caption="A simple macro for faking bold fonts" />
+  <package key="faktor" name="faktor" caption="Typeset quotient structures with LaTeX" />
+  <package key="faltblat" name="faltblat" caption="Making Leaflets" />
+  <package key="familytree" name="familytree" caption="Draw family trees" />
+  <package key="famt" name="famt" caption="Project Reports and Notices in FAMT institute" />
+  <package key="fancybox" name="fancybox" caption="Variants of \fbox and other games with boxes" />
+  <package key="fancychapters" name="fancychapters" caption="Chapters with quotations" />
+  <package key="fancyfolien" name="fancyfolien" caption="Fancyhdr outline for German readers" />
+  <package key="fancyhandout" name="fancyhandout" caption="A LaTeX class for producing nice-looking handouts" />
+  <package key="fancyhdr" name="fancyhdr" caption="Extensive control of page headers and footers in LaTeX2e" />
+  <package key="fancyhdr-it" name="fancyhdr-it" caption="Italian translation of fancyhdr documentation" />
+  <package key="fancyhdrboxed" name="fancyhdrboxed" caption="Elaborate page headers, specified in a non-LaTeX language" />
+  <package key="fancyheadings" name="fancyheadings" caption="Legacy headings package" />
+  <package key="fancylabel" name="fancylabel" caption="Complex labelling with LaTeX" />
+  <package key="fancynum" name="fancynum" caption="Typeset numbers" />
+  <package key="fancypar" name="fancypar" caption="Decoration of individual paragraphs" />
+  <package key="fancyqr" name="fancyqr" caption="Fancy QR-Codes with TikZ" />
+  <package key="fancyref" name="fancyref" caption="A LaTeX package for fancy cross-referencing" />
+  <package key="fancyslides" name="fancyslides" caption="Custom presentation class built upon LaTeX Beamer" />
+  <package key="fancytabs" name="fancytabs" caption="Fancy page border tabs" />
+  <package key="fancytooltips" name="fancytooltips" caption="Include a wide range of material in PDF tooltips" />
+  <package key="fancyvrb" name="fancyvrb" caption="Sophisticated verbatim text" />
+  <package key="fandol" name="fandol" caption="Four basic fonts for Chinese typesetting" />
+  <package key="faq-de" name="faq-de" caption="The DANTE TeX Users Group Frequently Asked Questions" />
+  <package key="faq-es" name="faq-es" caption="CervanTeX (Spanish TeX Group) FAQ" />
+  <package key="faq-fr" name="faq-fr" caption="French FAQ of the GUTenberg TeX user group" />
+  <package key="fascicules" name="fascicules" caption="Create mathematical manuals for schools" />
+  <package key="fast-diagram" name="fast-diagram" caption="Easy generation of FAST diagrams" />
+  <package key="fastpictex" name="fastpictex" caption="Simple specification of PicTeX diagrams" />
+  <package key="fax" name="fax" caption="Document class for preparing faxes" />
+  <package key="fbb" name="fbb" caption="A free Bembo-like font" />
+  <package key="fbithesis" name="fbithesis" caption="Computer Science thesis class for University of Dortmund" />
+  <package key="fbox" name="fbox" caption="Extended \fbox macro from standard LaTeX" />
+  <package key="fbs" name="fbs" caption="BibTeX style for Frontiers in Bioscience" />
+  <package key="fc" name="fc" caption="Fonts for African languages" />
+  <package key="fc-arith" name="fc-arith" caption="Create an arithmetic flash card" />
+  <package key="fcavtex" name="fcavtex" caption="A thesis class for the FCAV/UNESP (Brazil)" />
+  <package key="fchart" name="fchart" caption="Flow diagrams in LaTeX 2.09" />
+  <package key="fcltxdoc" name="fcltxdoc" caption="Macros for use in the author&apos;s documentation" />
+  <package key="fcolumn" name="fcolumn" caption="Typesetting financial tables" />
+  <package key="fdsymbol" name="fdsymbol" caption="A maths symbol font" />
+  <package key="fduthesis" name="fduthesis" caption="LaTeX thesis template for Fudan University" />
+  <package key="featpost" name="featpost" caption=" MetaPost macros for 3D" />
+  <package key="fei" name="fei" caption="Class for academic works at FEI University Center &#8212; Brazil" />
+  <package key="fenetrecas" name="FenetreCas" caption="Commands for CAS-like windows (Xcas or Geogebra) in TikZ" />
+  <package key="fenixpar" name="fenixpar" caption="One-shot changes to token registers such as \everypar" />
+  <package key="fepslatex" name="fepslatex" caption="French version of &quot;graphics in LaTeX&quot;" />
+  <package key="fetamont" name="fetamont" caption="Extended version of Knuth&#8217;s logo typeface" />
+  <package key="fetchbibpes" name="fetchbibpes" caption="Creates a DB of Bible verses from e-Sword, then fetches them on command" />
+  <package key="fetchcls" name="fetchcls" caption="Fetch the current class name" />
+  <package key="feupphdteses" name="feupphdteses" caption="Typeset Engineering PhD theses at the University of Porto" />
+  <package key="fewerfloatpages" name="fewerfloatpages" caption="Reduce the number of unnecessary float pages" />
+  <package key="feyn" name="feyn" caption="A font for in-text Feynman diagrams" />
+  <package key="feynman" name="feynman" caption="Feynman diagrams in LaTeX 2.09" />
+  <package key="feynmf" name="feynmf" caption="Macros and fonts for creating Feynman (and other) diagrams" />
+  <package key="feynmp-auto" name="feynmp-auto" caption="Automatic processing of feynmp graphics" />
+  <package key="ffcode" name="ffcode" caption="Fixed-font code blocks formatted nicely" />
+  <package key="ffslides" name="ffslides" caption="Freeform slides based on the article class" />
+  <package key="fge" name="fge" caption="A font for Frege&apos;s Grundgesetze der Arithmetik" />
+  <package key="fgruler" name="fgruler" caption="Draw rulers on the foreground or in the text" />
+  <package key="fi2t1" name="fi2t1" caption="Tools for installing Type 1 fonts in MiKTeX" />
+  <package key="fibeamer" name="fibeamer" caption="Beamer theme for thesis defense presentations at Masaryk University (Brno, Czech Republic)" />
+  <package key="fibnum" name="fibnum" caption="Generate Fibonacci numbers" />
+  <package key="fifinddo" name="fifinddo" caption="Filtering files using TeX" />
+  <package key="fifinddo-info" name="fifinddo-info" caption="German HTML beamer presentation on nicetext and morehype" />
+  <package key="fifo-stack" name="fifo-stack" caption="FIFO and stack implementation for package writers" />
+  <package key="fig2eng" name="fig2eng" caption="Convert fig files to English" />
+  <package key="fig2lat" name="fig2lat" caption="Convert .fig files to vector graphics" />
+  <package key="fig2mf" name="fig2mf" caption="Convert fig output to Metafont" />
+  <package key="fig2mfpic" name="fig2mfpic" caption="Convert fig output to mfpic" />
+  <package key="fig2sty" name="fig2sty" caption="Use fig as layout designer for LaTeX" />
+  <package key="fig2vect" name="fig2vect" caption="Yet another Fig to vector converter" />
+  <package key="fig4latex" name="fig4latex" caption="Management of figures for large LaTeX documents" />
+  <package key="figbas" name="figbas" caption="Mini-fonts for figured-bass notation in music" />
+  <package key="figbib" name="FigBib" caption="Organize figure databases with BibTeX" />
+  <package key="figcaps" name="figcaps" caption="Collect figure captions for later printing" />
+  <package key="figchild" name="figchild" caption="Pictures for creating children&#8217;s activities" />
+  <package key="figflow" name="figflow" caption="Flow text around a figure" />
+  <package key="figfrag" name="figfrag" caption="Convert xfig figures with embedded LaTeX commands to EPS" />
+  <package key="figplace" name="figplace" caption="Floating figures in Plain TeX" />
+  <package key="figput" name="figput" caption="Create interactive figures in LaTeX" />
+  <package key="figsinltx" name="figsinltx" caption="A tutorial on figures in LaTeX 2.09" />
+  <package key="figsize" name="FigSize" caption="Auto-size graphics" />
+  <package key="fihyph" name="fihyph" caption="Hyphenation patterns for Finnish language" />
+  <package key="filecontents" name="filecontents" caption="Create an external file from within a LaTeX document" />
+  <package key="filecontentsdef" name="filecontentsdef" caption="filecontents + macro + verbatim" />
+  <package key="filedate" name="filedate" caption="Access and compare info and modification dates" />
+  <package key="fileerr" name="fileerr" caption="LaTeX&#8217;s mechanisms for dealing with file errors" />
+  <package key="filehdr" name="filehdr" caption="Self-descriptions in file headers" />
+  <package key="filehook" name="filehook" caption="Hooks for input files" />
+  <package key="fileinfo" name="fileinfo" caption="Enhanced display of LaTeX File Information" />
+  <package key="filemod" name="filemod" caption="Provide file modification times, and compare them" />
+  <package key="fillform" name="fillform" caption="Typeset answers to overprint on printed forms" />
+  <package key="findbib" name="findbib" caption="Find bibliographic details from SPIRES" />
+  <package key="findhyph" name="findhyph" caption="Find hyphenated words in a document" />
+  <package key="fink" name="FiNK" caption="The LaTeX2e File Name Keeper" />
+  <package key="finomaton" name="Finomaton" caption="Comfortably draw and typeset finite state machines" />
+  <package key="finplain" name="finplain" caption="A Finnish version of plain.bst" />
+  <package key="finstrut" name="finstrut" caption="Adjust behaviour of the ends of footnotes" />
+  <package key="fira" name="fira" caption="Fira fonts with LaTeX support" />
+  <package key="firamath" name="firamath" caption="Fira sans serif font with Unicode math support" />
+  <package key="firamath-otf" name="firamath-otf" caption="Use OpenType math font Fira Math" />
+  <package key="firefox-ctan-plugins" name="firefox-ctan-plugins" caption="Firefox search proformas for CTAN" />
+  <package key="first-latex-doc" name="first-latex-doc" caption="A document for absolute LaTeX beginners" />
+  <package key="first-packages" name="first-packages" caption="A short list of go-to LaTeX packages, aimed at a beginner" />
+  <package key="firstline" name="firstline" caption="Print the first line of a paragraph in a different font" />
+  <package key="firststeps-xampl" name="firststeps-xampl" caption="Examples from &#8220;First steps in LaTeX&#8221;" />
+  <package key="fistrum" name="fistrum" caption="Access to 150 paragraphs of Lorem Fistrum very dummy text" />
+  <package key="fitbox" name="fitbox" caption="Fit graphics on a page" />
+  <package key="fithesis" name="fithesis" caption="Thesis class and template for Masaryk University (Brno, Czech Republic)" />
+  <package key="fitr" name="FitR" caption="Set a rectangular destination and jump to it" />
+  <package key="fix-cm" name="fix-cm" caption="Permit Computer Modern fonts at arbitrary sizes" />
+  <package key="fix2col" name="fix2col" caption="Fix miscellaneous two column mode features" />
+  <package key="fixbbl" name="fixbbl" caption="Patch bibliographies inappropriately broken by BibTeX" />
+  <package key="fixcmex" name="fixcmex" caption="Fully scalable version of Computer Modern Math Extension font" />
+  <package key="fixdif" name="fixdif" caption="Macros for typesetting differential operators" />
+  <package key="fixfoot" name="fixfoot" caption="Multiple use of the same footnote text" />
+  <package key="fixjfm" name="fixjfm" caption="Fix JFM (for *pTeX)" />
+  <package key="fixlatvian" name="fixlatvian" caption="Improve Latvian language support in XeLaTeX" />
+  <package key="fixltx2e" name="fixltx2e" caption="Patches for LaTeX" />
+  <package key="fixltxhyph" name="fixltxhyph" caption="Allow hyphenation of partially-emphasised substrings" />
+  <package key="fixmath" name="fixmath" caption="Make maths comply with ISO 31-0:1992 to ISO 31-13:1992" />
+  <package key="fixme" name="FiXme" caption="Collaborative annotation tool for LaTeX" />
+  <package key="fixmetodonotes" name="fixmetodonotes" caption="Add notes on document development" />
+  <package key="fixocgx" name="fixocgx" caption="Add support for dvips+ps2pdf, XeLaTeX, dvipdfmx to the ocgx package" />
+  <package key="fixpdfmag" name="fixpdfmag" caption="Fix magnification in pdfTeX" />
+  <package key="fiziko" name="fiziko" caption="A MetaPost library for physics textbook illustrations" />
+  <package key="fjodor" name="fjodor" caption="A selection of layout styles" />
+  <package key="flabels" name="flabels" caption="Labels for files and folders" />
+  <package key="flacards" name="flacards" caption="Generate flashcards for printing" />
+  <package key="flagderiv" name="flagderiv" caption="Flag style derivation package" />
+  <package key="flags" name="flags" caption="Setting and clearing of flags in bit fields" />
+  <package key="flashcard" name="flashcard" caption="Typeset flash cards" />
+  <package key="flashcards" name="flashcards" caption="A class for typesetting flashcards" />
+  <package key="flashmovie" name="flashmovie" caption="Directly embed flash movies into PDF files" />
+  <package key="flatex" name="flatex" caption="Flatten \input, etc., in a LaTeX file" />
+  <package key="flatten" name="flatten" caption="Flatten \input, etc., in a LaTeX file" />
+  <package key="fldigigal" name="fldigigal" caption="Create a Flash slide show of digital photos" />
+  <package key="flexipage" name="flexipage" caption=" Flexible page geometry with marginalia" />
+  <package key="flexisym" name="flexisym" caption="Symbol manipulation for breqn" />
+  <package key="flipbook" name="flipbook" caption="Typeset flipbook animations, in the corners of documents" />
+  <package key="flippdf" name="flippdf" caption="Horizontal flipping of pages with pdfLaTeX" />
+  <package key="float" name="float" caption="Improved interface for floating objects" />
+  <package key="floatfig" name="floatfig" caption="Deprecated: Allows text to be wrapped around figures" />
+  <package key="floatflt" name="floatflt" caption="Wrap text around floats" />
+  <package key="floatnohead" name="floatnohead" caption="Suppress page headings on float-only pages" />
+  <package key="floatpag" name="floatpag" caption="Different pagestyles on float pages" />
+  <package key="floatrow" name="floatrow" caption="Modifying the layout of floats" />
+  <package key="flow" name="flow" caption="Draw flow diagrams in picture mode" />
+  <package key="flowchart" name="flowchart" caption="Shapes for drawing flowcharts, using TikZ" />
+  <package key="flowfram" name="flowfram" caption="Create text frames for posters, brochures or magazines" />
+  <package key="flowframtk" name="FlowframTk" caption="Vector graphics application with support for flowfram.sty" />
+  <package key="fltpage" name="fltpage" caption="Place caption on an adjacent page" />
+  <package key="fltpoint" name="fltpoint" caption="Simple floating point arithmetic" />
+  <package key="flushend" name="flushend" caption="Balancing columns at last page" />
+  <package key="fmp" name="fmp" caption="Include Functional MetaPost in LaTeX" />
+  <package key="fmtcount" name="fmtcount" caption="Display the value of a LaTeX counter in a variety of formats" />
+  <package key="fn2end" name="fn2end" caption="Convert footnotes to endnotes" />
+  <package key="fnbreak" name="fnbreak" caption="Warn for split footnotes" />
+  <package key="fncychap" name="fncychap" caption="Seven predefined chapter heading styles" />
+  <package key="fncylab" name="fncylab" caption="Alter the format of \label references" />
+  <package key="fnlineno" name="fnlineno" caption="Number the lines of footnotes" />
+  <package key="fnote" name="fnote" caption="Auto-numbered footnotes in Plain TeX" />
+  <package key="fnpara" name="fnpara" caption="Footnotes in paragraphs" />
+  <package key="fnpara-pln" name="fnpara-pln" caption="Footnotes in paragraphs" />
+  <package key="fnpct" name="fnpct" caption="Manage footnote marks&#8217; interaction with punctuation" />
+  <package key="fnpos" name="fnpos" caption="Control the position of footnotes on the page" />
+  <package key="fnspe" name="fnspe" caption="Macros for supporting mainly students of FNSPE CTU in Prague" />
+  <package key="fntguide" name="fntguide" caption="Docmentation of LaTeX font commands" />
+  <package key="fntproof" name="fntproof" caption="A programmable font test pattern generator" />
+  <package key="fnumprint" name="fnumprint" caption="Print a number in &#8216;appropriate&#8217; format" />
+  <package key="foekfont" name="foekfont" caption="The title font of the Mads F&#248;k magazine" />
+  <package key="foilhtml" name="foilhtml" caption="Interface between foiltex and LaTeX2HTML" />
+  <package key="foiltex" name="foiltex" caption="A LaTeX2e class for overhead transparencies" />
+  <package key="foliono" name="foliono" caption=" Use folio numbers to replace page numbers" />
+  <package key="fonetika" name="fonetika" caption="Support for the Danish &quot;Dania&quot; phonetic system" />
+  <package key="font-change" name="font-change" caption="Macros to change text and mathematics fonts in plain TeX" />
+  <package key="font-change-xetex" name="font-change-xetex" caption="Macros to change text and mathematics fonts in plain XeTeX" />
+  <package key="font-selection" name="font_selection" caption="Font selection for plain TeX" />
+  <package key="fontawesome" name="fontawesome" caption="Font containing web-related icons" />
+  <package key="fontawesome5" name="fontawesome5" caption="Font Awesome 5 with LaTeX support" />
+  <package key="fontaxes" name="fontaxes" caption="Additional font axes for LaTeX" />
+  <package key="fontbl" name="fontbl" caption="A font sampler" />
+  <package key="fontbook" name="fontbook" caption="Generate a font book" />
+  <package key="fontch" name="fontch" caption="Changing fonts, sizes and encodings in Plain TeX" />
+  <package key="fontchart" name="fontchart" caption="A font sampler" />
+  <package key="fonteinf" name="fonteinf" caption="An introduction to font usage in LaTeX (German)" />
+  <package key="fontenc" name="fontenc" caption="Standard package for selecting font encodings" />
+  <package key="fontinst" name="fontinst" caption="Help with installing fonts for TeX and LaTeX" />
+  <package key="fontinstallationguide" name="fontinstallationguide" caption="Font installation guide" />
+  <package key="fontload" name="fontload" caption="A partial font downloading utility" />
+  <package key="fontloader-luaotfload" name="fontloader-luaotfload" caption="Alternative fontloaders for luaotfload" />
+  <package key="fontmfizz" name="fontmfizz" caption="Font Mfizz icons for use in LaTeX" />
+  <package key="fontname" name="fontname" caption="Scheme for naming fonts in TeX" />
+  <package key="fontools" name="fontools" caption="Tools to simplify using fonts (especially TT/OTF ones)" />
+  <package key="fonts-arundina" name="fonts-arundina" caption="DejaVu-compatible Thai fonts" />
+  <package key="fonts-churchslavonic" name="fonts-churchslavonic" caption="Fonts for typesetting in Church Slavonic language" />
+  <package key="fonts-tlwg" name="fonts-tlwg" caption="Thai fonts for LaTeX from TLWG" />
+  <package key="fontsampler" name="fontsampler" caption="Samples of fonts that come with TeX Live" />
+  <package key="fontsetup" name="fontsetup" caption="A front-end to fontspec, for selected fonts with math support" />
+  <package key="fontsetup-nonfree" name="fontsetup-nonfree" caption="A front-end to fontspec, for selected non-free fonts" />
+  <package key="fontsize" name="fontsize" caption="A small package to set arbitrary sizes for the main font of the document" />
+  <package key="fontsmpl" name="fontsmpl" caption="Print a sample of a font" />
+  <package key="fontspec" name="fontspec" caption="Advanced font selection in XeLaTeX and LuaLaTeX" />
+  <package key="fonttable" name="fonttable" caption="Print font tables from a LaTeX document" />
+  <package key="fontwrap" name="fontwrap" caption="Bind fonts to specific unicode blocks" />
+  <package key="footbib" name="footbib" caption="Bibliographic references as footnotes" />
+  <package key="footmisc" name="footmisc" caption="A range of footnote options" />
+  <package key="footmisx" name="footmisx" caption="A range of footnote options" />
+  <package key="footnote" name="footnote" caption="Improve on LaTeX&apos;s footnote handling" />
+  <package key="footnotebackref" name="footnotebackref" caption="Back-references from footnotes" />
+  <package key="footnotehyper" name="footnotehyper" caption="hyperref aware footnote.sty" />
+  <package key="footnoterange" name="footnoterange" caption="References to ranges of footnotes" />
+  <package key="footnpag" name="footnpag" caption="Per-page numbering of footnotes" />
+  <package key="forarray" name="forarray" caption="Using array structures in LaTeX" />
+  <package key="foreign" name="foreign" caption="Systematic treatment of &#8216;foreign&#8217; words in documents" />
+  <package key="forest" name="forest" caption="Drawing (linguistic) trees" />
+  <package key="forest-quickstart" name="forest-quickstart" caption="Quickstart Guide for Linguists package &#8220;forest&#8221;" />
+  <package key="forindex" name="forindex" caption="Manipulate \index commands in a LaTeX file" />
+  <package key="forloop" name="forloop" caption="Iteration in LaTeX" />
+  <package key="formal-grammar" name="formal-grammar" caption="Typeset formal grammars" />
+  <package key="format" name="format" caption="Format a counter as a fixed-point number" />
+  <package key="formation-latex-ul" name="formation-latex-ul" caption="Introductory LaTeX course in French" />
+  <package key="formlett" name="formlett" caption="Letters to multiple recipients" />
+  <package key="forms16be" name="forms16be" caption="Initialize form properties using big-endian encoding" />
+  <package key="formula" name="formula" caption="Typesetting physical units" />
+  <package key="formular" name="formular" caption="Create forms containing field for manual entry" />
+  <package key="fortran" name="fortran" caption="Print Fortran programs" />
+  <package key="forum" name="forum" caption="Forum fonts with LaTeX support" />
+  <package key="fotex" name="fotex" caption="Process XSL-FO" />
+  <package key="fouridx" name="fouridx" caption="Left sub- and superscripts in maths mode" />
+  <package key="fourier" name="fourier" caption="Using Utopia fonts in LaTeX documents" />
+  <package key="fouriernc" name="FourierNC" caption="Use New Century Schoolbook text with Fourier maths fonts" />
+  <package key="fourproject" name="fourproject" caption="Analyse and display the structure of a TeX document" />
+  <package key="fourspell" name="fourspell" caption="Windows32 spell checker for TeX, RTF, HTML, and BibTeX" />
+  <package key="fp" name="fp" caption="Fixed point arithmetic" />
+  <package key="fpl" name="fpl" caption="SC and OsF fonts for URW Palladio L" />
+  <package key="fptex" name="fpTeX" caption="A web2C-based TeX system for MS-Windows32" />
+  <package key="fragmaster" name="fragmaster" caption="Using psfrag with pdfLaTeX" />
+  <package key="fragments" name="fragments" caption="Fragments of LaTeX code" />
+  <package key="frame" name="frame" caption="Framed boxes for Plain TeX" />
+  <package key="framed" name="framed" caption="Framed or shaded regions that can break across pages" />
+  <package key="francais-bst" name="francais-bst" caption="Bibliographies conforming to French typographic standards" />
+  <package key="frankenbundle" name="frankenbundle" caption="Develop and distribute LaTeX packages and classes and BibTeX styles" />
+  <package key="frankenstein" name="frankenstein" caption="A collection of LaTeX packages" />
+  <package key="frankenstein-unsupported" name="frankenstein-unsupported" caption="Unsupported packages from the Frankenstein bundle" />
+  <package key="frcursive" name="frcursive" caption="French cursive hand fonts" />
+  <package key="frederika2016" name="frederika2016" caption="An OpenType Greek calligraphy font" />
+  <package key="free-math-font-survey" name="free-math-font-survey" caption="A survey of available free Mathematics fonts" />
+  <package key="free-math-font-survey-vn" name="free-math-font-survey-vn" caption="The survey of available free Mathematics fonts, translated to Vietnamese" />
+  <package key="freetype" name="freetype" caption="A full-featured font rasterizer library" />
+  <package key="frege" name="frege" caption="Typeset fregean Begriffsschrift" />
+  <package key="french-translations" name="french-translations" caption="French translation project" />
+  <package key="frenchle" name="frenchle" caption="French macros, usable stand-alone or with Babel" />
+  <package key="frenchmath" name="frenchmath" caption="Typesetting mathematics according to French rules" />
+  <package key="frenchponct" name="frenchponct" caption="Implement French-style spacing at punctuation" />
+  <package key="frenchpro" name="frenchpro" caption="Professional typesetting of French documents" />
+  <package key="frenchquote" name="frenchquote" caption="Make something like guillemets" />
+  <package key="frhyph" name="frhyph" caption="French hyphenation patterns" />
+  <package key="fribidixetex" name="FriBidiXeTeX" caption="A pre-processor for XeTeX files to support unicode bidirectional algorithm" />
+  <package key="fribrief" name="fribrief" caption="Two LaTeX classes for writing letters in German" />
+  <package key="frimurer" name="frimurer" caption="Access to the &apos;frimurer&apos; cipher for use with LaTeX" />
+  <package key="frletter" name="frletter" caption="Typeset letters in the French style" />
+  <package key="frontespizio" name="frontespizio" caption="Create a frontispiece for Italian theses" />
+  <package key="froufrou" name="froufrou" caption="Fancy section separators" />
+  <package key="frpseudocode" name="frpseudocode" caption="French translation for the algorithmicx package" />
+  <package key="ftc-notebook" name="ftc-notebook" caption="Typeset FIRST Tech Challenge (FTC) notebooks" />
+  <package key="ftcap" name="ftcap" caption="Allows \caption at the beginning of a table-environment" />
+  <package key="ftetx" name="ftetx" caption="TeX support in FTE text editor" />
+  <package key="ftn" name="ftn" caption="LaTeX footnotes anywhere" />
+  <package key="ftnright" name="ftnright" caption="Footnotes in two column documents in one column only" />
+  <package key="ftnxtra" name="ftnxtra" caption="Extend the applicability of the \footnote command" />
+  <package key="fullblck" name="fullblck" caption="Left-blocking for letter class" />
+  <package key="fullminipage" name="fullminipage" caption="Minipage spanning a complete page" />
+  <package key="fullpage" name="fullpage" caption="Set all page margins to 1.5cm" />
+  <package key="fullpict" name="fullpict" caption="Full page pictures" />
+  <package key="fullwidth" name="fullwidth" caption="Adjust margins of text block" />
+  <package key="functan" name="functan" caption="Macros for functional analysis and PDE theory" />
+  <package key="functional" name="functional" caption="Provide an intuitive functional programming interface for LaTeX2" />
+  <package key="fundus" name="fundus" caption="Providing LaTeX access to various font families" />
+  <package key="fundus-calligra" name="fundus-calligra" caption="Support for the calligra font in LaTeX documents" />
+  <package key="fundus-cyr" name="fundus-cyr" caption="Support for Washington University Cyrillic fonts" />
+  <package key="fundus-la" name="fundus-la" caption="Support for the la and lla fonts in LaTeX documents" />
+  <package key="fundus-outline" name="fundus-outline" caption="LaTeX support for CM outline fonts" />
+  <package key="fundus-pvscript" name="fundus-pvscript" caption="Support for Vanroose handwriting font" />
+  <package key="fundus-startrek" name="fundus-startrek" caption="&#8216;Startrek&#8217; fonts, and macros to support them" />
+  <package key="fundus-sueterlin" name="fundus-sueterlin" caption="S&#252;tterlin" />
+  <package key="fundus-twcal" name="fundus-twcal" caption="LaTeX support for the twcal handwriting font" />
+  <package key="fundus-va" name="fundus-va" caption="Support for the va fonts in LaTeX documents" />
+  <package key="funnelweb" name="funnelweb" caption="A flexible, language-independent web system" />
+  <package key="futhark" name="futhark" caption="Fonts for the Older Futhark script" />
+  <package key="futhorc" name="futhorc" caption="Anglo-Friesic futhorc alphabet font" />
+  <package key="futurans" name="futurans" caption="Metrics and LaTeX support for Futura Fonts From Adobe As Used By No Starch Press" />
+  <package key="fvextra" name="fvextra" caption="Extensions and patches for fancyvrb" />
+  <package key="fweb" name="fweb" caption="A literate programming tool working with LaTeX" />
+  <package key="fwlw" name="fwlw" caption="Get first and last words of a page" />
+  <package key="g-brief" name="g-brief" caption="Letter document class" />
+  <package key="gaceta" name="gaceta" caption="A class to typeset La Gaceta de la RSME" />
+  <package key="gahyph" name="gahyph" caption="Hyphenation patterns for the Irish language" />
+  <package key="galois" name="galois" caption="Typeset Galois connections" />
+  <package key="gamebook" name="gamebook" caption="Typeset gamebooks and other interactive novels" />
+  <package key="gamebooklib" name="Gamebooklib" caption="Macros for setting numbered entries in shuffled order" />
+  <package key="gammas" name="gammas" caption="Template for the GAMM Archive for Students" />
+  <package key="gandhi" name="gandhi" caption="Gandhi Serif and Sans fonts, with LaTeX support" />
+  <package key="gapfill" name="gapfill" caption="Generate LaTeX picture environments from PostScript output of drawing programs" />
+  <package key="garamond-libre" name="garamond-libre" caption="The Garamond Libre font face" />
+  <package key="garamond-math" name="garamond-math" caption="An OTF math font matching EB Garamond" />
+  <package key="garamondx" name="garamondx" caption="&#8216;Expert&#8217;-like extensions to URW Garamond, and maths italic" />
+  <package key="garrigues" name="garrigues" caption="MetaPost macros for the reproduction of Garrigues&apos; Easter nomogram" />
+  <package key="gastex" name="GasTeX" caption="Graphs and Automata Simplified in TeX" />
+  <package key="gatech-thesis" name="gatech-thesis" caption="Georgia Institute of Technology thesis class" />
+  <package key="gates" name="gates" caption="Support for writing modular and customisable code" />
+  <package key="gatherenum" name="gatherenum" caption="A crossover of align* and enumerate" />
+  <package key="gauss" name="gauss" caption="A package for Gaussian operations" />
+  <package key="gb4e" name="gb4e" caption="Linguistic tools" />
+  <package key="gbrief-creator" name="gbrief-creator" caption="A front end for the gbrief package" />
+  <package key="gbt7714" name="gbt7714" caption="BibTeX implementation of China&#8217;s bibliography style standard GB/T 7714-2015" />
+  <package key="gcard" name="gcard" caption="Arrange text on a sheet to fold into a greeting card" />
+  <package key="gchords" name="gchords" caption="Typeset guitar chords" />
+  <package key="gcite" name="gcite" caption="Citations in a reader-friendly style" />
+  <package key="gckanbun" name="gckanbun" caption="Kanbun typesetting for (u)pLaTeX and LuaLaTeX" />
+  <package key="gelasio" name="gelasio" caption="LaTeX support for the Gelasio family of fonts" />
+  <package key="gellmu" name="GELLMU" caption="LaTeX-like markup for writing XML documents" />
+  <package key="gen" name="gen" caption="Genealogy symbols" />
+  <package key="gender" name="gender" caption="Gender neutrality for languages with grammatical gender" />
+  <package key="gene-logic" name="gene-logic" caption="Typeset logic formulae, etc" />
+  <package key="genealogy" name="genealogy" caption="A compilation genealogy font" />
+  <package key="genealogytree" name="genealogytree" caption="Pedigree and genealogical tree diagrams" />
+  <package key="genfam" name="genfam" caption="Run Metafont to produce the bitmap fonts" />
+  <package key="genindex" name="genindex" caption="Alternative index series" />
+  <package key="genmpage" name="genmpage" caption="Generalization of LaTeX&apos;s minipages" />
+  <package key="gensymb" name="gensymb" caption="Generic symbols for both text and math mode" />
+  <package key="gentabtex" name="gentabtex" caption="Python helper for creating tables" />
+  <package key="gentium-original" name="gentium-original" caption="Gentium font and support files" />
+  <package key="gentium-tug" name="gentium-tug" caption="Gentium fonts (in two formats) and support files" />
+  <package key="gentl-gr" name="gentl-gr" caption="Modern Greek translation of the Gentle Introduction to TeX" />
+  <package key="gentle" name="gentle" caption="A Gentle Introduction to TeX" />
+  <package key="gentombow" name="gentombow" caption="Generate Japanese-style crop marks" />
+  <package key="geometry" name="geometry" caption="Flexible and complete interface to document dimensions" />
+  <package key="geometry-de" name="geometry-de" caption="German documentation for the geometry package" />
+  <package key="geomsty" name="geomsty" caption="Macros used in typesetting a geometry book" />
+  <package key="geophysics" name="geophysics" caption="Articles for the journal Geophysics" />
+  <package key="georgian" name="georgian" caption="Support for typesetting in Georgian" />
+  <package key="georgian-stanier" name="georgian-stanier" caption="A Georgian font" />
+  <package key="geradwp" name="geradwp" caption="Document class for the Cahiers du GERAD series" />
+  <package key="german" name="german" caption="Support for German typography" />
+  <package key="germbib" name="germbib" caption="German variants of standard BibTeX styles" />
+  <package key="germdoc" name="germdoc" caption="A collection of documentation available in German" />
+  <package key="germkorr" name="germkorr" caption="Change kerning for German quotation marks" />
+  <package key="geschichtsfrkl" name="geschichtsfrkl" caption="BibLaTeX style for historians" />
+  <package key="getargs" name="getargs" caption="A flexible list-parsing macro with configurable parsing character" />
+  <package key="getfiledate" name="getfiledate" caption="Find the date of last modification of a file" />
+  <package key="getitems" name="getitems" caption="Gathering items from a list-like environment" />
+  <package key="getmap" name="getmap" caption="Download OpenStreetMap maps for use in documents" />
+  <package key="getoptk" name="getoptk" caption="Define macros with sophisticated options" />
+  <package key="getrefs" name="getrefs" caption="BibTeX style to sort by &quot;journal&quot; entries of references" />
+  <package key="gettitlestring" name="gettitlestring" caption="Clean up title references" />
+  <package key="gfdl" name="gfdl" caption="Support for using GFDL in LaTeX" />
+  <package key="gfnotation" name="gfnotation" caption="Typeset Gottlob Frege&apos;s notation in plain TeX" />
+  <package key="gfs" name="GFS" caption="The GFS font collection" />
+  <package key="gfsartemisia" name="GFS Artemisia" caption="A modern Greek font design" />
+  <package key="gfsbaskerville" name="GFS Baskerville" caption="A Greek font, from one such by Baskerville" />
+  <package key="gfsbodoni" name="GFS Bodoni" caption="A Greek and Latin font based on Bodoni" />
+  <package key="gfscomplutum" name="GFS Complutum" caption="A Greek font with a long history" />
+  <package key="gfsdidot" name="GFSDidot" caption="A Greek font based on Didot&#8217;s work" />
+  <package key="gfsdidotclassic" name="GFSDidotClassic" caption="The classic version of GFSDidot" />
+  <package key="gfsneohellenic" name="GFS NeoHellenic" caption="A font in the Neo-Hellenic style" />
+  <package key="gfsneohellenicmath" name="GFSNeohellenicMath" caption="A math font in the Neo-Hellenic style" />
+  <package key="gfsporson" name="GFS Porson" caption="A Greek font, originally from Porson" />
+  <package key="gfssolomos" name="GFS Solomos" caption="A Greek-alphabet font" />
+  <package key="ghab" name="ghab" caption="Typeset ghab boxes in LaTeX" />
+  <package key="ghostscript" name="ghostscript" caption="Freely available PostScript interpreter" />
+  <package key="ghsystem" name="ghsystem" caption="Globally harmonised system of chemical (etc) naming" />
+  <package key="gillcm" name="gillcm" caption="Alternative unslanted italic Computer Modern fonts" />
+  <package key="gillius" name="gillius" caption="Gillius fonts with LaTeX support" />
+  <package key="gincltex" name="gincltex" caption="Include TeX files as graphics (.tex support for \includegraphics)" />
+  <package key="gindex" name="gindex" caption="Formatting indexes" />
+  <package key="ginpenc" name="ginpenc" caption="Modification of inputenc for German" />
+  <package key="git-latexdiff" name="git-latexdiff" caption="Call latexdiff on two Git revisions of a file" />
+  <package key="gitfile-info" name="gitfile-info" caption="Get git metadata for a specific file" />
+  <package key="gitinfo" name="gitinfo" caption="Access metadata from the git distributed version control system" />
+  <package key="gitinfo2" name="gitinfo2" caption="Access metadata from the git distributed version control system" />
+  <package key="gitlog" name="gitlog" caption="Typesetting git changelogs" />
+  <package key="gitstatus" name="gitstatus" caption="Include Git information in the document as watermark or via variables" />
+  <package key="gitver" name="gitver" caption="Get the current git hash of a project and typeset it in the document" />
+  <package key="gkpmac" name="gkpmac" caption="The macros used in &quot;Concrete Mathematics&quot;" />
+  <package key="gl-tree" name="gl-tree" caption="Linguistic trees with a preprocessor" />
+  <package key="gladtex" name="GladTeX" caption="LaTeX equations in HTML" />
+  <package key="gleitobjekte" name="gleitobjekte" caption="Tutorial from a DANTE meeting in November 1997" />
+  <package key="glhyph" name="glhyph" caption="Hyphenation patterns for Galician" />
+  <package key="globalvals" name="globalvals" caption="Declare global variables" />
+  <package key="glonti" name="glonti" caption="Virtual fonts for T2A-encoded fonts" />
+  <package key="glosmathtools" name="glosmathtools" caption="Mathematical nomenclature tools based on the glossaries package" />
+  <package key="gloss" name="gloss" caption="Create glossaries using BibTeX" />
+  <package key="gloss-occitan" name="gloss-occitan" caption="Polyglossia support for Occitan" />
+  <package key="glossaries" name="glossaries" caption="Create glossaries and lists of acronyms" />
+  <package key="glossaries-accsupp" name="glossaries-accsupp" caption="Accessibility support for glossaries" />
+  <package key="glossaries-danish" name="glossaries-danish" caption="Danish language module for glossaries package" />
+  <package key="glossaries-dutch" name="glossaries-dutch" caption="Dutch language module for glossaries package" />
+  <package key="glossaries-english" name="glossaries-english" caption="English language module for glossaries package" />
+  <package key="glossaries-estonian" name="glossaries-estonian" caption="Estonian language module for glossaries package" />
+  <package key="glossaries-extra" name="glossaries-extra" caption="An extension to the glossaries package" />
+  <package key="glossaries-finnish" name="glossaries-finnish" caption="Finnish language module for glossaries package" />
+  <package key="glossaries-french" name="glossaries-french" caption="French language module for glossaries package" />
+  <package key="glossaries-german" name="glossaries-german" caption="German language module for glossaries package" />
+  <package key="glossaries-irish" name="glossaries-irish" caption="Irish language module for glossaries package" />
+  <package key="glossaries-italian" name="glossaries-italian" caption="Italian language module for glossaries package" />
+  <package key="glossaries-magyar" name="glossaries-magyar" caption="Magyar language module for glossaries package" />
+  <package key="glossaries-norsk" name="glossaries-norsk" caption="Norsk Bokm&#229;l language module for the glossaries Package" />
+  <package key="glossaries-nynorsk" name="glossaries-nynorsk" caption="Nynorsk language module for the glossaries package" />
+  <package key="glossaries-polish" name="glossaries-polish" caption="Polish language module for glossaries package" />
+  <package key="glossaries-portuges" name="glossaries-portuges" caption="Portuges language module for glossaries package" />
+  <package key="glossaries-serbian" name="glossaries-serbian" caption="Serbian language module for glossaries package" />
+  <package key="glossaries-slovene" name="glossaries-slovene" caption="Slovene language module for glossaries package" />
+  <package key="glossaries-spanish" name="glossaries-spanish" caption="Spanish language module for glossaries package" />
+  <package key="glossaries-swedish" name="glossaries-swedish" caption="Swedish language module for glossaries package" />
+  <package key="glossary" name="glossary" caption="Create a glossary" />
+  <package key="glosstex" name="glosstex" caption="Prepare glossaries in LaTeX" />
+  <package key="glotex" name="glotex" caption="A glossary processor" />
+  <package key="gmdoc" name="gmdoc" caption="Documentation of LaTeX packages" />
+  <package key="gmdoc-enhance" name="gmdoc-enhance" caption="Some enhancements to the gmdoc package" />
+  <package key="gmeometric" name="gmeometric" caption="Change page size wherever it&apos;s safe" />
+  <package key="gmiflink" name="gmiflink" caption="Simplify usage of \hypertarget and \hyperlink" />
+  <package key="gmp" name="gmp" caption="Enable integration between MetaPost pictures and LaTeX" />
+  <package key="gmutils" name="gmutils" caption="Support macros for other packages" />
+  <package key="gmverb" name="gmverb" caption="A variant of LaTeX \verb, verbatim and shortvrb" />
+  <package key="gmverse" name="gmverse" caption="A package for typesetting (short) poems" />
+  <package key="gnu-freefont" name="gnu-freefont" caption="A Unicode font, with rather wide coverage" />
+  <package key="gnuplot" name="gnuplot" caption="General purpose plotting program" />
+  <package key="gnuplottex" name="gnuplottex" caption="Embed Gnuplot commands in LaTeX documents" />
+  <package key="go" name="go" caption="Fonts and macros for typesetting go games" />
+  <package key="go-make" name="go-make" caption="A make variant for LaTeX documents" />
+  <package key="gobble" name="gobble" caption="More gobble macros for PlainTeX and LaTeX" />
+  <package key="goblin" name="goblin" caption="Tolkien&apos;s goblin alphabet" />
+  <package key="gofonts" name="gofonts" caption="GoSans and GoMono fonts with LaTeX support" />
+  <package key="gost" name="gost" caption="BibTeX styles to format according to GOST" />
+  <package key="gothic" name="gothic" caption="A collection of old German-style fonts" />
+  <package key="gotoh" name="gotoh" caption="An implementation of the Gotoh sequence alignment algorithm" />
+  <package key="gpdata" name="gpdata" caption="Cause MetaPost graph package to ignore &apos;#&apos;-comments" />
+  <package key="gplot" name="gplot" caption="CGM-based graphics support" />
+  <package key="grabbox" name="grabbox" caption="Read an argument into a box and execute the code afterwards" />
+  <package key="gradback" name="gradback" caption="Gradient backgrounds for dvips output" />
+  <package key="gradient-text" name="gradient-text" caption="Decorate text with linear gradient colors" />
+  <package key="gradientframe" name="gradientframe" caption="Simple gradient frames around objects" />
+  <package key="grading-scheme" name="grading-scheme" caption="Typeset grading schemes in tabular format" />
+  <package key="gradstudentresume" name="gradstudentresume" caption="A generic template for graduate student resumes" />
+  <package key="grafcet" name="grafcet" caption="Draw Grafcet/SFC with TikZ" />
+  <package key="grafik" name="grafik" caption="EPS graphics under Windows" />
+  <package key="grant" name="grant" caption="Classes for formatting federal grant proposals" />
+  <package key="graph35" name="graph35" caption="Draw keys and screen items of several Casio calculators" />
+  <package key="graphbase" name="GraphBase" caption="A platform for combinatorial algorithms" />
+  <package key="graphbox" name="graphbox" caption="Extend graphicx to improve placement of graphics" />
+  <package key="graphconv" name="GraphConv" caption="Convert graph files to PSTricks" />
+  <package key="grapher" name="grapher" caption="Create graphs, state machine and data flow diagrams" />
+  <package key="graphfig" name="graphfig" caption="Simpler graphic, subfigure and float" />
+  <package key="graphicp" name="graphicp" caption="An enhanced version of graphics" />
+  <package key="graphics" name="graphics" caption="Standard LaTeX graphics" />
+  <package key="graphics-cfg" name="graphics-cfg" caption="Sample configuration files for LaTeX color and graphics" />
+  <package key="graphics-def" name="graphics-def" caption="Colour and graphics option files" />
+  <package key="graphics-pln" name="graphics-pln" caption="LaTeX-style graphics for Plain TeX users" />
+  <package key="graphicscache" name="graphicscache" caption="Cache includegraphics calls" />
+  <package key="graphicx" name="graphicx" caption="Enhanced support for graphics" />
+  <package key="graphicx-psmin" name="graphicx-psmin" caption="Reduce size of PostScript files by not repeating images" />
+  <package key="graphicxbox" name="graphicxbox" caption="Insert a graphical image as a background" />
+  <package key="graphicxpsd" name="graphicxpsd" caption="Adobe Photoshop Data format (PSD) support for graphicx package" />
+  <package key="graphicxsp" name="GraphicxSP" caption="An extension of the graphicx package" />
+  <package key="graphpap" name="graphpap" caption="For producing graph paper" />
+  <package key="graphpaper" name="graphpaper" caption="A LaTeX class to generate several types of graph papers" />
+  <package key="graphtex" name="GraphTeX" caption="Graphs theory and related diagrams in a TeX document" />
+  <package key="graphviz" name="graphviz" caption="Write graphviz (dot+neato) inline in LaTeX documents" />
+  <package key="gray" name="gray" caption="Fonts for gray-scales" />
+  <package key="grayhints" name="grayhints" caption="Produce &#8216;gray hints&#8217; to a variable text field" />
+  <package key="grchyph" name="grchyph" caption="Hyphenation for classical Greek, under XeTeX" />
+  <package key="greek-fontenc" name="greek-fontenc" caption="LICR macros and encoding definition files for Greek" />
+  <package key="greek-inputenc" name="greek-inputenc" caption="Greek encoding support for inputenc" />
+  <package key="greek-makeindex" name="greek-makeindex" caption="Makeindex working with Greek" />
+  <package key="greek4cbc" name="greek4cbc" caption="A Greek font from 394BC" />
+  <package key="greek6cbc" name="greek6cbc" caption="A Greek font from the sixth century BC" />
+  <package key="greekctr" name="greekctr" caption="Represent counters by letters of the Greek alphabet" />
+  <package key="greekdates" name="greekdates" caption="Provides ancient Greek day and month names, dates, etc" />
+  <package key="greekinfo3" name="greekinfo3" caption="Overview of systems, packages, and fonts for Greek TeX" />
+  <package key="greektex" name="greektex" caption="Fonts for typesetting Greek/English documents" />
+  <package key="greektex-fd" name="greektex-fd" caption="LaTeX font definition files for GreekTeX" />
+  <package key="greektonoi" name="greektonoi" caption="Facilitates writing/editing of multiaccented greek" />
+  <package key="greenpoint" name="greenpoint" caption="The Green Point logo" />
+  <package key="gregoriotex" name="gregoriotex" caption="Engraving Gregorian Chant scores" />
+  <package key="grfext" name="grfext" caption="Manipulate the graphics package&apos;s list of extensions" />
+  <package key="grffile" name="grffile" caption="Extended file name support for graphics (legacy package)" />
+  <package key="grfguide" name="grfguide" caption="LaTeX standard graphics and color packages documentation" />
+  <package key="grfpaste" name="grfpaste" caption="Include fragments of a dvi file" />
+  <package key="grid" name="grid" caption="Grid typesetting in LaTeX" />
+  <package key="grid-system" name="grid-system" caption="Page organisation, modelled on CSS facilities" />
+  <package key="gridpapers" name="gridpapers" caption="Graph paper backgrounds and color schemes" />
+  <package key="gridset" name="gridset" caption="Grid, a.k.a. in-register, setting" />
+  <package key="gridslides" name="gridslides" caption="Free form slides with blocks placed on a grid" />
+  <package key="grkfinst" name="grkfinst" caption="Install Greek Type 1 fonts" />
+  <package key="grnumalt" name="grnumalt" caption="Ancient Greek (Athenian) numbers" />
+  <package key="grtimes" name="grtimes" caption="Typeset Greek text with Times New Roman Greek" />
+  <package key="grundgesetze" name="grundgesetze" caption="Typeset Frege&#8217;s Grundgesetze der Arithmetik" />
+  <package key="grverb" name="grverb" caption="Typesetting Greek verbatim" />
+  <package key="gs1" name="GS1" caption="Typeset EAN barcodes using TeX rules, only" />
+  <package key="gsemthesis" name="gsemthesis" caption="Geneva School of Economics and Management PhD thesis format" />
+  <package key="gsftopk" name="gsftopk" caption="Convert &quot;Ghostscript fonts&quot; to PK files" />
+  <package key="gsview" name="gsview" caption="View PostScript under MS-Windows or OS/2" />
+  <package key="gtex-letter" name="gtex-letter" caption="A Gnome assistant to ease the writing of LaTeX letters" />
+  <package key="gtl" name="gtl" caption="Manipulating generalized token lists" />
+  <package key="gtrcrd" name="gtrcrd" caption="Add chords to lyrics" />
+  <package key="gtrlib-largetrees" name="gtrlib.largetrees" caption="Library for genealogytree aiming at large trees" />
+  <package key="gu" name="gu" caption="Typeset crystallographic group-subgroup-schemes" />
+  <package key="guarani" name="guarani" caption="Guarani support" />
+  <package key="gudea" name="gudea" caption="The Gudea font face with support for LaTeX and pdfLaTeX" />
+  <package key="guia-bibtex" name="guia-bibtex" caption="Guia casi completa de BibTeX" />
+  <package key="guide-latex-fr" name="guide-latex-fr" caption="A french guide on LaTeX &#8211; for beginners or advanced users" />
+  <package key="guit-corso" name="GuIT-corso" caption="Introduzione al mondo di LaTeX" />
+  <package key="guitar" name="guitar" caption="Guitar chords and song texts" />
+  <package key="guitarchordschemes" name="guitarchordschemes" caption="Guitar Chord and Scale Tablatures" />
+  <package key="guitartabs" name="guitartabs" caption="A class for drawing guitar tablatures easily" />
+  <package key="guitbeamer" name="GuITbeamer" caption="Beamer-based class for GuIT presentations" />
+  <package key="guitlogo" name="GuITlogo" caption="Macros for typesetting the GuIT logo" />
+  <package key="gurmukhi" name="gurmukhi" caption="Support for Gurmukhi" />
+  <package key="gurmukhi-singh" name="gurmukhi-singh" caption="Support for Gurmukhi in TeX" />
+  <package key="gurps" name="gurps" caption="Typeset Generic Universal Role Playing System (GURPS) materials" />
+  <package key="gutenberg" name="GUTenberg" caption="French TeX Users Group information" />
+  <package key="gv" name="gv" caption="An X front end for Ghostscript" />
+  <package key="gv-savepos" name="gv-savepos" caption="A patch to gv to save positions" />
+  <package key="gzt" name="gzt" caption="Bundle of classes for &#8220;La Gazette des Math&#233;maticiens&#8221;" />
+  <package key="h2020proposal" name="h2020proposal" caption="LaTeX class and template for EU H2020 RIA proposal" />
+  <package key="ha-prosper" name="ha-prosper" caption="Patches and improvements for prosper" />
+  <package key="hackalloc" name="hackalloc" caption="Make allocations local" />
+  <package key="hackthefootline" name="hackthefootline" caption="Footline selection and configuration for LaTeX beamer&#8217;s standard themes" />
+  <package key="hacm" name="hacm" caption="Font support for the Arka language" />
+  <package key="hagenberg-thesis" name="hagenberg-thesis" caption="Collection of LaTeX classes, style files and example documents for academic manuscripts" />
+  <package key="halftone" name="halftone" caption="Knuth&#8217;s halftone font and its uses" />
+  <package key="halloweenmath" name="halloweenmath" caption="Scary and creepy math symbols with AMS-LaTeX integration" />
+  <package key="hamnosys" name="hamnosys" caption="A font for sign languages" />
+  <package key="handin" name="handin" caption="Light weight template for creating school submissions using LaTeX" />
+  <package key="handout" name="handout" caption="Create handout for auditors of a talk" />
+  <package key="handoutwithnotes" name="handoutWithNotes" caption="Create Handouts with notes from your LaTeX beamer presentation" />
+  <package key="hands" name="hands" caption="Pointing hand font" />
+  <package key="hang" name="hang" caption="Environments for hanging paragraphs and list items" />
+  <package key="hangcaption" name="hangcaption" caption="Hanging layout for captions" />
+  <package key="hanging" name="hanging" caption="Hanging paragraphs" />
+  <package key="hanoi" name="hanoi" caption="Tower of Hanoi in TeX" />
+  <package key="hanzibox" name="hanzibox" caption="Boxed Chinese characters with Pinyin above and translation below" />
+  <package key="happy4th" name="happy4th" caption="A firework display in obfuscated TeX" />
+  <package key="har2nat" name="har2nat" caption="Replace the harvard package with natbib" />
+  <package key="haranoaji" name="haranoaji" caption="Harano Aji Fonts" />
+  <package key="haranoaji-extra" name="haranoaji-extra" caption="Harano Aji Fonts" />
+  <package key="hardwrap" name="hardwrap" caption="Hard wrap text to a certain character length" />
+  <package key="harmony" name="harmony" caption="Typeset harmony symbols, etc., for musicology" />
+  <package key="harnon-cv" name="harnon-cv" caption="A CV document class with a vertical timeline for experience" />
+  <package key="harpoon" name="harpoon" caption="Extra harpoons, using the graphics package" />
+  <package key="harvard" name="harvard" caption="Harvard citation package for use with LaTeX 2e" />
+  <package key="harvard-obsolete" name="harvard-obsolete" caption="The Harvard bibliography style family" />
+  <package key="harveyballs" name="harveyballs" caption="Create Harvey Balls using TikZ" />
+  <package key="harvmac" name="harvmac" caption="Macros for scientific articles" />
+  <package key="hatching" name="hatching" caption="MetaPost macros for hatching interior of closed paths" />
+  <package key="hausarbeit-jura" name="hausarbeit-jura" caption="Class for writing &#8220;juristische Hausarbeiten&#8221; at German Universities" />
+  <package key="havannah" name="havannah" caption="Diagrams of board positions in the games of Havannah and Hex" />
+  <package key="hc" name="hcbundle" caption="Replacement for the LaTeX classes" />
+  <package key="he-le-na" name="he-le-na" caption="Support for Serbian typesetting" />
+  <package key="he-she" name="he-she" caption="Alternating pronouns to aid gender-neutral writing" />
+  <package key="headerfooter" name="headerfooter" caption="Define the layouts of page headers and footers" />
+  <package key="hebtex" name="hebtex" caption="Support for Hebrew and other right-to-left languages" />
+  <package key="hecthese" name="hecthese" caption="A class for dissertations and theses at HEC Montr&#233;al" />
+  <package key="hellas" name="hellas" caption="Typeset bibliographies which include Greek" />
+  <package key="helmholtz-ellis-ji-notation" name="helmholtz-ellis-ji-notation" caption="Beautiful in-line microtonal just intonation accidentals" />
+  <package key="helvet" name="helvet" caption="Load Helvetica, scaled" />
+  <package key="hep" name="hep" caption="A &quot;convenience wrapper&quot; for High Energy Physics packages" />
+  <package key="hep-acronym" name="hep-acronym" caption="An acronym extension for glossaries" />
+  <package key="hep-bibliography" name="hep-bibliography" caption="An acronym extension for glossaries" />
+  <package key="hep-float" name="hep-float" caption="Convenience package for float placement" />
+  <package key="hep-font" name="hep-font" caption="Latin modern extended by computer modern" />
+  <package key="hep-gen" name="hep-gen" caption="Generic macros for quantum physics" />
+  <package key="hep-graphic" name="hep-graphic" caption="Extensions for graphics, plots and feynman graphs in high energy physics" />
+  <package key="hep-math" name="hep-math" caption="Extended math macros" />
+  <package key="hep-math-font" name="hep-math-font" caption="Extended Greek and sans-serif math" />
+  <package key="hep-paper" name="hep-paper" caption="Publications in High Energy Physics" />
+  <package key="hep-reference" name="hep-reference" caption="Adjustments for publications in High Energy Physics" />
+  <package key="hep-text" name="hep-text" caption="List and text extensions" />
+  <package key="hep-title" name="hep-title" caption="Extensions for the title page" />
+  <package key="hepnames" name="hepnames" caption="Pre-defined high energy particle names" />
+  <package key="hepparticles" name="HEPparticles" caption="Macros for typesetting high energy physics particle names" />
+  <package key="hepthesis" name="hepthesis" caption="A class for academic reports, especially PhD theses" />
+  <package key="hepunits" name="Hepunits" caption="A set of units useful in high energy physics applications" />
+  <package key="here" name="here" caption="Emulation of obsolete package for &quot;here&quot; floats" />
+  <package key="hereapplies" name="hereapplies" caption="A LaTeX package for referencing groups of pages that share something in common" />
+  <package key="heros-otf" name="heros-otf" caption="Using the OpenType fonts TeX Gyre Heros&gt;" />
+  <package key="hershey" name="hershey" caption="Experiments with the Hershey fonts" />
+  <package key="hershey-mp" name="hershey-mp" caption="MetaPost support for the Hershey font file format" />
+  <package key="heuristica" name="heuristica" caption="Fonts extending Utopia, with LaTeX support files" />
+  <package key="hex" name="hex" caption="Print a counter in hexadecimal" />
+  <package key="hexboard" name="hexboard" caption=" For drawing Hex boards and games" />
+  <package key="hexdump" name="hexdump" caption="Read and typeset ASCII hexdump files" />
+  <package key="hexgame" name="hexgame" caption="Provide an environment to draw a hexgame-board" />
+  <package key="hf-tikz" name="hf-tikz" caption="A simple way to highlight formulas and formula parts" />
+  <package key="hfbright" name="hfbright" caption="The hfbright fonts" />
+  <package key="hfoldsty" name="hfoldsty" caption="Old style numerals with EC fonts" />
+  <package key="hfutexam" name="HFUTExam" caption="Exam class for Hefei University of Technology (China)" />
+  <package key="hfutthesis" name="hfutthesis" caption="LaTeX Thesis Template for Hefei University of Technology" />
+  <package key="hge" name="hge" caption="An &#8220;Old English&#8221; font" />
+  <package key="hhline" name="hhline" caption="Better horizontal lines in tabulars and arrays" />
+  <package key="hhtensor" name="hhtensor" caption="Print vectors, matrices, and tensors" />
+  <package key="hideanswer" name="hideanswer" caption="Generate documents with and without answers by toggling a switch" />
+  <package key="hieroglf" name="hieroglf" caption="The &quot;poor man&apos;s&quot; Egyptian Hieroglyphic font" />
+  <package key="hieroglyph" name="hieroglyph" caption="Hieroglyph fonts and other support" />
+  <package key="highlight" name="highlight" caption="Converts source code to syntax highlighted TeX or LaTeX" />
+  <package key="highlightlatex" name="highlightlatex" caption="Syntax highlighting for LaTeX" />
+  <package key="hilowres" name="hilowres" caption="Support high and low resolution versions of same picture" />
+  <package key="hindawi-latex-template" name="hindawi-latex-template" caption="A LaTeX template for authors of the Hindawi journals" />
+  <package key="hindmadurai" name="hindmadurai" caption="The HindMadurai font face with support for LaTeX and pdfLaTeX" />
+  <package key="histogr" name="histogr" caption="Draw histograms with the LaTeX picture environment" />
+  <package key="historische-zeitschrift" name="historische-zeitschrift" caption="BibLaTeX style for the journal &apos;Historische Zeitschrift&apos;" />
+  <package key="histyle" name="histyle" caption="A &quot;HighStyle&quot; environment for TeX" />
+  <package key="hitec" name="hitec" caption="Class for documentation" />
+  <package key="hitex" name="hitex" caption="A TeX extension writing HINT output for on-screen reading" />
+  <package key="hitex-def" name="hitex-def" caption="Support files for HiTeX" />
+  <package key="hithesis" name="hithesis" caption="Harbin Institute of Technology Thesis Template" />
+  <package key="hitreport" name="hitreport" caption="Harbin Institute of Technology Report LaTeX Template" />
+  <package key="hitszbeamer" name="hitszbeamer" caption="A beamer theme for Harbin Institute of Technology, ShenZhen" />
+  <package key="hitszthesis" name="HITSZThesis" caption="A dissertation template for Harbin Institute of Technology, ShenZhen" />
+  <package key="hktex" name="hktex" caption="A TeX/LaTeX equivalent for Android" />
+  <package key="hlatex" name="hlatex" caption="Support for the Korean language" />
+  <package key="hlatex-fonts" name="HLaTeX fonts" caption="A collection of Korean (Hangul) fonts" />
+  <package key="hletter" name="hletter" caption="Flexible letter typesetting with flexible page headings" />
+  <package key="hlist" name="hlist" caption="Horizontal and columned lists" />
+  <package key="hmtrump" name="hmtrump" caption="Describe card games" />
+  <package key="hobby" name="hobby" caption="An implementation of Hobby&#8217;s algorithm for PGF/TikZ" />
+  <package key="hobete" name="hobete" caption="Unofficial beamer theme for the University of Hohenheim" />
+  <package key="hobsub" name="hobsub" caption="Construct package bundles" />
+  <package key="hoffset-voffset" name="hoffset-voffset" caption="Calculate values for \hoffset and \voffset" />
+  <package key="hologo" name="hologo" caption="A collection of logos with bookmark support" />
+  <package key="holtpolt" name="holtpolt" caption="Typeset Maxwell&apos;s non-commutative division" />
+  <package key="holtxdoc" name="holtxdoc" caption="Documentation macros for oberdiek bundle, etc" />
+  <package key="hook-pre-commit-pkg" name="hook-pre-commit-pkg" caption="Pre-commit git hook for LaTeX package developpers" />
+  <package key="hopatch" name="hopatch" caption="Load patches for packages" />
+  <package key="horoscop" name="horoscop" caption="Generate astrological charts in LaTeX" />
+  <package key="hp2pl" name="HPtfm2pl" caption="Create TeX PL files from HP AutoFont Support" />
+  <package key="hp2xx" name="hp2xx" caption="HP GL converter" />
+  <package key="hpgl2ps" name="hpgl2ps" caption="Translate HPGL to PostScript" />
+  <package key="hpsdiss" name="hpsdiss" caption="A dissertation class" />
+  <package key="href-ul" name="href-ul" caption="Underscored LaTeX hyperlinks" />
+  <package key="hrefhide" name="hrefhide" caption="Suppress hyper links when printing" />
+  <package key="hrhyph" name="hrhyph" caption="Croatian hyphenation" />
+  <package key="hrlatex" name="hrlatex" caption="LaTeX support for Croatian documents" />
+  <package key="hsindex" name="hsindex" caption="An alternative index processor to imakeidx written with Haskell" />
+  <package key="html2latex" name="html2latex" caption="Convert HTML to LaTeX" />
+  <package key="htmlhelp" name="htmlhelp" caption="HTML translation of VMS help files" />
+  <package key="hu-berlin-bundle" name="hu-berlin-bundle" caption="LaTeX classes for the Humboldt-Universit&#228;t zu Berlin" />
+  <package key="huawei" name="huawei" caption="Template for Huawei documents" />
+  <package key="huaz" name="huaz" caption="Automatic Hungarian definite articles" />
+  <package key="huffman" name="huffman" caption="Drawing binary Huffman trees with MetaPost and METAOBJ" />
+  <package key="huhyph" name="huhyph" caption="Hyphenation patterns for the Hungarian language" />
+  <package key="hulipsum" name="hulipsum" caption="Hungarian dummy text (L&#243;rum ipse)" />
+  <package key="humanbio" name="humanbio" caption="Bibliography style for &quot;Human Biology&quot;" />
+  <package key="humanist" name="humanist" caption="Humanist manuscript book-hand font" />
+  <package key="humannat" name="humannat" caption="Bibliography style for &quot;Human Nature&quot; and &quot;American Anthropologist&quot;" />
+  <package key="huncial" name="huncial" caption="Fonts based on the half Uncial manuscript book-hand" />
+  <package key="hungarian" name="hungarian" caption="New Hungarian hyphenation patterns" />
+  <package key="hustthesis" name="hustthesis" caption="Unofficial thesis template for Huazhong University" />
+  <package key="hvarabic" name="hvarabic" caption="Macros for RTL typesetting" />
+  <package key="hvdashln" name="hvdashln" caption="Horizontal and vertical dashed lines in arrays and tabulars" />
+  <package key="hvextern" name="hvextern" caption="Write and execute external code, and insert the output" />
+  <package key="hvfloat" name="hvfloat" caption="Controlling captions, fullpage and doublepage floats" />
+  <package key="hvindex" name="hvindex" caption="Support for indexing" />
+  <package key="hvlogos" name="hvlogos" caption="Print TeX-related names as logo" />
+  <package key="hvmath" name="hvmath" caption="Support for using the Micropress HV-Math fonts (Helvetica Maths)" />
+  <package key="hvmath-fonts" name="hvmath-fonts" caption="Bitmap versions of the Micropress HV-Math fonts (Helvetica Maths)" />
+  <package key="hvpygmentex" name="hvpygmentex" caption="Syntax-Highlighting of program code" />
+  <package key="hvqrurl" name="hvqrurl" caption="Insert a QR code in the margin" />
+  <package key="hwemoji" name="hwemoji" caption="Unicode emoji support for pdfLaTeX with sequences" />
+  <package key="hwkatakana" name="hwkatakana" caption="Half-width katakana fonts" />
+  <package key="hyacc-cm" name="hyacc-cm" caption="Hyphenation using 7-bit fonts" />
+  <package key="hybrid-latex" name="hybrid-latex" caption="Allow active Python code in LaTeX documents" />
+  <package key="hycolor" name="hycolor" caption="Implements colour for packages hyperref and bookmark" />
+  <package key="hypbmsec" name="hypbmsec" caption="Hypertext bookmarks in sectioning commands" />
+  <package key="hypcap" name="hypcap" caption="Adjusting the anchors of captions" />
+  <package key="hypdestopt" name="hypdestopt" caption="Hyperref destination optimizer" />
+  <package key="hypdoc" name="hypdoc" caption="Hyper extensions for doc.sty" />
+  <package key="hypdvips" name="hypdvips" caption="Hyperref extensions for use with dvips" />
+  <package key="hyper" name="hyper" caption="Hypertext cross referencing" />
+  <package key="hyperbar" name="hyperbar" caption="Add interactive Barcode fields to PDF forms" />
+  <package key="hyperlatex" name="hyperlatex" caption="A restricted LaTeX system that also produces HTML" />
+  <package key="hypernat" name="hypernat" caption="Allow hyperref and natbib to work together" />
+  <package key="hyperref" name="hyperref" caption="Extensive support for hypertext in LaTeX" />
+  <package key="hyperxmp" name="hyperxmp" caption="Embed XMP metadata within a LaTeX document" />
+  <package key="hypgotoe" name="hypgotoe" caption="Links to embedded files" />
+  <package key="hyph-utf8" name="hyph-utf8" caption="Hyphenation patterns expressed in UTF-8" />
+  <package key="hyphen-accent" name="hyphen-accent" caption="LaTeX 2.09 code for using DC fonts" />
+  <package key="hyphen-spanish" name="hyphen-spanish" caption="Standard hyphenation rules for Spanish" />
+  <package key="hyphenat" name="hyphenat" caption="Disable/enable hypenation" />
+  <package key="hyphenation-greek" name="hyphenation-greek" caption="Hyphenation patterns for ancient and modern Greek" />
+  <package key="hyphenex" name="hyphenex" caption="US English hyphenation exceptions file" />
+  <package key="hyphsubst" name="hyphsubst" caption="Substitute hyphenation patterns" />
+  <package key="hypht1" name="hypht1" caption="Additional hyphenation patterns" />
+  <package key="hyplain" name="HyPlain" caption="Basic support for multiple languages in Plain TeX" />
+  <package key="i-ching" name="i-ching" caption="An i-ching package" />
+  <package key="iagproc" name="iagproc" caption="Class for two column IAG Proceedings articles" />
+  <package key="iahyphen" name="iahyphen" caption="Hyphenation patterns for Interlingua" />
+  <package key="ibarra" name="ibarra" caption="LaTeX support for the Ibarra Real Nova family of fonts" />
+  <package key="ibm" name="ibm" caption="Metrics for IBM fonts" />
+  <package key="ibmres-tex" name="ibmres-tex" caption="A semi-automated approach to the production of resumes" />
+  <package key="ibrackets" name="ibrackets" caption="Intelligent brackets" />
+  <package key="ibycus-babel" name="ibycus-babel" caption="Use the Ibycus 4 Greek font with Babel" />
+  <package key="ibygrk" name="ibygrk" caption="Fonts and macros to typeset ancient Greek" />
+  <package key="icehyph" name="icehyph" caption="Icelandic hyphenation patterns" />
+  <package key="icelandic" name="icelandic" caption="Icelandic Fonts" />
+  <package key="iching" name="iching" caption="A font for I Ching divinations" />
+  <package key="icite" name="icite" caption="Indices locorum citatorum" />
+  <package key="icomma" name="icomma" caption="Intelligent commas for decimal numbers" />
+  <package key="icon-appr" name="icon-appr" caption="Creates icon appearances for form buttons" />
+  <package key="icons" name="icons" caption="TeX icons" />
+  <package key="icsv" name="icsv" caption="Class for typesetting articles for the ICSV conference" />
+  <package key="idealfonts" name="idealfonts" caption="Font and LaTeX support for Textures users" />
+  <package key="identkey" name="identkey" caption="Typesetting bracketed dichotomous identification keys" />
+  <package key="idverb" name="idverb" caption="Inline verbatim identifiers" />
+  <package key="idxcmds" name="idxcmds" caption="Semantic commands for adding formatted index entries" />
+  <package key="idxlayout" name="idxlayout" caption="Configurable index layout, responsive to KOMA-Script and memoir" />
+  <package key="idxtex" name="idxtex" caption="An index processor" />
+  <package key="ieeeannot" name="IEEEannot" caption="A sorting version of IEEEtran.bst" />
+  <package key="ieeeconf" name="IEEEconf" caption="Macros for IEEE conference proceedings" />
+  <package key="ieeepes" name="ieeepes" caption="IEEE Power Engineering Society Transactions" />
+  <package key="ieeetran" name="IEEEtran" caption="Document class for IEEE Transactions journals and conferences" />
+  <package key="ieeetrantools" name="ieeetrantools" caption="Functionality from IEEEtran for use with other classes" />
+  <package key="ieejtran" name="IEEJtran" caption="Unofficial bibliography style file for the Institute of Electrical Engineers of Japan" />
+  <package key="ietfbibs" name="ietfbibs" caption="Generate BibTeX entries for various IETF index files" />
+  <package key="iexec" name="iexec" caption="Execute shell commands and input their output" />
+  <package key="ifacmtg" name="ifacmtg" caption="Elsevier Science preprint style for IFAC meetings" />
+  <package key="ifallfalse" name="ifallfalse" caption="Compare a string against a set of other strings" />
+  <package key="ifdraft" name="ifdraft" caption="Detect &#8220;draft&#8221; and &#8220;final&#8221; class options" />
+  <package key="ifetex" name="ifetex" caption="Provides \ifetex switch" />
+  <package key="iffont" name="iffont" caption="Conditionally load fonts with fontspec" />
+  <package key="iflang" name="iflang" caption="Expandable checks for the current language" />
+  <package key="ifluatex" name="ifluatex" caption="Provides the \ifluatex switch" />
+  <package key="ifmslide" name="ifmslide" caption="Presentation slides for screen and printouts" />
+  <package key="ifmtarg" name="ifmtarg" caption="If-then-else command for processing potentially empty arguments" />
+  <package key="ifnextok" name="ifnextok" caption="Utility macro: peek ahead without ignoring spaces" />
+  <package key="ifoddpage" name="ifoddpage" caption="Determine if the current page is odd or even" />
+  <package key="ifpdf" name="ifpdf" caption="Provides the \ifpdf conditional" />
+  <package key="ifplatform" name="ifplatform" caption="Conditionals to test which platform is being used" />
+  <package key="ifptex" name="ifptex" caption="Check if the engine is pTeX or one of its derivatives" />
+  <package key="ifsym" name="ifsym" caption="A collection of symbols" />
+  <package key="iftex" name="iftex" caption="Am I running under pdfTeX, XeTeX or LuaTeX?" />
+  <package key="ifthen" name="ifthen" caption="Conditional commands in LaTeX documents" />
+  <package key="ifthenx" name="ifthenx" caption="Extra tests for \ifthenelse" />
+  <package key="ifvtex" name="ifvtex" caption="Detects use of VTeX and its facilities" />
+  <package key="ifxetex" name="ifxetex" caption="Am I running under XeTeX?" />
+  <package key="ifxptex" name="ifxptex" caption="Detect pTeX and its derivatives" />
+  <package key="igo" name="igo" caption="Fonts and macro to typeset Go diagrams" />
+  <package key="iitem" name="iitem" caption="Multiple level of lists in one list-like environment" />
+  <package key="ijc" name="ijc" caption="International Journal of Control style" />
+  <package key="ijcai89" name="ijcai89" caption="Format papers for IJCAI 1989" />
+  <package key="ijmart" name="ijmart" caption="LaTeX Class for the Israel Journal of Mathematics" />
+  <package key="ijqc" name="ijqc" caption="BibTeX style file for the Intl. J. Quantum Chem" />
+  <package key="ijsra" name="ijsra" caption=" LaTeX document class for the International Journal of Student Research in Archaeology" />
+  <package key="imac" name="imac" caption="International Modal Analysis Conference format" />
+  <package key="image-gallery" name="image-gallery" caption="Create an overview of pictures from a digital camera or from other sources" />
+  <package key="imakeidx" name="imakeidx" caption="A package for producing multiple indexes" />
+  <package key="imaketex" name="Imake-TeX" caption="An Imake system for TeX" />
+  <package key="imfellenglish" name="imfellEnglish" caption="IM Fell English fonts with LaTeX support" />
+  <package key="imfellflowers" name="imfellflowers" caption="IM Fell Flower OpenType fonts" />
+  <package key="impatient" name="impatient" caption="Free edition of the book &quot;TeX for the Impatient&quot;" />
+  <package key="impnattypo" name="impnattypo" caption="Support typography of l&#8217;Imprimerie Nationale Fran&#231;aise" />
+  <package key="import" name="import" caption="Establish input relative to a directory" />
+  <package key="impose" name="impose" caption="PostScript imposition and support utilities" />
+  <package key="imprintmtshadow" name="imprintmtshadow" caption="Support files for the Monotype Imprint Shadow fonts" />
+  <package key="imsproc" name="imsproc" caption="Typeset IMS conference proceedings" />
+  <package key="imtekda" name="IMTEKda" caption="IMTEK thesis class" />
+  <package key="incgraph" name="incgraph" caption="Sophisticated graphics inclusion in a PDF document" />
+  <package key="includernw" name="includeRnw" caption="Include .Rnw inside .tex" />
+  <package key="includex" name="includex" caption="Extended \include" />
+  <package key="inconsolata" name="inconsolata" caption="A monospaced font, with support files for use with TeX" />
+  <package key="indent" name="indent" caption="Environments that change margins" />
+  <package key="indentfirst" name="indentfirst" caption="Indent first paragraph after section header" />
+  <package key="index" name="index" caption="Extended index for LaTeX including multiple indexes" />
+  <package key="indextools" name="indextools" caption="Producing multiple indices" />
+  <package key="indic-type1" name="indic-type1" caption="Indic Type 1 fonts converted from public Metafont sources" />
+  <package key="induni-om" name="induni-om" caption="Omega fonts for characters used in study of Sanskrit" />
+  <package key="indxcite" name="indxcite" caption="Generate author index based on citations" />
+  <package key="infpic" name="infpic" caption="Macros to insert pictures in paragraphs" />
+  <package key="infwarerr" name="infwarerr" caption="Complete set of information/warning/error message macros" />
+  <package key="inhyph" name="inhyph" caption="Hyphenation patterns for Bahasa Indonesia" />
+  <package key="initials" name="initials" caption="Adobe Type 1 decorative initial fonts" />
+  <package key="inkpaper" name="inkpaper" caption="A mathematical paper template" />
+  <package key="inline-images" name="inline-images" caption="Inline images in base64 encoding" />
+  <package key="inlinebib" name="inlinebib" caption="Citations in footnotes" />
+  <package key="inlinedef" name="inlinedef" caption="Inline expansions within definitions" />
+  <package key="inlinelabel" name="inlinelabel" caption="Assign equation numbers to inline equations" />
+  <package key="innerscript" name="innerscript" caption="Modifies automatic mathematics spacing" />
+  <package key="inputenc" name="inputenc" caption="Accept different input encodings" />
+  <package key="inputenx" name="inputenx" caption="Enhanced input encoding handling" />
+  <package key="inputfile" name="inputfile" caption="Input LaTeX files, remembering the file name" />
+  <package key="inputnormalization" name="inputnormalization" caption="Wrapper for XeTeX&apos;s and LuaTeX&apos;s input normalization" />
+  <package key="inputtrc" name="inputtrc" caption="Trace which file loads which" />
+  <package key="inriafonts" name="inriafonts" caption="Inria fonts with LaTeX support" />
+  <package key="inrstex" name="inrstex" caption="Extended Plain TeX for use with MLTeX" />
+  <package key="insbox" name="insbox" caption="Insert pictures/boxes into paragraphs" />
+  <package key="inscrutable" name="inscrutable" caption="A response to Perl hackers&apos; silliness" />
+  <package key="insdljs" name="insdljs" caption="Insert document-level JavaScript in LaTeX documents" />
+  <package key="inslrmaj" name="inslrmaj" caption="Fonts based on the Insular Majuscule manuscript book-hand" />
+  <package key="inslrmin" name="inslrmin" caption="Fonts based on the Insular Minuscule manuscript book-hand" />
+  <package key="install-latex-guide-zh-cn" name="Install-LaTeX-Guide-zh-cn" caption="A short introduction to LaTeX installation written in Chinese" />
+  <package key="installfont" name="installfont" caption="A bash script for installing a LaTeX font family" />
+  <package key="intcalc" name="intcalc" caption="Expandable arithmetic operations with integers" />
+  <package key="inter" name="inter" caption="The inter font face with support for LaTeX, XeLaTeX, and LuaLaTeX" />
+  <package key="interactiveanimation" name="interactiveanimation" caption="Create PDF files with branching animations" />
+  <package key="interactiveplot" name="interactiveplot" caption="Provides an interface to create interactive 2D/3D functions inside a PDF file" />
+  <package key="interactiveworkbook" name="interactiveworkbook" caption="LaTeX-based interactive PDF on the Web" />
+  <package key="interchar" name="interchar" caption="Managing character class schemes in XeTeX" />
+  <package key="interfaces" name="interfaces" caption="Set parameters for other packages, conveniently" />
+  <package key="interpol" name="interpol" caption="Add interpolation to MetaPost graph package" />
+  <package key="interpreter" name="interpreter" caption="Translate input files on the fly" />
+  <package key="interval" name="interval" caption="Format mathematical intervals, ensuring proper spacing" />
+  <package key="intex" name="intex" caption="Support typesetting and indexing words and phrases" />
+  <package key="intopdf" name="intopdf" caption="Embed non-PDF files into PDF with hyperlink" />
+  <package key="intro-scientific" name="intro-scientific" caption="Introducing scientific/mathematical documents using LaTeX" />
+  <package key="inversepath" name="inversepath" caption="Calculate inverse file paths" />
+  <package key="invertedparagraphs" name="invertedparagraphs" caption="Indented text with negative paragraph indentation" />
+  <package key="invoice" name="invoice" caption="Generate invoices" />
+  <package key="invoice-class" name="invoice-class" caption="Produces a standard US invoice from a CSV file" />
+  <package key="invoice2" name="invoice2" caption="Intelligent invoices with LaTeX3" />
+  <package key="iodhbwm" name="iodhbwm" caption="Unofficial template of the DHBW Mannheim" />
+  <package key="ionumbers" name="ionumbers" caption="Restyle numbers in maths mode" />
+  <package key="iopart-num" name="iopart-num" caption="Numeric citation style for IOP journals" />
+  <package key="ipa" name="ipa" caption="LaTeX macros for using WSUIPA fonts" />
+  <package key="ipaex" name="ipaex" caption="IPA (Japanese) fonts" />
+  <package key="ipaex-type1" name="ipaex-type1" caption="IPAex fonts converted to Type-1 format Unicode subfonts" />
+  <package key="is-bst" name="is-bst" caption="Extended versions of standard BibTeX styles" />
+  <package key="iscram" name="iscram" caption="A LaTeX class to publish article to ISCRAM conferences" />
+  <package key="isf" name="isf" caption="Access italic computer modern sans in LaTeX 2.09" />
+  <package key="ishyph" name="ishyph" caption="Hyphenation patterns for Icelandic" />
+  <package key="isi2bib" name="isi2bib-vim" caption="Vim script to convert bib database from ISI to BibTeX format" />
+  <package key="isi2bibtex" name="isi2bibtex" caption="Converter for ISI to  BibTeX" />
+  <package key="iso" name="iso" caption="Generic ISO standards typesetting macros" />
+  <package key="iso-tex" name="ISO-TeX" caption="Display (La)TeX accented letters in GNU Emacs" />
+  <package key="iso10303" name="iso10303" caption="Typesetting the STEP standards" />
+  <package key="iso209" name="iso209" caption="A document style for ISO standards" />
+  <package key="isodate" name="isodate" caption="Tune the output format of dates according to language" />
+  <package key="isodoc" name="isodoc" caption="A LaTeX class for typesetting letters and invoices" />
+  <package key="isolatin1" name="isolatin1" caption="An obsolete means to use ISO 8859-1 with TeX" />
+  <package key="isomath" name="isomath" caption="Mathematics style for science and technology" />
+  <package key="isonums" name="isonums" caption="Display numbers in maths mode according to ISO 31-0" />
+  <package key="isopt" name="isopt" caption="Writing a TeX length with a space between number and unit" />
+  <package key="isorot" name="isorot" caption="Rotation of document elements" />
+  <package key="isotope" name="isotope" caption="A package for typesetting isotopes" />
+  <package key="ispell" name="ispell" caption="Multi-platform spell checker" />
+  <package key="issuulinks" name="issuulinks" caption="Produce external links instead of internal ones" />
+  <package key="ist21" name="ist21" caption="Title page for the old BSI IST/21 committee" />
+  <package key="istgame" name="istgame" caption="Draw Game Trees with TikZ" />
+  <package key="ital" name="ital" caption="Automatic italic correction" />
+  <package key="italic" name="italic" caption="Automatic italic correction for italic and slanted text" />
+  <package key="ite" name="iTe" caption="Interactive TeX editor" />
+  <package key="ithyph" name="ithyph" caption="Hyphenation patterns for the Italian language" />
+  <package key="itnumpar" name="itnumpar" caption="Spell numbers in words (Italian)" />
+  <package key="itrans-processor" name="itrans-processor" caption="Transliteration of Indian Languages" />
+  <package key="ivd2dvi" name="ivd2dvi" caption="Convert IVD-DVI files to DVI" />
+  <package key="iwhdp" name="iwhdp" caption="Halle Institute for Economic Research (IWH) Discussion Papers" />
+  <package key="iwona" name="iwona" caption="A two-element sans-serif font" />
+  <package key="izhitsa" name="izhitsa" caption="Support for the old Russian font &quot;Izhitsa&quot;" />
+  <package key="jablantile" name="jablantile" caption="Metafont version of tiles in the style of Slavik Jablan" />
+  <package key="jabref" name="jabref" caption="Graphical frontend to manage BibTeX databases" />
+  <package key="jacow" name="jacow" caption="A class for submissions to the proceedings of conferences on JACoW.org" />
+  <package key="jadetex" name="jadetex" caption="Macros supporting Jade DSSSL output" />
+  <package key="jamtimes" name="jamtimes" caption="Expanded Times Roman fonts" />
+  <package key="japanese-mathformulas" name="japanese-mathformulas" caption="Compiling basic math formulas in Japanese using LuaLaTeX" />
+  <package key="japanese-otf" name="japanese-otf" caption="Advanced font selection for platex and its friends" />
+  <package key="japanese-otf-uptex" name="japanese-otf-uptex" caption="Support for Japanese OTF files in upLaTeX" />
+  <package key="jas99" name="jas99" caption="BibTeX style for American Meteorological Society (AMS)" />
+  <package key="jas99m" name="jas99_m" caption="BibTeX style for American Meteorological Society (AMS)" />
+  <package key="jasthesis" name="jasthesis" caption="A &apos;standard&apos; thesis class" />
+  <package key="javabib" name="JavaBib" caption="A BibTeX file manager written in Java" />
+  <package key="javadoc" name="javadoc" caption="Documenting source code" />
+  <package key="javadvi" name="javaDVI" caption="DVI viewer and printer coded in Java" />
+  <package key="javascript-texed" name="javascript_TeXed" caption="Small MikTeX-editor for Win32 Intel platform" />
+  <package key="javascripthttp" name="JavascriptHTTP" caption="Add buttons to a PDF to easily get and post web content" />
+  <package key="javatex" name="javatex" caption="A Java implementation of TeX" />
+  <package key="jbact" name="jbact" caption="BibTeX style for biology journals" />
+  <package key="jbibtexmanager" name="JBibtexManager" caption="Managing citations in BibTeX format" />
+  <package key="jcc" name="jcc" caption="BibTeX style file for J. Comp. Chem" />
+  <package key="jeep" name="jeep" caption="Modified LaTeX2.09 article and report styles" />
+  <package key="jeopardy" name="jeopardy" caption="Build a jeopardy game in LaTeX" />
+  <package key="jeuxcartes" name="JeuxCartes" caption="Macros to insert playing cards" />
+  <package key="jflap2tikz" name="jflap2tikz" caption="Convert JFlap file into a LaTeX file depicting the automaton using TikZ" />
+  <package key="jfmutil" name="jfmutil" caption="Utility to process pTeX-extended TFM and VF" />
+  <package key="jfontmaps" name="jfontmaps" caption="Font maps and configuration tools for Japanese fonts" />
+  <package key="jhep" name="jhep" caption="Class for JHEP" />
+  <package key="jieeetran" name="jIEEEtran" caption="UnofficiaL BibTeX style for citing Japanese articles in IEEE format" />
+  <package key="jigsaw" name="jigsaw" caption="Draw jigsaw pieces with TikZ" />
+  <package key="jj-game" name="jj-game" caption="A LaTeX class to construct Jeopardy-like games" />
+  <package key="jkmath" name="jkmath" caption="Macros for mathematics that make the code more readable" />
+  <package key="jknappen" name="jknappen" caption="Miscellaneous packages by Joerg Knappen" />
+  <package key="jkthesis" name="jkthesis" caption="Document class for formatting a thesis" />
+  <package key="jlabels" name="jlabels" caption="Make letter-sized pages of labels" />
+  <package key="jlm" name="jlm" caption="J&#246;rg&apos;s LaTeX Mode - an advanced LaTeX mode for Jed" />
+  <package key="jlreq" name="jlreq" caption="Japanese document class based on requirements for Japanese text layout" />
+  <package key="jlreq-deluxe" name="jlreq-deluxe" caption="Multi-weight Japanese font support for the jlreq class" />
+  <package key="jmakepdfx" name="jmakepdfx" caption="A Java interface to Ghostscript to convert PDF to PDF/X" />
+  <package key="jmb" name="jmb" caption="BibTeX style for the Journal of Theoretical Biology" />
+  <package key="jmlr" name="jmlr" caption="Class files for the Journal of Machine Learning Research" />
+  <package key="jmsdelim" name="jmsdelim" caption="A package for compositional delimiter sizing" />
+  <package key="jneurosci" name="jneurosci" caption="BibTeX style for the Journal of Neuroscience" />
+  <package key="jnuexam" name="jnuexam" caption="Exam class for Jinan University" />
+  <package key="jobname-suffix" name="jobname-suffix" caption="Compile differently based on the filename" />
+  <package key="joinbox" name="joinbox" caption="Join boxes vertically or horizontally" />
+  <package key="josefin" name="josefin" caption="Josefin fonts with LaTeX support" />
+  <package key="jourcl" name="jourcl" caption="Cover letter for journal submissions" />
+  <package key="jourrr" name="jourrr" caption="A LaTeX template for journal rebuttal letters" />
+  <package key="joy-of-tex" name="joy-of-tex" caption="User documentation for the AMS-TeX macro collection" />
+  <package key="jpeg2ps-os2" name="jpeg2ps-os2" caption="JPEG to PostScript converter for OS/2" />
+  <package key="jphysiol" name="jphysiol" caption="BibTeX style for the Journal of Physiology" />
+  <package key="jpicedt" name="JPicEdt" caption="A graphical editor generating LaTeX commands" />
+  <package key="jpneduenumerate" name="jpneduenumerate" caption="Enumerative expressions in Japanese education" />
+  <package key="jpnedumathsymbols" name="jpnedumathsymbols" caption="Mathematical equation representation in Japanese education" />
+  <package key="jpsj" name="jpsj" caption="Document Class for Journal of the Physical Society of Japan" />
+  <package key="jqt1999" name="jqt1999" caption="Journal of Quality Technology BibTeX format" />
+  <package key="js-misc" name="js-misc" caption="Miscellaneous macros from Joachim Schrod" />
+  <package key="jsclasses" name="jsclasses" caption="Classes tailored for use with Japanese" />
+  <package key="jslectureplanner" name="jslectureplanner" caption="Creation and management of university course material" />
+  <package key="jspell" name="jspell" caption="An ASCII file spelling checker" />
+  <package key="jtb" name="jtb" caption="BibTeX style for Journal of Theoretical Biology" />
+  <package key="jtbnew" name="jtbnew" caption="BibTeX style for Journal of Theoretical Biology" />
+  <package key="jumplines" name="jumplines" caption="Articles with teasers and continuation later on" />
+  <package key="junicode" name="junicode" caption="A TrueType font for mediaevalists" />
+  <package key="jupynotex" name="jupynotex" caption="Include whole or partial Jupyter notebooks in LaTeX documents" />
+  <package key="jura" name="jura" caption="A document class for German legal texts" />
+  <package key="juraabbrev" name="juraabbrev" caption="Abbreviations for typesetting (German) juridical documents" />
+  <package key="jurabib" name="jurabib" caption="Extended BibTeX citation support for the humanities and legal texts" />
+  <package key="juramisc" name="juramisc" caption="Typesetting German juridical documents" />
+  <package key="jurarsp" name="jurarsp" caption="Citations of judgements and official documents in (German) juridical documents" />
+  <package key="justfontitte" name="JustFontItTE" caption="JustFontIt TeX Edition" />
+  <package key="jvlisting" name="jvlisting" caption="A replacement for LaTeX&apos;s verbatim package" />
+  <package key="jwjournal" name="jwjournal" caption="A personal class for writing journals" />
+  <package key="kalendarium" name="kalendarium" caption="Print dates according to the classical Latin calendar" />
+  <package key="kalender" name="kalender" caption="Create a calendar, in German" />
+  <package key="kalender-209" name="kalender-209" caption="Produce page-per-day calendars" />
+  <package key="kanaparser" name="kanaparser" caption="Kana parser for LuaTeX" />
+  <package key="kanbun" name="kanbun" caption="Typeset kanbun-kundoku with support for kanbun annotation" />
+  <package key="kantlipsum" name="kantlipsum" caption="Generate sentences in Kant&apos;s style" />
+  <package key="karnaugh" name="karnaugh" caption="Typeset Karnaugh-Veitch-maps" />
+  <package key="karnaugh-map" name="karnaugh-map" caption="LaTeX package for drawing karnaugh maps with up to 6 variables" />
+  <package key="karnaughmap" name="karnaughmap" caption="Typeset Karnaugh maps" />
+  <package key="karta" name="karta" caption="Cartographic signs" />
+  <package key="kaytannollista-latexia" name="kaytannollista-latexia" caption="Practical manual for LaTeX (Finnish)" />
+  <package key="kblocks" name="kblocks" caption="Easily typeset Control Block Diagrams and Signal Flow Graphs" />
+  <package key="kbordermatrix" name="kbordermatrix" caption="LaTeX version of \bordermatrix" />
+  <package key="kdgdocs" name="kdgdocs" caption="Document classes for Karel de Grote University College" />
+  <package key="kdgreek" name="kdgreek" caption="Greek fonts and macros" />
+  <package key="kdpcover" name="kdpcover" caption="Covers for books published by Kindle Direct Publishing" />
+  <package key="kelly-greek-font" name="kelly-greek-font" caption="Simple fonts for Greek" />
+  <package key="kerkis" name="kerkis" caption="Kerkis (Greek) font family" />
+  <package key="kerntest" name="kerntest" caption="Print tables and generate control files to adjust kernings" />
+  <package key="ketcindy" name="ketcindy" caption="Creating graphics for TeX using Cinderella" />
+  <package key="keycommand" name="keycommand" caption="Simple creation of commands with key-value arguments" />
+  <package key="keyfloat" name="keyfloat" caption="Provides a key/value interface for generating floats" />
+  <package key="keyindex" name="keyindex" caption="Index entries by key lookup" />
+  <package key="keyparse" name="keyparse" caption=" Key based parser" />
+  <package key="keyreader" name="keyreader" caption="A robust interface to xkeyval" />
+  <package key="keystroke" name="keystroke" caption="Graphical representation of keys on keyboard" />
+  <package key="keyval" name="keyval" caption="Process &apos;key=value&apos; schemes" />
+  <package key="keyval2e" name="keyval2e" caption="A lightweight and robust key-value parser" />
+  <package key="keyvaltable" name="keyvaltable" caption="Re-usable table layouts separating content and presentation" />
+  <package key="kfupm-math-exam" name="kfupm-math-exam" caption="A LaTeX document style to produce homework, quiz and exam papers" />
+  <package key="kile" name="kile" caption="A user friendly TeX/LaTeX editor for KDE" />
+  <package key="kinematikz" name="kinematikz" caption="Design kinematic chains and mechanisms" />
+  <package key="kix" name="kix" caption="Typeset KIX codes" />
+  <package key="kixfont" name="KIXfont" caption="A font for KIX codes" />
+  <package key="klinz" name="klinz" caption="A Klingon font" />
+  <package key="kmrhyph" name="kmrhyph" caption="Hyphenation patterns for Kurmanji, T1 encoded" />
+  <package key="knit" name="knit" caption="Tangle and weave with multiple change files" />
+  <package key="knitting" name="knitting" caption="Produce knitting charts, in Plain TeX or LaTeX" />
+  <package key="knittingpattern" name="knittingpattern" caption="Create knitting patterns" />
+  <package key="knot" name="knot" caption="A Celtic knotwork font" />
+  <package key="knowledge" name="knowledge" caption="Displaying, hyperlinking, and indexing notions in a document" />
+  <package key="knst" name="knst" caption="Multiple-guess tests" />
+  <package key="knuth-base" name="knuth-base" caption="The current state of Knuth&apos;s contributions" />
+  <package key="knuth-dist" name="knuth-dist" caption="The current state of Knuth&apos;s contributions" />
+  <package key="knuth-errata" name="knuth-errata" caption="Knuth&#8217;s published errata" />
+  <package key="knuth-hint" name="knuth-hint" caption="HINT collection of typeset C/WEB sources in TeX Live" />
+  <package key="knuth-letter" name="knuth-letter" caption="Knuth&#8217;s example letter macros" />
+  <package key="knuth-lib" name="knuth-lib" caption="Core TeX and Metafont sources from Knuth" />
+  <package key="knuth-local" name="knuth-local" caption="Knuth&#8217;s local information" />
+  <package key="knuth-pdf" name="knuth-pdf" caption="PDF collection of typeset C/WEB sources in TeX Live" />
+  <package key="koi8" name="koi8" caption="KOI-8 input support" />
+  <package key="koma-moderncvclassic" name="koma-moderncvclassic" caption="Makes the style and command of moderncv (style classic) available
+       for koma-classes and thus compatible with BibLaTeX" />
+  <package key="koma-script" name="koma-script" caption="A bundle of versatile classes and packages" />
+  <package key="koma-script-examples" name="koma-script-examples" caption="Examples from the KOMA-Script book" />
+  <package key="koma-script-examples-3" name="koma-script-examples-3" caption="Examples from the 3rd edition of the KOMA-Script book" />
+  <package key="koma-script-examples-4" name="koma-script-examples-4" caption="Examples from the 4th edition of the KOMA-Script book" />
+  <package key="koma-script-examples-5" name="koma-script-examples-5" caption="Examples from the 5th edition of the KOMA-Script book" />
+  <package key="koma-script-obsolete" name="koma-script-obsolete" caption="Deprecated packages from koma-script" />
+  <package key="koma-script-sfs" name="koma-script-sfs" caption="Koma-script letter class option for Finnish" />
+  <package key="komacv" name="komacv" caption="Typesetting a beautiful CV with various style options" />
+  <package key="komacv-rg" name="komacv-rg" caption="LaTeX packages that aid in creating CVs based on the komacv class and creating related documents" />
+  <package key="konwerter" name="konwerter" caption="A program for automatic numbering of compounds in chemical publications" />
+  <package key="korigamik" name="KorigamiK" caption="Typeset articles using KorigamiK&#8217;s document class" />
+  <package key="kotex-oblivoir" name="kotex-oblivoir" caption="A LaTeX document class for typesetting Korean documents" />
+  <package key="kotex-plain" name="kotex-plain" caption="Macros for typesetting Korean under Plain TeX" />
+  <package key="kotex-utf" name="kotex-utf" caption="Typeset Hangul, coded in UTF-8" />
+  <package key="kotex-utils" name="kotex-utils" caption="Utility scripts and support files for typesetting Korean" />
+  <package key="kpathsea" name="kpathsea" caption="Path searching library for TeX-related files" />
+  <package key="kpfonts" name="kpfonts" caption="A complete set of fonts for text and mathematics" />
+  <package key="kpfonts-otf" name="kpfonts-otf" caption="OTF version of the Kp-fonts" />
+  <package key="ksfh-nat" name="ksfh-nat" caption="BibTeX style for KSFH Munich" />
+  <package key="ksp-thesis" name="ksp-thesis" caption="A LaTeX class for theses published with KIT Scientific Publishing" />
+  <package key="ktexshell" name="KTeXShell" caption="Graphical frontend to TeX" />
+  <package key="ktv-texdata" name="ktv-texdata" caption="Extract subsets of documents" />
+  <package key="ku-template" name="ku-template" caption="Copenhagen University or faculty logo for front page" />
+  <package key="kurdishlipsum" name="kurdishlipsum" caption="A &#8216;lipsum&#8217; package for the Kurdish language" />
+  <package key="kurier" name="kurier" caption="A two-element sans-serif typeface" />
+  <package key="kuvio" name="kuvio" caption="Drawing macros and fonts for diagrams" />
+  <package key="kvdefinekeys" name="kvdefinekeys" caption="Define keys for use in the kvsetkeys package" />
+  <package key="kvmap" name="kvmap" caption="Create Karnaugh maps with LaTeX" />
+  <package key="kvoptions" name="kvoptions" caption="Key value format for package options" />
+  <package key="kvsetkeys" name="kvsetkeys" caption="Key value parser with default handler support" />
+  <package key="l2a" name="l2a" caption="LaTeX to ASCII" />
+  <package key="l2picfaq" name="l2picfaq" caption="LaTeX pictures &quot;how-to&quot; (German)" />
+  <package key="l2tabu" name="l2tabu" caption="Obsolete packages and commands" />
+  <package key="l2tabu-english" name="l2tabu-english" caption="English translation of &quot;Obsolete packages and commands&quot;" />
+  <package key="l2tabu-french" name="l2tabu-french" caption="French translation of l2tabu" />
+  <package key="l2tabu-italian" name="l2tabu-italian" caption="Italian Translation of Obsolete packages and commands" />
+  <package key="l2tabu-spanish" name="l2tabu-spanish" caption="Spanish translation of &quot;Obsolete packages and commands&quot;" />
+  <package key="l2x" name="l2x" caption="LaTeX to ASCII" />
+  <package key="l3backend" name="l3backend" caption="LaTeX3 backend drivers" />
+  <package key="l3build" name="l3build" caption="A testing and building system for (La)TeX" />
+  <package key="l3docstrip" name="l3docstrip" caption="Strip documentation in LaTeX3 source" />
+  <package key="l3experimental" name="l3experimental" caption="Experimental LaTeX3 concepts" />
+  <package key="l3kernel" name="l3kernel" caption="LaTeX3 programming conventions" />
+  <package key="l3keys2e" name="l3keys2e" caption="LaTeX2e option processing using LaTeX3 keys" />
+  <package key="l3packages" name="l3packages" caption="High-level LaTeX3 concepts" />
+  <package key="l3regex" name="l3regex" caption="Regular expression facilities for LaTeX" />
+  <package key="la" name="la" caption="School handwriting fonts" />
+  <package key="laansort" name="laansort" caption="Sorting within TeX" />
+  <package key="labbook" name="labbook" caption="Typeset laboratory journals" />
+  <package key="label-pln" name="label-pln" caption="Print address labels in three columns" />
+  <package key="labelcas" name="labelcas" caption="Check the existence of labels, and fork accordingly" />
+  <package key="labelfig" name="labelfig" caption="Label LaTeX 2.09 figures included in documents" />
+  <package key="labelmac3" name="labelmac3" caption="Print Avery 5160 labels for laser printers" />
+  <package key="labelmag" name="labelmag" caption="Manage a collection of labels" />
+  <package key="labels" name="labels" caption="Print sheets of sticky labels" />
+  <package key="labels4easylist" name="labels4easylist" caption="Add reference labels to easylist items" />
+  <package key="labelschanged" name="labelschanged" caption="Identify labels which cause endless &#8220;may have changed&#8221; warnings" />
+  <package key="lablst-pkg" name="lablst-pkg" caption="List names of labels in a document" />
+  <package key="labtex" name="labtex" caption="Label diagrams produced in Metafont" />
+  <package key="labyrinth" name="labyrinth" caption="Draw labyrinths and solution paths" />
+  <package key="lacheck" name="lacheck" caption="LaTeX checker" />
+  <package key="ladder" name="ladder" caption="Draw simple ladder diagrams using TikZ" />
+  <package key="lahyph" name="lahyph" caption="Hyphenation patterns for the Latin language" />
+  <package key="laletter" name="laletter" caption="Los Alamos letter style" />
+  <package key="lambda-lists" name="lambda-lists" caption="Lists in TeX&apos;s mouth" />
+  <package key="lambdax" name="lambdax" caption="Use Lambda expression within LaTeX" />
+  <package key="lamemo" name="lamemo" caption="Memo style as used at Los Alamos" />
+  <package key="lametex" name="lametex" caption="A PostScript translator for a subset of LaTeX" />
+  <package key="lamstex" name="LamsTeX" caption="A merge of the best in AMS-TeX and LaTeX" />
+  <package key="lamstex-index" name="lamstex-index" caption="Index processor for LamsTeX" />
+  <package key="landscape" name="landscape" caption="Set up for typesetting in landscape" />
+  <package key="langcode" name="langcode" caption="Simple language-dependent settings based on language codes" />
+  <package key="langnames" name="langnames" caption="Name languages and their genetic affiliations consistently" />
+  <package key="langsci" name="langsci" caption="Typeset books for publication with Language Science Press" />
+  <package key="langsci-affiliations" name="langsci-affiliations" caption="Collect and order authors and affiliations" />
+  <package key="langsci-avm" name="langsci-avm" caption="Feature structures and attribute-value matrices (AVM)" />
+  <package key="lapdf" name="lapdf" caption="PDF drawing directly in TeX documents" />
+  <package key="laps" name="laps" caption="Zero-width boxes for annotations, etc" />
+  <package key="lastbib" name="lastbib" caption="Record the number of citations in a document" />
+  <package key="lastpackage" name="lastpackage" caption="Indicates the last loaded package" />
+  <package key="lastpage" name="lastpage" caption="Reference last page for Page N of M type footers" />
+  <package key="latable" name="LaTable" caption="A near-WYSIWYG editor for LaTeX tables" />
+  <package key="lated" name="lated" caption="Graphical LaTeX picture editor" />
+  <package key="latex" name="latex" caption="A TeX macro package that defines LaTeX" />
+  <package key="latex-amsmath" name="latex-amsmath" caption="AMS mathematical facilities for LaTeX" />
+  <package key="latex-amsmath-dev" name="latex-amsmath-dev" caption="Development pre-release of the LaTeX amsmath bundle" />
+  <package key="latex-base" name="latex-base" caption="Base sources of LaTeX" />
+  <package key="latex-base-dev" name="latex-base-dev" caption="Development pre-release of the LaTeX kernel" />
+  <package key="latex-bib-ex" name="latex-bib-ex" caption="Examples for the book Bibliografien mit LaTeX" />
+  <package key="latex-bib2-ex" name="latex-bib2-ex" caption="Examples for the book Bibliografien mit LaTeX" />
+  <package key="latex-bnf" name="latex-bnf" caption="LaTeX macros for typing BNF specifications" />
+  <package key="latex-brochure" name="LaTeX-brochure" caption="A publicity flyer for LaTeX" />
+  <package key="latex-context-ppchtex" name="latex-context-ppchtex" caption="Legacy stub to allow loading pictex as m-pictex" />
+  <package key="latex-course" name="latex-course" caption="A LaTeX course as a projected presentation" />
+  <package key="latex-cyrillic" name="cyrillic" caption="Support for Cyrillic fonts in LaTeX" />
+  <package key="latex-doc" name="latex-doc" caption="Documentation supplied as part of the LaTeX distribution" />
+  <package key="latex-doc-ptr" name="latex-doc-ptr" caption="A direction-finder for LaTeX resources available online" />
+  <package key="latex-errata" name="latex-errata" caption="Errata for the LaTeX Manual" />
+  <package key="latex-essential" name="latex-essential" caption="Essential information for writing LaTeX documents" />
+  <package key="latex-firstaid" name="latex-firstaid" caption="First aid for external LaTeX files and packages that need updating" />
+  <package key="latex-firstaid-dev" name="latex-firstaid-dev" caption="Development pre-release of the LaTeX firstaid package" />
+  <package key="latex-fonts" name="latex-fonts" caption="A collection of fonts used in LaTeX distributions" />
+  <package key="latex-for-undergraduates" name="latex-for-undergraduates" caption="A tutorial aimed at introducing undergraduate students to LaTeX" />
+  <package key="latex-git-log" name="latex-git-log" caption="Typeset git log information" />
+  <package key="latex-graphics" name="latex-graphics" caption="The LaTeX standard graphics bundle" />
+  <package key="latex-graphics-dev" name="latex-graphics-dev" caption="Development pre-release of the LaTeX graphics bundle" />
+  <package key="latex-hlp" name="latex-hlp" caption="A VMS help file for LaTeX 2.09" />
+  <package key="latex-info" name="latex-info" caption="Unofficial reference manual for LaTeX" />
+  <package key="latex-lab" name="latex-lab" caption="LaTeX laboratory" />
+  <package key="latex-lab-dev" name="latex-lab-dev" caption="LaTeX laboratory: Development pre-release" />
+  <package key="latex-make" name="latex-make" caption="Easy compiling of complex (and simple) LaTeX documents" />
+  <package key="latex-mr" name="latex-mr" caption="A practical guide to LaTeX and Polyglossia for Marathi and other Indian languages" />
+  <package key="latex-notes-zh-cn" name="latex-notes-zh-cn" caption="Chinese Introduction to TeX and LaTeX" />
+  <package key="latex-papersize" name="latex-papersize" caption="Calculate LaTeX settings for any font and paper size" />
+  <package key="latex-pro-pragmatiky" name="latex-pro-pragmatiky" caption="LaTeX for pragmatists" />
+  <package key="latex-referenz" name="LaTeX-Referenz" caption="Examples from the book &quot;LaTeX Referenz&quot;" />
+  <package key="latex-refsheet" name="latex-refsheet" caption="LaTeX Reference Sheet for a thesis with KOMA-Script" />
+  <package key="latex-sciences-humaines" name="latex-sciences-humaines" caption="(Xe)LaTeX Appliqu&#233; aux sciences humaines" />
+  <package key="latex-tabellen" name="latex-tabellen" caption="LaTeX Tabellen" />
+  <package key="latex-tds" name="LaTeX-tds" caption="A structured copy of the LaTeX distribution" />
+  <package key="latex-tools" name="latex-tools" caption="The LaTeX standard tools bundle" />
+  <package key="latex-tools-dev" name="latex-tools-dev" caption="Development pre-release of the LaTeX tools bundle" />
+  <package key="latex-uni8" name="latex-uni8" caption="Universal inputenc, fontenc, and babel for pdfLaTeX and LuaLaTeX" />
+  <package key="latex-veryshortguide" name="LaTeX-veryshortguide" caption="The Very Short Guide to LaTeX" />
+  <package key="latex-via-exemplos" name="latex-via-exemplos" caption="A LaTeX course written in brazilian portuguese language" />
+  <package key="latex209" name="latex209" caption="Old, unsupported, LaTeX" />
+  <package key="latex2e-help-texinfo" name="latex2e-help-texinfo" caption="Unofficial reference manual covering LaTeX2e" />
+  <package key="latex2e-help-texinfo-fr" name="latex2e-help-texinfo-fr" caption="A French translation of &#8220;latex2e-help-texinfo&#8221;" />
+  <package key="latex2e-reference" name="latex2e-reference" caption="A reference for LaTeX in HTML" />
+  <package key="latex2html" name="latex2html" caption="Convert LaTeX into HTML documents" />
+  <package key="latex2man" name="latex2man" caption="Translate LaTeX-based manual pages into Unix man format" />
+  <package key="latex2nemeth" name="Latex2Nemeth" caption="Convert LaTeX source to Braille with math in Nemeth" />
+  <package key="latex2rtf" name="latex2rtf" caption="Convert LaTeX into Rich Text Format" />
+  <package key="latex4jed" name="latex4jed" caption="A much enhanced LaTeX mode for the Jed editor" />
+  <package key="latex4musicians" name="LaTeX4Musicians" caption="A guide for combining LaTeX and music" />
+  <package key="latex4wp" name="latex4wp" caption="A LaTeX guide specifically designed for word processor users" />
+  <package key="latex4wp-it" name="latex4wp-it" caption="LaTeX guide for word processor users, in Italian" />
+  <package key="latexalpha2" name="latexalpha2" caption="Embed Mathematica code and plots into LaTeX" />
+  <package key="latexbangla" name="latexbangla" caption="Enhanced LaTeX integration for Bangla" />
+  <package key="latexbug" name="latexbug" caption="Bug-classification for LaTeX related bugs" />
+  <package key="latexcad" name="latexcad" caption="A CAD drawing package" />
+  <package key="latexcheat" name="latexcheat" caption="A LaTeX cheat sheet" />
+  <package key="latexcheat-de" name="latexcheat-de" caption="A LaTeX cheat sheet, in German" />
+  <package key="latexcheat-esmx" name="latexcheat-esmx" caption="A LaTeX cheat sheet, in Spanish" />
+  <package key="latexcheat-ptbr" name="latexcheat-ptbr" caption="A LaTeX cheat sheet, in Brazilian Portuguese" />
+  <package key="latexcolors" name="latexcolors" caption="Use color definitions from latexcolor.com" />
+  <package key="latexcount" name="latexcount" caption="Perl script to count words of LaTeX documents" />
+  <package key="latexcourse-rug" name="latexcourse-rug" caption="A LaTeX course book" />
+  <package key="latexdb" name="LaTeXDB" caption="Integrates LaTeX and SQL databases" />
+  <package key="latexdemo" name="latexdemo" caption="Demonstrate LaTeX code with its resulting output" />
+  <package key="latexdiff" name="latexdiff" caption="Determine and mark up significant differences between LaTeX files" />
+  <package key="latexdraw" name="latexdraw" caption="CAD oriented drawing program" />
+  <package key="latexfileinfo-pkgs" name="latexfileinfo-pkgs" caption="A comparison of packages showing LaTeX file information" />
+  <package key="latexfileversion" name="latexfileversion" caption="Prints the version and date of a LaTeX class or style file" />
+  <package key="latexgit" name="LaTeXgit" caption="A LaTeX git wrapper" />
+  <package key="latexindent" name="latexindent" caption="Indent a LaTeX document, highlighting the programming structure" />
+  <package key="latexinfo" name="latexinfo" caption="Texinfo for LaTeX 2.09" />
+  <package key="latexmake" name="latexmake" caption="LaTeX Makefile" />
+  <package key="latexmk" name="latexmk" caption="Fully automated LaTeX document generation" />
+  <package key="latexmng" name="LaTexMng" caption="An integrated development environment for Windows" />
+  <package key="latexmp" name="latexMP" caption="Interface for LaTeX-based typesetting in MetaPost" />
+  <package key="latexn" name="latexn" caption="Run LaTeX as many times as needed" />
+  <package key="latexpand" name="latexpand" caption="Expand \input and \include in a LaTeX document" />
+  <package key="latexpix" name="LaTeXPiX" caption="LaTeX picture editor for Windows" />
+  <package key="latexrelease" name="latexrelease" caption="LaTeX release emulation" />
+  <package key="latexrender" name="LatexRender" caption="Use LaTeX in PHP programs" />
+  <package key="latexwide" name="LaTeX-WIDE" caption="Multifunctional editor for LaTeX" />
+  <package key="latexwizard" name="latexwizard" caption="Create the header of a LaTeX document" />
+  <package key="latin" name="latin" caption="Latin language definition for Babel" />
+  <package key="latin1jk" name="latin1jk" caption="Inputenc encoding for verbatim ISO 8859-1 use" />
+  <package key="latin2jk" name="latin2jk" caption="Inputenc encoding for verbatim ISO 8859-2 use" />
+  <package key="latin3jk" name="latin3jk" caption="Inputenc encoding for verbatim ISO 8859-3 use" />
+  <package key="latino-sine-flexione" name="latino-sine-flexione" caption="LaTeX support for documents written in Peano&#8217;s Interlingua" />
+  <package key="lato" name="lato" caption="Lato font family and LaTeX support" />
+  <package key="layaureo" name="Layaureo" caption="A package to improve the A4 page layout" />
+  <package key="layout" name="layout" caption="View the layout of a document" />
+  <package key="layouts" name="layouts" caption="Display various elements of a document&apos;s layout" />
+  <package key="lazylist" name="lazylist" caption="Lists in TeX&#8217;s &#8220;mouth&#8221;" />
+  <package key="lb2-examples" name="lb2-examples" caption="Examples from &#8220;Der LaTeX Begleiter&#8221;" />
+  <package key="lccaps" name="lccaps" caption="Lowercased (spaced) small capitals" />
+  <package key="lcd" name="lcd" caption="Alphanumerical LCD-style displays" />
+  <package key="lcdf-typetools" name="LCDF-typetools" caption="A bundle of outline font manipulation tools" />
+  <package key="lcg" name="lcg" caption="Generate random integers" />
+  <package key="lcircuit" name="lcircuit" caption="Circuit symbols for use in LaTeX picture mode" />
+  <package key="lcyw" name="lcyw" caption="Make Classic Cyrillic CM fonts accessible in LaTeX" />
+  <package key="ldiff" name="ldiff" caption="A script for marking the differences between two LaTeX files" />
+  <package key="leading" name="leading" caption="Define leading with a length" />
+  <package key="leadsheets" name="leadsheets" caption="Typesetting leadsheets and songbooks" />
+  <package key="leaflet" name="leaflet" caption="Create small handouts (flyers)" />
+  <package key="leawood" name="leawood" caption="LaTeX support for use of ITC Leawood font family" />
+  <package key="lebhart" name="lebhart" caption="Write your articles in a colorful way" />
+  <package key="lecturer" name="lecturer" caption="On-screen presentations for (almost) all formats" />
+  <package key="lectures" name="lectures" caption="A document class for quickly drafting nice looking lecture notes" />
+  <package key="lectureslides" name="lectureslides" caption="Combine single PDF files into one file" />
+  <package key="led" name="LEd" caption="An environment for LaTeX document development" />
+  <package key="ledarab" name="ledarab" caption="Typeset scholarly editions in arabic" />
+  <package key="ledmac" name="ledmac" caption="Typeset scholarly editions" />
+  <package key="ledpar" name="ledpar" caption="Typeset scholarly editions in parallel texts" />
+  <package key="leftidx" name="leftidx" caption="Left and right subscripts and superscripts in math mode" />
+  <package key="leftindex" name="leftindex" caption="Left indices with better spacing" />
+  <package key="leiletter" name="LEIletter" caption="A letter class for Leiden University" />
+  <package key="leipzig" name="leipzig" caption="Typeset and index linguistic gloss abbreviations" />
+  <package key="lengthconvert" name="lengthconvert" caption="Express lengths in arbitrary units" />
+  <package key="letgut" name="letgut" caption="Class for the newsletter &#8220;La Lettre GUTenberg&#8221; of the French TeX User Group GUTenberg" />
+  <package key="letltxmacro" name="letltxmacro" caption="Let assignment for LaTeX macros" />
+  <package key="letter" name="letter" caption="The standard LaTeX2e letter document class" />
+  <package key="letter-plain" name="letter-plain" caption="Letter macros for Plain TeX" />
+  <package key="letter1" name="letter1" caption="Letter formatting macros" />
+  <package key="lettergothic" name="lettergothic" caption="The Adobe Type 1 font family Letter GothicType" />
+  <package key="lettermac" name="lettermac" caption="Simple macros for writing letters (Plain TeX)" />
+  <package key="letterspacing" name="letterspacing" caption="Letter spacing" />
+  <package key="letterswitharrows" name="letterswitharrows" caption="Draw arrows over math letters" />
+  <package key="lettre" name="lettre" caption="Letters and faxes in French" />
+  <package key="lettrine" name="lettrine" caption="Typeset dropped capitals" />
+  <package key="levy-font" name="levy-font" caption="Fonts for typesetting classical greek" />
+  <package key="levy-latex" name="levy-latex" caption="Macros for using Silvio Levy&apos;s Greek fonts" />
+  <package key="lewis" name="lewis" caption="Draw Lewis structures" />
+  <package key="lexend" name="lexend" caption="The Lexend fonts for XeLaTeX and LuaLaTeX through fontspec" />
+  <package key="lexikon" name="lexikon" caption="Macros for a two language dictionary" />
+  <package key="lexitex" name="lexitex" caption="Footnote-style citations for law journals" />
+  <package key="lexref" name="lexref" caption="Convenient and uniform references to legal provisions" />
+  <package key="lextex" name="lextex" caption="Typesetting legal documents using plain TeX" />
+  <package key="lfb" name="lfb" caption="A Greek font with normal and bold variants" />
+  <package key="lfonts-ams" name="lfonts-ams" caption="Use AMS fonts as standard LaTeX 2.09 fonts" />
+  <package key="lgc-examples" name="lgc-examples" caption="Examples from The LaTeX Graphics Companion" />
+  <package key="lgc2-examples" name="lgc2-examples" caption="Examples from The LaTeX Graphics Companion, second edition" />
+  <package key="lgraph" name="lgraph" caption="A program to generate graphs" />
+  <package key="lgreek" name="lgreek" caption="LaTeX macros for using Silvio Levy&apos;s Greek fonts" />
+  <package key="lgrind" name="lgrind" caption="Produce beautiful listings of source code with LaTeX" />
+  <package key="lgrmath" name="lgrmath" caption="Use LGR-encoded fonts in math mode" />
+  <package key="lgrx" name="lgrx" caption="Obsolete package for Greek in text" />
+  <package key="lh" name="lh" caption="Cyrillic fonts that support LaTeX standard encodings" />
+  <package key="lhcyr" name="lhcyr" caption="A non-standard Cyrillic input scheme" />
+  <package key="lhelp" name="lhelp" caption="Miscellaneous helper packages" />
+  <package key="libertine" name="libertine" caption="Use of Linux Libertine and Biolinum fonts with LaTeX" />
+  <package key="libertine-legacy" name="libertine-legacy" caption="Linux Libertine fonts for (La)TeX and pdf(La)TeX users" />
+  <package key="libertine-type1" name="libertine-type1" caption="(pdf)LaTeX support for the Libertine family of fonts" />
+  <package key="libertinegc" name="libertinegc" caption="Libertine add-on to support Greek and Cyrillic" />
+  <package key="libertineotf" name="libertineotf" caption="Linux Libertine fonts for use with Lua(La)TeX and Xe(La)TeX" />
+  <package key="libertinus" name="libertinus" caption="Wrapper to use the correct libertinus package according to the used TeX engine" />
+  <package key="libertinus-fonts" name="libertinus-fonts" caption="The Libertinus font family" />
+  <package key="libertinus-otf" name="libertinus-otf" caption="Support for Libertinus OpenType" />
+  <package key="libertinus-type1" name="libertinus-type1" caption="Support for using Libertinus fonts with LaTeX/pdfLaTeX" />
+  <package key="libertinust1math" name="LibertinusT1Math" caption="A Type 1 font and LaTeX support for Libertinus Math" />
+  <package key="libgreek" name="libgreek" caption="Greek letters in math mode from Libertinus or Linux Libertine/Biolinum" />
+  <package key="librarian" name="librarian" caption="Tools to create bibliographies in TeX" />
+  <package key="librebaskerville" name="librebaskerville" caption="The Libre Baskerville family of fonts with LaTeX support" />
+  <package key="librebodoni" name="librebodoni" caption="Libre Bodoni fonts with LaTeX support" />
+  <package key="librecaslon" name="librecaslon" caption="Libre Caslon fonts, with LaTeX support" />
+  <package key="librefranklin" name="librefranklin" caption="LaTeX support for the Libre-Franklin family of fonts" />
+  <package key="libris" name="libris" caption="Libris ADF fonts, with LaTeX support" />
+  <package key="lie-hasse" name="lie-hasse" caption="Draw Hasse diagrams" />
+  <package key="lifia-th" name="lifia-th" caption="A thesis class for LIFIA, Grenoble" />
+  <package key="liftarm" name="liftarm" caption="Draw liftarms" />
+  <package key="ligatex" name="LigaTeX" caption="Remove unnecessary ligatures" />
+  <package key="light-latex-make" name="Light LaTeX Make" caption="llmk: A build tool for LaTeX documents" />
+  <package key="ligtype" name="ligtype" caption="Comprehensive ligature suppression functionalities" />
+  <package key="lilyglyphs" name="lilyglyphs" caption="Access lilypond fragments and glyphs, in LaTeX" />
+  <package key="limap" name="limap" caption="Typeset maps and blocks according to the Information Mapping&#174; method" />
+  <package key="limecv" name="limecv" caption="A (Xe/Lua)LaTeX document class for curriculum vit&#230;" />
+  <package key="lineara" name="linearA" caption="Linear A script fonts" />
+  <package key="linearb" name="linearb" caption="Linear B script used in the Bronze Age for Mycenaean Greek" />
+  <package key="linebreaker" name="linebreaker" caption="Prevent overflow boxes with LuaLaTeX" />
+  <package key="linegoal" name="linegoal" caption="A &#8220;dimen&#8221; that returns the space left on the line" />
+  <package key="lineno" name="lineno" caption="Line numbers on paragraphs" />
+  <package key="linenoamsmath" name="linenoamsmath" caption="Use the lineno package together with amsmath" />
+  <package key="ling-macros" name="ling-macros" caption="Macros for typesetting formal linguistics" />
+  <package key="lingtrees" name="lingtrees" caption="Linguistics trees preprocessor and macros" />
+  <package key="linguex" name="linguex" caption="Format linguists&apos; examples" />
+  <package key="linguisticspro" name="linguisticspro" caption="LinguisticsPro fonts with LaTeX support" />
+  <package key="linop" name="linop" caption="Typeset linear operators as they appear in quantum theory or linear algebra" />
+  <package key="linsys" name="linsys" caption="Typeset systems of linear equations" />
+  <package key="lintex" name="lintex" caption="Tidy up after a TeX run" />
+  <package key="lion-msc" name="lion-msc" caption="LaTeX class for B.Sc. and M.Sc. reports at Leiden Institute of Physics (LION)" />
+  <package key="lips" name="lips" caption="Text ellipses in LaTeX" />
+  <package key="lipsum" name="lipsum" caption="Easy access to the Lorem Ipsum and other dummy texts" />
+  <package key="lisp-on-tex" name="lisp-on-tex" caption="Execute LISP code in a LaTeX document" />
+  <package key="list" name="list" caption="List ASCII text files" />
+  <package key="listbib" name="listbib" caption="Lists contents of BibTeX files" />
+  <package key="listing" name="listing" caption="Produce formatted program listings" />
+  <package key="listing-pln" name="listing-pln" caption="Almost-verbatim list programs" />
+  <package key="listings" name="listings" caption="Typeset source code listings using LaTeX" />
+  <package key="listings-ext" name="listings-ext" caption="Automated input of source" />
+  <package key="listingsutf8" name="listingsutf8" caption="Allow UTF-8 in listings input" />
+  <package key="listlbls" name="listlbls" caption="Creates a list of all labels used throughout a document" />
+  <package key="listliketab" name="listliketab" caption="Typeset lists as tables" />
+  <package key="listofanswers" name="listofanswers" caption="Provide a list of answers to mathematical problems" />
+  <package key="listofitems" name="listofitems" caption="Grab items in lists using user-specified sep char" />
+  <package key="listofsymbols" name="listofsymbols" caption="Create and manipulate lists of symbols" />
+  <package key="literate" name="literate" caption="A literate programming system, not tied to any language" />
+  <package key="literaturnaya" name="literaturnaya" caption="The Literaturnaya family of fonts" />
+  <package key="lithuanian" name="lithuanian" caption="Lithuanian language support" />
+  <package key="liturg" name="liturg" caption="Support for typesetting Catholic liturgical texts" />
+  <package key="ljmetrics" name="ljmetrics" caption="Metrics for Laserjet built-in fonts" />
+  <package key="lkort" name="lkort" caption="A short introduction to LaTeX, in Dutch" />
+  <package key="lkproof" name="LKproof" caption="LK Proof figure macros" />
+  <package key="llist" name="llist" caption="List ASCII text files in landscape" />
+  <package key="llncs" name="llncs" caption="Document class and bibliography style for Lecture Notes in Computer Science (LNCS)" />
+  <package key="llncs209" name="llncs209" caption="Macros for Springer books" />
+  <package key="llncsconf" name="llncsconf" caption="LaTeX package extending Springer&apos;s llncs class" />
+  <package key="lm" name="lm" caption="Latin modern fonts in outline formats" />
+  <package key="lm-math" name="lm-math" caption="OpenType maths fonts for Latin Modern" />
+  <package key="lmacs" name="lmacs" caption="A simple package for including support files" />
+  <package key="lmake" name="lmake" caption="Process lists to do repetitive actions" />
+  <package key="lms" name="lms" caption="LaTeX 2.09 style for LMS journals" />
+  <package key="ln03dvi" name="ln03dvi" caption="DVI to LN03 driver" />
+  <package key="lni" name="lni" caption="Official class for the &#8220;Lecture Notes in Informatics&#8221;" />
+  <package key="lobster2" name="lobster2" caption="Lobster Two fonts, with support for all LaTeX engines" />
+  <package key="locality" name="locality" caption="Various macros for keeping things local" />
+  <package key="localloc" name="localloc" caption="Macros for localizing TeX register allocations" />
+  <package key="logbox" name="logbox" caption="e-TeX showbox facilities for exploration purposes" />
+  <package key="logfilter" name="logfilter" caption="Choose what you want to see of a (La)TeX log" />
+  <package key="loggates" name="loggates" caption="A small font for logic gates, and LaTeX support" />
+  <package key="logic" name="logic" caption="A font for electronic logic design" />
+  <package key="logical-markup-utils" name="logical-markup-utils" caption="Packages for language-dependent inline quotes and dashes" />
+  <package key="logicproof" name="logicproof" caption="Box proofs for propositional and predicate logic" />
+  <package key="logicpuzzle" name="logicpuzzle" caption="Typeset (grid-based) logic puzzles" />
+  <package key="logix" name="logix" caption="Supplement to the Unicode math symbols" />
+  <package key="logpap" name="logpap" caption="Generate logarithmic graph paper with LaTeX" />
+  <package key="logreq" name="logreq" caption="Support for automation of the LaTeX workflow" />
+  <package key="logsys" name="logsys" caption="Draw logarithmic coordinate systems" />
+  <package key="lollipop" name="lollipop" caption="TeX made easy" />
+  <package key="longdiv" name="longdiv" caption="Long division arithmetic problems" />
+  <package key="longdivision" name="longdivision" caption="Typesets long division" />
+  <package key="longfbox" name="longfbox" caption="Draw framed boxes with standard CSS attributes that can break over multiple pages" />
+  <package key="longfigure" name="longfigure" caption="Provides a figure-like environment that break over pages" />
+  <package key="longnamefilelist" name="longnamefilelist" caption="Tidy \listfiles with long file names" />
+  <package key="longtable" name="longtable" caption="Allow tables to flow over page boundaries" />
+  <package key="longtocline" name="longtocline" caption="Macros to produce a table of contents" />
+  <package key="lookbibtex" name="lookbibtex" caption="Tools for examining BibTeX files" />
+  <package key="loops" name="loops" caption="General looping macros for use with LaTeX" />
+  <package key="losymbol" name="losymbol" caption="Defines a mechanism for producing a list of symbols" />
+  <package key="lout" name="lout" caption="An alternative typesetting system" />
+  <package key="loval" name="loval" caption="Round-cornered framed boxes" />
+  <package key="lparse" name="lparse" caption="A Lua module for parsing key-value options" />
+  <package key="lpform" name="lpform" caption="Typesetting linear programming formulations and sets of equations" />
+  <package key="lpic" name="lpic" caption="Put LaTeX material over included graphics" />
+  <package key="lplfitch" name="lplfitch" caption="Fitch-style natural deduction proofs" />
+  <package key="lps" name="lps" caption="Class for &quot;Logic and Philosophy of Science&quot;" />
+  <package key="lpw" name="lpw" caption="A literate programming environment for Macs" />
+  <package key="lroundrect" name="lroundrect" caption="LaTeX macros for utilizing the roundrect MetaPost routines" />
+  <package key="lsabon" name="lsabon" caption="Support files for the Linotype Sabon fonts" />
+  <package key="lsc" name="lsc" caption="Typesetting Live Sequence Charts" />
+  <package key="lscape" name="lscape" caption="Place selected parts of a document in landscape" />
+  <package key="lshort" name="lshort" caption="A short introduction to LaTeX 2e" />
+  <package key="lshort-bulgarian" name="lshort-bulgarian" caption="Bulgarian translation of the &quot;Short Introduction to LaTeX2e&quot;" />
+  <package key="lshort-czech" name="lshort-czech" caption="Czech translation of the &#8220;Short Introduction to LaTeX2e&#8221;" />
+  <package key="lshort-dutch" name="lshort-dutch" caption="Introduction to LaTeX in Dutch" />
+  <package key="lshort-english" name="lshort-english" caption="A (Not So) Short Introduction to LaTeX2e" />
+  <package key="lshort-estonian" name="lshort-estonian" caption="Estonian introduction to LaTeX" />
+  <package key="lshort-finnish" name="lshort-finnish" caption="Finnish introduction to LaTeX" />
+  <package key="lshort-french" name="lshort-french" caption="Short introduction to LaTeX, French translation" />
+  <package key="lshort-german" name="lshort-german" caption="
+      German version of A Short
+      Introduction to LaTeX2e: LaTeX2e-Kurzbeschreibung
+  " />
+  <package key="lshort-italian" name="lshort-italian" caption="Introduction to LaTeX in Italian" />
+  <package key="lshort-japanese" name="lshort-japanese" caption="
+      Japanese version of A Short
+      Introduction to LaTeX2e
+    " />
+  <package key="lshort-korean" name="lshort-korean" caption="Korean introduction to LaTeX" />
+  <package key="lshort-mongol" name="lshort-mongol" caption="Short introduction to LaTeX, in Mongolian" />
+  <package key="lshort-mongolian" name="lshort-mongolian" caption="Short introduction to LaTeX 2.09, Mongolian translation" />
+  <package key="lshort-persian" name="lshort-persian" caption="Persian (Farsi) introduction to LaTeX" />
+  <package key="lshort-polish" name="lshort-polish" caption="Introduction to LaTeX in Polish" />
+  <package key="lshort-portuguese" name="lshort-portuguese" caption="Introduction to LaTeX in Portuguese" />
+  <package key="lshort-portuguese-br" name="lshort-portuguese-br" caption="Introduction to LaTeX in Portuguese (Brazil)" />
+  <package key="lshort-russian" name="lshort-russian" caption="Russian introduction to LaTeX" />
+  <package key="lshort-slovak" name="lshort-slovak" caption="Slovak introduction to LaTeX" />
+  <package key="lshort-slovenian" name="lshort-slovenian" caption="Slovenian translation of lshort" />
+  <package key="lshort-spanish" name="lshort-spanish" caption="Short introduction to LaTeX, Spanish translation" />
+  <package key="lshort-thai" name="lshort-thai" caption="Introduction to LaTeX in Thai" />
+  <package key="lshort-turkish" name="lshort-turkish" caption="Turkish introduction to LaTeX" />
+  <package key="lshort-ukr" name="lshort-ukr" caption="Ukrainian version of the LaTeX introduction" />
+  <package key="lshort-vietnamese" name="lshort-vietnamese" caption="Vietnamese version of the LaTeX introduction" />
+  <package key="lshort-zh-cn" name="lshort-zh-cn" caption="Introduction to LaTeX, in Chinese" />
+  <package key="lstaddons" name="lstaddons" caption="Add-on packages for listings: autogobble and line background" />
+  <package key="lstbayes" name="lstbayes" caption="Listings language driver for Bayesian modeling languages" />
+  <package key="lstfiracode" name="lstfiracode" caption="Use Fira Code font for listings" />
+  <package key="lt3graph" name="lt3graph" caption="Provide a graph datastructure for experimental LaTeX3" />
+  <package key="lt3luabridge" name="lt3luabridge" caption="Execute Lua code in any TeX engine that exposes the shell" />
+  <package key="lt3rawobjects" name="lt3rawobjects" caption="Objects and proxies in LaTeX3" />
+  <package key="ltablex" name="ltablex" caption="Table package extensions" />
+  <package key="ltabptch" name="ltabptch" caption="Bug fix for longtable" />
+  <package key="ltb2bib" name="ltb2bib" caption="Converts amsrefs&apos; .ltb bibliographical databases to BibTeX format" />
+  <package key="ltcaption" name="ltcaption" caption="Fix some caption problems in longtables" />
+  <package key="ltnews" name="ltnews" caption="The latest LaTeX news" />
+  <package key="ltoh" name="ltoh" caption="A converter from LaTeX to HTML" />
+  <package key="ltt" name="ltt" caption="Example code for &quot;LaTeX Tipps und Tricks&quot; book" />
+  <package key="ltx2mathml" name="ltx2mathml" caption="Convert LaTeX math to MathML" />
+  <package key="ltx2rtf" name="ltx2rtf" caption="A conversion program from LaTeX to Rich Text Format" />
+  <package key="ltx2x" name="ltx2x" caption="Replace LaTeX commands in a document by user-defined strings" />
+  <package key="ltx3pub" name="ltx3pub" caption="Early publications of the LaTeX project" />
+  <package key="ltx4yt" name="ltx4yt" caption="Play YouTube videos in the default browser" />
+  <package key="ltxcmds" name="ltxcmds" caption="Some LaTeX kernel commands for general use" />
+  <package key="ltxdiff" name="ltxdiff" caption="A Win32 program that compares tokens in two .tex files" />
+  <package key="ltxdoc" name="ltxdoc" caption="Class for documented LaTeX macro files" />
+  <package key="ltxdockit" name="ltxdockit" caption="Documentation support" />
+  <package key="ltxfileinfo" name="ltxfileinfo" caption="Print version information for a LaTeX file" />
+  <package key="ltxgrid" name="ltxgrid" caption="Control of the page grid" />
+  <package key="ltxguidex" name="ltxguidex" caption="An extended ltxguide class" />
+  <package key="ltximg" name="ltximg" caption="Extract LaTeX environments into separate image files" />
+  <package key="ltxindex" name="ltxindex" caption="A LaTeX package to typeset indices with GNU&#8217;s Texindex" />
+  <package key="ltxinput" name="ltxinput" caption="Find files input by a document" />
+  <package key="ltxkeys" name="ltxkeys" caption="A robust key parser for LaTeX" />
+  <package key="ltxmisc" name="ltxmisc" caption="Miscellaneous LaTeX packages, etc" />
+  <package key="ltxnew" name="ltxnew" caption="A simple means of creating commands" />
+  <package key="ltxtable" name="ltxtable" caption="Longtable and tabularx merge" />
+  <package key="ltxtools" name="ltxtools" caption="A collection of LaTeX API macros" />
+  <package key="ltxutil" name="ltxutil" caption="LaTeX utility macros" />
+  <package key="lua-alt-getopt" name="lua-alt-getopt" caption="Process application arguments the same way as getopt_long" />
+  <package key="lua-check-hyphen" name="lua-check-hyphen" caption="Mark hyphenations in a document, for checking" />
+  <package key="lua-physical" name="lua-physical" caption="Functions and objects for the computation of physical quantities" />
+  <package key="lua-tinyyaml" name="lua-tinyyaml" caption="A tiny YAML (subset) parser for pure Lua" />
+  <package key="lua-typo" name="lua-typo" caption="Highlighting typographical flaws with LuaLaTeX" />
+  <package key="lua-uca" name="Lua-UCA" caption="Unicode Collation Algorithm library for Lua" />
+  <package key="lua-ul" name="LuauL" caption="Underlining for LuaLaTeX" />
+  <package key="lua-uni-algos" name="lua-uni-algos" caption="Unicode algorithms for LuaTeX" />
+  <package key="lua-visual-debug" name="lua-visual-debug" caption="Visual debugging with LuaLaTeX" />
+  <package key="lua-widow-control" name="lua-widow-control" caption="Automatically remove widows and orphans from any document" />
+  <package key="lua2dox" name="lua2dox" caption="Auto-documentation of lua code" />
+  <package key="luaaddplot" name="luaaddplot" caption="An extension to pgfplots&#8217; \addplot macro" />
+  <package key="luabibentry" name="luabibentry" caption="Repeat BibTeX entries in a LuaLaTeX document body" />
+  <package key="luabidi" name="luabidi" caption="Bidi functions for LuaTeX" />
+  <package key="luacas" name="luacas" caption="A computer algebra system for users of LuaLaTeX" />
+  <package key="luacensor" name="luacensor" caption="Securely redact sensitive information using Lua" />
+  <package key="luacode" name="luacode" caption="Helper for executing lua code from within TeX" />
+  <package key="luacolor" name="luacolor" caption="Color support based on LuaTeX&#8217;s node attributes" />
+  <package key="luacomplex" name="luacomplex" caption="Operations on complex numbers inside LaTeX documents using Lua" />
+  <package key="luafindfont" name="luafindfont" caption="Search fonts in the LuaTeX font database" />
+  <package key="luagcd" name="luagcd" caption="Computation of gcd of integers inside LaTeX using Lua" />
+  <package key="luahttp" name="luahttp" caption="Compile-time internet-interactive PDF-documents using Lua and LuaTeX" />
+  <package key="luahyphenrules" name="luahyphenrules" caption="Loading patterns in LuaLaTeX with language.dat" />
+  <package key="luaimageembed" name="luaimageembed" caption="Embed images as base64-encoded strings" />
+  <package key="luaindex" name="luaindex" caption="Create index using LuaLaTeX" />
+  <package key="luainputenc" name="luainputenc" caption="Replacing inputenc for use in LuaTeX" />
+  <package key="luaintro" name="luaintro" caption="Examples from the book &#8220;Einf&#252;hrung in LuaTeX und LuaLaTeX&#8221;" />
+  <package key="luakeys" name="luakeys" caption="A Lua module for parsing key-value options" />
+  <package key="lualatex-doc" name="lualatex-doc" caption="A guide to use of LaTeX with LuaTeX" />
+  <package key="lualatex-doc-de" name="lualatex-doc-de" caption="Guide to LuaLaTeX (German translation)" />
+  <package key="lualatex-math" name="lualatex-math" caption="Fixes for mathematics-related LuaLaTeX issues" />
+  <package key="lualatex-platform" name="luaLaTeX-platform" caption="Load platform-specific code into LuaTeX" />
+  <package key="lualatex-truncate" name="lualatex-truncate" caption="A wrapper for using the truncate package with LuaLaTeX" />
+  <package key="lualibs" name="lualibs" caption="Additional Lua functions for LuaTeX macro programmers" />
+  <package key="lualinalg" name="lualinalg" caption="A linear algebra package for LuaLaTeX" />
+  <package key="luamathalign" name="luamathalign" caption="More flexible alignment in amsmath environments" />
+  <package key="luamaths" name="luamaths" caption="Provide standard mathematical operations inside LaTeX documents using Lua" />
+  <package key="luamesh" name="luamesh" caption="Computes and draws 2D Delaunay triangulation" />
+  <package key="luamodulartables" name="luamodulartables" caption="Generate modular addition and multiplication tables" />
+  <package key="luamplib" name="luamplib" caption="Use LuaTeX&#8217;s built-in MetaPost interpreter" />
+  <package key="luanumint" name="luanumint" caption="Numerical integration using Lua inside LaTeX documents" />
+  <package key="luaoptions" name="luaoptions" caption="Option handling for LuaLaTeX packages" />
+  <package key="luaotfload" name="luaotfload" caption="OpenType &#8216;loader&#8217; for Plain TeX and LaTeX" />
+  <package key="luapackageloader" name="luapackageloader" caption="Allow LuaTeX to load external Lua packages" />
+  <package key="luaplot" name="luaplot" caption="Plotting graphs using Lua" />
+  <package key="luaprogtable" name="luaprogtable" caption="Programmable table interface for LuaLaTeX" />
+  <package key="luapstricks" name="luapstricks" caption="A PSTricks backend for LuaLaTeX" />
+  <package key="luaquotes" name="luaquotes" caption="Smart setting of quotation marks" />
+  <package key="luarandom" name="luarandom" caption="Create lists of random numbers" />
+  <package key="luaset" name="luaset" caption="Set Operations inside LaTeX documents using Lua" />
+  <package key="luasseq" name="luasseq" caption="Drawing spectral sequences in LuaLaTeX" />
+  <package key="luatex" name="luatex" caption="The LuaTeX engine" />
+  <package key="luatex-def" name="luatex-def" caption="LuaTeX option file for color and graphics" />
+  <package key="luatex-pkg" name="luatex-pkg" caption="Basic definitions for LuaTeX" />
+  <package key="luatex85" name="luatex85" caption="pdfTeX aliases for LuaTeX" />
+  <package key="luatexbase" name="luatexbase" caption="Basic resource management for LuaTeX code" />
+  <package key="luatexja" name="luatexja" caption="Typeset Japanese with Lua(La)TeX" />
+  <package key="luatexko" name="luatexko" caption="Typeset Korean with Lua(La)TeX" />
+  <package key="luatextra" name="luatextra" caption="Additional macros for Plain TeX and LaTeX in LuaTeX" />
+  <package key="luatodonotes" name="luatodonotes" caption="Add editing annotations in a LuaLaTeX document" />
+  <package key="luatruthtable" name="luatruthtable" caption="Generate truth tables of boolean values in LuaLaTeX" />
+  <package key="luavlna" name="luavlna" caption="Prevent line breaks after single letter words, units, or academic titles" />
+  <package key="luaxml" name="luaxml" caption="Lua library for reading and serialising XML files" />
+  <package key="lucida" name="lucida" caption="Metrics, etc., for Lucida Bright and Lucida Math" />
+  <package key="lucida-otf" name="lucida-otf" caption="Support for the Lucida Bright fonts (OpenType)" />
+  <package key="lucidabr" name="lucidabr" caption="PSNFSS support for Lucida Type 1 fonts" />
+  <package key="lucold" name="lucold" caption="Use old-style digits with Lucida fonts" />
+  <package key="lug" name="lug" caption="Create and edit TeX Local User Group web pages" />
+  <package key="lutabulartools" name="lutabulartools" caption="Some useful LuaLaTeX-based tabular tools" />
+  <package key="luximono" name="LuxiMono" caption="Free monospace fonts" />
+  <package key="lwarp" name="lwarp" caption="Converts LaTeX to HTML" />
+  <package key="lwc-examples" name="lwc-examples" caption="Examples from The LaTeX Web Companion" />
+  <package key="lxfonts" name="LXfonts" caption="Set of slide fonts based on CM" />
+  <package key="lxmail" name="lxmail" caption="A letter-generator that produces LaTeX output" />
+  <package key="ly1" name="ly1" caption="Support for LY1 LaTeX encoding" />
+  <package key="lyluatex" name="lyluatex" caption="Commands to include lilypond scores within a (Lua)LaTeX document" />
+  <package key="lyx" name="lyx" caption="Document processor based on LaTeX" />
+  <package key="m-pictex" name="m-pictex" caption="Enable PicTeX to run with LaTeX" />
+  <package key="m-tx" name="M-Tx" caption="A preprocessor for pmx" />
+  <package key="m3d" name="m3D" caption="Extension of plain MetaPost for 3D graphics" />
+  <package key="maad" name="maad" caption="Mathematical Approximations and Documentation" />
+  <package key="mab2bib" name="mab2bib" caption="Converter tools: MAB to BibTeX and UTF-8 to LaTeX ASCII" />
+  <package key="macbibtex" name="macbibtex" caption="BibTeX for the Macintosh" />
+  <package key="macfont" name="macfont" caption="Convert Apple type 1 fonts for use under Windows" />
+  <package key="macrolist" name="macrolist" caption="List operations for LaTeX2e" />
+  <package key="macros2e" name="macros2e" caption="A list of internal LaTeX2e macros" />
+  <package key="macroswap" name="macroswap" caption="Swap the definitions of two LaTeX macros" />
+  <package key="mactex" name="mactex" caption="The TeX Live Mac distribution" />
+  <package key="mactex-basic" name="mactex-basic" caption="A basic TeX distribution for the Macintosh" />
+  <package key="mactextras" name="mactextras" caption="Extras for the MacTeX distribution" />
+  <package key="mactotex" name="mactotex" caption="Convert &quot;Macintosh PostScript&quot; for use with TeX" />
+  <package key="mafr" name="mafr" caption="Mathematics in accord with French usage" />
+  <package key="magaz" name="magaz" caption="Magazine layout" />
+  <package key="magic" name="magic" caption="A font to go with the Magic(TM) game" />
+  <package key="magicnum" name="magicnum" caption="Access TeX systems&#8217; &#8220;magic numbers&#8221;" />
+  <package key="magicwatermark" name="magicwatermark" caption="An easy and flexible way to set watermarks" />
+  <package key="magra" name="magra" caption="The Magra font face with support for LaTeX and pdfLaTeX" />
+  <package key="mahjong" name="mahjong" caption="Typeset Mahjong Tiles using MPSZ Notation" />
+  <package key="mailing" name="mailing" caption="Macros for mail merging" />
+  <package key="mailmerge" name="mailmerge" caption="Repeating text field substitution" />
+  <package key="make-env" name="make-env" caption="Print USPS standard envelopes" />
+  <package key="make-latex" name="make_latex" caption="LaTeX Makefile" />
+  <package key="make4ht" name="make4ht" caption="A build system for tex4ht" />
+  <package key="makebarcode" name="makebarcode" caption="Print various kinds 2/5 and Code 39 bar codes" />
+  <package key="makebase" name="makebase" caption="Typeset counters in a different base" />
+  <package key="makebox" name="makebox" caption="Defines a \makebox* command" />
+  <package key="makecell" name="makecell" caption=" Tabular column heads and multilined cells" />
+  <package key="makecirc" name="MakeCirc" caption="A MetaPost library for drawing electrical circuit diagrams" />
+  <package key="makecmds" name="makecmds" caption="The new \makecommand command always (re)defines a command" />
+  <package key="makecookbook" name="makecookbook" caption="Make a Cookbook" />
+  <package key="makedoc" name="makedoc" caption="Preprocessing documentation with TeX" />
+  <package key="makedtx" name="makedtx" caption="Perl script to help generate dtx and ins files" />
+  <package key="makefonts" name="makefonts" caption="Shell scripts to generate bitmaps from Metafont sources" />
+  <package key="makeglos" name="makeglos" caption="Include a glossary into a document" />
+  <package key="makeglossariesgui" name="MakeGlossariesGUI" caption="Java GUI alternative to makeglossaries script" />
+  <package key="makeidx" name="makeidx" caption="Standard LaTeX package for creating indexes" />
+  <package key="makeindex" name="makeindex" caption="Process index output to produce typesettable code" />
+  <package key="makeindexk" name="makeindexk" caption="Makeindex development sources" />
+  <package key="makelabels" name="makelabels" caption="Add a &#8216;\makelabels&#8217; feature to KOMA-Script letter classes and package" />
+  <package key="makeplot" name="makeplot" caption="Easy plots from Matlab in LaTeX" />
+  <package key="makeprog" name="makeprog" caption="A literate system for TeX programming" />
+  <package key="maker" name="maker" caption="Include Arduino or Processing code in LaTeX documents" />
+  <package key="makerobust" name="makerobust" caption="Making a macro robust (legacy package)" />
+  <package key="makerobust209" name="makerobust209" caption="Make an existing LaTeX command robust" />
+  <package key="makeshape" name="makeshape" caption="Declare new PGF shapes" />
+  <package key="maketable" name="maketable" caption="Convert Word or Excel tables to TeX tabular structures" />
+  <package key="makor2" name="Makor 2" caption="Typeset pointed Hebrew using Omega" />
+  <package key="malayalam-latex" name="malayalam-latex" caption="LaTeX for Malayalam" />
+  <package key="malayalam-obsolete" name="malayalam-obsolete" caption="Fonts for typesetting Malayalam, with a pre-processor" />
+  <package key="malayalam-omega" name="malayalam-omega" caption="Typesetting Malayalam using Omega" />
+  <package key="maltese" name="maltese" caption="Support input in Maltese" />
+  <package key="malvern" name="malvern" caption="A sans-serif font family" />
+  <package key="mandel" name="mandel" caption="Compute the Mandelbrot set" />
+  <package key="mandi" name="mandi" caption="Macros for introductory physics and astronomy" />
+  <package key="manfnt" name="manfnt" caption="LaTeX support for the TeX book symbols" />
+  <package key="manjutex" name="manjutex" caption="Manju language support" />
+  <package key="manpage" name="manpage" caption="Man pages in LaTeX" />
+  <package key="manual" name="manual" caption="Knuth&apos;s &quot;manual&quot; fonts" />
+  <package key="manual209" name="manual209" caption="A document style for manuals" />
+  <package key="manuscript" name="Manuscript" caption="Emulate look of a document typed on a typewriter" />
+  <package key="manyfoot" name="manyfoot" caption="Adds footnote levels to standard LaTeX&#8217;s footnote mechanism" />
+  <package key="manyind" name="manyind" caption="Provides support for many indexes" />
+  <package key="mapcodes" name="mapcodes" caption="Support for multiple character sets and encodings" />
+  <package key="maple" name="maple" caption="Styles and examples for the MAPLE newsletter" />
+  <package key="marathi" name="marathi" caption="Typeset Marathi language using XeLaTeX or LuaLaTeX" />
+  <package key="marcellus" name="Marcellus" caption="Marcellus fonts with LaTeX support" />
+  <package key="margbib" name="margbib" caption="Display bibitem tags in the margins" />
+  <package key="marginal" name="marginal" caption="Extensions to \marginpar handling" />
+  <package key="marginfit" name="marginfit" caption="Improved margin notes" />
+  <package key="marginfix" name="marginfix" caption="Patch \marginpar to avoid overfull margins" />
+  <package key="marginnote" name="marginnote" caption="Notes in the margin, even where \marginpar fails" />
+  <package key="marginote" name="marginote" caption="Make numbered notes in the margin" />
+  <package key="markdown" name="markdown" caption="Converting and rendering markdown documents inside TeX" />
+  <package key="marnote" name="marnote" caption="Place text in the margin of a document" />
+  <package key="marvosym" name="marvosym" caption="Martin Vogel&apos;s Symbols (marvosym) font" />
+  <package key="matapli" name="matapli" caption="Class for the french journal &#8220;MATAPLI&#8221;" />
+  <package key="matc3" name="matc3" caption="Commands for MatematicaC3 textbooks" />
+  <package key="matc3mem" name="matc3mem" caption="Class for MatematicaC3 textbooks" />
+  <package key="match_parens" name="match_parens" caption="
+    Find mismatches of parentheses, braces, (angle) brackets,
+    in texts
+  " />
+  <package key="math-e" name="math-e" caption="Examples from the book Typesetting Mathematics with LaTeX" />
+  <package key="math-into-latex-4" name="math-into-latex-4" caption="Samples from Math into LaTeX, 4th Edition" />
+  <package key="mathabx" name="mathabx" caption="Three series of mathematical symbols" />
+  <package key="mathabx-type1" name="mathabx-type1" caption="Outline version of the mathabx fonts" />
+  <package key="mathalpha" name="mathalpha" caption="General package for loading maths alphabets in LaTeX" />
+  <package key="mathalphabets" name="mathalphabets" caption="Chinese introduction to mathematical alphabets" />
+  <package key="mathastext" name="mathastext" caption="Use the text font in maths mode" />
+  <package key="mathbbol" name="mathbbol" caption="Use the bbold fonts in mathematics" />
+  <package key="mathcmd" name="mathcmd" caption="Mathematics support commands" />
+  <package key="mathcommand" name="mathcommand" caption="\newcommand-like commands for defining math macros" />
+  <package key="mathcomp" name="mathcomp" caption="Text symbols in maths mode" />
+  <package key="mathdesign" name="mathdesign" caption="Mathematical fonts to fit with particular text fonts" />
+  <package key="mathdots" name="mathdots" caption="Commands to produce dots in math that respect font size" />
+  <package key="mathematica" name="mathematica" caption="Support for fonts distributed with Mathematica" />
+  <package key="mathesatz-examples" name="mathesatz-examples" caption="Examples from the book &quot;Mathematiksatz mit LaTeX&quot;" />
+  <package key="mathexam" name="mathexam" caption="Package for typesetting exams" />
+  <package key="mathfam256" name="mathfam256" caption="Extend math family up to 256 for pLaTeX/upLaTeX/Lamed" />
+  <package key="mathfixs" name="mathfixs" caption="Fix various layout issues in math mode" />
+  <package key="mathfont" name="mathfont" caption="Use TrueType and OpenType fonts in math mode" />
+  <package key="mathgifg" name="mathgifg" caption="Support for Microsoft Georgia and ITC Franklin Gothic" />
+  <package key="mathinst" name="mathinst" caption="Merge font families to create mathematical font sets" />
+  <package key="mathkit" name="mathkit" caption="Generate maths fonts to match outline fonts" />
+  <package key="mathlig" name="mathlig" caption="Define maths &quot;ligatures&quot;" />
+  <package key="mathpartir" name="mathpartir" caption="Typesetting sequences of math formulas, e.g. type inference rules" />
+  <package key="mathpazo" name="mathpazo" caption="Fonts to typeset mathematics to match Palatino" />
+  <package key="mathpple" name="mathpple" caption="Use PostScript Palatino for typesetting maths" />
+  <package key="mathptm" name="mathptm" caption="Adobe Times Roman (or equivalent) for text and maths" />
+  <package key="mathptmx" name="mathptmx" caption="Use Times as default text font, and provide maths support" />
+  <package key="mathpunctspace" name="mathpunctspace" caption="Control the space after punctuation in math expressions" />
+  <package key="mathrsfs" name="mathrsfs" caption="Support for using RSFS fonts in maths" />
+  <package key="maths-symbols" name="maths-symbols" caption="Summary of mathematical symbols available in LaTeX" />
+  <package key="mathsci2bibtex" name="mathsci2bibtex" caption="Convert Mathsci database information to BibTeX" />
+  <package key="mathscinet" name="mathscinet" caption="Retrieve references from MathSciNet in BibTeX format" />
+  <package key="mathsemantics" name="mathsemantics" caption="Semantic math commands in LaTeX" />
+  <package key="mathspad" name="MathSpad" caption="A mathematics-capable word processor with LaTeX output" />
+  <package key="mathspec" name="mathspec" caption="Specify arbitrary fonts for mathematics in XeTeX" />
+  <package key="mathspic" name="mathspic" caption="A Perl filter program for use with PiCTeX" />
+  <package key="mathstone" name="mathstone" caption="Use Adobe Stone Serif and Stone Sans for typesetting maths" />
+  <package key="mathstyle" name="mathstyle" caption="Manage mathematics typesetting style" />
+  <package key="mathtex" name="mathtex" caption="A CGI program to use LaTeX to put mathematics on the web" />
+  <package key="mathtime-ltx" name="mathtime-ltx" caption="LaTeX macros for using MathTime and MathTime Plus" />
+  <package key="mathtime-metrics" name="mathtime-metrics" caption="MathTime AFM files" />
+  <package key="mathtime-pln" name="mathtime-pln" caption="Plain TeX macros for using MathTime and MathTime Plus" />
+  <package key="mathtools" name="mathtools" caption="Mathematical tools to use with amsmath" />
+  <package key="mathtrip" name="MathTrip" caption="A trip to the wonderful world of mathematics" />
+  <package key="mathtype" name="MathType" caption="Evaluation version of a commercial equation editor" />
+  <package key="matlab-prettifier" name="matlab-prettifier" caption="Pretty-print Matlab source code" />
+  <package key="matlabweb" name="matlabweb" caption="Literate programming system for Matlab" />
+  <package key="matrix-skeleton" name="matrix-skeleton" caption="A PGF/TikZ library that simplifies working with multiple matrix nodes" />
+  <package key="mattens" name="mattens" caption="Matrices/tensor typesetting" />
+  <package key="mattex" name="mattex" caption="Import Matlab values to LaTeX documents" />
+  <package key="maybeload" name="maybeload" caption="Prevent reloading of files" />
+  <package key="maybemath" name="maybemath" caption="Make math bold or italic according to context" />
+  <package key="maze" name="maze" caption="Generate random mazes" />
+  <package key="mbboard" name="mbboard" caption="Comprehensive blackboard bold fonts" />
+  <package key="mbenotes" name="mbenotes" caption="Notes in tables or images" />
+  <package key="mboxfill" name="mboxfill" caption="Fill free space with a pattern" />
+  <package key="mcaption" name="mcaption" caption="Put captions in the margin" />
+  <package key="mceinleger" name="mceinleger" caption="Creating covers for music cassettes" />
+  <package key="mcexam" name="mcexam" caption="Create randomized Multiple Choice questions" />
+  <package key="mcf2graph" name="mcf2graph" caption="Draw chemical structure diagrams with MetaPost" />
+  <package key="mcite" name="mcite" caption="Multiple items in a single citation" />
+  <package key="mciteplus" name="mciteplus" caption="Enhanced multiple citations" />
+  <package key="mcmthesis" name="mcmthesis" caption="Template designed for MCM/ICM" />
+  <package key="mctex" name="mctex" caption="Convert VAXIMA output to (La)TeX code" />
+  <package key="mdframed" name="mdframed" caption="Framed environments that can split at page boundaries" />
+  <package key="mdputu" name="mdputu" caption="Upright digits in Adobe Utopia Italic" />
+  <package key="mdsymbol" name="mdsymbol" caption="Symbol fonts to match Adobe Myriad Pro" />
+  <package key="mdvi" name="mdvi" caption="A DVI previewer" />
+  <package key="mdwfonts" name="mdwfonts" caption="A model for font manipulation" />
+  <package key="mdwlist" name="mdwlist" caption="Miscellaneous list-related commands" />
+  <package key="mdwmath" name="mdwmath" caption="Some maths extensions" />
+  <package key="mdwtab" name="mdwtab" caption="A reimplementation of tabular and array environments" />
+  <package key="mdwtools" name="mdwtools" caption="Miscellaneous tools by Mark Wooding" />
+  <package key="mecaso" name="mecaso" caption="Formulas frequently used in rigid body mechanics" />
+  <package key="media4svg" name="media4svg" caption="Multimedia inclusion for the dvisvgm backend" />
+  <package key="media9" name="media9" caption="Multimedia inclusion package with Adobe Reader-9/X compatibility" />
+  <package key="medstarbeamer" name="medstarbeamer" caption="Beamer document class for MedStar Health Research Institute" />
+  <package key="meetingmins" name="meetingmins" caption="Format written minutes of meetings" />
+  <package key="megatape" name="megatape" caption="Make cassette tape labels" />
+  <package key="mem" name="mem" caption="A multilingual system for Lamed" />
+  <package key="membranecomputing" name="membranecomputing" caption="Membrane Computing notation" />
+  <package key="memdesign" name="memdesign" caption="Notes on book design" />
+  <package key="memexsupp" name="memexsupp" caption="Experimental memoir support" />
+  <package key="memhfixc" name="memhfixc" caption="Adjustment for using hyperref in memoir documents" />
+  <package key="memo-pln" name="memo-pln" caption="Plain TeX macros for memoranda" />
+  <package key="memo2" name="memo2" caption="A memo document style" />
+  <package key="memo209" name="memo209" caption="A memo document style" />
+  <package key="memoir" name="memoir" caption="Typeset fiction, non-fiction and mathematical books" />
+  <package key="memoirchapterstyles" name="MemoirChapterStyles" caption="Chapter styles in memoir class" />
+  <package key="memory" name="memory" caption="Containers for data in LaTeX" />
+  <package key="memorygraphs" name="memorygraphs" caption="TikZ styles to typeset graphs of program memory" />
+  <package key="mendex-doc" name="mendex-doc" caption="Documentation for Mendex index processor" />
+  <package key="mensa-tex" name="mensa-tex" caption="Typeset simple school cafeteria menus" />
+  <package key="mentis" name="mentis" caption="A basis for books to be published by Mentis publishers" />
+  <package key="menu" name="menu" caption="Typesetting menus" />
+  <package key="menucard" name="menucard" caption="Typesetting menu cards with LaTeX" />
+  <package key="menukeys" name="menukeys" caption="Format menu sequences, paths and keystrokes from lists" />
+  <package key="meparticle" name="MEP article" caption="Class for Mechanical Engineering Publications" />
+  <package key="meper" name="meper" caption="MetaPost editor and previewer" />
+  <package key="mercatormap" name="mercatormap" caption="Spherical Mercator coordinate systems and Web Mercator tile integration" />
+  <package key="merge" name="merge" caption="Perform mail merges in LaTeX" />
+  <package key="merriweather" name="merriweather" caption="Merriweather and MerriweatherSans fonts, with LaTeX support" />
+  <package key="messagebubbles" name="messagebubbles" caption="Display message bubbles as a conversation" />
+  <package key="messagepassing" name="messagepassing" caption="Draw diagrams to represent communication protocols" />
+  <package key="meta-mode" name="meta-mode" caption="Emacs mode for Metafont/post" />
+  <package key="metafont" name="Metafont" caption="A system for specifying fonts" />
+  <package key="metafont-beginners" name="metafont-beginners" caption="An introductory tutorial for Metafont" />
+  <package key="metafp" name="metafp" caption="Some Experiences in Running Metafont and MetaPost" />
+  <package key="metago" name="metago" caption="MetaPost output of Go positions" />
+  <package key="metainfo" name="metainfo" caption="Typeset document outline with metainfo" />
+  <package key="metalogo" name="metalogo" caption="Extended TeX logo macros" />
+  <package key="metalogox" name="metalogox" caption="Adjust TeX logos, with font detection" />
+  <package key="metanorma" name="metanorma" caption="Write Metanorma standardization documents using LaTe" />
+  <package key="metaobj" name="metaobj" caption="MetaPost package providing high-level objects" />
+  <package key="metaplot" name="MetaPlot" caption="Plot-manipulation macros for use in MetaPost" />
+  <package key="metapost" name="metapost" caption="A development of Metafont for creating graphics" />
+  <package key="metapost-colorbrewer" name="metapost-colorbrewer" caption="An implementation of the colorbrewer2.org colours for MetaPost" />
+  <package key="metapost-examples" name="MetaPost examples" caption="Example drawings using MetaPost" />
+  <package key="metapost-matlab" name="metapost-matlab" caption="MetaPost data plotting in Matlab style" />
+  <package key="metastr" name="metastr" caption="Store and compose strings" />
+  <package key="metatex" name="METATeX" caption="Incorporate Metafont pictures in TeX source" />
+  <package key="metatype1" name="metatype1" caption="Generate Type 1 fonts from MetaPost" />
+  <package key="metauml" name="metauml" caption="MetaPost library for typesetting UML diagrams" />
+  <package key="method" name="method" caption="Typeset method and variable declarations" />
+  <package key="metre" name="metre" caption="Support for the work of classicists" />
+  <package key="metrix" name="metrix" caption="Typeset metric marks for Latin text" />
+  <package key="mewltx" name="mewltx" caption="MicroEmacs for Windows LaTeX interface" />
+  <package key="mex" name="mex" caption="Polish formats for TeX" />
+  <package key="mf-ps" name="mf-ps" caption="Metafont-PostScript conversions" />
+  <package key="mf2ps" name="mf2ps" caption="Modification of Metafont to produce PostScript output" />
+  <package key="mf2pt1" name="mf2pt1" caption="Convert stylized Metafont to PostScript Type 1" />
+  <package key="mf2pt3" name="mf2pt3" caption="Create Adobe Type 3 fonts" />
+  <package key="mf2tex" name="mf2tex" caption="Add labels into drawings created with Metafont" />
+  <package key="mfbook" name="mfbook" caption="The source of The Metafontbook" />
+  <package key="mff" name="mff" caption="Multiple font formats" />
+  <package key="mff-util" name="mff-util" caption="Metafont management" />
+  <package key="mfirstuc" name="mfirstuc" caption="Uppercase the first letter of a word" />
+  <package key="mflogo" name="mflogo" caption="LaTeX support for Metafont logo fonts" />
+  <package key="mflogo-font" name="mflogo-font" caption="Metafont logo font" />
+  <package key="mflogo209" name="mflogo209" caption="Typeset the Metafont logo under LaTeX 2.09" />
+  <package key="mfnfss" name="mfnfss" caption="Packages to typeset oldgerman and pandora fonts in LaTeX" />
+  <package key="mfpic" name="mfpic" caption="Draw Metafont/post pictures from (La)TeX commands" />
+  <package key="mfpic4ode" name="mfpic4ode" caption="Macros to draw direction fields and solutions of ODEs" />
+  <package key="mftinc" name="mftinc" caption="Pretty-print Metafont source" />
+  <package key="mftrace" name="mftrace" caption="Convert Metafont fonts to Adobe Type 1" />
+  <package key="mfware" name="mfware" caption="Supporting tools for use with Metafont" />
+  <package key="mfwl" name="MFwL" caption="Making friends with LaTeX" />
+  <package key="mgltex" name="mglTeX" caption="High-quality graphics from MGL scripts embedded in LaTeX documents" />
+  <package key="mh" name="mh" caption="Stub for the (old) &#8216;mh&#8217; bundle" />
+  <package key="mhack" name="mhack" caption="Macros for marginal notes, in Plain TeX" />
+  <package key="mhchem" name="mhchem" caption="Typeset chemical formulae/equations and H and P statements" />
+  <package key="mhequ" name="mhequ" caption="Multicolumn equations, tags, labels, sub-numbering" />
+  <package key="mhs" name="mhs" caption="Historical mathematics" />
+  <package key="mhsetup" name="mhsetup" caption="The mathtools &#8220;setup&#8221; function" />
+  <package key="mi-solns" name="mi-solns" caption="Extract solutions from exercises and quizzes" />
+  <package key="miama" name="miama" caption="The Miama Nueva handwriting font with LaTeX support" />
+  <package key="microimp" name="MicroIMP" caption="A TeX-based word processor" />
+  <package key="microtype" name="microtype" caption="Subliminal refinements towards typographical perfection" />
+  <package key="microtype-de" name="microtype-de" caption="Translation into German of the documentation of microtype" />
+  <package key="mid2tex" name="Mid2TeX/Free" caption="Convert MIDI to MusicTeX input" />
+  <package key="midfloat" name="midfloat" caption="Mixing onecolumn and twocolumn modes at any place of page" />
+  <package key="midi2tex" name="Midi2TeX/Free" caption="Convert MIDI to MusicTeX input" />
+  <package key="midnight" name="midnight" caption="A set of useful macro tools" />
+  <package key="midpage" name="midpage" caption="Environment for vertical centring" />
+  <package key="mif2xfig" name="mif2xfig" caption="Conversion between Frame Maker and Xfig" />
+  <package key="miktex" name="miktex" caption="A free TeX distribution for MS-Windows" />
+  <package key="miktex-portable" name="miktex-portable" caption="A version of MikTeX to carry around" />
+  <package key="miktex_update" name="miktex_update" caption="A cygwin bash script for automatic updating and installing new packages of MiKTeX" />
+  <package key="mil" name="mil" caption="Samples from Math into LaTeX" />
+  <package key="mil3" name="mil3" caption="Samples from Math into LaTeX, third edition" />
+  <package key="miller" name="miller" caption="Typeset miller indices" />
+  <package key="milog" name="milog" caption="A LaTeX class for fulfilling the documentation duties
+    according to the German minimum wage law MiLoG" />
+  <package key="milstd" name="milstd" caption="Generate documents according to MIL STD 490" />
+  <package key="milsymb" name="MilSymb" caption="LaTeX package for TikZ based drawing of military symbols as per NATO APP-6(C)" />
+  <package key="mimetex" name="mimetex" caption="Parse LaTeX math expressions and emit gif or xbitmaps" />
+  <package key="mindflow" name="mindflow" caption="Write your ideas in a clear way" />
+  <package key="minibox" name="minibox" caption="A simple type of box for LaTeX" />
+  <package key="minidocument" name="minidocument" caption="Creates miniature documents inside other LaTeX documents" />
+  <package key="minifp" name="minifp" caption="Fixed-point real computations to 8 decimals" />
+  <package key="miniltx" name="miniltx" caption="An abstract of LaTeX facilities for use with Plain TeX" />
+  <package key="minim" name="minim" caption="A modern plain format for the LuaTeX engine" />
+  <package key="minim-hatching" name="minim-hatching" caption="Create tiling patterns with the minim-mp MetaPost processor" />
+  <package key="minim-math" name="minim-math" caption="Extensive maths for LuaTeX" />
+  <package key="minim-mp" name="minim-mp" caption="Low-level mplib integration for LuaTeX" />
+  <package key="minim-pdf" name="minim-pdf" caption="Low-level PDF integration for LuaTeX" />
+  <package key="minim-xmp" name="minim-xmp" caption="Embed XMP metadata in PDF with LuaTeX" />
+  <package key="minimal" name="minimal" caption="A trivial class, for use when testing" />
+  <package key="minimalist" name="minimalist" caption="Write your articles or books in a simple and clear way" />
+  <package key="minion2newtx" name="minion2newtx" caption="Enable use of Minion Pro with newtx" />
+  <package key="minionpro" name="minionpro" caption="LaTeX support for Adobe MinionPro fonts" />
+  <package key="minipage-marginpar" name="minipage-marginpar" caption="Minipages with marginal notes" />
+  <package key="miniplot" name="MiniPlot" caption="A package for easy figure arrangement" />
+  <package key="minitoc" name="minitoc" caption="Produce a table of contents for each chapter, part or section" />
+  <package key="minorrevision" name="minorrevision" caption="Quote and refer to a manuscript for minor revisions" />
+  <package key="minted" name="minted" caption="Highlighted source code for LaTeX" />
+  <package key="mintspirit" name="mintspirit" caption="LaTeX support for MintSpirit font families" />
+  <package key="minutes" name="minutes" caption="Typeset the minutes of meetings" />
+  <package key="mirr" name="mirr" caption="PostScript mirror header (for dvips)" />
+  <package key="mismath" name="mismath" caption="Miscellaneous mathematical macros" />
+  <package key="missaali" name="missaali" caption="A late medieval OpenType textura font" />
+  <package key="mitpress" name="mitpress" caption="Typeset documents for MIT Press" />
+  <package key="mitthesis" name="mitthesis" caption="A LaTeX template for MIT theses" />
+  <package key="mk" name="mk" caption="A TeX and LaTeX maker" />
+  <package key="mkbangtex" name="mkbangtex" caption="A preprocessor for BangTeX" />
+  <package key="mkbib" name="mkbib" caption="BibTeX file creator" />
+  <package key="mkjobtexmf" name="mkjobtexmf" caption="Generate a texmf tree for a particular job" />
+  <package key="mkpattern" name="mkpattern" caption="A utility for making hyphenation patterns" />
+  <package key="mkpic" name="mkpic" caption="Perl interface to mfpic" />
+  <package key="mkpkfontdir" name="mkpkfontdir" caption="Manipulate TDS directories for PK fonts" />
+  <package key="mkstmp_pro" name="mkstmp" caption="Provides a simple workflow for creating custom stamps" />
+  <package key="mla" name="mla" caption="MLA BibTeX styles" />
+  <package key="mla-paper" name="mla-paper" caption="Proper MLA formatting" />
+  <package key="mlacls" name="mlacls" caption="LaTeX class for MLA papers" />
+  <package key="mlawriter" name="mlawriter" caption="Write MLA style documents in Plain TeX" />
+  <package key="mlbib" name="mlbib" caption="Support for multilingual bibliographies" />
+  <package key="mleftright" name="mleftright" caption="Variants of delimiters that act as maths open/close" />
+  <package key="mlist" name="mlist" caption="Logical markup for lists" />
+  <package key="mlmath" name="MLMath" caption="Mathematical notation for Machine Learning" />
+  <package key="mlmodern" name="MLModern" caption="A blacker Type 1 version of Computer Modern, with multilingual support" />
+  <package key="mltex" name="mltex" caption="The MLTeX system" />
+  <package key="mltex-ltx" name="mltex-ltx" caption="LaTeX support for MLTeX" />
+  <package key="mluexercise" name="mluexercise" caption="Exercises/homework at the Martin Luther University Halle-Wittenberg" />
+  <package key="mm" name="mm" caption="A jiffy Multiple Master tool" />
+  <package key="mma2ltx" name="mma2ltx" caption="Use Mathematica graphics in a LaTeX document" />
+  <package key="mmafm" name="mmafm" caption="Font metrics for multiple-master font" />
+  <package key="mmap" name="mmap" caption="Include CMap resources in PDF files from pdfTeX" />
+  <package key="mmpfb" name="mmpfb" caption="Create instance of multiple-master font" />
+  <package key="mmtools" name="mmtools" caption="Multiple master fonts tools" />
+  <package key="mnhyphn" name="mnhyphn" caption="Hyphenation patterns for Mongolian" />
+  <package key="mnotes" name="mnotes" caption="Margin annotation for collaborative writing" />
+  <package key="mnras" name="mnras" caption="Monthly Notices of the Royal Astronomical Society" />
+  <package key="mnras-plain" name="mnras-plain" caption="Plain TeX macros for MNRAS" />
+  <package key="mnsymbol" name="MnSymbol" caption="Mathematical symbol font for Adobe MinionPro" />
+  <package key="mnttex" name="mnttex" caption="Tools for the &quot;The Secret History of the Mongols&quot;" />
+  <package key="modeles-factures-belges-assocs" name="modeles-factures-belges-assocs" caption="Generate invoices for Belgian non-profit organizations" />
+  <package key="moderncv" name="moderncv" caption="A modern curriculum vitae class" />
+  <package key="modernposter" name="modernposter" caption="A modern LaTeX poster theme" />
+  <package key="moderntimeline" name="moderntimeline" caption="Timelines for use with moderncv" />
+  <package key="modes" name="modes" caption="A collection of Metafont mode_def&#8217;s" />
+  <package key="modguide" name="modguide" caption="The rules about modifying LaTeX" />
+  <package key="modiagram" name="modiagram" caption="Drawing molecular orbital diagrams" />
+  <package key="modref" name="modref" caption="Customisation of cross-references in LaTeX" />
+  <package key="modroman" name="modroman" caption="Write numbers in lower case roman numerals" />
+  <package key="modular" name="modular" caption="Relative section headings for modular documents" />
+  <package key="modulus" name="modulus" caption="A non-destructive modulus and integer quotient operator for TeX" />
+  <package key="mol2chemfig" name="mol2chemfig" caption="Convert chemical structures from MDL molfile format
+           to chemfig source code" />
+  <package key="mongolian-babel" name="mongolian-babel" caption="A language definition file for Mongolian in Babel" />
+  <package key="monofill" name="monofill" caption="Alignment of plain text" />
+  <package key="monster" name="monster" caption="Obsolete name for Frankenstein" />
+  <package key="montex" name="montex" caption="Mongolian LaTeX" />
+  <package key="montserrat" name="montserrat" caption="Montserrat sans serif, otf and pfb, with LaTeX support files" />
+  <package key="moodle" name="moodle" caption="Generating Moodle quizzes via LaTeX" />
+  <package key="moonphase" name="moonphase" caption="Font for representing the phases of the moon" />
+  <package key="moredefs" name="moredefs" caption="LaTeX defining, expansion, and debugging commands" />
+  <package key="moreenum" name="moreenum" caption="More enumeration options" />
+  <package key="morefloats" name="morefloats" caption="Increase the number of simultaneous LaTeX floats" />
+  <package key="morehelp" name="morehelp" caption="Improve LaTeX error messages" />
+  <package key="morehype" name="morehype" caption="Hypertext tools for use with LaTeX" />
+  <package key="moresize" name="moresize" caption="Allows font sizes up to 35.83pt" />
+  <package key="moreverb" name="moreverb" caption="Extended verbatim" />
+  <package key="morewrites" name="morewrites" caption="Always room for a new write stream" />
+  <package key="morisawa" name="morisawa" caption="Enables selection of 5 standard Japanese fonts for pLaTeX + dvips" />
+  <package key="morse" name="morse" caption="Support for printing Morse code signs" />
+  <package key="movement-arrows" name="movement-arrows" caption="Drawing movement arrows on linguistic example sentences" />
+  <package key="movie15" name="movie15" caption="Multimedia inclusion package" />
+  <package key="mp3d" name="threed" caption="3D animations" />
+  <package key="mparhack" name="mparhack" caption="Work around a LaTeX bug in marginpars" />
+  <package key="mparrows" name="mparrows" caption="MetaPost module with different types of arrow heads" />
+  <package key="mpattern" name="mpattern" caption="Patterns in MetaPost" />
+  <package key="mpchess" name="MPchess" caption="Drawing chess boards and positions with MetaPost" />
+  <package key="mpcolornames" name="mpcolornames" caption="Extend list of predefined colour names for MetaPost" />
+  <package key="mpdinbrief" name="mpdinbrief" caption="An enhanced version of dinbrief" />
+  <package key="mpedit" name="MPEdit" caption="MetaPost text editor for Win32" />
+  <package key="mpfonts" name="mpfonts" caption="Computer Modern Type 3 fonts converted using MetaPost" />
+  <package key="mpgraphics" name="mpgraphics" caption="Process and display MetaPost figures inline" />
+  <package key="mpman-ru" name="mpman-ru" caption="A Russian translation of the MetaPost manual" />
+  <package key="mpostinl" name="mpostinl" caption="Embed MetaPost figures within LaTeX documents" />
+  <package key="mpstoeps" name="MPStoEPS" caption="A convertor from MetaPost output to Encapsulated PostScript" />
+  <package key="mptrees" name="mptrees" caption="Probability trees with MetaPost" />
+  <package key="mrcheckbib" name="mrcheckbib" caption="A BibTeX file verification tool" />
+  <package key="mrecog" name="mrecog" caption="Recognise un-escaped command names in maths" />
+  <package key="ms" name="ms" caption="Various LaTeX packages by Martin Schr&#246;der" />
+  <package key="msc" name="msc" caption="Draw MSC diagrams" />
+  <package key="msg" name="msg" caption="A package for LaTeX localisation" />
+  <package key="mslapa" name="mslapa" caption="Michael Landy&#8217;s APA citation style" />
+  <package key="msu-thesis" name="msu-thesis" caption="Class for Michigan State University Master&#8217;s and PhD theses" />
+  <package key="msx2msa" name="msx2msa" caption="Simulate msxm and msym fonts using msam and msbm" />
+  <package key="msym" name="msym" caption="A partial implementation of the old msym10 font" />
+  <package key="mt11p" name="mt11p" caption="Use MathTime complete under LaTeX" />
+  <package key="mtbe" name="mtbe" caption="Macros for &quot;Mathematical TeX by Example&quot;" />
+  <package key="mtex" name="mtex" caption="The pioneering music-in-TeX macros" />
+  <package key="mtgreek" name="mtgreek" caption="Use italic and upright greek letters with mathtime" />
+  <package key="mtp2lite" name="mtp2lite" caption="Subset of MathTime Pro 2 font set" />
+  <package key="mucproc" name="mucproc" caption="Conference proceedings for the German MuC-conference" />
+  <package key="mugsthesis" name="mugsthesis" caption="Thesis class complying with Marquette University Graduate School requirements" />
+  <package key="muling" name="muling" caption="MA Thesis class for the Department of Linguistics, University of Mumbai" />
+  <package key="multenum" name="multenum" caption="Multi-column enumerated lists" />
+  <package key="multiaudience" name="multiaudience" caption="Several versions of output from the same source" />
+  <package key="multibbl" name="multibbl" caption="Multiple bibliographies" />
+  <package key="multibib" name="multibib" caption="Multiple bibliographies within one document" />
+  <package key="multibibliography" name="multibibliography" caption="Multiple versions of a bibliography, with different sort orders" />
+  <package key="multibox" name="multibox" caption="Multiple boxes and frames for the picture environment" />
+  <package key="multicap" name="multicap" caption="Format captions inside multicols" />
+  <package key="multicol" name="multicol" caption="Intermix single and multiple columns" />
+  <package key="multicolpar" name="multicolpar" caption="Put successive paragraphs in different columns" />
+  <package key="multicolrule" name="multicolrule" caption="Decorative rules between columns" />
+  <package key="multidef" name="multidef" caption="Quickly define several similar macros" />
+  <package key="multido" name="multido" caption="A loop facility for Generic TeX" />
+  <package key="multienv" name="multienv" caption="Multiple environments using a &#8220;key=value&#8221; syntax" />
+  <package key="multiexpand" name="multiexpand" caption="Variations on the primitive command \expandafter" />
+  <package key="multifootnote" name="multifootnote" caption="Multiple numbers for the same footnote" />
+  <package key="multilang" name="multilang" caption="A LaTeX package for maintaining multiple translations of a document" />
+  <package key="multind" name="multind" caption="Multiple indexes in LaTeX documents" />
+  <package key="multiobjective" name="multiobjective" caption="Symbols for multiobjective optimisation etc" />
+  <package key="multiple-choice" name="multiple-choice" caption="LaTeX package for multiple-choice questions" />
+  <package key="multirow" name="multirow" caption="Create tabular cells spanning multiple rows" />
+  <package key="multitoc" name="multitoc" caption="Set table of contents in multiple columns" />
+  <package key="munich" name="munich" caption="An alternative authordate bibliography style" />
+  <package key="musical" name="musical" caption="Typeset (musical) theatre scripts" />
+  <package key="musicography" name="musicography" caption="Accessing symbols for music writing with pdfLaTeX" />
+  <package key="musictex" name="musictex" caption="Typesetting music with TeX" />
+  <package key="musikui" name="musikui" caption="Easy creation of &#8220;arithmetical restoration&#8221; puzzles" />
+  <package key="musixguit" name="musixguit" caption="Easy notation for guitar music, in MusixTeX" />
+  <package key="musixtex" name="MusiXTeX" caption="Sophisticated music typesetting" />
+  <package key="musixtex-egler" name="musixtex-egler" caption="Multi-pass music typesetting" />
+  <package key="musixtex-fonts" name="musixtex-fonts" caption="Fonts used by MusixTeX" />
+  <package key="musixtex-t1fonts" name="musixtex-t1fonts" caption="Adobe Type 1 versions of MusiXTeX fonts" />
+  <package key="musixtnt" name="musixtnt" caption="A MusiXTeX extension library that enables transformations of the effect of notes commands" />
+  <package key="musuos" name="musuos" caption="Typeset papers for the department of music, Osnabr&#252;ck" />
+  <package key="muthesis" name="muthesis" caption="Classes for University of Manchester Dept of Computer Science" />
+  <package key="mversion" name="mversion" caption="Keeping track of document versions" />
+  <package key="mwcls" name="mwcls" caption="Polish-oriented document classes" />
+  <package key="mwe" name="mwe" caption="Packages and image files for MWEs" />
+  <package key="mweights" name="mweights" caption="Support for multiple-weight font packages" />
+  <package key="mwrite" name="mwrite" caption="Write information to files" />
+  <package key="mxd" name="mxd" caption="Support for Mongolian &#8220;horizontal&#8221; (Xewtee Dorwoljin) script" />
+  <package key="mxedruli" name="mxedruli" caption="A pair of fonts for different Georgian alphabets" />
+  <package key="mychemistry" name="mychemistry" caption="Create reaction schemes with LaTeX and chemfig" />
+  <package key="mycv" name="mycv" caption="A list-driven CV class, allowing TikZ decorations" />
+  <package key="myfilist" name="myfilist" caption="Configuring the output of the \listfiles command" />
+  <package key="mylatex" name="mylatex" caption="Make a format containing a document&#8217;s preamble" />
+  <package key="mylatexformat" name="mylatexformat" caption="Build a format based on the preamble of a LaTeX file" />
+  <package key="myletter" name="myletter" caption="An old letter class" />
+  <package key="mynsfc" name="mynsfc" caption="XeLaTeX template for writing the main body of NSFC proposals" />
+  <package key="na-border" name="na-border" caption="Decorative borders for texts in Arabic and French" />
+  <package key="na-box" name="na-box" caption="Arabic-aware version of pas-cours package" />
+  <package key="na-position" name="na-position" caption="Tables of relative positions of curves and asymptotes or tangents in Arabic documents" />
+  <package key="nabatean" name="nabatean" caption="Font for Nabatean script" />
+  <package key="nag" name="nag" caption="Detecting and warning about obsolete LaTeX commands" />
+  <package key="nahuatl" name="nahuatl" caption="Render nahuatl glyphs" />
+  <package key="naive-ebnf" name="naive-ebnf" caption="EBNF in plain text" />
+  <package key="nameauth" name="nameauth" caption="Name authority mechanism for consistency in body text and index" />
+  <package key="named" name="named" caption="&quot;Named&quot; bibliography style" />
+  <package key="namedef" name="namedef" caption="TeX definitions with named parameters" />
+  <package key="namedtensor" name="namedtensor" caption=" Macros for named tensor notation" />
+  <package key="nameref" name="nameref" caption="Make reference to section names, etc" />
+  <package key="namespc" name="namespc" caption="Rudimentary C++-like namespaces in LaTeX" />
+  <package key="namunsrt" name="namunsrt" caption="An unsorted BibTeX style with labels provided in the database" />
+  <package key="nanicolle" name="nanicolle" caption="Typesetting herbarium specimen labels" />
+  <package key="nanumtype1" name="nanumtype1" caption="Type1 subfonts of Nanum Korean fonts" />
+  <package key="nar" name="nar" caption="BibTeX style for Nucleic Acid Research" />
+  <package key="nassflow" name="nassflow" caption="Drawing Nassi-Shneiderman diagrams and flowcharts" />
+  <package key="natbib" name="natbib" caption="Flexible bibliography support" />
+  <package key="natded" name="natded" caption="Typeset natural deduction proofs" />
+  <package key="nath" name="Nath" caption="Natural mathematics notation" />
+  <package key="natmove" name="natmove" caption="Move punctuation following a citation" />
+  <package key="nature" name="nature" caption="Prepare papers for the journal Nature" />
+  <package key="navigator" name="navigator" caption="PDF features across formats and engines" />
+  <package key="navydocs" name="navydocs" caption="Support for Technical Reports by US Navy Organizations" />
+  <package key="nb4latex" name="nb4latex" caption="Convert NotaBene4 to LaTeX" />
+  <package key="nbaseprt" name="nbaseprt" caption="Print numbers in non-decimal bases" />
+  <package key="nbaskerv" name="nbaskerv" caption="Metrics and LaTeX support for ITC New Baskerville Font From Adobe" />
+  <package key="nccbbb" name="nccbbb" caption="&#8220;Poor man&#8217;s&#8221; blackboard bold" />
+  <package key="nccboxes" name="nccboxes" caption="Elaborate box commands" />
+  <package key="ncccomma" name="ncccomma" caption="Use comma as decimal separator in mathematics" />
+  <package key="ncccropbox" name="ncccropbox" caption="Crop-marked boxes" />
+  <package key="ncccropmark" name="ncccropmark" caption="Draw cropmarks on the output page" />
+  <package key="nccfancyhdr" name="nccfancyhdr" caption="Extensive control of page headers and footers" />
+  <package key="nccfloats" name="nccfloats" caption="Extensions of the LaTeX float mechanisms" />
+  <package key="nccfoots" name="nccfoots" caption="User-generated footnote marks" />
+  <package key="ncclatex" name="NCC-LaTeX" caption="An extended general-purpose class" />
+  <package key="nccmath" name="nccmath" caption="Extended mathematics capabilities" />
+  <package key="nccparskip" name="nccparskip" caption="Modify skips between paragraphs" />
+  <package key="nccpic" name="nccpic" caption="Extend the graphicx package for more formats" />
+  <package key="nccrules" name="nccrules" caption="Compose dashed lines" />
+  <package key="nccsect" name="nccsect" caption="A re-implementation of sections, captions and tocs" />
+  <package key="nccstretch" name="nccstretch" caption="Insert a stretch between each token of a string" />
+  <package key="nccthm" name="nccthm" caption="Another theorem environment" />
+  <package key="ncctools" name="ncctools" caption="A collection of general packages for LaTeX" />
+  <package key="nchairx" name="nChairX" caption="Maths macros from chair X of W&#252;rzburg University" />
+  <package key="nddiss" name="nddiss" caption="Notre Dame Dissertation format class" />
+  <package key="ndsu-thesis" name="ndsu-thesis" caption="North Dakota State University disquisition class" />
+  <package key="ndsu-thesis-2022" name="ndsu-thesis-2022" caption="North Dakota State University disquisition class 2022" />
+  <package key="nedit-latex-extensions" name="NEdit-LaTeX-Extensions" caption="The LaTeX-Mode is a set of macros for the NEdit text editor" />
+  <package key="needspace" name="needspace" caption="Insert pagebreak if not enough space" />
+  <package key="nehyph" name="NL hyphenation" caption="Hyphenation patterns for Dutch" />
+  <package key="nemocal" name="nemocal" caption="Calendar maker" />
+  <package key="nestquot" name="nestquot" caption="Alternate quotes between double and single with nesting" />
+  <package key="neufont" name="neufont" caption="New font installation" />
+  <package key="neuralnetwork" name="neuralnetwork" caption="Graph-drawing for neural networks" />
+  <package key="neuron" name="neuron" caption="BibTeX style for the journal Neuron" />
+  <package key="nevelok" name="nevelok" caption="LaTeX package for automatic definite articles for Hungarian" />
+  <package key="newalg" name="newalg" caption="Format algorithms like Cormen, Leiserson and Rivest" />
+  <package key="newapa" name="newapa" caption="Another APA citation mechanism" />
+  <package key="newcastle-bst" name="newcastle-bst" caption="A BibTeX style to format reference lists in the Harvard at Newcastle style" />
+  <package key="newclude" name="newclude" caption="Reimplemented \include system for LaTeX" />
+  <package key="newcommand" name="newcommand" caption="Generate new LaTeX command definitions" />
+  <package key="newcomputermodern" name="NewComputerModern" caption="Computer Modern fonts including matching non-latin alphabets" />
+  <package key="newenviron" name="newenviron" caption="Processing an environment&#8217;s body" />
+  <package key="newfile" name="newfile" caption="User level management of LaTeX input and output" />
+  <package key="newfloat" name="newfloat" caption="Define new floating environments" />
+  <package key="newinsert" name="newinsert" caption="Reworking Plain TeX&apos;s insert macros" />
+  <package key="newlfm" name="newlfm" caption="Write letters, facsimiles, and memos" />
+  <package key="newpax" name="newpax" caption="Experimental package to extract and reinsert PDF annotations" />
+  <package key="newproof" name="newproof" caption="Make commands to define proofs" />
+  <package key="newpx" name="newpx" caption="Alternative uses of the PX fonts, with improved metrics" />
+  <package key="newsletr" name="newsletr" caption="Macros for making newsletters with Plain TeX" />
+  <package key="newspaper" name="newspaper" caption="Typeset newsletters to resemble newspapers" />
+  <package key="newthm" name="newthm" caption="Obsolete version of ntheorem" />
+  <package key="newtx" name="newtx" caption="Alternative uses of the TX fonts, with improved metrics" />
+  <package key="newtxsf" name="newtxsf" caption="Sans-math fonts for use with newtx" />
+  <package key="newtxtt" name="newtxtt" caption="Enhancement of typewriter fonts from newtx" />
+  <package key="newunicodechar" name="newunicodechar" caption="Definitions of the meaning of Unicode characters" />
+  <package key="newvbtm" name="newvbtm" caption="Define your own verbatim-like environment" />
+  <package key="newverbs" name="newverbs" caption="Define new versions of \verb, including short verb versions" />
+  <package key="nextpage" name="nextpage" caption="Generalisations of the page advance commands" />
+  <package key="nexus-otf" name="nexus-otf" caption="Supporting for the Nexus OpenType or True Type Fonts" />
+  <package key="nfssext-cfr" name="nfssext-cfr" caption="Extensions to the LaTeX NFSS" />
+  <package key="nfssfont" name="nfssfont" caption="Typesetting font tables using LaTeX&#8217;s NFSS notation" />
+  <package key="ngerman" name="ngerman" caption="Support for new German typography" />
+  <package key="nicefilelist" name="nicefilelist" caption="Provide \listfiles alignment" />
+  <package key="nicefrac" name="nicefrac" caption="Typeset in-line fractions in a &quot;nice&quot; way" />
+  <package key="niceframe" name="niceframe" caption="Support for fancy frames" />
+  <package key="niceframe-type1" name="niceframe-type1" caption="Type 1 versions of the fonts recommended in niceframe" />
+  <package key="nicematrix" name="nicematrix" caption="Improve the typesetting of mathematical matrices with PGF" />
+  <package key="nicetext" name="nicetext" caption="Minimal markup for simple text (Wikipedia style) and documentation" />
+  <package key="niceverb" name="niceverb" caption="Minimising markup for documenting LaTeX packages" />
+  <package key="nidanfloat" name="nidanfloat" caption="Bottom placement option for double float in two column mode (nidan-kumi)" />
+  <package key="nih" name="nih" caption="A class for NIH grant applications" />
+  <package key="nihbiosketch" name="nihbiosketch" caption="A class for NIH biosketches based on the 2015 updated format" />
+  <package key="nimbus15" name="nimbus15" caption="Support files for Nimbus 2015 Core fonts" />
+  <package key="nimsticks" name="nimsticks" caption="Draws sticks for games of multi-pile Nim" />
+  <package key="ninecolors" name="ninecolors" caption="Select colors with proper WCAG color contrast" />
+  <package key="njurepo" name="NJUrepo" caption="Reports for Nanjing University" />
+  <package key="njustthesis" name="njustthesis" caption="Thesis template for the Nanjing University of Science and Technology" />
+  <package key="njuthesis" name="njuthesis" caption="LaTeX thesis template for Nanjing University" />
+  <package key="njuvisual" name="njuvisual" caption="Display logos related to Nanjing University" />
+  <package key="nkarta" name="nkarta" caption="A &quot;new&quot; version of the karta cartographic fonts" />
+  <package key="nl-interval" name="nl-interval" caption="Represent intervals on the number line" />
+  <package key="nlatexdb" name="nlatexdb" caption="Database reports using LaTeX and .Net (or Mono)" />
+  <package key="nlctdoc" name="nlctdoc" caption="Package documentation class" />
+  <package key="nmbib" name="nmbib" caption="Multiple versions of a bibliography, with different sort orders" />
+  <package key="nndraw" name="nndraw" caption="Draw neural networks" />
+  <package key="nnext" name="nnext" caption="Extension for the gb4e package" />
+  <package key="nnfootnote" name="nnfootnote" caption="&quot;No number&quot; footnotes" />
+  <package key="noconflict" name="noconflict" caption="Resolve macro name conflict between packages" />
+  <package key="nodetree" name="nodetree" caption="Visualize node lists in a tree view" />
+  <package key="nofill" name="nofill" caption="Preserve spaces and line breaks when setting text" />
+  <package key="nohyph" name="nohyph" caption="Norwegian hyphenation" />
+  <package key="nohyphbx" name="nohyphbx" caption="General hyphenation patterns for Norwegian" />
+  <package key="noindentafter" name="noindentafter" caption="Prevent paragraph indentation after environments or macros" />
+  <package key="noitcrul" name="noitcrul" caption="Improved underlines in mathematics" />
+  <package key="nolbreaks" name="nolbreaks" caption="No line breaks in text" />
+  <package key="nomencl" name="nomencl" caption="Produce lists of symbols as in nomenclature" />
+  <package key="nomentbl" name="nomentbl" caption="Nomenclature typeset  in a longtable" />
+  <package key="nonfloat" name="nonfloat" caption="Non-floating table and figure captions" />
+  <package key="nonumonpart" name="nonumonpart" caption="Prevent page numbers on part pages" />
+  <package key="nopageno" name="nopageno" caption="No page numbers in LaTeX documents" />
+  <package key="noprot" name="noprot" caption="Avoid the need for protection" />
+  <package key="norbib" name="norbib" caption="Norwegian bibliography styles" />
+  <package key="normalcolor" name="normalcolor" caption="Changing \normalcolor" />
+  <package key="nostarch" name="nostarch" caption="LaTeX class for No Starch Press" />
+  <package key="notes" name="notes" caption="Mark sections of a document" />
+  <package key="notes2bib" name="notes2bib" caption="Integrating notes into the bibliography" />
+  <package key="notespages" name="NotesPages" caption="Filling documents with notes pages and notes areas" />
+  <package key="notestex" name="NotesTeX" caption="An all-in-one LaTeX notes package for students" />
+  <package key="notex-bst" name="noTeX-bst" caption="A BibTeX style that outputs HTML" />
+  <package key="noto" name="noto" caption="Support for Noto fonts" />
+  <package key="noto-emoji" name="noto-emoji" caption="Noto Emoji fonts" />
+  <package key="notoccite" name="notoccite" caption="Prevent trouble from citations in table of contents, etc" />
+  <package key="notocjksc" name="notoCJKsc" caption="This package provides Noto CJK fonts" />
+  <package key="notocondensed" name="notocondensed" caption="Support for the condensed variants of the Noto fonts" />
+  <package key="notomath" name="notomath" caption="Math support for Noto fonts" />
+  <package key="novel" name="novel" caption="Class for printing fiction, such as novels" />
+  <package key="noweb" name="noweb" caption="A simple extensible literate programming tool" />
+  <package key="nowidow" name="nowidow" caption="Avoid widows" />
+  <package key="nox" name="nox" caption="Adaptable tables" />
+  <package key="npp-for-context" name="npp-for-context" caption="ConTeXt plugin for Notepad++" />
+  <package key="nrc" name="nrc" caption="Class for the NRC technical journals" />
+  <package key="ntabbing" name="ntabbing" caption="Simple tabbing extension for automatic line numbering" />
+  <package key="ntg" name="ntg" caption="Dutch TeX Users Group information" />
+  <package key="ntg-maps" name="ntg-maps" caption="The NTG&apos;s journal MAPS" />
+  <package key="ntgclass" name="ntgclass" caption="&quot;European&quot; versions of standard classes" />
+  <package key="nth" name="nth" caption="Generate English ordinal numbers" />
+  <package key="ntheorem" name="ntheorem" caption="Enhanced theorem environment" />
+  <package key="ntheorem-vn" name="ntheorem-vn" caption="Vietnamese translation of documentation of ntheorem" />
+  <package key="nts" name="NTS" caption="New Typesetting System" />
+  <package key="nts-l" name="NTS-L" caption="NTS mailing list digests" />
+  <package key="ntsfaq" name="ntsfaq" caption="Frequently answered questions about TeX extension" />
+  <package key="nuc" name="nuc" caption="Notation for nuclear isotopes" />
+  <package key="nucleardata" name="nucleardata" caption="Provides data about atomic nuclides for documents" />
+  <package key="numalg" name="numalg" caption="BibTeX style for Kluwer&apos;s Numerical Algorithms" />
+  <package key="numberedblock" name="numberedblock" caption="Print a block of code, with unique index number" />
+  <package key="numberpt" name="numberpt" caption="Counters spelled out in Portuguese" />
+  <package key="numending" name="numending" caption="Generates morphological end of units" />
+  <package key="numerica" name="numerica" caption="Numerically evaluate mathematical expressions in LaTeX form" />
+  <package key="numerica-plus" name="numerica-plus" caption="Iteration and recurrence relations: finding fixed points, zeros and extrema of functions" />
+  <package key="numerica-tables" name="numerica-tables" caption="Create multi-column tables of mathematical functions" />
+  <package key="numericplots" name="numericplots" caption="Plot numeric data (including Matlab export) using PSTricks" />
+  <package key="numline" name="numline" caption="LaTeX macros for numbering lines" />
+  <package key="numname" name="numname" caption="Convert a number to its English expression" />
+  <package key="numnameru" name="numnameru" caption="Converts a number to the russian spelled out name" />
+  <package key="numprint" name="numprint" caption="Print numbers with separators and exponent if necessary" />
+  <package key="numspell" name="numspell" caption="Spelling cardinal and ordinal numbers" />
+  <package key="nunito" name="Nunito" caption="The Nunito font face with support for LaTeX and pdfLaTeX" />
+  <package key="nwafuthesis" name="nwafuthesis" caption="A thesis template package for Northwest A&amp;F University, China" />
+  <package key="nwejm" name="nwejm" caption="Support for the journal &#8220;North-Western European Journal of Mathematics&#8221;" />
+  <package key="oands" name="oands" caption="Glyphs used when transliterating ancient scripts" />
+  <package key="obas" name="obas" caption="Web based interface to a bibliographical database" />
+  <package key="oberdiek" name="oberdiek" caption="A bundle of packages submitted by Heiko Oberdiek" />
+  <package key="objectz" name="objectz" caption="Macros for typesetting Object Z" />
+  <package key="obnov" name="obnov" caption="Obyknovennaya Novaya fonts" />
+  <package key="obsolete" name="obsolete" caption="A tree holding obsolete software" />
+  <package key="oca" name="oca" caption="OCR A font" />
+  <package key="occam" name="occam" caption="Strip unnecessary macros from a file" />
+  <package key="ocg-p" name="ocg-p" caption="PDF OCG support in LaTeX" />
+  <package key="ocgtools" name="ocgtools" caption="Manipulate OCG layers in PDF presentations" />
+  <package key="ocgx" name="ocgx" caption="Use OCGs within a PDF document without JavaScript" />
+  <package key="ocgx2" name="ocgx2" caption="Drop-in replacement for &#8216;ocgx&#8217; and &#8216;ocg-p&#8217;" />
+  <package key="ochem" name="ochem" caption="Typeset chemical formulae with LaTeX" />
+  <package key="ocherokee" name="ocherokee" caption="LaTeX Support for the Cherokee language" />
+  <package key="ocr-a" name="ocr-a" caption="Fonts for OCR-A" />
+  <package key="ocr-b" name="ocr-b" caption="Fonts for OCR-B" />
+  <package key="ocr-b-outline" name="ocr-b-outline" caption="OCR-B fonts in Type 1 and OpenType" />
+  <package key="ocr-latex" name="ocr-latex" caption="LaTeX support for ocr fonts" />
+  <package key="octave" name="octave" caption="Typeset musical pitches with octave designations" />
+  <package key="octavo" name="octavo" caption="Typeset books following classical design and layout" />
+  <package key="odsfile" name="odsfile" caption="Read OpenDocument Spreadsheet documents as LaTeX tables" />
+  <package key="oesch" name="oesch" caption="Font to provide the &#214;sterreichische Schulschrift" />
+  <package key="ofntinst" name="ofntinst" caption="Install Type 1 for use with Omega" />
+  <package key="ofs" name="ofs" caption="Macros for managing large font collections" />
+  <package key="ogham" name="ogham" caption="Fonts for typesetting Ogham script" />
+  <package key="ogonek" name="ogonek" caption="Support for Polish typography and the ogonek" />
+  <package key="oinuit" name="oinuit" caption="LaTeX Support for the Inuktitut Language" />
+  <package key="okuda" name="okuda" caption="Fonts for Klingon" />
+  <package key="old-arrows" name="old-arrows" caption="Computer Modern old-style arrows with smaller arrowheads" />
+  <package key="old-faq-en" name="old-faq-en" caption="An early FAQ in English" />
+  <package key="old-fontch" name="old-fontch" caption="Changing fonts, sizes and encodings in Plain TeX (obsolete version)" />
+  <package key="oldlatin" name="oldlatin" caption="Compute Modern-like font with long s" />
+  <package key="oldprsn" name="oldprsn" caption="Fonts old Persian cuneiform script" />
+  <package key="oldstandard" name="oldstandard" caption="OldStandard fonts with LaTeX support" />
+  <package key="oldstandardt1" name="OldStandardT1" caption=" Type 1 versions of Old Standard fonts with LaTeX support" />
+  <package key="oldstyle" name="oldstyle" caption="Old style numbers in OT1 encoding" />
+  <package key="oletex" name="oletex" caption="OLE - LaTeX interface" />
+  <package key="olsak-misc" name="olsak-misc" caption="Collection of plain TeX macros written by Petr Ol&#353;&#225;k" />
+  <package key="omega" name="omega" caption="A wide-character-set extension of TeX" />
+  <package key="one2many" name="12many" caption="Generalising mathematical index sets" />
+  <package key="onedown" name="OneDown" caption="Typeset Bridge Diagrams" />
+  <package key="onepagem" name="onepagem" caption="If the document has only one page, omit page number" />
+  <package key="onlyamsmath" name="onlyamsmath" caption="Inhibit use of non-amsmath mathematics markup when using amsmath" />
+  <package key="onrannual" name="onrannual" caption="Class for Office of Naval Research Ocean Battlespace Sensing annual report" />
+  <package key="oops" name="oops" caption=" A framework for making definitions, typically mathematical, inline" />
+  <package key="opacity-pro" name="opacity-pro" caption="Set transparency and blend mode" />
+  <package key="opcit" name="opcit" caption="Footnote-style bibliographical references" />
+  <package key="opencolor" name="opencolor" caption="Definitions from the Open Color library" />
+  <package key="opensans" name="opensans" caption="The Open Sans font family, and LaTeX support" />
+  <package key="oplotsymbl" name="oPlotSymbl" caption="Some symbols which are not easily available" />
+  <package key="opteng" name="opteng" caption="SPIE Optical Engineering and OE Letters manuscript template" />
+  <package key="optex" name="OpTeX" caption="LuaTeX format based on Plain TeX and OPmac" />
+  <package key="optexcount" name="OpTeXcount" caption="Python script for counting words in OpTeX documents" />
+  <package key="optidef" name="optidef" caption="Environments for writing optimization problems" />
+  <package key="optional" name="optional" caption="Facilitate optional printing of parts of a document" />
+  <package key="options" name="options" caption="Provides convenient key-value options for LaTeX package writers" />
+  <package key="optparams" name="optparams" caption="Macros with multiple optional parameters" />
+  <package key="orcidlink" name="orcidlink" caption="Insert hyperlinked ORCiD logo" />
+  <package key="orderer" name="Orderer" caption="Order references in a TeX file" />
+  <package key="orderrefs" name="orderrefs" caption="Sort bibliography in LaTeX document by order of citation" />
+  <package key="ordinalpt" name="ordinalpt" caption="Counters as ordinal numbers in Portuguese" />
+  <package key="oriental" name="oriental" caption="A version of TeX for which Oriental languages are native" />
+  <package key="orientation" name="orientation" caption="Set page orientation with dvips/Ghostscript (ps2pdf)" />
+  <package key="oriya" name="oriya" caption="Typesetting the Oriya script using TeX" />
+  <package key="orkhun" name="orkhun" caption="A font for orkhun script" />
+  <package key="os2tex" name="os2tex" caption="A distribution of TeX for OS/2 Warp" />
+  <package key="osa" name="osa" caption="Macros for Optical Society of America Journals, etc" />
+  <package key="oscola" name="oscola" caption="BibLaTeX style for the Oxford Standard for the Citation of Legal Authorities" />
+  <package key="osda" name="OSDA" caption="Commands for Proceedings of the Workshop on Open-Source Design Automation" />
+  <package key="osmanian" name="osmanian" caption="Osmanian font for writing Somali" />
+  <package key="oststud" name="oststud" caption="Templates for the student organization at OST FH, Switzerland" />
+  <package key="oswald" name="Oswald" caption="The Oswald family of fonts with support for LaTeX and pdfLaTeX" />
+  <package key="ot-tableau" name="ot-tableau" caption="Optimality Theory tableaux in LaTeX" />
+  <package key="ot2cyr" name="ot2cyr" caption="Macros, metrics, etc., to use the OT2 Cyrillic encoding" />
+  <package key="ot2woff" name="OT2Woff" caption="OpenType to Woff converter" />
+  <package key="otfinst" name="otfinst" caption="Install OpenType fonts for use in TeX/LaTeX systems" />
+  <package key="otftofd" name="otftofd" caption="Generate control files for OpenType fonts" />
+  <package key="othello" name="othello" caption="Modification of a Go package to create othello boards" />
+  <package key="othelloboard" name="othelloboard" caption="Typeset Othello (Reversi) diagrams of any size, with annotations" />
+  <package key="oubraces" name="oubraces" caption="Braces over and under a formula" />
+  <package key="oup-authoring-template" name="oup-authoring-template" caption="A general template for journals published by Oxford University Press (OUP)" />
+  <package key="outerhbox" name="outerhbox" caption="Collect horizontal material for contributing to a paragraph" />
+  <package key="outilsgeomtikz" name="OutilsGeomTikZ" caption="Some geometric tools, with TikZ" />
+  <package key="outline" name="outline" caption="List environment for making outlines" />
+  <package key="outliner" name="outliner" caption="Change section levels easily" />
+  <package key="outlines" name="outlines" caption="Produce &quot;outline&quot; lists" />
+  <package key="outlining" name="outlining" caption="Create outlines for scientific documents" />
+  <package key="oval" name="oval" caption="Round-cornered framed boxes" />
+  <package key="ovalfbox" name="ovalfbox" caption="Boxes with frames whose corners are rounded" />
+  <package key="overarrows" name="overarrows" caption="Custom extensible arrows over math expressions" />
+  <package key="overcite" name="overcite" caption="Compressed lists of superscript numerical citations" />
+  <package key="overlays" name="overlays" caption="Incremental slides" />
+  <package key="overlock" name="overlock" caption="Overlock sans fonts with LaTeX support" />
+  <package key="overpic" name="overpic" caption="Combine LaTeX commands over included graphics" />
+  <package key="overrightarrow" name="overrightarrow" caption="Doubled &quot;over&quot; arrow" />
+  <package key="overword" name="overword" caption="Parse text" />
+  <package key="oxford" name="oxford" caption="A BibTeX style geared for use in the humanities" />
+  <package key="oztex" name="oztex" caption="TeX for the Macintosh" />
+  <package key="oztex-fonts" name="oztex-fonts" caption="Fonts packaged for use in OzTeX" />
+  <package key="oztex-german" name="OzTeX-german" caption="German packaging of OzTeX" />
+  <package key="pacioli" name="pacioli" caption="Fonts designed by Fra Luca de Pacioli in 1497" />
+  <package key="padauk" name="padauk" caption="A high-quality TrueType font that supports the many diverse languages that use the Myanmar script" />
+  <package key="padcount" name="padcount" caption="Pad numbers with arbitrary characters" />
+  <package key="pagecolor" name="pagecolor" caption="Interrogate page color" />
+  <package key="pagecont" name="pagecont" caption="Page numbering that continues between documents" />
+  <package key="pagedraw" name="pagedraw" caption="Drawing program with EPS output" />
+  <package key="pagefoots" name="pagefoots" caption="Footnote numbering per page" />
+  <package key="pageframe" name="pageframe" caption="Page frames, grids, etc., for LaTeX 2.09" />
+  <package key="pagegrid" name="pagegrid" caption="Print page grid in background" />
+  <package key="pagelayout" name="pagelayout" caption="Layout graphic rich documents" />
+  <package key="pagella-otf" name="pagella-otf" caption="Using the OpenType fonts TeX Gyre Pagella" />
+  <package key="pageno" name="pageno" caption="Page number-only page styles" />
+  <package key="pagenote" name="pagenote" caption="Notes at end of document" />
+  <package key="pagerange" name="pagerange" caption="Flexible and configurable page range typesetting" />
+  <package key="pagereference" name="pagereference" caption="Labels and references in Plain TeX" />
+  <package key="pagesel" name="pagesel" caption="Select pages of a document for output" />
+  <package key="pageslts" name="pageslts" caption="Variants of last page labels" />
+  <package key="palatino-nfss" name="palatino-nfss" caption="Select Adobe Palatino as default text font" />
+  <package key="palette" name="palette" caption="Create palettes for colors and symbols that can be swapped in" />
+  <package key="palladam" name="palladam" caption="A Tamil font for Macintosh users" />
+  <package key="pandora" name="pandora" caption="The Pandora font family" />
+  <package key="pandora-latex" name="pandora-latex" caption="LaTeX support for the Pandora fonts" />
+  <package key="pandora-type1" name="pandora-type1" caption="The Pandora font family" />
+  <package key="pangram" name="pangram" caption="A LaTeX package for testing fonts" />
+  <package key="panneauxroute" name="panneauxroute" caption="Commands to display French road signs (vector graphics)" />
+  <package key="paper" name="paper" caption="Versions of article class, tuned for scholarly  publications" />
+  <package key="papercdcase" name="papercdcase" caption="Origami-style folding paper CD case" />
+  <package key="papermas" name="papermas" caption="Compute the mass of a printed version of a document" />
+  <package key="papertex" name="papertex" caption="Class for newspapers, etc" />
+  <package key="paracol" name="paracol" caption="Multiple columns with texts &#8220;in parallel&#8221;" />
+  <package key="parades" name="parades" caption="Tabulators and space between paragraphs in galley approach" />
+  <package key="paragraphs" name="paragraphs" caption="Paragraph &quot;tricks&quot; macros" />
+  <package key="paralist" name="paralist" caption="Enumerate and itemize within paragraphs" />
+  <package key="parallel" name="parallel" caption="Typeset parallel texts" />
+  <package key="paratype" name="paratype" caption="LaTeX support for free fonts by ParaType" />
+  <package key="parboxx" name="parboxx" caption="Two extra alignment options for \parbox" />
+  <package key="parcolumns" name="parcolumns" caption="Multiple column parallel typesetting" />
+  <package key="paresse" name="paresse" caption="Define simple macros for greek letters" />
+  <package key="parisa" name="parisa" caption="Parisa family of fonts" />
+  <package key="parnotes" name="parnotes" caption="Notes after every paragraph (or elsewhere)" />
+  <package key="parrun" name="parrun" caption="Typesets (two) streams of text running parallel" />
+  <package key="parsa" name="parsa" caption="A XeLaTeX package for theses and dissertations at Iranian Universities" />
+  <package key="parselines" name="parselines" caption="Apply a macro to each line of an environment" />
+  <package key="parsitex" name="parsitex" caption="A localized Persian and bidirectional extension of TeX" />
+  <package key="parskip" name="parskip" caption="Layout with zero \parindent, non-zero \parskip" />
+  <package key="pas-cours" name="pas-cours" caption="Macros useful in preparing teaching material" />
+  <package key="pas-crosswords" name="pas-crosswords" caption="Creating crossword grids, using TikZ" />
+  <package key="pas-cv" name="pas-cv" caption="Flexible typesetting of Curricula Vitae" />
+  <package key="pas-tableur" name="pas-tableur" caption="Create a spreadsheet layout" />
+  <package key="pascaltriangle" name="pascaltriangle" caption="Draw beautiful Pascal (Yanghui) triangles" />
+  <package key="passivetex" name="passivetex" caption="Support package for XML/SGML typesetting" />
+  <package key="patch" name="patch" caption="Patch loaded packages, etc" />
+  <package key="patchcmd" name="patchcmd" caption="Change the definition of an existing command" />
+  <package key="patgen" name="patgen" caption="Generate hyphenation patterns" />
+  <package key="patgen2-tutorial" name="patgen2-tutorial" caption="A tutorial on the use of Patgen 2" />
+  <package key="path" name="path" caption="Typeset paths, making them breakable" />
+  <package key="pauldoc" name="pauldoc" caption="German LaTeX package documentation" />
+  <package key="pawpict" name="pawpict" caption="Using graphics from PAW" />
+  <package key="pax" name="pax" caption="Extract and reinsert PDF annotations with pdfTeX" />
+  <package key="pb-diagram" name="pb-diagram" caption="A commutative diagram package using LAMSTeX or Xy-pic fonts" />
+  <package key="pbalance" name="pbalance" caption="Balance last page in two-column mode" />
+  <package key="pbibtex-base" name="pbibtex-base" caption="Bibliography styles and miscellaneous files for pBibTeX" />
+  <package key="pbibtex-manual" name="pbibtex-manual" caption="Documentation files for (u)pBibTeX" />
+  <package key="pbm2tex" name="pbm2tex" caption="Translate PBM format to LaTeX" />
+  <package key="pbmtogf" name="pbmtogf" caption="Convert PBM images to GF font files" />
+  <package key="pbmtopk" name="PBMtoPK" caption="Conversion between PBM and PK formats" />
+  <package key="pbox" name="pbox" caption="A variable-width \parbox command" />
+  <package key="pbsheet" name="pbsheet" caption="Problem sheet class" />
+  <package key="pcarl" name="pcarl" caption="LaTeX Support for Adobe Caslon Open Face" />
+  <package key="pcfonts" name="pcfonts" caption="Hebrew fonts for use on DOS PCs" />
+  <package key="pclnfss" name="pclnfss" caption="Font support for current PCL printers" />
+  <package key="pdbf-toolkit" name="pdbf-toolkit" caption="A Toolkit for Creating Janiform Data Documents" />
+  <package key="pdcmac" name="pdcmac" caption="Damian Cugley&apos;s document tools" />
+  <package key="pdf-forms-tutorial" name="pdf-forms-tutorial" caption="Tutorial on creating PDF forms using pdfLaTeX" />
+  <package key="pdf-mps-supp" name="pdf-mps-supp" caption="PDF MetaPost graphics support bundle" />
+  <package key="pdf-trans" name="pdf-trans" caption="A set of macros for various transformations of TeX boxes" />
+  <package key="pdf14" name="pdf14" caption="Restore PDF 1.4 to a TeX live 2010 format" />
+  <package key="pdfarticle" name="pdfarticle" caption="Class for pdf publications" />
+  <package key="pdfbook" name="pdfbook" caption="Rearrange pages of a PDF file for booklet printing" />
+  <package key="pdfbook2" name="pdfbook2" caption="Create booklets from PDF files" />
+  <package key="pdfcol" name="pdfcol" caption="Macros for maintaining colour stacks under pdfTeX" />
+  <package key="pdfcolfoot" name="pdfcolfoot" caption="Separate color stack for footnotes with pdfTeX" />
+  <package key="pdfcolmk" name="pdfcolmk" caption="Improved colour support under pdfTeX (legacy stub)" />
+  <package key="pdfcolparallel" name="pdfcolparallel" caption="Fix colour problems in package &apos;parallel&apos;" />
+  <package key="pdfcolparcolumns" name="pdfcolparcolumns" caption="Fix colour problems in package &apos;parcolumns&apos;" />
+  <package key="pdfcomment" name="pdfcomment" caption="A user-friendly interface to pdf annotations" />
+  <package key="pdfcprot" name="pdfcprot" caption="Activating and setting of character protruding using pdfLaTeX" />
+  <package key="pdfcrop" name="pdfcrop" caption="Crop PDF graphics" />
+  <package key="pdfcrypt" name="pdfcrypt" caption="Allows the setting of pdf encryption" />
+  <package key="pdfescape" name="pdfescape" caption="Implements pdfTeX&apos;s escape features using TeX or e-TeX" />
+  <package key="pdfextra" name="pdfextra" caption="Extra PDF features for (Op)TeX" />
+  <package key="pdfjam" name="pdfjam" caption="Shell scripts interfacing to pdfpages" />
+  <package key="pdflatexpicscale" name="pdflatexpicscale" caption="Support software for downscaling graphics to be included by pdfLaTeX" />
+  <package key="pdflscape" name="pdflscape" caption="Make landscape pages display as landscape" />
+  <package key="pdfmanagement-testphase" name="pdfmanagement-testphase" caption="LaTeX PDF management testphase bundle" />
+  <package key="pdfmarginpar" name="pdfmarginpar" caption="Generate marginpar-equivalent PDF annotations" />
+  <package key="pdfmsym" name="pdfMsym" caption="PDF Math Symbols &#8212; various drawn mathematical symbols" />
+  <package key="pdfoverlay" name="pdfoverlay" caption="A LaTeX style for overlaying text on a PDF" />
+  <package key="pdfpagediff" name="pdfpagediff" caption="Find difference between two PDF&apos;s" />
+  <package key="pdfpages" name="pdfpages" caption="Include PDF documents in LaTeX" />
+  <package key="pdfpc" name="pdfpc" caption="Define data for the pdfpc presentation viewer" />
+  <package key="pdfpc-movie" name="pdfpc-movie" caption="Pdfpc viewer-compatible hyperlinks to movies" />
+  <package key="pdfprivacy" name="pdfprivacy" caption="A LaTeX package to remove or suppress pdf meta-data" />
+  <package key="pdfrack" name="PDFrack" caption="Use psfrag with pdfLaTeX" />
+  <package key="pdfrender" name="pdfrender" caption="Control rendering parameters" />
+  <package key="pdfreview" name="pdfreview" caption="Annotate PDF files with margin notes" />
+  <package key="pdfscreen" name="pdfscreen" caption="Support screen-based document design" />
+  <package key="pdfslide" name="pdfslide" caption="Presentation slides using pdfTeX" />
+  <package key="pdfsync" name="pdfsync" caption="Provide links between source and PDF" />
+  <package key="pdftex" name="pdftex" caption="A TeX extension for direct creation of PDF" />
+  <package key="pdftex-def" name="pdftex-def" caption="Colour and Graphics support for pdfTeX" />
+  <package key="pdftex-djgpp" name="pdftex-djgpp" caption=" An msdos-djgpp binary of the pdfTeX engine" />
+  <package key="pdftex-oztex" name="pdftex-oztex" caption="pdfTeX designed to run with OzTeX" />
+  <package key="pdftex-quiet" name="pdftex-quiet" caption="A bash wrapper for pdfTeX limiting its output to relevant errors" />
+  <package key="pdftexcmds" name="pdftexcmds" caption="LuaTeX support for pdfTeX utility functions" />
+  <package key="pdftricks" name="pdftricks" caption="Support for PSTricks in pdfTeX" />
+  <package key="pdftricks2" name="pdftricks2" caption="Use PSTricks in pdfTeX" />
+  <package key="pdfx" name="pdfx" caption="PDF/X and PDF/A support for pdfTeX, LuaTeX and XeTeX" />
+  <package key="pdfxup" name="pdfxup" caption="Create n-up PDF pages with minimal margins" />
+  <package key="pecha" name="Pecha" caption="Print Tibetan text in the classic pecha layout style" />
+  <package key="pedigree-perl" name="pedigree-perl" caption="Generate TeX pedigree files from CSV files" />
+  <package key="penlight" name="penlight" caption="Penlight Lua libraries made available to LuaLaTeX users" />
+  <package key="penlightplus" name="penlightplus" caption="Additions to the Penlight Lua libraries" />
+  <package key="penrose" name="penrose" caption="A TikZ library for producing Penrose tilings" />
+  <package key="perception" name="perception" caption="BibTeX style for the journal Perception" />
+  <package key="perfectcut" name="perfectcut" caption="Nested delimiters that consistently grow regardless of the contents" />
+  <package key="perltex" name="perltex" caption="Define LaTeX macros in terms of Perl code" />
+  <package key="permute" name="permute" caption="Support for symmetric groups" />
+  <package key="perpage" name="perpage" caption="Make a counter reset at every page boundary" />
+  <package key="persian-bib" name="persian-bib" caption="Persian translations of classic BibTeX styles" />
+  <package key="petiteannonce" name="petiteannonce" caption="A class for small advertisements" />
+  <package key="petri-nets" name="Petri-nets" caption="A set TeX/LaTeX packages for drawing Petri nets" />
+  <package key="pf2afm" name="pf2afm" caption="AFM generator for Adobe Type 1 fonts" />
+  <package key="pfarrei" name="pfarrei" caption="LaTeX support of pastors&#8217; and priests&#8217; work" />
+  <package key="pfdicons" name="pfdicons" caption="Draw process flow diagrams in chemical engineering" />
+  <package key="pfm2afm" name="pfm2afm" caption="Convert PFM files to AFM, and vice versa" />
+  <package key="pfnote" name="pfnote" caption="Number footnotes per page" />
+  <package key="pgf" name="pgf" caption="Create PostScript and PDF graphics in TeX" />
+  <package key="pgf-blur" name="pgf-blur" caption="PGF/TikZ package for &quot;blurred&quot; shadows" />
+  <package key="pgf-cmykshadings" name="pgf-cmykshadings" caption="Support for CMYK and grayscale shadings in PGF/TikZ" />
+  <package key="pgf-interference" name="pgf-interference" caption="Drawing interference patterns with PGF/TikZ" />
+  <package key="pgf-periodictable" name="pgf-PeriodicTable" caption="Create custom periodic tables of elements" />
+  <package key="pgf-pie" name="pgf-pie" caption="Draw pie charts, using PGF" />
+  <package key="pgf-soroban" name="pgf-soroban" caption="Create images of the soroban using TikZ/PGF" />
+  <package key="pgf-spectra" name="pgf-spectra" caption="Draw continuous or discrete spectra using PGF/TikZ" />
+  <package key="pgf-umlcd" name="pgf-umlcd" caption="Some LaTeX macros for UML Class Diagrams" />
+  <package key="pgf-umlsd" name="pgf-umlsd" caption="Draw UML Sequence Diagrams" />
+  <package key="pgfgantt" name="pgfgantt" caption="Draw Gantt charts with TikZ" />
+  <package key="pgfkeys" name="pgfkeys" caption="Key value control for PGF" />
+  <package key="pgfkeyx" name="pgfkeyx" caption="Extended and more robust version of pgfkeys" />
+  <package key="pgfmath-xfp" name="pgfmath-xfp" caption="Define pgfmath functions using xfp" />
+  <package key="pgfmolbio" name="pgfmolbio" caption="Draw graphs typically found in molecular biology texts" />
+  <package key="pgfmorepages" name="pgfmorepages" caption="Assemble multiple logical pages onto a physical page" />
+  <package key="pgfopts" name="pgfopts" caption="LaTeX package options with pgfkeys" />
+  <package key="pgfornament" name="pgfornament" caption="Drawing of Vectorian ornaments with PGF/TikZ" />
+  <package key="pgfornament-han" name="pgfornament-han" caption="pgfornament library for Chinese traditional motifs and patterns" />
+  <package key="pgfplots" name="pgfplots" caption="Create normal/logarithmic plots in two and three dimensions" />
+  <package key="pgfplotstable" name="pgfplotstable" caption="Loads, rounds, formats and postprocesses numerical tables" />
+  <package key="pgothic" name="pgothic" caption="Fonts based on the Gothic Textura Prescisus manuscript book-hand" />
+  <package key="phaistos" name="phaistos" caption="Disk of Phaistos font" />
+  <package key="phfcc" name="phfcc" caption="Convenient inline commenting in collaborative documents" />
+  <package key="phfextendedabstract" name="phfextendedabstract" caption="Typeset extended abstracts for conferences, such as often encountered in quantum information theory" />
+  <package key="phffullpagefigure" name="phffullpagefigure" caption="Figures which fill up a whole page" />
+  <package key="phfnote" name="phfnote" caption="Basic formatting for short documents" />
+  <package key="phfparen" name="phfparen" caption="Parenthetic math expressions made simpler and less redundant" />
+  <package key="phfqit" name="phfqit" caption="Macros for typesetting Quantum Information Theory" />
+  <package key="phfquotetext" name="phfquotetext" caption="Quote verbatim text without white space formatting" />
+  <package key="phfsvnwatermark" name="phfsvnwatermark" caption="Watermarks with version control information from SVN" />
+  <package key="phfthm" name="phfthm" caption="Goodies for theorems and proofs" />
+  <package key="philex" name="philex" caption="Cross references for named and numbered environments" />
+  <package key="philokalia" name="philokalia" caption="A font to typeset the Philokalia Books" />
+  <package key="philosophersimprint" name="philosophersimprint" caption="Typesetting articles for &quot;Philosophers&apos; Imprint&quot;" />
+  <package key="phoenician" name="phoenician" caption="Fonts for the Phoenician script in use from about 1600 BC" />
+  <package key="phoncard" name="phoncard" caption="Format telephone number lists" />
+  <package key="phonenumbers" name="phonenumbers" caption="Typesetting telephone numbers with LaTeX" />
+  <package key="phonetic" name="phonetic" caption="Metafont Phonetic fonts, based on Computer Modern" />
+  <package key="phonrule" name="phonrule" caption="Typeset linear phonological rules" />
+  <package key="photo" name="photo" caption="A float environment for photographs" />
+  <package key="photobook" name="photobook" caption="A document class for typesetting photo books" />
+  <package key="phy-bstyles" name="phy-bstyles" caption="A collection of BibTeX styles for physics journals" />
+  <package key="physconst" name="physconst" caption="Macros for commonly used physical constants" />
+  <package key="physe" name="physe" caption="The PHYSE format" />
+  <package key="physics" name="physics" caption="Macros supporting the Mathematics of Physics" />
+  <package key="physics2" name="physics2" caption="Macros for typesetting maths faster and more simply" />
+  <package key="physunits" name="physunits" caption="Macros for commonly used physical units" />
+  <package key="physymb" name="physymb" caption="Assorted macros for Physicists" />
+  <package key="phyzzx" name="phyzzx" caption="A TeX format for physicists" />
+  <package key="pi" name="pi" caption="Calculate pi" />
+  <package key="piano" name="piano" caption="Typeset a basic 2-octave piano diagram" />
+  <package key="picinpar" name="picinpar" caption="Insert pictures into paragraphs" />
+  <package key="picins" name="picins" caption="Insert pictures into paragraphs" />
+  <package key="picmac" name="picmac" caption="A picture mode in Plain TeX" />
+  <package key="pict2e" name="pict2e" caption="New implementation of picture commands" />
+  <package key="pictex" name="PicTeX" caption="Picture drawing macros for TeX and LaTeX" />
+  <package key="pictex-autoarea" name="pictex-autoarea" caption="Automatic computation of bounding boxes with PiCTeX" />
+  <package key="pictex2" name="pictex2" caption="Adds relative coordinates and improves the \plot command" />
+  <package key="pictexsum" name="PicTeXsum" caption="A summary of PicTeX commands" />
+  <package key="pictexwd" name="pictexwd" caption="A patched version of PicTeX using fewer registers" />
+  <package key="picture" name="picture" caption="Dimens for picture macros" />
+  <package key="piechart" name="piechart" caption="Simple pie-charts with PSTricks" />
+  <package key="piechartmp" name="piechartmp" caption="Draw pie-charts using MetaPost" />
+  <package key="piff" name="piff" caption="Macro tools by Mike Piff" />
+  <package key="piff-ams" name="piff-ams" caption="Early macros for using AMS fonts" />
+  <package key="pifont" name="pifont" caption="Access to PostScript standard Symbol and Dingbats fonts" />
+  <package key="pigpen" name="pigpen" caption="A font for the pigpen (or masonic) cipher" />
+  <package key="pinlabel" name="pinlabel" caption="A TeX labelling package" />
+  <package key="pinoutikz" name="pinouTikZ" caption="Draw chip pinouts with TikZ" />
+  <package key="pitex" name="pitex" caption="Documentation macros" />
+  <package key="piton" name="piton" caption="Typeset Python listings with LPEG" />
+  <package key="pittetd" name="pittetd" caption="Electronic Theses and Dissertations at Pitt" />
+  <package key="pitthesis" name="pitthesis" caption="Document class for University of Pittsburgh theses" />
+  <package key="pixelart" name="pixelart" caption="Draw pixel-art pictures" />
+  <package key="pixelarttikz" name="PixelArtTikz" caption="Work with PixelArts, with TikZ" />
+  <package key="pkbbox" name="pkbbox" caption="Derive glyph bounding boxes by building PK file" />
+  <package key="pkfind" name="pkfind" caption="A &#8216;find&#8217; command which understands pk files" />
+  <package key="pkfix" name="pkfix" caption="Replace pk fonts in PostScript with Type 1 fonts" />
+  <package key="pkfix-helper" name="pkfix-helper" caption="Make PostScript files accessible to pkfix" />
+  <package key="pkgcheck" name="pkgcheck" caption="CTAN package checker" />
+  <package key="pkgloader" name="pkgloader" caption="Manage the options and loading order of other packages" />
+  <package key="pkuthss" name="pkuthss" caption="LaTeX template for dissertations in Peking University" />
+  <package key="pkware" name="pkware" caption="Utility programs for use with PK bitmap fonts" />
+  <package key="pl" name="pl" caption="Literate Programming for Prolog with LaTeX" />
+  <package key="pl-mf" name="pl-mf" caption="Polish extension of Computer Modern fonts" />
+  <package key="placeat" name="placeat" caption="Absolute content positioning" />
+  <package key="placeins" name="placeins" caption="Control float placement" />
+  <package key="placeins-plain" name="placeins-plain" caption="Insertions that keep their place" />
+  <package key="plain" name="plain" caption="The Plain TeX format" />
+  <package key="plain-cm" name="plain-cm" caption="Variable sized fonts in Plain TeX" />
+  <package key="plain-ltx" name="plain-ltx" caption="Make plain TeX files LaTeXable" />
+  <package key="plainmisc" name="plainmisc" caption="Miscellaneous contributed macros for plain TeX" />
+  <package key="plainpkg" name="plainpkg" caption="A minimal method for making generic packages" />
+  <package key="plainyr" name="plainyr" caption="Plain bibliography style, sorted by year first" />
+  <package key="plantslabels" name="plantslabels" caption="Write labels for plants" />
+  <package key="plantuml" name="plantuml" caption="Support for rendering UML diagrams using PlantUML" />
+  <package key="plari" name="plari" caption="Typesetting stageplay scripts" />
+  <package key="plates" name="plates" caption="Arrange for &quot;plates&quot; sections of documents" />
+  <package key="platex" name="platex" caption="pLaTeX2e and miscellaneous macros for pTeX" />
+  <package key="platex-tools" name="platex-tools" caption="pLaTeX standard tools bundle" />
+  <package key="platexcheat" name="platexcheat" caption="A LaTeX cheat sheet, in Japanese" />
+  <package key="plautopatch" name="plautopatch" caption="Automated patches for pLaTeX/upLaTeX" />
+  <package key="play" name="play" caption="Typeset drama using LaTeX" />
+  <package key="play-font" name="play-font" caption="The Play font face with support for LaTeX and pdfLaTeX" />
+  <package key="playcards" name="playcards" caption="A simple template for drawing playcards" />
+  <package key="playfair" name="playfair" caption="Playfair Display fonts with LaTeX support" />
+  <package key="plcalendar" name="plcalendar" caption="Plain macros for making nice calendars" />
+  <package key="plex" name="plex" caption="Support for IBM Plex fonts" />
+  <package key="plex-otf" name="plex-otf" caption="Support for the OpenType font IBM Plex" />
+  <package key="plfonts" name="plfonts" caption="Polish extension to Computer Modern fonts" />
+  <package key="plhyph" name="plhyph" caption="Hyphenation for Polish" />
+  <package key="plimsoll" name="plimsoll" caption="Fonts with the Plimsoll symbol and LaTeX support" />
+  <package key="plipsum" name="plipsum" caption="&apos;Lorem ipsum&apos; for Plain TeX developers" />
+  <package key="plnfss" name="plnfss" caption="Font selection for Plain TeX" />
+  <package key="plpsfont" name="plpsfont" caption="Polish extension of CM fonts in Type 1 format" />
+  <package key="plstmary" name="plstmary" caption="St. Mary&#8217;s Road font support for plain TeX" />
+  <package key="pm-isomath" name="pm-isomath" caption="Poor man ISO math for pdfLaTeX users" />
+  <package key="pmat" name="pmat" caption="Typeset partitioned matrices" />
+  <package key="pmboxdraw" name="pmboxdraw" caption="Poor man&#8217;s box drawing characters" />
+  <package key="pmcstex" name="pmcstex" caption="LaTeX in emTeX IDE/FrontEnd for EPM" />
+  <package key="pmdb" name="pmdb" caption="Create a DB (PDF) document for selecting content for inclusion in another documents" />
+  <package key="pmdpl" name="pmdpl" caption="Examples from &quot;Praca magisterska i dyplomowa&quot;" />
+  <package key="pmgraph" name="pmgraph" caption="&quot;Poor man&apos;s&quot; graphics" />
+  <package key="pmhanguljamo" name="pmhanguljamo" caption="Poor man&#8217;s Hangul Jamo input method" />
+  <package key="pmtex" name="pmtex" caption="Preprocessor for MusicTeX" />
+  <package key="pmx" name="pmx" caption="Preprocessor for MusiXTeX" />
+  <package key="pmxchords" name="pmxchords" caption="Produce chord information to go with pmx output" />
+  <package key="pnas" name="PNAS" caption="BibTeX style for PNAS (old version)" />
+  <package key="pnas2009" name="PNAS 2009" caption="BibTeX style for PNAS (newer version)" />
+  <package key="png2pdf" name="png2pdf" caption="PNG to PDF converter" />
+  <package key="poemscol" name="poemscol" caption="Typesetting Critical Editions of Poetry" />
+  <package key="poetica" name="poetica" caption="Support for Adobe Poetica fonts in  Type 1 format" />
+  <package key="poetry" name="poetry" caption="Facilities for typesetting poetry and poetical structure" />
+  <package key="poetrytex" name="poetrytex" caption="Typeset anthologies of poetry" />
+  <package key="pointruler" name="pointruler" caption="12&quot; Ruler containing Points and Inches" />
+  <package key="poiretone" name="poiretone" caption="PoiretOne family of fonts with LaTeX support" />
+  <package key="polexpr" name="polexpr" caption="A parser for polynomial expressions" />
+  <package key="poligraf" name="poligraf" caption="A TeX macro package for prepress" />
+  <package key="polski" name="polski" caption="Typeset Polish documents with LaTeX and Polish fonts" />
+  <package key="poltawski" name="poltawski" caption="Antykwa P&#243;&#322;tawskiego Family of Fonts" />
+  <package key="polyglossia" name="polyglossia" caption="An alternative to babel for XeLaTeX and LuaLaTeX" />
+  <package key="polynom" name="polynom" caption="Macros for manipulating polynomials" />
+  <package key="polynomial" name="polynomial" caption="Typeset (univariate) polynomials" />
+  <package key="polytable" name="polytable" caption="Tabular-like environments with named columns" />
+  <package key="poorman" name="poorman" caption="Raster Chinese and Japanese fonts" />
+  <package key="poormanlog" name="poormanlog" caption="Logarithms and powers with (almost) 9 digits" />
+  <package key="popupmenu" name="popupmenu" caption="Create popup menus in PDF files" />
+  <package key="portable-miktex" name="Portable MikTeX" caption="Instructions for setting up MikTeX on a portable device" />
+  <package key="portland" name="portland" caption="Simple portrait/landscape switching" />
+  <package key="pos-at" name="pos-at" caption="Position things at absolute positions on the page" />
+  <package key="postage" name="postage" caption="Stamp letters with &#187;Deutsche Post&#171;&apos;s service &#187;Internetmarke&#171;" />
+  <package key="postcards" name="postcards" caption="Facilitates mass-mailing of postcards (junkmail)" />
+  <package key="poster" name="poster" caption="Scale PostScript images for larger media or tiling" />
+  <package key="poster-mac" name="poster-mac" caption="Make posters and banners with TeX" />
+  <package key="postit" name="postit" caption="A LaTeX package for displaying Post-it notes" />
+  <package key="postnotes" name="postnotes" caption="Endnotes for LaTeX" />
+  <package key="powerdot" name="powerdot" caption="A presentation class" />
+  <package key="powerdot-fuberlin" name="powerdot-fuberlin" caption="Powerdot, using the style of FU Berlin" />
+  <package key="powerdot-tuliplab" name="powerdot-tuliplab" caption="A style package for Powerdot to provide the design of TULIP Lab" />
+  <package key="ppchtex" name="ppchtex" caption="Typeset chemical formula diagrams" />
+  <package key="pphlp" name="pphlp" caption="Generate VMS help files from LaTeX 2.09 source" />
+  <package key="ppower4" name="ppower4" caption="A postprocessor for PDF presentations" />
+  <package key="ppr-prv" name="ppr-prv" caption="Prosper preview" />
+  <package key="ppt-slides" name="ppt-slides" caption="Good-looking slide decks &#224; la PowerPoint (PPT)" />
+  <package key="pracjourn" name="pracjourn" caption="Typeset articles for PracTeX" />
+  <package key="practical-latex" name="practical-latex" caption="Example files for &#8220;Practical LaTeX&#8221;" />
+  <package key="practicalreports" name="practicalreports" caption="Some macros for writing practical reports" />
+  <package key="precattl" name="precattl" caption="Prepare special catcodes from token list" />
+  <package key="prelim" name="prelim" caption="Mark preliminary copies with a line of information" />
+  <package key="prelim2e" name="prelim2e" caption="Allows the marking of preliminary versions of a document" />
+  <package key="prepr" name="prepr" caption="Preprint macros" />
+  <package key="preprint" name="preprint" caption="A bundle of packages provided &quot;as is&quot;" />
+  <package key="prerex" name="prerex" caption="Interactive editor and macro support for prerequisite charts" />
+  <package key="present" name="present" caption="Presentations with Plain TeX" />
+  <package key="presentations" name="presentations" caption="Examples from the book Presentationen mit LaTeX" />
+  <package key="presentations-en" name="presentations-en" caption="Examples from the book Presentations with LaTeX" />
+  <package key="pressrelease" name="pressrelease" caption="A class for typesetting press releases" />
+  <package key="prettyref" name="prettyref" caption="Make label references &quot;self-identify&quot;" />
+  <package key="prettytok" name="prettytok" caption="Pretty-print token lists" />
+  <package key="preview" name="preview" caption="Extract bits of a LaTeX source for output" />
+  <package key="preview-latex" name="preview-latex" caption="Preview equations in Emacs" />
+  <package key="prftree" name="prftree" caption="Macros for building proof trees" />
+  <package key="principia" name="principia" caption="Notations for typesetting the &#8220;Principia Mathematica&#8221;" />
+  <package key="printbib" name="printbib" caption="Print the contents of a bibliography" />
+  <package key="printlen" name="printlen" caption="Print lengths using specified units" />
+  <package key="proba" name="proba" caption="Shortcuts commands to symbols used in probability texts" />
+  <package key="probsoln" name="probsoln" caption="Generate problem sheets and their solution sheets" />
+  <package key="proc" name="proc" caption="Class for producing &#8220;proceedings&#8221;" />
+  <package key="processkv" name="processkv" caption="Process key-value pairs" />
+  <package key="prociagssymp" name="procIAGssymp" caption="Macros for IAG symposium papers" />
+  <package key="prodint" name="prodint" caption="A font that provides the product integral symbol" />
+  <package key="productbox" name="productbox" caption="Typeset a three-dimensional product box" />
+  <package key="profcollege" name="ProfCollege" caption="A LaTeX package for French maths teachers in college" />
+  <package key="proflabo" name="proflabo" caption="Draw laboratory equipment" />
+  <package key="proflycee" name="ProfLycee" caption="A LaTeX package for French maths teachers in high school" />
+  <package key="profmaquette" name="profmaquette" caption="Use exercises in different types of documents" />
+  <package key="profsio" name="profsio" caption="Commands (with TikZ) to work with French &#8220;BTS SIO&#8221; maths themes" />
+  <package key="progkeys" name="progkeys" caption="Typeset programs, recognising keywords" />
+  <package key="program" name="program" caption="Typesetting programs and algorithms" />
+  <package key="progress" name="progress" caption="Creates an overview of a document&apos;s state" />
+  <package key="progressbar" name="progressbar" caption="Visualize shares of total amounts in the form of a (progress-)bar" />
+  <package key="projlib" name="ProjLib" caption="A series of tools to simplify your workflow" />
+  <package key="proof" name="proof" caption="Shell based proofing for TeX-related files" />
+  <package key="proof-at-the-end" name="proof-at-the-end" caption="A package to move proofs to appendix" />
+  <package key="proofread" name="proofread" caption="Commands for inserting annotations" />
+  <package key="proofs" name="proofs" caption="Macros for building proof trees" />
+  <package key="prooftrees" name="prooftrees" caption="Forest-based proof trees (symbolic logic)" />
+  <package key="properties" name="properties" caption="Load properties from a file" />
+  <package key="proposal" name="proposal" caption="A set of LaTeX classes for preparing proposals for
+    collaborative projects" />
+  <package key="prosper" name="prosper" caption="LaTeX class for high quality slides" />
+  <package key="protecteddef" name="protecteddef" caption="Define protected commands" />
+  <package key="protex" name="protex" caption="Literate programming package" />
+  <package key="protext" name="protext" caption="A MikTeX-based TeX installation for MS-Windows" />
+  <package key="protocol" name="protocol" caption="A class for minutes of meetings" />
+  <package key="protosem" name="protosem" caption="Fonts for proto-Semitic cuneiform script" />
+  <package key="prtec" name="prtec" caption="A template for PRTEC conference papers" />
+  <package key="prv" name="prv" caption="Compile, preview, and print LaTeX documents" />
+  <package key="przechlewski-book" name="przechlewski-book" caption="Examples from Przechlewski&apos;s LaTeX book" />
+  <package key="ps2eps" name="ps2eps" caption="Produce Encapsulated PostScript from PostScript" />
+  <package key="ps2mf" name="ps2mf" caption="Make Metafont files from Adobe Type 1 files" />
+  <package key="ps2pk" name="ps2pk" caption="Generate a PK font from an Adobe Type 1 font" />
+  <package key="ps4mf" name="ps4mf" caption="Convert Adobe Type 1 fonts to Metafont" />
+  <package key="ps4mf-dos" name="ps4mf-dos" caption="Convert Adobe Type 1 fonts to Metafont, MS-DOS version" />
+  <package key="ps4pdf" name="ps4pdf" caption="Use PostScript commands inside a pdfLaTeX document" />
+  <package key="ps_conv" name="ps_conv" caption="A converter from PostScript to Encapsulated PostScript" />
+  <package key="ps_view" name="ps_view" caption="A PostScript previewer of PostScript files" />
+  <package key="psbao" name="psbao" caption="Draw Bao diagrams" />
+  <package key="psbox" name="psbox" caption="PostScript box macros, etc" />
+  <package key="psboxit" name="psboxit" caption="Enables one to put a PostScript drawing behind a TeX box" />
+  <package key="pseudo" name="pseudo" caption="Straightforward pseudocode" />
+  <package key="pseudocode" name="pseudocode" caption="LaTeX environment for specifying algorithms in a natural way" />
+  <package key="psfig" name="psfig" caption="A graphics inclusion package" />
+  <package key="psfixbb" name="psfixbb" caption="Correct the bounding box of a PostScript file" />
+  <package key="psfont" name="psfont" caption="Alternative font handling in LaTeX" />
+  <package key="psfonts" name="psfonts" caption="PostScript fonts for use with TeX and LaTeX" />
+  <package key="psfonts-tools" name="psfonts-tools" caption="Tools for creating a distribution of font metrics" />
+  <package key="psfrag" name="psfrag" caption="Replace strings in encapsulated PostScript figures" />
+  <package key="psfrag-italian" name="Il sistema PSfrag" caption="PSfrag documentation in Italian" />
+  <package key="psfragger" name="psfragger" caption="Use psfrag and LaTeX to label an eps file" />
+  <package key="psfragx" name="psfragx" caption="A psfrag eXtension" />
+  <package key="psgo" name="psgo" caption="Typeset go diagrams with PSTricks" />
+  <package key="psgreek" name="psgreek" caption="LaTeX support for Greek Type 1 fonts" />
+  <package key="psizzl" name="psizzl" caption="A TeX format for physics papers" />
+  <package key="pslatex" name="pslatex" caption="Use PostScript fonts by default" />
+  <package key="psmerge" name="psmerge" caption="Concatenate PostScript files" />
+  <package key="psnfss" name="psnfss" caption="Font support for common PostScript fonts" />
+  <package key="psnfss-source" name="psnfss-source" caption="Sources of the metrics used in PSNFSS" />
+  <package key="psnfssx" name="psnfssx" caption="Extra styles and encodings for PostScript fonts" />
+  <package key="psnfssx-8r" name="psnfssx-8r" caption="Raw Type 1 fonts with LaTeX" />
+  <package key="psnfssx-adobe" name="psnfssx-adobe" caption="Packages to use a selection of Adobe Type 1 fonts" />
+  <package key="psnfssx-em" name="psnfssx-em" caption="Support for the em family of fonts" />
+  <package key="pspic" name="pspic" caption="Drawing pictures using PostScript specials" />
+  <package key="pspicture" name="pspicture" caption="PostScript picture support" />
+  <package key="psrip" name="psrip" caption="Extract images from PostScript files" />
+  <package key="pssplit" name="pssplit" caption="Select pages from PostScript files" />
+  <package key="pst-2dplot" name="pst-2dplot" caption="A PSTricks package for drawing 2D curves" />
+  <package key="pst-3d" name="pst-3d" caption="A PSTricks package for tilting and other pseudo-3D tricks" />
+  <package key="pst-3dplot" name="pst-3dplot" caption="Draw 3D objects in parallel projection, using PSTricks" />
+  <package key="pst-abspos" name="pst-abspos" caption="Put objects at an absolute position" />
+  <package key="pst-am" name="pst-am" caption="Simulation of modulation and demodulation" />
+  <package key="pst-antiprism" name="pst-antiprism" caption="A  PSTricks related package which draws an antiprism" />
+  <package key="pst-arrow" name="pst-arrow" caption="Special arrows for PSTricks" />
+  <package key="pst-asr" name="pst-asr" caption="Typeset autosegmental representations for linguists" />
+  <package key="pst-bar" name="pst-bar" caption="Produces bar charts using PSTricks" />
+  <package key="pst-barcode" name="pst-barcode" caption="Print barcodes using PostScript" />
+  <package key="pst-bezier" name="pst-bezier" caption="Draw Bezier curves" />
+  <package key="pst-blur" name="pst-blur" caption="PSTricks package for &quot;blurred&quot; shadows" />
+  <package key="pst-bspline" name="pst-bspline" caption="Draw cubic Bspline curves and interpolations" />
+  <package key="pst-calculate" name="pst-calculate" caption="Support for floating point operations at LaTeX level" />
+  <package key="pst-calendar" name="pst-calendar" caption="Plot calendars in &quot;fancy&quot; ways" />
+  <package key="pst-cie" name="pst-cie" caption="CIE color space" />
+  <package key="pst-circ" name="pst-circ" caption="PSTricks package for drawing electric circuits" />
+  <package key="pst-coil" name="pst-coil" caption="A PSTricks package for coils, etc" />
+  <package key="pst-contourplot" name="pst-contourplot" caption="Draw  implicit functions using the &#8220;marching squares&#8221; algorithm" />
+  <package key="pst-cox" name="pst-cox" caption="Drawing regular complex polytopes with PSTricks" />
+  <package key="pst-dart" name="pst-dart" caption="Plotting dart boards" />
+  <package key="pst-dbicons" name="pst-dbicons" caption="Support for drawing ER diagrams" />
+  <package key="pst-diffraction" name="pst-diffraction" caption="Print diffraction patterns from various apertures" />
+  <package key="pst-electricfield" name="pst-electricfield" caption="Draw electric field and equipotential lines with PSTricks" />
+  <package key="pst-eps" name="pst-eps" caption="Create EPS files from PSTricks figures" />
+  <package key="pst-eucl" name="pst-eucl" caption="Euclidian geometry with PSTricks" />
+  <package key="pst-eucl-translation-bg" name="pst-eucl-translation-bg" caption="Bulgarian translation of the pst-eucl documentation" />
+  <package key="pst-exa" name="pst-exa" caption="Typeset PSTricks examples, with code" />
+  <package key="pst-feyn" name="pst-feyn" caption="Draw graphical elements for Feynman diagrams" />
+  <package key="pst-fill" name="pst-fill" caption="Fill or tile areas with PSTricks" />
+  <package key="pst-fit" name="pst-fit" caption="Macros for curve fitting" />
+  <package key="pst-flags" name="PST-Flags" caption="Draw flags of countries using PSTricks" />
+  <package key="pst-fp" name="pst-fp" caption="Fixed-point arithmetic in PSTricks" />
+  <package key="pst-fr3d" name="pst-fr3d" caption="Draw 3-dimensional framed boxes using PSTricks" />
+  <package key="pst-fractal" name="pst-fractal" caption="Draw fractal sets using PSTricks" />
+  <package key="pst-fun" name="pst-fun" caption="Draw &quot;funny&quot; objects with PSTricks" />
+  <package key="pst-func" name="pst-func" caption="PSTricks package for plotting mathematical functions" />
+  <package key="pst-gantt" name="pst-gantt" caption="Draw GANTT charts with PSTricks" />
+  <package key="pst-geo" name="pst-geo" caption="Geographical Projections" />
+  <package key="pst-geometrictools" name="pst-geometrictools" caption="A PSTricks package to draw geometric tools" />
+  <package key="pst-gr3d" name="pst-gr3d" caption="Three dimensional grids with PSTricks" />
+  <package key="pst-grad" name="pst-grad" caption="Filling with colour gradients, using PSTricks" />
+  <package key="pst-graphicx" name="pst-graphicx" caption="A PSTricks-compatible graphicx for use with Plain TeX" />
+  <package key="pst-hsb" name="pst-hsb" caption="Curves with continuous colours" />
+  <package key="pst-infixplot" name="pst-infixplot" caption="Using PSTricks plotting capacities with infix expressions rather than RPN" />
+  <package key="pst-intersect" name="pst-intersect" caption="Compute intersections of arbitrary curves" />
+  <package key="pst-jtree" name="pst-Jtree" caption="Typeset complex trees for linguists" />
+  <package key="pst-knot" name="pst-knot" caption="PSTricks package for displaying knots" />
+  <package key="pst-labo" name="pst-labo" caption="Draw objects for Chemistry laboratories" />
+  <package key="pst-layout" name="pst-layout" caption="Page layout macros based on PSTricks packages" />
+  <package key="pst-lens" name="pst-lens" caption="Lenses with PSTricks" />
+  <package key="pst-light3d" name="pst-light3d" caption="Three dimensional lighting effects (PSTricks)" />
+  <package key="pst-lsystem" name="pst-lsystem" caption="Create images based on a L-system" />
+  <package key="pst-magneticfield" name="pst-magneticfield" caption="Plotting a magnetic field with PSTricks" />
+  <package key="pst-marble" name="pst-marble" caption="A PSTricks package to draw marble-like patterns" />
+  <package key="pst-math" name="pst-math" caption="Enhancement of PostScript math operators to use with PSTricks" />
+  <package key="pst-mirror" name="pst-mirror" caption="Images on a spherical mirror" />
+  <package key="pst-moire" name="pst-moire" caption="A PSTricks package to draw moir&#233; patterns" />
+  <package key="pst-node" name="pst-node" caption="Nodes and node connections in PSTricks" />
+  <package key="pst-ob3d" name="pst-ob3d" caption="Three dimensional objects using PSTricks" />
+  <package key="pst-ode" name="pst-ode" caption="Solving initial value problems for sets of Ordinary Differential Equations" />
+  <package key="pst-optexp" name="pst-optexp" caption="Drawing optical experimental setups" />
+  <package key="pst-optic" name="pst-optic" caption="Drawing optics diagrams" />
+  <package key="pst-osci" name="pst-osci" caption="Oscgons with PSTricks" />
+  <package key="pst-ovl" name="pst-ovl" caption="Create and manage graphical overlays" />
+  <package key="pst-pad" name="pst-pad" caption="Draw simple attachment systems with PSTricks" />
+  <package key="pst-pdf" name="pst-pdf" caption="Make PDF versions of graphics by processing between runs" />
+  <package key="pst-pdgr" name="pst-pdgr" caption="Draw medical pedigrees using PSTricks" />
+  <package key="pst-perspective" name="pst-perspective" caption="Draw perspective views using PSTricks" />
+  <package key="pst-platon" name="pst-platon" caption="Platonic solids in PSTricks" />
+  <package key="pst-plot" name="pst-plot" caption="Plot data using PSTricks" />
+  <package key="pst-poker" name="pst-poker" caption="Drawing poker cards" />
+  <package key="pst-poly" name="pst-poly" caption="Polygons with PSTricks" />
+  <package key="pst-pulley" name="pst-pulley" caption="Plot pulleys, using PSTricks" />
+  <package key="pst-qtree" name="pst-qtree" caption="Simple syntax for trees" />
+  <package key="pst-rputover" name="pst-rputover" caption=" Place text over objects without obscuring background colors" />
+  <package key="pst-rubans" name="pst-rubans" caption="Draw three-dimensional ribbons" />
+  <package key="pst-shell" name="pst-shell" caption="Plotting sea shells" />
+  <package key="pst-sigsys" name="pst-sigsys" caption="Support of signal processing-related disciplines" />
+  <package key="pst-slpe" name="pst-slpe" caption="Sophisticated colour gradients" />
+  <package key="pst-solarsystem" name="pst-solarsystem" caption="Plot the solar system for a specific date" />
+  <package key="pst-solides3d" name="pst-solides3d" caption="Draw perspective views of 3D solids" />
+  <package key="pst-soroban" name="pst-soroban" caption="Draw a Soroban using PSTricks" />
+  <package key="pst-spectra" name="pst-spectra" caption="Draw continuum, emission and absorption spectra with PSTricks" />
+  <package key="pst-spinner" name="pst-spinner" caption="Drawing a fidget spinner" />
+  <package key="pst-spirograph" name="pst-spirograph" caption="Drawing hypotrochoids as with a spirograph" />
+  <package key="pst-stru" name="pst-stru" caption="Civil engineering diagrams, using PSTricks" />
+  <package key="pst-support" name="pst-support" caption="Assorted support files for use with PSTricks" />
+  <package key="pst-text" name="pst-text" caption="Text and character manipulation in PSTricks" />
+  <package key="pst-thick" name="pst-thick" caption="Drawing very thick lines and curves" />
+  <package key="pst-tools" name="pst-tools" caption="PSTricks support functions" />
+  <package key="pst-tree" name="pst-tree" caption="Trees, using PSTricks" />
+  <package key="pst-turtle" name="pst-turtle" caption="Commands for &#8220;turtle operations&#8221;" />
+  <package key="pst-tvz" name="pst-tvz" caption="Draw trees with more than one root node, using PSTricks" />
+  <package key="pst-uml" name="pst-uml" caption="UML diagrams with PSTricks" />
+  <package key="pst-vectorian" name="pst-vectorian" caption="Printing ornaments" />
+  <package key="pst-vehicle" name="pst-vehicle" caption="A PSTricks package for rolling vehicles on graphs of mathematical functions" />
+  <package key="pst-venn" name="pst-venn" caption="A PSTricks package for drawing Venn sets" />
+  <package key="pst-vowel" name="pst-vowel" caption="Enable arrows showing diphthongs on vowel charts" />
+  <package key="pst-vue3d" name="pst-vue3d" caption="Draw perspective views of three dimensional objects" />
+  <package key="pst-xkey" name="pst-xkey" caption="Key-value syntax for PSTricks packages" />
+  <package key="pst2pdf" name="pst2pdf" caption="A script to compile PSTricks documents via pdfTeX" />
+  <package key="pstdoc" name="pstdoc" caption="A tool for PSTricks documentation" />
+  <package key="pstex" name="pstex" caption="Processor for including figures in LaTeX" />
+  <package key="pstoedit" name="pstoedit" caption="Translate PostScript and PDF to other formats" />
+  <package key="pstool" name="pstool" caption="Support for psfrag within pdfLaTeX" />
+  <package key="pstotext" name="pstotext" caption="Extract ASCII from PostScript and PDF" />
+  <package key="pstrees" name="pstrees" caption="Construct linguistics trees using a preprocessor" />
+  <package key="pstricks-add" name="pstricks-add" caption="A collection of add-ons and bugfixes for PSTricks" />
+  <package key="pstricks-base" name="pstricks-base" caption="PostScript macros for TeX" />
+  <package key="pstricks-calcnotes" name="pstricks-calcnotes" caption="Use of PSTricks in calculus lecture notes" />
+  <package key="pstricks-examples" name="pstricks-examples" caption="PSTricks examples" />
+  <package key="pstricks-examples-7" name="pstricks-examples-7" caption="PSTricks examples files of the 7th edition of the book PSTricks" />
+  <package key="pstricks-examples-en" name="pstricks-examples-en" caption="Examples from PSTricks book (English edition)" />
+  <package key="pstring" name="pstring" caption="Typeset sequences with justification pointers" />
+  <package key="psu-thesis" name="psu-thesis" caption="Package for writing a thesis at Penn State University" />
+  <package key="psutils" name="psutils" caption="PostScript utilities" />
+  <package key="ptex" name="ptex" caption="A TeX system for publishing in Japanese" />
+  <package key="ptex-base" name="ptex-base" caption="Plain TeX format for pTeX and e-pTeX" />
+  <package key="ptex-fontmaps" name="ptex-fontmaps" caption="Font maps and configuration tools for Japanese/Chinese/Korean fonts with (u)ptex" />
+  <package key="ptex-fonts" name="ptex-fonts" caption="Fonts for use with pTeX" />
+  <package key="ptex-manual" name="ptex-manual" caption="Japanese pTeX manual" />
+  <package key="ptex-texmf" name="ptex-texmf" caption="Macro and other extensions for use with PTeX" />
+  <package key="ptex2pdf" name="ptex2pdf" caption="Convert Japanese TeX documents to PDF" />
+  <package key="ptext" name="ptext" caption="A &#8216;lipsum&#8217; for Persian" />
+  <package key="pthyphs" name="pthyphs" caption="Hyphenation Patterns for Portuguese" />
+  <package key="ptlatexcommands" name="ptlatexcommands" caption="LaTeX to commands in Portuguese" />
+  <package key="ptmsc" name="ptmsc" caption="Addon to the newtx package" />
+  <package key="ptolemaicastronomy" name="ptolemaicastronomy" caption="Diagrams of sphere models for variably strict conditionals (Lewis counterfactuals)" />
+  <package key="ptptex" name="ptptex" caption="Macros for &apos;Progress of Theoretical Physics&apos;" />
+  <package key="ptsans" name="ptsans" caption="PT Sans font and LaTeX support" />
+  <package key="ptserif" name="ptserif" caption="PT Serif font and LaTeX support" />
+  <package key="punk" name="punk" caption="Donald Knuth&apos;s punk font" />
+  <package key="punk-latex" name="Punk-LaTeX" caption="LaTeX support for punk fonts" />
+  <package key="punknova" name="punknova" caption="OpenType version of Knuth&apos;s Punk font" />
+  <package key="purifyeps" name="purifyeps" caption="Make EPS work with both LaTeX/dvips and pdfLaTeX" />
+  <package key="puyotikz" name="PuyoTikZ" caption="Quickly typeset board states of Puyo Puyo games" />
+  <package key="pwebmac" name="pwebmac" caption="Consolidated WEB macros for DVI and PDF output" />
+  <package key="pwt" name="PWT" caption="An outline of publishing with TeX" />
+  <package key="pxbase" name="pxbase" caption="Tools for use with (u)pLaTeX" />
+  <package key="pxchfon" name="pxchfon" caption="Japanese font setup for pLaTeX and upLaTeX" />
+  <package key="pxcjkcat" name="pxcjkcat" caption="LaTeX interface for the CJK category codes of upTeX" />
+  <package key="pxfonts" name="pxfonts" caption="Palatino-like fonts in support of mathematics" />
+  <package key="pxgreeks" name="pxgreeks" caption="Shape selection for PX fonts Greek letters" />
+  <package key="pxjahyper" name="pxjahyper" caption="Hyperref support for pLaTeX" />
+  <package key="pxjodel" name="pxjodel" caption="Help change metrics of fonts from japanese-otf" />
+  <package key="pxpgfmark" name="pxpgfmark" caption="e-pTeX driver for PGF inter-picture connections" />
+  <package key="pxpic" name="pxpic" caption="Draw pixel pictures" />
+  <package key="pxrubrica" name="pxrubrica" caption="Ruby annotations according to JIS X 4051" />
+  <package key="pxtatescale" name="pxtatescale" caption="Patch to graphics driver for scaling in vertical direction of pTeX" />
+  <package key="pxtxalfa" name="pxtxalfa" caption="Virtual maths alphabets based on pxfonts and txfonts" />
+  <package key="pxufont" name="pxufont" caption="Emulate non-Unicode Japanese fonts using Unicode fonts" />
+  <package key="pybib" name="pybib" caption="Command line utilities to check, sort, merge BibTeX files" />
+  <package key="pybliographer" name="pybliographer" caption="A tool for managing bibliographic databases" />
+  <package key="pydocstrip" name="pydocstrip" caption="Scripted version of LaTeX docstrip" />
+  <package key="pygmentex" name="pygmentex" caption="Use Pygments to format code listings in documents" />
+  <package key="pyluatex" name="PyLuaTeX" caption="Execute Python code on the fly in your LaTeX documents" />
+  <package key="python" name="python" caption="Embed Python code in LaTeX" />
+  <package key="pythonhighlight" name="pythonhighlight" caption="Highlighting of Python code, based on the listings package" />
+  <package key="pythonimmediate" name="pythonimmediate" caption="Library to run Python code" />
+  <package key="pythontex" name="pythontex" caption="Run Python from within a document, typesetting the results" />
+  <package key="pzccal" name="pzccal" caption="Zapf Chancery as calligraphic math alphabet" />
+  <package key="qbibman" name="qbibman" caption="Graphical frontend to BibTool" />
+  <package key="qcircuit" name="qcircuit" caption="Macros to generate quantum ciruits" />
+  <package key="qcm" name="QCM" caption="A LaTeX2e class for making multiple choice questionnaires" />
+  <package key="qdtexvpl" name="qdtexvpl" caption="Quick and dirty virtual font creation" />
+  <package key="qed" name="qed" caption="Produce an &quot;end-of-proof&quot; mark" />
+  <package key="qfig" name="qfig" caption="DOS graphics program" />
+  <package key="qfonts" name="qfonts" caption="PostScript (Adobe Type 1) fonts in QX layout" />
+  <package key="qm" name="qm" caption="Commands for bras and kets and the like" />
+  <package key="qms" name="qms" caption="VMS tools for controlling QMS printers" />
+  <package key="qobitree" name="qobitree" caption="LaTeX macros for typesetting trees" />
+  <package key="qrbill" name="qrbill" caption="Create QR bills using LaTeX" />
+  <package key="qrcode" name="qrcode" caption="Generate QR codes in LaTeX" />
+  <package key="qrcstamps" name="qrcstamps" caption="Create QR codes using stamps" />
+  <package key="qsharp" name="qsharp" caption="Syntax highlighting for the Q# language" />
+  <package key="qstest" name="qstest" caption="Bundle for unit tests and pattern matching" />
+  <package key="qsymbols" name="qsymbols" caption="Maths symbol abbreviations" />
+  <package key="qtree" name="qtree" caption="Draw tree structures" />
+  <package key="qualitype" name="qualitype" caption="The QualiType font collection " />
+  <package key="quantikz" name="quantikz" caption="Draw quantum circuit diagrams" />
+  <package key="quantumarticle" name="quantumarticle" caption="Document class for submissions to the Quantum journal" />
+  <package key="quattrocento" name="quattrocento" caption="Quattrocento and Quattrocento Sans fonts with LaTeX support" />
+  <package key="quickreaction" name="quickreaction" caption="A simple and fast way to typeset chemical reactions" />
+  <package key="quicktype" name="quicktype" caption="LaTeX package for quick typesetting" />
+  <package key="quiver" name="quiver" caption="Draw commutative diagrams exported from https://q.uiver.app" />
+  <package key="quiz2socrative" name="quiz2socrative" caption="Prepare questions for socrative quizzes" />
+  <package key="quizztex" name="quizztex" caption="Create quizzes like in TV shows" />
+  <package key="quotation" name="quotation" caption="Typeset an attributed quotation" />
+  <package key="quotchap" name="quotchap" caption="Decorative chapter headings" />
+  <package key="quote" name="quote" caption="Match pairs of double-quote characters" />
+  <package key="quotes" name="quotes" caption="Smart double quotes in LaTeX input" />
+  <package key="quoting" name="quoting" caption="Consolidated environment for displayed text" />
+  <package key="quotmark" name="quotmark" caption="Consistent quote marks" />
+  <package key="quran" name="quran" caption="An easy way to typeset any part of The Holy Quran" />
+  <package key="quran-bn" name="quran-bn" caption="Bengali translations to the quran package" />
+  <package key="quran-de" name="quran-de" caption="German translations to the  quran package" />
+  <package key="quran-ur" name="quran-ur" caption="Urdu translations to the  quran package" />
+  <package key="qyxf-book" name="qyxf-book" caption="Book Template for Qian Yuan Xue Fu" />
+  <package key="r-und-s" name="r_und_s" caption="Chemical hazard codes" />
+  <package key="r2bib" name="r2bib" caption="Convert refer and EndNote files to BibTeX" />
+  <package key="ragged" name="ragged" caption="Generic ragged left and ragged right options" />
+  <package key="ragged2e" name="ragged2e" caption="Alternative versions of &#8220;ragged&#8221;-type commands" />
+  <package key="raggedr" name="raggedr" caption="Set an entire document raggedright" />
+  <package key="rail" name="rail" caption="Syntax specification in EBNF" />
+  <package key="rake4latex" name="rake4latex" caption="A rake-based tool to compile LaTeX projects" />
+  <package key="raleway" name="raleway" caption="Use Raleway with TeX(-alike) systems" />
+  <package key="ran_toks" name="ran_toks" caption="Randomise token strings" />
+  <package key="randbild" name="randbild" caption="Marginal pictures" />
+  <package key="random" name="random" caption="Generating &#8220;random&#8221; numbers in TeX" />
+  <package key="randomlist" name="randomlist" caption="Deal with database, loop, and random in order to build personalized exercises" />
+  <package key="randomwalk" name="randomwalk" caption="Random walks using TikZ" />
+  <package key="randtext" name="randtext" caption="Randomise the order of characters in strings" />
+  <package key="rangecite" name="rangecite" caption="Will turn a range of citations into something like [1..3]" />
+  <package key="rangen" name="rangen" caption="Generate random integers, rational and decimal numbers" />
+  <package key="rank-2-roots" name="rank-2-roots" caption="Draw (mathematical) rank 2 root systems" />
+  <package key="ransom" name="ransom" caption="A &quot;very bad typewriter&quot; font" />
+  <package key="ratex" name="ratex" caption="A package for German lawyers" />
+  <package key="ratexdb" name="ratexdb" caption="Database reports using LaTeX and Ruby" />
+  <package key="rawfonts" name="rawfonts" caption="Low level font compatibility mode for LaTeX" />
+  <package key="rawprint" name="rawprint" caption="Print raw Russian text" />
+  <package key="rbt-mathnotes" name="rbt-mathnotes" caption="Rebecca Turner&#8217;s personal macros and styles for typesetting mathematics notes" />
+  <package key="rccol" name="rccol" caption="Decimal-centered optionally rounded numbers in tabular" />
+  <package key="rcs" name="rcs" caption="Use RCS (revision control system) tags in LaTeX documents" />
+  <package key="rcs-multi" name="rcs-multi" caption="Typeset RCS version control in multiple-file documents" />
+  <package key="rcs-pln" name="rcs-pln" caption="RCS data in Plain TeX documents" />
+  <package key="rcsinfo" name="rcsinfo" caption="Support for the revision control system" />
+  <package key="readablecv" name="ReadableCV" caption=" A highly readable and good looking CV and letter class" />
+  <package key="readarray" name="readarray" caption="Read, store and recall array-formatted data" />
+  <package key="readprov" name="readprov" caption="Provides GetFileInfo without the need to load the file" />
+  <package key="realboxes" name="realboxes" caption="Variants of common box-commands that read their content as real box and not as macro argument" />
+  <package key="realcalc" name="realcalc" caption="Macros for real arithmetic calculations" />
+  <package key="realhats" name="realhats" caption="Put real hats on symbols instead of ^" />
+  <package key="realscripts" name="realscripts" caption="Access OpenType subscript and superscript glyphs" />
+  <package key="realtranspose" name="realtranspose" caption="The &#8220;real&#8221; way to transpose a Matrix" />
+  <package key="rec-thy" name="rec-thy" caption="Commands to typeset recursion theory papers" />
+  <package key="recipe" name="recipe" caption="A LaTeX class to typeset recipes" />
+  <package key="recipebook" name="recipebook" caption="Typeset 5.5&quot; x 8&quot; recipes for browsing or printing" />
+  <package key="recipecard" name="recipecard" caption="Typeset recipes in note-card-sized boxes" />
+  <package key="recorder-fingering" name="recorder-fingering" caption="Package to display recorder fingering diagrams" />
+  <package key="rectopma" name="rectopma" caption="Recycle top matter" />
+  <package key="recycle" name="recycle" caption="A font providing the &quot;recyclable&quot; logo" />
+  <package key="redefine" name="redefine" caption="Conditional macro, etc., definitions" />
+  <package key="redis" name="redis" caption="A Hebrew font" />
+  <package key="redit" name="REdit" caption="Menu-based editor" />
+  <package key="refcheck" name="refcheck" caption="Check references (in figures, table, equations, etc)" />
+  <package key="refcount" name="refcount" caption="Counter operations with label references" />
+  <package key="refenums" name="refenums" caption="Define named items and provide back-references with that name" />
+  <package key="refer" name="refer" caption="Convert a BibTeX bibliography to refer format" />
+  <package key="refer-tools" name="refer-tools" caption="Convert between refer format and BibTeX format" />
+  <package key="references" name="references" caption="Bibliographic software supporting LaTeX/BibTeX" />
+  <package key="reflectgraphics" name="reflectgraphics" caption="Techniques for reflecting graphics" />
+  <package key="refman" name="refman" caption="Format technical reference manuals" />
+  <package key="refreshpdf" name="refreshpdf" caption="Refresh PDF files &quot;remotely&quot;" />
+  <package key="refstyle" name="refstyle" caption="Advanced formatting of cross references" />
+  <package key="regcount" name="regcount" caption="Display the allocation status of the TeX registers" />
+  <package key="regexpatch" name="regexpatch" caption="High level patching of commands" />
+  <package key="register" name="register" caption="Typeset programmable elements in digital hardware (registers)" />
+  <package key="regstats" name="regstats" caption="Information about register use" />
+  <package key="reledmac" name="reledmac" caption="Typeset scholarly editions" />
+  <package key="reledpar" name="reledpar" caption="Typeset scholarly editions in parallel texts" />
+  <package key="relenc" name="relenc" caption="A &quot;relaxed&quot; font encoding" />
+  <package key="relsize" name="relsize" caption="Set the font size relative to the current font size" />
+  <package key="removefr" name="removefr" caption="Remove from counter-reset lists" />
+  <package key="remreset" name="remreset" caption="Remove counters from reset list" />
+  <package key="renditions" name="renditions" caption="Multiple versions from the same content" />
+  <package key="reotex" name="reotex" caption="Draw Reo Channels and Circuits" />
+  <package key="repeat" name="repeat" caption="Repeat execution of macros" />
+  <package key="repeatindex" name="repeatindex" caption="Repeat items in an index after a page or column break" />
+  <package key="repere" name="repere" caption="MetaPost macros for secondary school mathematics teachers" />
+  <package key="repltext" name="repltext" caption="Control how text gets copied from a PDF file" />
+  <package key="report" name="report" caption="Typeset a multi-chapter report" />
+  <package key="required" name="required" caption="Packages &quot;required&quot; of a LaTeX distribution" />
+  <package key="rerunfilecheck" name="rerunfilecheck" caption="Checksum based rerun checks on auxiliary files" />
+  <package key="res" name="res" caption="A resum&#233; class" />
+  <package key="rescansync" name="rescansync" caption="Re-scan tokens with synctex information" />
+  <package key="resizegather" name="resizegather" caption="Automatically resize overly large equations" />
+  <package key="resmes" name="resmes" caption="Measure restriction symbol in LaTeX" />
+  <package key="resolsysteme" name="ResolSysteme" caption="Work on linear systems using xint or pyluatex" />
+  <package key="resphilosophica" name="resphilosophica" caption="Typeset articles for the journal Res Philosophica" />
+  <package key="rest-api" name="rest-api" caption="Describing a rest api" />
+  <package key="resumecls" name="resumecls" caption="Typeset a resume both in English and Chinese" />
+  <package key="resumemac" name="resumemac" caption="Plain TeX macros for resum&#233;s" />
+  <package key="returntogrid" name="returntogrid" caption="Semi-automatic grid typesetting" />
+  <package key="reverxii" name="reverxii" caption="Playing Reversi in TeX" />
+  <package key="revnum" name="revnum" caption="Reverse enumerate" />
+  <package key="revquantum" name="revquantum" caption="Hacks to make writing quantum papers for revtex4-1 less painful" />
+  <package key="revtex" name="revtex" caption="Styles for various Physics Journals" />
+  <package key="revtex4-0" name="revtex4-0" caption="Styles for various Physics Journals (old version)" />
+  <package key="revtex4-1" name="revtex4-1" caption="Styles for various Physics Journals" />
+  <package key="rfc2bib" name="rfc2bib" caption="Generate BibTeX entries for IETF RFCs" />
+  <package key="rfil" name="rfil" caption="Ruby font installer library" />
+  <package key="rgb" name="RGB" caption="Tables of RGB colour parameters" />
+  <package key="rgltxdoc" name="rgltxdoc" caption="Common code for documentation of the author&#8217;s packages" />
+  <package key="ribbonproofs" name="ribbonproofs" caption="Drawing ribbon proofs" />
+  <package key="richtext" name="richtext" caption="Create rich text strings" />
+  <package key="rit-fonts" name="rit-fonts" caption="Malayalam fonts by Rachana Institute of Typography (RIT)" />
+  <package key="rjlparshap" name="rjlparshap" caption="Support for use of \parshape in LaTeX" />
+  <package key="rlepsf" name="rlepsf" caption="Rewrite labels in EPS graphics" />
+  <package key="rmannot" name="rmannot" caption="Create rich media annotations in a PDF file" />
+  <package key="rmathbr" name="rmathbr" caption="Repeating of math operator at the broken line and the new line in inline equations" />
+  <package key="rmligs" name="rmligs" caption="Remove incorrect ligatures in German documents" />
+  <package key="rmpage" name="rmpage" caption="A package to help change page layout parameters in LaTeX" />
+  <package key="rmthm" name="rmthm" caption="Use a roman font for theorem statements" />
+  <package key="rnototex" name="rnototex" caption="Convert from Runoff to LaTeX" />
+  <package key="robot-man" name="Robot Man" caption="A fun demo of AcroTeX eDucation Bundle facilities" />
+  <package key="robotarm" name="robotarm" caption="TikZ powered LaTeX package to draw parameterized 2D robot arms" />
+  <package key="roboto" name="roboto" caption="Support for the Roboto family of fonts" />
+  <package key="robustcommand" name="robustcommand" caption="Declare robust command, with \newcommand checks" />
+  <package key="robustindex" name="robustindex" caption="Create index with pagerefs" />
+  <package key="rojud" name="rojud" caption="A font with the images of the counties of Romania" />
+  <package key="romanbar" name="romanbar" caption="Write roman number with &quot;bars&quot;" />
+  <package key="romanbarpagenumber" name="romanbarpagenumber" caption="Typesetting roman page numbers" />
+  <package key="romandeadf" name="romandeadf" caption="Romande ADF fonts and LaTeX support" />
+  <package key="romaniantex" name="romaniantex" caption="LaTeX support for Romanian" />
+  <package key="romanneg" name="romanneg" caption="Roman page numbers negative" />
+  <package key="romannum" name="romannum" caption="Generate roman numerals instead of arabic digits" />
+  <package key="rorlink" name="rorlink" caption="Create ROR symbols which links to the given ROR-IDs" />
+  <package key="rosario" name="rosario" caption="Using the free Rosario fonts with LaTeX" />
+  <package key="rotate" name="rotate" caption="Rotate TeX boxes" />
+  <package key="rotate-textures" name="rotate-textures" caption="Box rotation macros for Textures" />
+  <package key="rotating" name="rotating" caption="Rotation tools, including rotated full-page floats" />
+  <package key="rotchiffre" name="rotchiffre" caption="Perform simple rotation cyphers" />
+  <package key="rotfloat" name="rotfloat" caption="Rotate floats" />
+  <package key="rotpages" name="rotpages" caption="Typeset sets of pages upside-down and backwards" />
+  <package key="rotunda" name="rotunda" caption="Rotunda manuscript book-hand font" />
+  <package key="rouequestions" name="RoueQuestions" caption="Draw a &#8220;question wheel&#8221; (roue de questions)" />
+  <package key="roundbox" name="roundbox" caption="Round boxes in LaTeX" />
+  <package key="roundrect" name="roundrect" caption="MetaPost macros for highly configurable rounded rectangles (optionally with text)" />
+  <package key="rpg-module" name="rpg-module" caption="Typesetting old-school Dungeons and Dragons modules" />
+  <package key="rplain" name="rplain" caption="Redefines the plain pagestyle" />
+  <package key="rputover" name="rputover" caption="Place text over PSTricks objects without obscuring background colors" />
+  <package key="rrgtrees" name="RRGtrees" caption="Linguistic tree diagrams for Role and Reference Grammar (RRG) with LaTeX" />
+  <package key="rsc" name="rsc" caption="BibTeX style for use with RSC journals" />
+  <package key="rsfs" name="rsfs" caption="Ralph Smith&apos;s Formal Script font" />
+  <package key="rsfso" name="rsfso" caption="A mathematical calligraphic font based on rsfs" />
+  <package key="rst" name="RST" caption="Drawing rhetorical structure analysis diagrams in LaTeX" />
+  <package key="rterface" name="rterface" caption="Access to R analysis from within a document" />
+  <package key="rtf2latex2e" name="rtf2latex2e" caption="Convert Rich Text Format (RTF) files to LaTeX2e" />
+  <package key="rtf2tex" name="rtf2tex" caption="Convert RTF to TeX" />
+  <package key="rtkinenc" name="rtkinenc" caption="Input encoding with fallback procedures" />
+  <package key="rtklage" name="rtklage" caption="Make suit details for German courts" />
+  <package key="rtsched" name="rtsched" caption="Draw Real-Time scheduling (GANTT) charts" />
+  <package key="rubik" name="rubik" caption="Document Rubik cube configurations and rotation sequences" />
+  <package key="rubikcube" name="rubikcube" caption="Typeset Rubik cubes and move notation" />
+  <package key="rubikrotation" name="rubikrotation" caption="Processes a sequence of Rubik rotations" />
+  <package key="rubiktwocube" name="rubiktwocube" caption="Typeset Rubik TwoCubes and move notation" />
+  <package key="ruhyphen" name="ruhyphen" caption="Russian hyphenation" />
+  <package key="rule-d" name="rule-d" caption="Provide LaTeX3 commands for typesetting rules" />
+  <package key="ruled-tables" name="ruled-tables" caption="Plain TeX table macros, with ruled capability" />
+  <package key="ruler" name="ruler" caption="A typographic ruler for TeX" />
+  <package key="rulerbox" name="rulerbox" caption="Draw rulers around a box" />
+  <package key="rulercompass" name="rulercompass" caption="A TikZ library for straight-edge and compass diagrams" />
+  <package key="runcode" name="runcode" caption="Execute foreign source code and embed the result in the pdf file" />
+  <package key="rune" name="rune" caption="Two rune fonts" />
+  <package key="runic" name="runic" caption="Fonts for Anglo-Saxon futharc script" />
+  <package key="runtex" name="runtex" caption="Windows program to run TeX variant and various utils as needed" />
+  <package key="russ" name="russ" caption="LaTeX in Russian, without babel" />
+  <package key="russian-help" name="russian-help" caption="LaTeX help in Russian" />
+  <package key="rustic" name="rustic" caption="Roman Rustic manuscript book-hand font" />
+  <package key="rutitlepage" name="rutitlepage" caption="Radboud University Titlepage Package" />
+  <package key="rviewport" name="rviewport" caption="Relative Viewport for Graphics Inclusion" />
+  <package key="rvwrite" name="rvwrite" caption="Increase the number of available output streams in LaTeX" />
+  <package key="ryersonsgsthesis" name="ryersonSGSThesis" caption="Ryerson School of Graduate Studies thesis template" />
+  <package key="ryethesis" name="ryethesis" caption="Class for Ryerson Unversity Graduate School requirements" />
+  <package key="s2latex" name="s2latex" caption="A scribe to LaTeX converter" />
+  <package key="sa-tikz" name="sa-tikz" caption="TikZ library to draw switching architectures" />
+  <package key="sacsymb" name="sacsymb" caption="&#8220;Sacred Symbols&#8221; prepared with TikZ" />
+  <package key="sae" name="sae" caption="Typeset an SAE technical paper" />
+  <package key="saferef" name="saferef" caption="Safer references through strong typing of references" />
+  <package key="sageep" name="sageep" caption="Format papers for the annual meeting of EEGS" />
+  <package key="sagetex" name="SageTeX" caption="Embed Sage code and plots into LaTeX" />
+  <package key="sam2p" name="sam2p" caption="Convert bitmap formats to compact PS/PDF" />
+  <package key="samples" name="samples" caption="Samples of Plain TeX coding" />
+  <package key="sanhyph" name="sanhyph" caption="Sanskrit hyphenation patterns" />
+  <package key="sanitize-umlaut" name="sanitize-umlaut" caption="Sanitize umlauts for MakeIndex and pdfLaTeX" />
+  <package key="sankey" name="sankey" caption="Draw Sankey diagrams with TikZ" />
+  <package key="sans" name="sans" caption="Exchange Roman and Sans faces in a document" />
+  <package key="sanskrit" name="sanskrit" caption="Sanskrit support" />
+  <package key="sanskrit-t1" name="sanskrit-t1" caption="Type 1 version of &#8216;skt&#8217; fonts for Sanskrit" />
+  <package key="sansmath" name="sansmath" caption="Maths in a sans font" />
+  <package key="sansmathaccent" name="sansmathaccent" caption="Correct placement of accents in sans-serif maths" />
+  <package key="sansmathfonts" name="sansmathfonts" caption="Extended Computer Modern sans serif fonts" />
+  <package key="sapthesis" name="sapthesis" caption="Typeset theses for Sapienza-University, Rome" />
+  <package key="sarabian" name="sarabian" caption="Archaic South Arabian script font" />
+  <package key="sasnrdisplay" name="SASnRdisplay" caption="Typeset SAS or R code or output" />
+  <package key="sauerj" name="sauerj" caption="A bundle of utilities by Jonathan Sauer" />
+  <package key="sauter" name="sauter" caption="Wide range of design sizes for CM fonts" />
+  <package key="sauterfonts" name="sauterfonts" caption="Use Sauter&apos;s fonts in LaTeX" />
+  <package key="saveenv" name="saveenv" caption="Save environment content verbatim" />
+  <package key="savefnmark" name="savefnmark" caption="Save name of the footnote mark for reuse" />
+  <package key="savesym" name="savesym" caption="Redefine symbols where names conflict" />
+  <package key="savetrees" name="savetrees" caption="Optimise the use of each page of a LaTeX document" />
+  <package key="sbtex" name="sbtex" caption="A compact TeX distribution for MS-DOS" />
+  <package key="sc21" name="sc21" caption="Title page for the old ISO TC97/SC21 committee" />
+  <package key="sc21-wg1" name="sc21-wg1" caption="Title page for the old ISO TC97/SC21/WG1 working group" />
+  <package key="scale" name="scale" caption="Scale document by sqrt(2) or magstep(2)" />
+  <package key="scalebar" name="scalebar" caption="Create scalebars for maps, diagrams or photos" />
+  <package key="scalefnt" name="scalefnt" caption="Rescale fonts to arbitrary sizes" />
+  <package key="scalerel" name="scalerel" caption="Constrained scaling and stretching of objects" />
+  <package key="scanpages" name="scanpages" caption="Support importing and embellishing scanned documents" />
+  <package key="schedule" name="schedule" caption="Weekly schedules" />
+  <package key="schedule209" name="schedule209" caption="Typeset schedules" />
+  <package key="schemabloc" name="schemabloc" caption="Draw block diagrams, using TikZ" />
+  <package key="schemata" name="schemata" caption="Print topical diagrams" />
+  <package key="schemetex" name="schemeTeX" caption="Typesetting Scheme programs with LaTeX" />
+  <package key="schemeweb" name="schemeweb" caption="Simple support for literate programming in Lisp" />
+  <package key="schola-otf" name="schola-otf" caption="Using the OpenType fonts TeX Gyre schola" />
+  <package key="scholax" name="ScholaX" caption="Extension of TeXGyreSchola (New Century Schoolbook) with math support" />
+  <package key="schooldocs" name="schooldocs" caption="Various layout styles for school documents" />
+  <package key="schule" name="schule" caption="Support for teachers at German schools" />
+  <package key="schulmathematik" name="schulmathematik" caption="Commands and document classes for German-speaking teachers of mathematics and physics" />
+  <package key="schulschriften" name="schulschriften" caption="German &#8220;school scripts&#8221; from Suetterlin to the present day" />
+  <package key="schwalbe-chess" name="schwalbe-chess" caption="Typeset the German chess magazine &#8220;Die Schwalbe&#8221;" />
+  <package key="schwell" name="schwell" caption="Calligraphic font for typesetting handwriting in Schwell style" />
+  <package key="scientific-thesis-cover" name="scientific-thesis-cover" caption="Provides cover page and affirmation at the end of a thesis" />
+  <package key="scientificauthor" name="scientificauthor" caption="Visual LaTeX editor" />
+  <package key="scientificpaper" name="scientificpaper" caption="Format a scientific paper for journal publication" />
+  <package key="scientificviewer" name="scientificviewer" caption="MacKichan software viewer" />
+  <package key="scikgtex" name="SciKGTeX" caption="Mark research contributions in scientific documents and embed them in PDF metadata" />
+  <package key="sciposter" name="sciposter" caption="Make posters of ISO A3 size and larger" />
+  <package key="sciwordconv" name="SciWordConv" caption="Use Scientific Word/WorkPlace files with another TeX" />
+  <package key="sclang-prettifier" name="sclang-prettifier" caption="Prettyprinting SuperCollider source code" />
+  <package key="scmac" name="scmac" caption="Typeset scripts with Plain TeX" />
+  <package key="scontents" name="scontents" caption="Stores LaTeX contents in memory or files" />
+  <package key="scorecard" name="scorecard" caption="Format a Baseball scorecard" />
+  <package key="scrabble" name="Scrabble" caption="Commands for Scrabble boards" />
+  <package key="scraddr" name="scraddr" caption="Provide data from scrlttr2&apos;s address files" />
+  <package key="scrambledenvs" name="scrambledenvs" caption="Create and print scrambled environments" />
+  <package key="scrartcl" name="scrartcl" caption="Koma-Script &#8216;article&#8217; class" />
+  <package key="scratch" name="scratch" caption="Draw programs like &#8220;scratch&#8221;" />
+  <package key="scratch3" name="scratch3" caption="Draw programs like &#8220;scratch&#8221;" />
+  <package key="scratchx" name="ScratchX" caption="Include Scratch programs in LaTeX documents" />
+  <package key="scrbase" name="scrbase" caption="Provide basic features for KOMA-Script" />
+  <package key="scrbook" name="scrbook" caption="Koma-Script &#8216;book&#8217; class" />
+  <package key="scrdate" name="scrdate" caption="Calendar date operations" />
+  <package key="screen" name="screen" caption="Prepare a document for a simple previewer" />
+  <package key="screenplay" name="screenplay" caption="A class file to typeset screenplays" />
+  <package key="screenplay-pkg" name="screenplay-pkg" caption="Package version of the screenplay document class" />
+  <package key="scrextend" name="scrextend" caption="Use of components of KOMA-Script by other packages" />
+  <package key="scrindex" name="scrindex" caption="Make index package work with Koma-script classes" />
+  <package key="script" name="script" caption="Variant report and book styles" />
+  <package key="script-font" name="script-font" caption="Handwriting font" />
+  <package key="scriptfonts" name="scriptfonts" caption="A summary of mathematical script fonts for LaTeX users" />
+  <package key="scripttex" name="ScriptTeX" caption="Macros for scripts and screenplays" />
+  <package key="scripture" name="scripture" caption="A LaTeX style for typesetting Bible quotations" />
+  <package key="scrjrnl" name="scrjrnl" caption="Typeset diaries or journals" />
+  <package key="scrjura" name="scrjura" caption="Koma-Script support for lawyers, etc" />
+  <package key="scrlayer" name="scrlayer" caption="Manage text &#8216;layers&#8217; within Koma-Script" />
+  <package key="scrlayer-fancyhdr" name="scrlayer-fancyhdr" caption="Combining package fancyhdr with KOMA-Script&#8217;s scrlayer" />
+  <package key="scrlayer-notecolumn" name="scrlayer-notecolumn" caption="Control note columns parallel to the main text" />
+  <package key="scrlayer-scrpage" name="scrlayer-scrpage" caption="Define and manage page styles" />
+  <package key="scrletter" name="scrletter" caption="Letter extention to KOMA-Script classes" />
+  <package key="scrlfile" name="scrlfile" caption="Installation control for koma-script packages" />
+  <package key="scrlttr2" name="scrlttr2" caption="Koma-Script &#8216;letter&#8217; class" />
+  <package key="scrlttr2copy" name="scrlttr2copy" caption="A letter class option file for the automatic creation of copies" />
+  <package key="scrpage2" name="scrpage2" caption="Control of page headers and footers in LaTeX" />
+  <package key="scrreprt" name="scrreprt" caption="Koma-Script &#8216;report&#8217; class" />
+  <package key="scrtime" name="scrtime" caption="Show the time of a LaTeX run" />
+  <package key="scrwfile" name="scrwfile" caption="Use LaTeX .aux file in place of \newrite files" />
+  <package key="scsnowman" name="scsnowman" caption="Snowman variants using TikZ" />
+  <package key="scyrillic" name="scyrillic" caption="A family of cyrillic fonts" />
+  <package key="sdaps" name="sdaps" caption="LaTeX support files for SDAPS" />
+  <package key="sdrt" name="sdrt" caption="Macros for Segmented Discourse Representation Theory" />
+  <package key="sduthesis" name="sduthesis" caption="Thesis Template of Shandong University" />
+  <package key="se2thesis" name="se2thesis" caption="A Thesis Class for the Chair of Software Engineering II at the University of Passau, Germany" />
+  <package key="secdot" name="secdot" caption="Section numbers with trailing dots" />
+  <package key="seceqn" name="seceqn" caption="Number theorems by section" />
+  <package key="secnum" name="secnum" caption="A macro to format section numbering intuitively" />
+  <package key="secret" name="secret" caption="Put security classification marks in a document" />
+  <package key="section" name="section" caption="Modifying section commands in LaTeX" />
+  <package key="sectionbox" name="sectionbox" caption="Create fancy boxed ((sub)sub)sections" />
+  <package key="sectionbreak" name="sectionbreak" caption="LaTeX support for section breaks" />
+  <package key="sectsty" name="sectsty" caption="Control sectional headers" />
+  <package key="seealso" name="seealso" caption="Improve the performance of \see macros with makeindex" />
+  <package key="sehyph" name="sehyph" caption="Hyphenation patterns for Swedish" />
+  <package key="selectp" name="selectp" caption="Select pages to be output" />
+  <package key="selectpage" name="selectpage" caption="Select pages to be output from a document" />
+  <package key="selinput" name="selinput" caption="Semi-automatic detection of input encoding" />
+  <package key="selnolig" name="selnolig" caption="Selectively disable typographic ligatures" />
+  <package key="semantex" name="SemanTeX" caption="Semantic, keyval-based mathematics" />
+  <package key="semantic" name="semantic" caption="Help for writing programming language semantics" />
+  <package key="semantic-markup" name="semantic-markup" caption="Meaningful semantic markup in the spirit of the Text Encoding Initiative" />
+  <package key="semaphor" name="semaphor" caption="Semaphore alphabet font" />
+  <package key="semesterplanner" name="semesterplanner" caption="Create beautiful semester timetables and more" />
+  <package key="seminar" name="seminar" caption="Make overhead slides" />
+  <package key="semioneside" name="semioneside" caption="Put only special contents on left-hand pages in two sided layout" />
+  <package key="semproc" name="semproc" caption="Seminar proceedings" />
+  <package key="semtex" name="SemTeX" caption="Deals with stripped SemanTeX documents" />
+  <package key="semtrans" name="semtrans" caption="Transliteration of semitic languages" />
+  <package key="sentences" name="sentences" caption="Numbered lists for sentences" />
+  <package key="sepfootnotes" name="sepfootnotes" caption="Support footnotes and endnotes from separate files" />
+  <package key="sepnum" name="sepnum" caption="Print numbers in a &quot;friendly&quot; format" />
+  <package key="seqsplit" name="seqsplit" caption="Split long sequences of characters in a neutral way" />
+  <package key="serbian-apostrophe" name="serbian-apostrophe" caption="Commands for Serbian words with apostrophes" />
+  <package key="serbian-book" name="serbian-book" caption="Support for use of memoir in Serbian" />
+  <package key="serbian-date-lat" name="serbian-date-lat" caption="Updated date typesetting for Serbian" />
+  <package key="serbian-def-cyr" name="serbian-def-cyr" caption="Serbian cyrillic localization" />
+  <package key="serbian-lig" name="serbian-lig" caption="Control ligatures in Serbian" />
+  <package key="serbianpart" name="serbianpart" caption="Redefines \thepart to be used in Roman lettered Serbian" />
+  <package key="serial" name="serial" caption="Generate serial letters" />
+  <package key="sesamanuel" name="sesamanuel" caption="Class and package for sesamath books or paper" />
+  <package key="sesstime" name="sesstime" caption="Session and timing information in lecture notes" />
+  <package key="setdeck" name="setdeck" caption="Typeset cards for Set" />
+  <package key="setouterhbox" name="setouterhbox" caption="Set hbox in outer horizontal mode" />
+  <package key="setspace" name="setspace" caption="Set space between lines" />
+  <package key="setspaceenhanced" name="setspaceenhanced" caption="An enhancement of the setspace package" />
+  <package key="setstrut" name="setstrut" caption="Automatic strut computation" />
+  <package key="settobox" name="settobox" caption="Assigning dimensions of a box to a length register" />
+  <package key="settosize" name="settosize" caption="Scale text to given width" />
+  <package key="settosize-ltx" name="settosize-ltx" caption="Scale text to make it fit a given width" />
+  <package key="seu-ml-assign" name="seu-ml-assign" caption="Southeast University Machine Learning Assignment template" />
+  <package key="seuthesis" name="seuthesis" caption="LaTeX template for theses at Southeastern University" />
+  <package key="seuthesix" name="seuthesix" caption="LaTeX class for theses at Southeast University, Nanjing, China" />
+  <package key="sexam" name="sexam" caption="Package for typesetting arabic exam scripts" />
+  <package key="sf298" name="sf298" caption="Standard form 298" />
+  <package key="sfarticle" name="sfarticle" caption="A LaTeX 2.09 article style with an sf switch" />
+  <package key="sffms" name="sffms" caption="Typesetting science fiction/fantasy manuscripts" />
+  <package key="sfg" name="sfg" caption="Draw signal flow graphs" />
+  <package key="sfheaders" name="sfheaders" caption="Sans headers" />
+  <package key="sfmath" name="sfmath" caption="Sans-serif mathematics" />
+  <package key="sfwmac" name="sfwmac" caption="A set of definitions for Unix system documentation" />
+  <package key="sgame" name="sgame" caption="LaTeX style for typesetting strategic games" />
+  <package key="sgmlcmpt" name="sgmlcmpt" caption="Suppport for LaTeX formulae as SGML PCDATA" />
+  <package key="shadbox" name="shadbox" caption="Shade the background of any box" />
+  <package key="shade" name="shade" caption="Shade pieces of text" />
+  <package key="shadebox" name="shadebox" caption="Shade boxes using PostScript specials" />
+  <package key="shadethm" name="Shaded theorems" caption="Theorem environments that are shaded" />
+  <package key="shading" name="shading" caption="LaTeX package for putting text on a shaded background" />
+  <package key="shadow" name="shadow" caption="Shadow boxes" />
+  <package key="shadowtext" name="shadowtext" caption="Produce text with a shadow behind it" />
+  <package key="shalom" name="shalom" caption="A simple Hebrew typesetting bundle" />
+  <package key="shapepar" name="shapepar" caption="A macro to typeset paragraphs in specific shapes" />
+  <package key="shapepatch" name="shapepatch" caption="Transfig patch supporting shapepar" />
+  <package key="shapes" name="shapes" caption="Draw polygons, reentrant stars, and fractions in circles with MetaPost" />
+  <package key="shavian" name="shavian" caption="A Shavian spelling alphabet font" />
+  <package key="shdoc" name="shdoc" caption="Float environment to document the shell commands of a terminal session" />
+  <package key="shellesc" name="shellesc" caption="Unified shell escape interface for LaTeX" />
+  <package key="shhyphl" name="shhyphl" caption="Serbo-Croatian hyphenation (Latin alphabet)" />
+  <package key="shipunov" name="shipunov" caption="A collection of LaTeX packages and classes" />
+  <package key="shlatex" name="shlatex" caption="LaTeX compilation script for Linux (written in Bash)" />
+  <package key="shobhika" name="shobhika" caption="An OpenType Devan&#257;gar&#299; font designed for scholars" />
+  <package key="short-math-guide" name="short-math-guide" caption="Guide to using amsmath and related packages to typeset mathematical notation with LaTeX" />
+  <package key="shortcuttool" name="shortcuttool" caption="Enables shortcut file import to the input tool Shortcut" />
+  <package key="shortlst" name="shortlst" caption="Compact lists by running several items per line" />
+  <package key="shortmathj" name="shortmathj" caption="Automatically shortify titles of mathematical journals" />
+  <package key="shorttoc" name="shorttoc" caption="Table of contents with different depths" />
+  <package key="shortvrb" name="shortvrb" caption="Abbreviated verbatim commands" />
+  <package key="show2e" name="show2e" caption="Variants of \show for LaTeX2e" />
+  <package key="showcharinbox" name="showcharinbox" caption="Show characters inside a box" />
+  <package key="showdim" name="showdim" caption="Variants on printing dimensions" />
+  <package key="showexpl" name="showexpl" caption="Typesetting LaTeX source code" />
+  <package key="showframe" name="showframe" caption="Draw a page-layout diagram" />
+  <package key="showhyphenation" name="showhyphenation" caption="Marking of hyphenation points" />
+  <package key="showhyphens" name="showhyphens" caption="Show all possible hyphenations in LuaLaTeX" />
+  <package key="showkerning" name="showkerning" caption="Showing kerns in a document" />
+  <package key="showkeys" name="showkeys" caption="Show label, ref, cite and bib keys" />
+  <package key="showlabels" name="showlabels" caption="Show label commands in the margin" />
+  <package key="showtags" name="showtags" caption="Print the tags of bibliography entries" />
+  <package key="shsulet" name="shsulet" caption="A letter document style for use at SHSU" />
+  <package key="shtthesis" name="ShtThesis" caption="An unofficial LaTeX thesis template for ShanghaiTech University" />
+  <package key="shuffle" name="shuffle" caption="A symbol for the shuffle product" />
+  <package key="si" name="si" caption="A comprehensive (SI) units package" />
+  <package key="siam" name="siam" caption="Styles for SIAM publications" />
+  <package key="side" name="side" caption="Rotated floats for LaTeX 2.09" />
+  <package key="sidecap" name="sidecap" caption="Typeset captions sideways" />
+  <package key="sidenotes" name="sidenotes" caption="Typeset notes containing rich content, in the margin" />
+  <package key="sidenotesplus" name="sidenotesplus" caption="Place referenced notes, alerts, figures and tables into the document margin" />
+  <package key="sides" name="sides" caption="A LaTeX class for typesetting stage plays" />
+  <package key="siggraph" name="siggraph" caption="SIGGRAPH conference class" />
+  <package key="signchart" name="signchart" caption="Create beautifully typeset sign charts" />
+  <package key="sikumuna" name="Sikumuna" caption="Lyx template for Hebrew article format" />
+  <package key="silence" name="silence" caption="Selective filtering of error messages and warnings" />
+  <package key="sillypage" name="sillypage" caption="John Cleese&#8217;s Silly Walk as page numbering style" />
+  <package key="simple-resume-cv" name="simple-resume-cv" caption="Template for a simple resume or curriculum vitae (CV), in XeLaTeX" />
+  <package key="simple-thesis-dissertation" name="simple-thesis-dissertation" caption="Template for a simple thesis or dissertation (Ph.D. or master&apos;s degree) or technical
+  report, in XeLaTeX" />
+  <package key="simplebnf" name="simplebnf" caption="A simple package to format Backus-Naur form (BNF)" />
+  <package key="simplecd" name="simplecd" caption="Simple CD, DVD covers for printing" />
+  <package key="simplecv" name="simplecv" caption="A simple class for writing curricula vitae" />
+  <package key="simpleicons" name="simpleicons" caption="Simple Icons for LaTeX" />
+  <package key="simpleinvoice" name="simpleinvoice" caption="Easy typesetting of invoices" />
+  <package key="simplekv" name="simplekv" caption="A simple key/value system for TeX and LaTeX" />
+  <package key="simplenodes" name="simplenodes" caption="Simple nodes in four colors written in TikZ for LaTeX" />
+  <package key="simpleoptics" name="simpleoptics" caption="Drawing lenses and mirrors for optical diagrams" />
+  <package key="simpler-wick" name="simpler-wick" caption="Simpler Wick contractions" />
+  <package key="simples-matrices" name="simples-matrices" caption="Define matrices by given list of values" />
+  <package key="simplewick" name="simplewick" caption="Simple Wick contractions" />
+  <package key="simplified-latex" name="simplified-latex" caption="A Simplified Introduction to LaTeX" />
+  <package key="simplivre" name="simplivre" caption="Write your books in a simple and clear way" />
+  <package key="simpsons" name="simpsons" caption="Metafont source for Simpsons characters" />
+  <package key="simurgh" name="simurgh" caption="Typeset Parsi in LuaLaTeX" />
+  <package key="sines" name="sines" caption="Calculate sin function values" />
+  <package key="sinhala" name="sinhala" caption="Support for the Sinhala language" />
+  <package key="sirlin" name="sirlin" caption="Fonts and macros for typesetting Tibetan" />
+  <package key="sistyle" name="SIstyle" caption="Package to typeset SI units, numbers and angles" />
+  <package key="sitem" name="sitem" caption="Save the optional argument of \item" />
+  <package key="siunits" name="siunits" caption="International System of Units" />
+  <package key="siunitx" name="siunitx" caption="A comprehensive (SI) units package" />
+  <package key="skak" name="skak" caption="Fonts and macros for typesetting chess games" />
+  <package key="skaknew" name="SkakNew" caption="The skak chess fonts redone in Adobe Type 1" />
+  <package key="skb" name="skb" caption="Tools for a repository of long-living documents" />
+  <package key="skdoc" name="skdoc" caption="Documentation and extraction for packages and document classes" />
+  <package key="skeldoc" name="skeldoc" caption="Placeholders for unfinished documents" />
+  <package key="sketch" name="sketch" caption="A 3d sketch language translator" />
+  <package key="skeycommand" name="skeycommand" caption="Create commands using parameters and keyval in parallel" />
+  <package key="skeyval" name="skeyval" caption="Key-value parsing combining features of xkeyval and pgfkeys" />
+  <package key="skills" name="skills" caption="Create proficiency tests" />
+  <package key="skmath" name="skmath" caption="Extensions to the maths command repertoir" />
+  <package key="skrapport" name="skrapport" caption="&#8216;Simple&#8217; class for reports, etc" />
+  <package key="skull" name="skull" caption="A font to draw a skull" />
+  <package key="slantsc" name="slantsc" caption="Access different-shaped small-caps fonts" />
+  <package key="slashbox" name="slashbox" caption="Both column and row headings in a tabular cell" />
+  <package key="slashed" name="slashed" caption="Put a slash through characters" />
+  <package key="slatex" name="slatex" caption="LaTeX support for writing Swedish" />
+  <package key="slatex-scheme" name="slatex-scheme" caption="A pretty-printer for Scheme code in TeX documents" />
+  <package key="slem" name="slem" caption="Slanted emphasis in LaTeX 2.09" />
+  <package key="slemph" name="slemph" caption="Slanted emphasis in LaTeX" />
+  <package key="slhyph" name="slhyph" caption="Slovenian hyphenation patterns" />
+  <package key="slidenotes" name="slidenotes" caption="Typeset slides accompanied by notes" />
+  <package key="slides" name="slides" caption="Class for creating slides" />
+  <package key="slideshow" name="slideshow" caption="Generate slideshow with MetaPost" />
+  <package key="sltables" name="sltables" caption="Simplified tables for LaTeX" />
+  <package key="smallcap" name="smallcap" caption="Promote small caps to a font family, so NFSS can deal with different shapes" />
+  <package key="smaller" name="smaller" caption="Choose an &quot;adjacent&quot; size in LaTeX" />
+  <package key="smalltableof" name="smalltableof" caption="Create listoffigures etc. in a single chapter" />
+  <package key="smalltalk" name="smalltalk" caption="Typeset Smalltalk program fragments" />
+  <package key="smart-eqn" name="smart-eqn" caption="Automatic math symbol styling for LaTeX documents" />
+  <package key="smartdiagram" name="smartdiagram" caption="Generate diagrams from lists" />
+  <package key="smartmn" name="smartmn" caption="Make hyphens print as minus signs where appropriate" />
+  <package key="smartref" name="smartref" caption="Extend LaTeX&apos;s \ref capability" />
+  <package key="smartunits" name="smartunits" caption="Converting between common metric and Imperial units" />
+  <package key="smflatex" name="smflatex" caption="Classes for Soci&#233;t&#233; math&#233;matique de France publications" />
+  <package key="smiletex" name="SmileTeX" caption="Create LaTeX documents and more from simple texts" />
+  <package key="snapshot" name="snapshot" caption="List the external dependencies of a LaTeX document" />
+  <package key="snaptodo" name="snaptodo" caption="A todo that snaps to the closer side" />
+  <package key="snote" name="snote" caption="Shaped notes for MusicTeX" />
+  <package key="snotez" name="snotez" caption="Typeset notes, in the margin" />
+  <package key="sober" name="sober" caption="Makes appearance of standard styles more &quot;sober&quot;" />
+  <package key="sobolev" name="sobolev" caption="Commands for dealing with Sobolev spaces (and relatives)" />
+  <package key="softfonts" name="softfonts" caption="Manage the &quot;soft fonts&quot; in a LaserWriter printer" />
+  <package key="softmaker-alteschwabacher" name="softmaker-alteschwabacher" caption="LaTeX Support files for the SoftMaker Alte Schwabacher font" />
+  <package key="softmaker-artistic" name="softmaker-artistic" caption="LaTeX Support files for the SoftMaker Artistic font" />
+  <package key="softmaker-baskervillenova" name="softmaker-baskervillenova" caption="LaTeX Support files for the SoftMaker Baskerville Nova fonts" />
+  <package key="softmaker-bonita" name="softmaker-bonita" caption="LaTeX Support files for SoftMaker Bonita" />
+  <package key="softmaker-broadway" name="softmaker-broadway" caption="LaTeX Support files for the SoftMaker Broadway fonts" />
+  <package key="softmaker-canossa" name="softmaker-canossa" caption="LaTeX Support files for the SoftMaker Canossa fonts" />
+  <package key="softmaker-congress" name="softmaker-congress" caption="LaTeX Support files for the SoftMaker Congress fonts" />
+  <package key="softmaker-delanocaps" name="softmaker-delanocaps" caption="LaTeX Support files for the SoftMaker Delano Caps font" />
+  <package key="softmaker-digital" name="softmaker-digital" caption="LaTeX Support files for the SoftMaker Digital fonts" />
+  <package key="softmaker-egyptiennestd" name="softmaker-egyptiennestd" caption="LaTeX Support files for the SoftMaker EgyptienneStd fonts" />
+  <package key="softmaker-flagstaff" name="softmaker-flagstaff" caption="LaTeX Support files for the SoftMaker Flagstaff font" />
+  <package key="softmaker-grenoble" name="softmaker-grenoble" caption="LaTeX Support files for the SoftMaker Grenoble fonts" />
+  <package key="softmaker-helium" name="softmaker-helium" caption="LaTeX Support files for the SoftMaker Helium fonts" />
+  <package key="softmaker-heliumtwo" name="softmaker-heliumtwo" caption="LaTeX Support files for the SoftMaker Helium fonts" />
+  <package key="softmaker-henderson" name="softmaker-henderson" caption="LaTeX Support files for the SoftMaker Henderson font" />
+  <package key="softmaker-iceberg" name="softmaker-iceberg" caption="LaTeX Support files for the SoftMaker Iceberg font" />
+  <package key="softmaker-inverserif" name="softmaker-inverserif" caption="LaTeX Support files for the SoftMaker Inverserif font" />
+  <package key="softmaker-jugendstil" name="softmaker-jugendstil" caption="LaTeX Support files for the SoftMaker Jugendstil font" />
+  <package key="softmaker-marseille" name="softmaker-marseille" caption="LaTeX Support files for the SoftMaker Marseille fonts" />
+  <package key="softmaker-moab" name="softmaker-moab" caption="LaTeX Support files for the SoftMaker Moab font" />
+  <package key="softmaker-nevada" name="softmaker-nevada" caption="LaTeX Support files for the SoftMaker Nevada fonts" />
+  <package key="softmaker-newcastle" name="softmaker-newcastle" caption="LaTeX Support files for the SoftMaker Newcastle fonts" />
+  <package key="softmaker-oldblackletter" name="softmaker-oldblackletter" caption="LaTeX Support files for the SoftMaker Old Blackletter font" />
+  <package key="softmaker-quadrat" name="softmaker-quadrat" caption="LaTeX Support files for the SoftMaker Quadrat fonts" />
+  <package key="softmaker-stonehand" name="softmaker-stonehand" caption="LaTeX Support files for the SoftMaker Stone Handwriting font" />
+  <package key="softmaker-sunset" name="softmaker-sunset" caption="LaTeX Support files for the SoftMaker Sunset fonts" />
+  <package key="softmaker-tampa" name="softmaker-tampa" caption="LaTeX Support files for the SoftMaker Congress fonts" />
+  <package key="softmaker-vagrounded" name="softmaker-vagrounded" caption="LaTeX Support files for the SoftMaker VAGRounded font" />
+  <package key="softmaker-velo" name="softmaker-velo" caption="LaTeX Support files for the SoftMaker Velo font" />
+  <package key="softmaker-veracruz" name="softmaker-veracruz" caption="LaTeX Support files for the SoftMaker Veracruz fonts" />
+  <package key="softmakerfreefont" name="softmakerfreefont" caption="Support files for SoftMaker free fonts" />
+  <package key="somedefs" name="somedefs" caption="Save loading all of another package" />
+  <package key="songbook" name="songbook" caption="Package for typesetting song lyrics and chord books" />
+  <package key="songproj" name="songproj" caption="Generate Beamer slideshows with song lyrics" />
+  <package key="songs" name="songs" caption="Produce song books for church or fellowship" />
+  <package key="sorhyph" name="sorhyph" caption="Upper Sorbian hyphenation patterns" />
+  <package key="sort-by-letters" name="sort-by-letters" caption="Bibliography styles for alphabetic sorting" />
+  <package key="soton" name="soton" caption="University of Southampton-compliant slides" />
+  <package key="soul" name="soul" caption="Hyphenation for letterspacing, underlining, and more" />
+  <package key="soulpos" name="soulpos" caption="A fancy means of underlining" />
+  <package key="soup" name="soup" caption="Generate alphabet soup puzzles" />
+  <package key="source2e" name="source2e" caption="LaTeX2e kernel documentation for the entire system as one document" />
+  <package key="sourcecodepro" name="sourcecodepro" caption="Use SourceCodePro with TeX(-alike) systems" />
+  <package key="sourcesanspro" name="SourceSansPro" caption="Use SourceSansPro with TeX(-alike) systems" />
+  <package key="sourceserifpro" name="sourceserifpro" caption="Use SourceSerifPro with TeX(-alike) systems" />
+  <package key="southarabian" name="SouthArabian" caption="A font for an archaic South Arabia script" />
+  <package key="soyombo" name="soyombo" caption="Fonts and a macro for Soyombo under LaTeX" />
+  <package key="spacekern" name="spacekern" caption="Kerning between words and against space" />
+  <package key="spacingtricks" name="spacingtricks" caption="Addressing various spacing issues" />
+  <package key="spain" name="spain" caption="Bibliography style for Spanish documents" />
+  <package key="spalign" name="spalign" caption="Typeset matrices and arrays with spaces and semicolons as delimiters" />
+  <package key="spanish-mx" name="spanish-mx" caption="Typeset Spanish as in Mexico" />
+  <package key="spark-otf" name="spark-otf" caption="Support OpenType Spark fonts" />
+  <package key="sparklines" name="sparklines" caption="Drawing sparklines: intense, simple, wordlike graphics" />
+  <package key="spath3" name="spath3" caption="Manipulate &#8220;soft paths&#8221; in PGF" />
+  <package key="spbmark" name="spbmark" caption="Customize superscripts and subscripts" />
+  <package key="spectral" name="spectral" caption="Spectral fonts with LaTeX support" />
+  <package key="spectralsequences" name="spectralsequences" caption="Print spectral sequence diagrams using PGF/TikZ" />
+  <package key="spelling" name="spelling" caption="Support for spell-checking of LuaTeX documents" />
+  <package key="sphack" name="sphack" caption="Patch LaTeX kernel spacing macros" />
+  <package key="sphdthesis" name="sphdthesis" caption="LaTeX template for writing PhD Thesis" />
+  <package key="sphyphb" name="sphyphb" caption="Experimental Spanish hyphenation patterns" />
+  <package key="spiderweb" name="spiderweb" caption="A tool for building WEB systems" />
+  <package key="spie" name="spie" caption="Support for formatting SPIE Proceedings manuscripts" />
+  <package key="spix" name="SpiX" caption="Yet another TeX compilation tool: simple, human readable, no option, no magic" />
+  <package key="splines" name="splines" caption="MetaPost macros for drawing cubic spline interpolants" />
+  <package key="splint" name="splint" caption="Write LALR(1) parsers in TeX using bison and flex" />
+  <package key="split" name="split" caption="Box two chunks of text side-by side" />
+  <package key="splitbib" name="splitbib" caption="Split and reorder your bibliography" />
+  <package key="splitindex" name="splitindex" caption="Unlimited number of indexes" />
+  <package key="spot" name="spot" caption="Spotlight highlighting for Beamer" />
+  <package key="spotcolor" name="spotcolor" caption="Spot colours for pdfLaTeX" />
+  <package key="spreadtab" name="spreadtab" caption="Spreadsheet features for LaTeX tabular environments" />
+  <package key="springer" name="springer" caption="Macros for Springer journals" />
+  <package key="sprite" name="sprite" caption="Macros to typeset simple bitmaps with LaTeX" />
+  <package key="spverbatim" name="spverbatim" caption="Allow line breaks within \verb and verbatim output" />
+  <package key="sqltex" name="SQLTeX" caption="An SQL Preprocessor for LaTeX" />
+  <package key="sqrcaps" name="sqrcaps" caption="Square Capitals manuscript book-hand font" />
+  <package key="sr-half-compound" name="sr-half-compound" caption="Hyphenation of Serbian half-compound words in cyrillic scripts" />
+  <package key="sr-hyphen-spec" name="sr-hyphen-spec" caption="Hyphenation of special cases in Serbian" />
+  <package key="sr-vorl" name="sr-vorl" caption="Class for Springer books" />
+  <package key="srbtiks" name="srbtiks" caption="Font STIX2 for Serbian and Macedonian" />
+  <package key="srcltx" name="srcltx" caption="Jump between DVI and TeX files" />
+  <package key="srcredact" name="srcredact" caption="A tool for redacting sources" />
+  <package key="srdp-mathematik" name="srdp-mathematik" caption="Typeset Austrian SRDP in mathematics" />
+  <package key="srhyphc" name="srhyphc" caption="Hyphenation patterns for Serbian Cyrillic" />
+  <package key="srune" name="srune" caption="Saxon rune font" />
+  <package key="sseq" name="sseq" caption="Typesetting spectral sequence charts" />
+  <package key="sshdbk10" name="sshdbk10" caption="Sans headers in book style" />
+  <package key="sslides" name="sslides" caption="Slides with headers and footers" />
+  <package key="ssqquote" name="ssqquote" caption="Use the cmssq fonts" />
+  <package key="stables" name="stables" caption="Simplified Plain TeX tables" />
+  <package key="stabular" name="stabular" caption="Multipage tabular" />
+  <package key="stack" name="stack" caption="Tools to define and use stacks" />
+  <package key="stackengine" name="stackengine" caption="Highly customised stacking of objects, insets, baseline changes, etc" />
+  <package key="stackrel" name="stackrel" caption="Enhancement to the \stackrel command" />
+  <package key="stage" name="stage" caption="A LaTeX class for stage plays" />
+  <package key="stampinclude" name="stampinclude" caption="Inclusion based on .aux file date stamps" />
+  <package key="standalone" name="standalone" caption="Compile TeX pictures stand-alone or as part of a document" />
+  <package key="stanli" name="stanli" caption="TikZ Library for Structural Analysis" />
+  <package key="starfont" name="starfont" caption="The StarFont Sans astrological font" />
+  <package key="starray" name="starray" caption="A structured array (of properties) based on expl3" />
+  <package key="startex" name="startex" caption="An XML-inspired format for student use" />
+  <package key="statex" name="statex" caption="Statistics style" />
+  <package key="statex2" name="statex2" caption="Statistics style" />
+  <package key="statistics" name="statistics" caption=" Compute and typeset statistics tables and graphics" />
+  <package key="statistik" name="statistik" caption="Store statistics of a document" />
+  <package key="statmath" name="statmath" caption="A LaTeX package for simple use of statistical notation" />
+  <package key="statrep" name="statrep" caption="Displays SAS code and results of running the code" />
+  <package key="staves" name="staves" caption="Typeset Icelandic staves and runic letters" />
+  <package key="stdclsdv" name="stdclsdv" caption="Provide sectioning information for package writers" />
+  <package key="stdpage" name="stdpage" caption="Standard pages with n lines of at most m characters each" />
+  <package key="stealcaps" name="stealcaps" caption="&#8220;Steal&#8221; small capitals" />
+  <package key="steinmetz" name="steinmetz" caption="Print Steinmetz notation" />
+  <package key="stellenbosch" name="stellenbosch" caption="Stellenbosch thesis bundle (legacy version)" />
+  <package key="stellenbosch-2" name="stellenbosch-2" caption="Stellenbosch University thesis bundle" />
+  <package key="step" name="step" caption="A free Times-like font" />
+  <package key="stepgreek" name="stepgreek" caption="A free Times/Elsevier-style Greek font" />
+  <package key="stex" name="sTeX" caption="An Infrastructure for Semantic Preloading of LaTeX Documents" />
+  <package key="stfloats" name="stfloats" caption="Commands to control the presentation of floats" />
+  <package key="stickstoo" name="SticksToo" caption="A reworking of STIX2" />
+  <package key="stix" name="stix" caption="OpenType Unicode maths fonts" />
+  <package key="stix2-otf" name="stix2-otf" caption="OpenType Unicode text and  maths fonts" />
+  <package key="stix2-type1" name="stix2-type1" caption="Type1 versions of the STIX Two OpenType fonts" />
+  <package key="stmaryrd" name="stmaryrd" caption="St Mary Road symbols for theoretical computer science" />
+  <package key="stoneipa" name="stoneipa" caption="Support for the Stone Sans Phonetic font" />
+  <package key="storebox" name="storebox" caption="Storing information for reuse" />
+  <package key="storecmd" name="storecmd" caption="Store the name of a defined command in a container" />
+  <package key="strands" name="strands" caption="Draw objects constructed from strands" />
+  <package key="streetex" name="streetex" caption="Structural organic chemistry" />
+  <package key="stricttex" name="stricttex" caption="Strictly balanced brackets and numbers in command names" />
+  <package key="string-diagrams" name="string-diagrams" caption="Create string diagrams with LaTeX and TikZ" />
+  <package key="stringenc" name="stringenc" caption="Converting a string between different encodings" />
+  <package key="stringstrings" name="stringstrings" caption="String manipulation for cosmetic and programming application" />
+  <package key="structmech" name="structmech" caption="A TikZ command set for structural mechanics drawings" />
+  <package key="struktex" name="struktex" caption="Draw Nassi-Shneiderman charts" />
+  <package key="sttools" name="sttools" caption="Various macros" />
+  <package key="stubs" name="stubs" caption="Create tear-off stubs at the bottom of a page" />
+  <package key="studenthandouts" name="Student Handouts" caption="Management and styling of student handout projects" />
+  <package key="studies-lm" name="studies-lm" caption="An interactive LaTeX course for students" />
+  <package key="sty2dtx" name="sty2dtx" caption="Create a .dtx file from a .sty file" />
+  <package key="style-showcase" name="style-showcase" caption="Make a web page to compare styles" />
+  <package key="styledcmd" name="styledcmd" caption="Handling multiple versions of user-defined macros" />
+  <package key="suanpan" name="suanpan" caption="MetaPost macros for drawing Chinese and Japanese abaci" />
+  <package key="subcaption" name="subcaption" caption="Support for sub-captions" />
+  <package key="subdepth" name="subdepth" caption="Unify maths subscript height" />
+  <package key="subdocs" name="subdocs" caption="Multifile documents" />
+  <package key="subeqn" name="subeqn" caption="Package for subequation numbering" />
+  <package key="subeqnarray" name="subeqnarray" caption="Equation array with sub numbering" />
+  <package key="subfig" name="subfig" caption="Figures broken into subfigures" />
+  <package key="subfigmat" name="subfigmat" caption="Automates layout when using the subfigure package" />
+  <package key="subfigure" name="subfigure" caption="Deprecated: Figures divided into subfigures" />
+  <package key="subfiles" name="subfiles" caption="Individual typesetting of subfiles of a &#8220;main&#8221; document" />
+  <package key="subfloat" name="subfloat" caption="Sub-numbering for figures and tables" />
+  <package key="sublabel" name="sublabel" caption="Sub-number counters" />
+  <package key="subscript" name="subscript" caption="Provides the \textsubscript command" />
+  <package key="substances" name="substances" caption="A database of chemicals" />
+  <package key="substitutefont" name="substitutefont" caption="Easy font substitution" />
+  <package key="substr" name="substr" caption="Deal with substrings in strings" />
+  <package key="subsupscripts" name="subsupscripts" caption="A range of sub- and superscript commands" />
+  <package key="subtext" name="subtext" caption="Easy text-style subscripts in math mode" />
+  <package key="sudoku" name="sudoku" caption="Create sudoku grids" />
+  <package key="sudokubundle" name="sudokubundle" caption="A set of sudoku-related packages" />
+  <package key="sueterlin" name="sueterlin" caption="Calligraphic font for typesetting handwriting in S&#252;tterlin style" />
+  <package key="suffix" name="suffix" caption="Define commands with suffixes" />
+  <package key="suftesi" name="suftesi" caption="A document class for typesetting theses, books and articles" />
+  <package key="sugconf" name="sugconf" caption="SAS(R) user group conference proceedings document class" />
+  <package key="superiors" name="superiors" caption="Attach superior figures to a font family" />
+  <package key="supertabular" name="supertabular" caption="A multi-page tables package" />
+  <package key="suppose" name="suppose" caption="Abbreviate the word &#8220;Suppose&#8221;" />
+  <package key="susy" name="susy" caption="Macros for SuperSymmetry-related work" />
+  <package key="suthesis" name="suthesis" caption="Typeset a Stanford University thesis" />
+  <package key="sverb" name="sverb" caption="A set of verbatim text manipulations" />
+  <package key="svg" name="svg" caption="Include and extract SVG pictures in LaTeX documents" />
+  <package key="svg-inkscape" name="svg-inkscape" caption="How to include an SVG image in LaTeX using Inkscape" />
+  <package key="svgcolor" name="svgcolor" caption="Define SVG named colours" />
+  <package key="svn" name="svn" caption="Typeset Subversion keywords" />
+  <package key="svn-multi" name="svn-multi" caption="Subversion keywords in multi-file LaTeX documents" />
+  <package key="svn-prov" name="svn-prov" caption="Subversion variants of \Provides... macros" />
+  <package key="svninfo" name="svninfo" caption="Typeset Subversion keywords" />
+  <package key="svrsymbols" name="svrsymbols" caption="A font with symbols for use in physics texts" />
+  <package key="swebib" name="swebib" caption="Swedish bibliography styles" />
+  <package key="swetex" name="swetex" caption="Plain TeX support for writing Swedish" />
+  <package key="swfigure" name="swfigure" caption="Insert large images that do not fit into a single page" />
+  <package key="swiftex" name="swiftex" caption="Edit doc.sty and normal LaTeX files with GNU Emacs" />
+  <package key="swimgraf" name="Swimgraf" caption="Graphical/textual representations of swimming performances" />
+  <package key="switcheml" name="switcheml" caption="Obfuscate email addresses (now obsolete)" />
+  <package key="swrule" name="swrule" caption="Lines thicker in the middle than at the ends" />
+  <package key="swungdash" name="swungdash" caption="Typeset a swung dash in LaTeX" />
+  <package key="syllogism" name="syllogism" caption="Typeset syllogisms in LaTeX" />
+  <package key="symbats3" name="symbats3" caption="Macros to use the Symbats3 dingbats fonts" />
+  <package key="symbolindex" name="symbolindex" caption="Generate a list of symbols with different subgroups" />
+  <package key="sympycalc" name="SympyCalc" caption="Work with SymPy and PyLuaTeX" />
+  <package key="sympytex" name="sympytex" caption="Include symbolic computation (using sympy) in documents" />
+  <package key="synapsen" name="Synapsen" caption="Reference management tool for BibTeX" />
+  <package key="synctex-parser" name="synctex-parser" caption="SyncTeX output file parser" />
+  <package key="syngen" name="syngen" caption="A tool for generating syntax diagrams from BNF" />
+  <package key="synproof" name="synproof" caption="Easy drawing of syntactic proofs" />
+  <package key="syntax-mdw" name="syntax-mdw" caption="Typeset syntax descriptions" />
+  <package key="syntax2" name="syntax2" caption="Creation of syntax diagrams" />
+  <package key="syntaxdi" name="syntaxdi" caption="Create &#8220;railroad&#8221; syntax diagrams" />
+  <package key="syntonly" name="syntonly" caption="Run a document through LaTeX for syntax checking" />
+  <package key="syntrace" name="syntrace" caption="Labels for tracing in a syntax tree" />
+  <package key="synttree" name="synttree" caption="Typeset syntactic trees" />
+  <package key="syriac" name="syriac" caption="A font for Syriac written in Estrangelo" />
+  <package key="systcontrolletters" name="systcontrolletters" caption="Support for Systems and Control Letters" />
+  <package key="systeme" name="systeme" caption="Format systems of equations" />
+  <package key="t-angles" name="t-angles" caption="Draw tangles, trees, Hopf algebra operations and other pictures" />
+  <package key="t1-fraktur" name="t1-fraktur" caption="A pair of fraktur font families in T1 encoding" />
+  <package key="t1enc" name="t1enc" caption="Standard package for activating ec fonts" />
+  <package key="t1infos" name="t1infos" caption="Utilities for PostScript fonts" />
+  <package key="t1subset" name="T1Subset" caption="A C++ library for subsetting PostScript Type 1 fonts" />
+  <package key="t1tools" name="t1tools" caption="Facilities for handling Adobe Type 1 fonts" />
+  <package key="t1utils" name="t1utils" caption="Simple Type 1 font manipulation programs" />
+  <package key="t2" name="t2" caption="Support for using T2 encoding" />
+  <package key="tab4tex" name="tab4tex" caption="Preprocessor for LaTeX tabular environments" />
+  <package key="tabbing" name="tabbing" caption="Tabbing with accented letters" />
+  <package key="tabbingbox" name="tabbingbox" caption="Save a tabbing environment in a box" />
+  <package key="tabfigures" name="tabfigures" caption="Maintain vertical alignment of figures" />
+  <package key="table-fct" name="table-fct" caption="Draw a variations table of functions and a convexity table of its graph" />
+  <package key="tableauvariations" name="tableauVariations" caption="Variation tables in MetaPost" />
+  <package key="tableaux" name="tableaux" caption="Construct tables of signs and variations" />
+  <package key="tablefootnote" name="tablefootnote" caption="Permit footnotes in tables" />
+  <package key="tableof" name="tableof" caption="Tagging tables of contents" />
+  <package key="tables" name="tables" caption="Tables without the need for a preamble" />
+  <package key="tablestyles" name="tablestyles" caption="Styles for tables with new commands" />
+  <package key="tablists" name="tablists" caption="Tabulated lists of short items" />
+  <package key="tablor" name="tablor" caption="Create tables of signs and of variations" />
+  <package key="tabls" name="tabls" caption="Better vertical spacing in tables and arrays" />
+  <package key="tablvar" name="tablvar" caption="Typesetting pretty tables of signs and variations according to French usage" />
+  <package key="tabriz-thesis" name="tabriz-thesis" caption="A template for the University of Tabriz" />
+  <package key="tabsatz" name="tabsatz" caption="How to use tables in LaTeX" />
+  <package key="tabstackengine" name="tabstackengine" caption="&#8220;Tabbing&#8221; front-end to stackengine" />
+  <package key="tabto-generic" name="tabto-generic" caption="&quot;Tab&quot; to a measured position in the line" />
+  <package key="tabto-ltx" name="tabto-ltx" caption="&#8220;Tab&#8221; to a measured position in the line" />
+  <package key="tabu" name="tabu" caption="Flexible LaTeX tabulars" />
+  <package key="tabularborder" name="tabularborder" caption="Remove excess space at left and right of tabular" />
+  <package key="tabularcalc" name="tabularcalc" caption="Calculate formulas in a tabular environment" />
+  <package key="tabularew" name="tabularew" caption="A variation on the tabular environment" />
+  <package key="tabularht" name="tabularht" caption="Tabular environments with height specified" />
+  <package key="tabularkv" name="tabularkv" caption="Tabular environments with key-value interface" />
+  <package key="tabularray" name="tabularray" caption="Typeset tabulars and arrays with LaTeX3" />
+  <package key="tabulars-e" name="tabulars-e" caption="Examples from the book &quot;Typesetting tables with LaTeX&quot;" />
+  <package key="tabularx" name="tabularx" caption="Tabulars with adjustable-width columns" />
+  <package key="tabulary" name="tabulary" caption="Tabular with variable width columns balanced" />
+  <package key="tabvar" name="tabvar" caption="Typesetting tables showing variations of functions" />
+  <package key="tabverb" name="tabverb" caption="Verbatim text respecting TAB characters" />
+  <package key="tagging" name="tagging" caption="Document configuration with tags" />
+  <package key="tagpair" name="tagpair" caption="Word-by-word glosses, translations, and bibliographic attributions" />
+  <package key="tagpdf" name="tagpdf" caption="Tools for experimenting with tagging using pdfLaTeX and LuaLaTeX" />
+  <package key="talk" name="talk" caption="A LaTeX class for presentations" />
+  <package key="talos" name="talos" caption="A Greek cult font from the eighties" />
+  <package key="tamefloats" name="tamefloats" caption="Experimentally use \holdinginserts with LaTeX floats" />
+  <package key="tamethebeast" name="TameTheBeast" caption="A manual about bibliographies and especially BibTeX" />
+  <package key="tamil-omega" name="tamil-omega" caption="Tamil support for Omega/Aleph" />
+  <package key="tangle" name="tangle" caption="Generate compilable source from web" />
+  <package key="tango-weevil" name="tango-weevil" caption="A simple Web system" />
+  <package key="tangocolors" name="tangocolors" caption="Use colors from the Tango color palette" />
+  <package key="tangramtikz" name="TangramTikZ" caption="Tangram puzzles, with TikZ" />
+  <package key="tap" name="tap" caption="TeX macros for typesetting complex tables" />
+  <package key="tape" name="tape" caption="Generate cassette labels from a simple database" />
+  <package key="tapir" name="tapir" caption="A simple geometrical font" />
+  <package key="tasks" name="tasks" caption="Horizontally columned lists" />
+  <package key="taylor" name="taylor" caption="Macros for category-theoretic diagrams" />
+  <package key="tbe" name="tbe" caption="Extracts from &quot;TeX by Example&quot;" />
+  <package key="tccompat" name="tccompat" caption="Provide compatibility names for textcomp.sty" />
+  <package key="tclldoc" name="tclldoc" caption="Doc/docstrip for tcl" />
+  <package key="tcltexed" name="tcltexed" caption="LaTeX editor written in TCL" />
+  <package key="tcobrowser" name="tcobrowser" caption="Local browsing of the Catalogue on Mac OS X" />
+  <package key="tcolorbox" name="tcolorbox" caption="Coloured boxes, for LaTeX examples and theorems, etc" />
+  <package key="tcvn" name="tcvn" caption="Vietnamese Windows support" />
+  <package key="tdclock" name="tdclock" caption="A ticking digital clock package for PDF output" />
+  <package key="tds" name="tds" caption="The TeX Directory Structure standard" />
+  <package key="tdsfrmath" name="tdsfrmath" caption="Macros for French teachers of mathematics" />
+  <package key="techexplorer" name="techexplorer" caption="Browser plugin for viewing TeX and LaTeX sources" />
+  <package key="technica" name="Technica" caption="Typesetting for the humanities" />
+  <package key="technics" name="technics" caption="A package to format technical documents" />
+  <package key="technion-thesis-template" name="technion-thesis-template" caption="Template for theses on the Technion graduate school" />
+  <package key="techreport" name="techreport" caption="Generate Technical Reports using USC thesis style" />
+  <package key="ted" name="ted" caption="A (primitive) token list editor" />
+  <package key="teencontrex" name="TeEncontreX" caption="Help for users of TeX and LaTeX" />
+  <package key="telprint" name="telprint" caption="Format German phone numbers" />
+  <package key="telugu" name="telugu" caption="(La)TeX Support for writing the Telugu Language" />
+  <package key="templates-fenn" name="templates-fenn" caption="Templates for TeX usage" />
+  <package key="templates-sommer" name="templates-sommer" caption="Templates for TeX usage" />
+  <package key="templatetools" name="templatetools" caption="Commands useful in LaTeX templates" />
+  <package key="tempora" name="tempora" caption="Greek and Cyrillic to accompany Times" />
+  <package key="tengtex" name="tengtex" caption="Typesetting in Tolkien&#8217;s Tengwar script" />
+  <package key="tengwar" name="tengwar" caption="Font to set Tolkien&apos;s Tengwar script" />
+  <package key="tengwarscript" name="TengwarScript" caption="LaTeX support for using Tengwar fonts" />
+  <package key="tensind" name="tensind" caption="Typeset tensors" />
+  <package key="tensor" name="tensor" caption="Typeset tensors" />
+  <package key="termcal" name="termcal" caption="Print a class calendar" />
+  <package key="termcal-de" name="termcal-de" caption="German localization for termcal" />
+  <package key="termes-otf" name="termes-otf" caption="Using the OpenType fonts TeX Gyre Termes" />
+  <package key="termlist" name="termlist" caption="Label any kind of term with a continuous counter" />
+  <package key="termmenu" name="termmenu" caption="The package provides support for terminal-based menus using expl3" />
+  <package key="termsim" name="termsim" caption="Simulate Win10, Ubuntu, and Mac terminals" />
+  <package key="tesla" name="tesla" caption="A special-purpose language for knowledge base rules" />
+  <package key="testeq" name="testeq" caption="An equality test for use in MetaPost" />
+  <package key="testflow" name="testflow" caption="A tool to validate PS/PDF output from LaTeX" />
+  <package key="testfont" name="testfont" caption="A testbed for font evaluation" />
+  <package key="testhyphens" name="testhyphens" caption="Testing hyphenation patterns " />
+  <package key="testidx" name="testidx" caption="Dummy text for testing index styles and indexing applications" />
+  <package key="testmath" name="testmath" caption="Examples of the AMS-LaTeX package" />
+  <package key="tetex" name="tetex" caption="Obsolete TeX distribution for Unix/Linux" />
+  <package key="tetragonos" name="tetragonos" caption="Four-Corner codes of Chinese characters" />
+  <package key="teubner" name="teubner" caption="Philological typesetting of classical Greek" />
+  <package key="tex" name="TeX" caption="A sophisticated typesetting engine" />
+  <package key="tex--xet" name="tex--xet" caption="Bidirectional extension of TeX" />
+  <package key="tex-converter" name="TeX Converter" caption="Windows front-end to various LaTeX to HTML converters" />
+  <package key="tex-ewd" name="tex-ewd" caption="Macros to typeset calculational proofs and programs in Dijkstra&apos;s style" />
+  <package key="tex-extensions" name="tex-extensions" caption="Proposals for extensions to TeX" />
+  <package key="tex-font-errors-cheatsheet" name="tex-font-errors-cheatsheet" caption="Cheat sheet outlining the most common TeX font errors" />
+  <package key="tex-fpc" name="TeX-FPC" caption="A collection of change files for a TeX system based on Free Pascal" />
+  <package key="tex-gpc" name="TeX-GPC" caption="A collection of change files for a TeX system based on GNU Pascal" />
+  <package key="tex-gyre" name="tex-gyre" caption="TeX Fonts extending freely available URW fonts" />
+  <package key="tex-gyre-adventor" name="tex-gyre-adventor" caption="A font family that extends URW Gothic L" />
+  <package key="tex-gyre-bonum" name="tex-gyre-bonum" caption="A font family that extends URW Bookman L" />
+  <package key="tex-gyre-chorus" name="tex-gyre-chorus" caption="A font that extends URW Chancery L" />
+  <package key="tex-gyre-cursor" name="tex-gyre-cursor" caption="A font that extends URW Nimbus Mono L" />
+  <package key="tex-gyre-heros" name="tex-gyre-heros" caption="A font family that extends URW Nimbus Sans L" />
+  <package key="tex-gyre-math" name="tex-gyre-math" caption="Maths fonts to match tex-gyre text fonts" />
+  <package key="tex-gyre-math-bonum" name="tex-gyre-math-bonum" caption="Maths fonts to match TeX Gyre Bonum" />
+  <package key="tex-gyre-math-dejavu" name="tex-gyre-math-dejavu" caption="Maths fonts to match TeX Gyre Dejavu" />
+  <package key="tex-gyre-math-pagella" name="tex-gyre-math-pagella" caption="Maths fonts to match the tex-gyre-pagella text font" />
+  <package key="tex-gyre-math-schola" name="tex-gyre-math-schola" caption="Maths fonts to match TeX Gyre Schola" />
+  <package key="tex-gyre-math-termes" name="tex-gyre-math-termes" caption="Maths fonts to match TeX Gyre Termes" />
+  <package key="tex-gyre-pagella" name="tex-gyre-pagella" caption="A font family that extends URW Palladio L" />
+  <package key="tex-gyre-schola" name="tex-gyre-schola" caption="A font that extends URW Century Schoolbook L" />
+  <package key="tex-gyre-termes" name="tex-gyre-termes" caption="A font family that extends URW Nimbus Roman" />
+  <package key="tex-implementors" name="tex-implementors" caption="Entries from the tex-implementors mailing list" />
+  <package key="tex-ini-files" name="tex-ini-files" caption="Model TeX format creation files" />
+  <package key="tex-it" name="tex-it" caption="Controller for TeX processing" />
+  <package key="tex-kurs" name="tex-kurs" caption="A LaTeX (2.09) course in German" />
+  <package key="tex-label" name="tex-label" caption="Place a classification on each page of a document" />
+  <package key="tex-locale" name="tex-locale" caption="Localisation support for TeX and LaTeX documents" />
+  <package key="tex-mag" name="TeX-mag" caption="An on-line TeX magazine" />
+  <package key="tex-math" name="tex-math" caption="Maths mode documentation for OS/2 users" />
+  <package key="tex-nutshell" name="TeX-nutshell" caption="A short document about TeX principles" />
+  <package key="tex-overview" name="tex-overview" caption="An overview of the development of TeX" />
+  <package key="tex-ps" name="tex-ps" caption="TeX to PostScript generic macros and add-ons" />
+  <package key="tex-references" name="tex-references" caption="References for TeX and Friends" />
+  <package key="tex-virtual-academy-pl" name="tex-virtual-academy-pl" caption="TeX usage web pages, in Polish" />
+  <package key="tex-vpat" name="tex-vpat" caption="TeX Accessibility Conformance Report" />
+  <package key="tex2bib" name="tex2bib" caption="Extract a BibTeX database from a document source" />
+  <package key="tex2ltx" name="tex2ltx" caption="AMS-TeX to AMS-LaTeX converter" />
+  <package key="tex2mail" name="tex2mail" caption="Converts TeX to mailable &quot;ASCII art&quot;" />
+  <package key="tex2page" name="tex2page" caption="Produce HTML from TeX/LaTeX" />
+  <package key="tex2rtf" name="tex2rtf" caption="TeX translator, output formats include RTF" />
+  <package key="tex2tok" name="tex2tok" caption="Convert a TeX source file into tokens" />
+  <package key="tex2word" name="tex2word" caption="Convert TeX/LaTeX to MSWord" />
+  <package key="tex4ebook" name="tex4ebook" caption="Converter from LaTeX to ebook formats" />
+  <package key="tex4ht" name="TeX4ht" caption="Convert (La)TeX to HTML/XML" />
+  <package key="texaccents" name="texaccents" caption="Convert composite accented characters to Unicode" />
+  <package key="texapi" name="texapi" caption="Macros to write format-independent packages" />
+  <package key="texas" name="texas" caption="32-bit TeX 3.14 compiled for MS-DOS 386/486 computers" />
+  <package key="texbook" name="texbook" caption="The source of The TeXbook" />
+  <package key="texbuch" name="texbuch" caption="&quot;The little TeXBook&quot;" />
+  <package key="texbytopic" name="TeXbyTopic" caption="Freed version of the book TeX by Topic" />
+  <package key="texcad32" name="texcad32" caption="Win32 drawing package for mathematical diagrams" />
+  <package key="texchord" name="texchord" caption="Typeset guitar-chord diagrams" />
+  <package key="texcount" name="TeXcount" caption="Count words in a LaTeX document" />
+  <package key="texdate" name="texdate" caption="Date printing, formatting, and manipulation in TeX" />
+  <package key="texdef" name="texdef" caption="Display the definitions of TeX commands" />
+  <package key="texdepend" name="texdepend" caption="Find dependencies in a LaTeX file" />
+  <package key="texdeps" name="texdeps" caption="Find the dependencies of a (La)TeX file" />
+  <package key="texdiff" name="texdiff" caption="Compare documents and produce tagged merge" />
+  <package key="texdimens" name="texdimens" caption="Conversion of TeX dimensions to decimals" />
+  <package key="texdirflatten" name="texdirflatten" caption="Collect files related to a LaTeX job in a single directory" />
+  <package key="texdoc" name="texdoc" caption="Documentation access for TeX Live" />
+  <package key="texdoctk" name="texdoctk" caption="Easy access to package documentation" />
+  <package key="texdraw" name="texdraw" caption="Graphical macros, using embedded PostScript" />
+  <package key="texed" name="texed" caption="A TeX shell for OS/2" />
+  <package key="texemplar" name="texemplar" caption="A class for the journal of CervanTeX" />
+  <package key="texfaq" name="texfaq" caption="A compilation of Frequently Asked Questions with answers" />
+  <package key="texfilt" name="texfilt" caption="A (La)TeX log filter" />
+  <package key="texfindpkg" name="TeXFindPkg" caption="Query or install TeX packages and their dependencies" />
+  <package key="texfot" name="texfot" caption="Filter clutter from the output of a TeX run" />
+  <package key="texhax" name="TeXhax" caption="Digests of a general TeX mailing list" />
+  <package key="texi2dvi-latest" name="texi2dvi-latest" caption="Process Texinfo or (La)TeX source to DVI" />
+  <package key="texi2html" name="texi2html" caption="Converts TeXinfo to HTML" />
+  <package key="texi2roff" name="texi2roff" caption="Translate texinfo to troff" />
+  <package key="texi2www" name="texi2www" caption="Converts texinfo to display on the Web" />
+  <package key="texilikechaps" name="texilikechaps" caption="Format chapters with a texi-like format" />
+  <package key="texilikecover" name="texi-like cover" caption="A cover-page package, like TeXinfo" />
+  <package key="texindex" name="texindex" caption="Simple indexing using standard Unix commands" />
+  <package key="texinfo" name="texinfo" caption="Texinfo documentation system" />
+  <package key="texinfo-latest" name="texinfo-latest" caption="Current releases of texinfo.tex and texi2dvi" />
+  <package key="texlab" name="TeXLab" caption="LaTeX Language Server" />
+  <package key="texline" name="TeXline" caption="A TeX-based magazine" />
+  <package key="texlipse" name="texlipse" caption="LaTeX plugin for Eclipse" />
+  <package key="texlist" name="texlist" caption="Typeset program listings" />
+  <package key="texlive" name="texlive" caption="A comprehensive distribution of TeX and friends" />
+  <package key="texlive-dummy-enterprise-linux" name="texlive-dummy-enterprise-linux" caption="Dummy TeX Live RPM for use with RHEL 6 and derived distributions" />
+  <package key="texlive-dummy-enterprise-linux-6" name="texlive-dummy-enterprise-linux-6" caption="Dummy TeX Live RPM for use with RHEL 6 and derived distributions" />
+  <package key="texlive-dummy-enterprise-linux-7" name="texlive-dummy-enterprise-linux-7" caption="Dummy TeX Live RPM for use with RHEL 7 and derived distributions" />
+  <package key="texlive-dummy-enterprise-linux-8" name="texlive-dummy-enterprise-linux-8" caption="Dummy TeX Live RPM for use with RHEL 8 and derived distributions" />
+  <package key="texlive-dummy-fedora" name="texlive-dummy-fedora" caption="Dummy TeX Live RPM for use with Fedora and similar distributions" />
+  <package key="texlive-dummy-opensuse" name="texlive-dummy-opensuse" caption="Dummy TeX Live RPM for use with Open SUSE" />
+  <package key="texlive-repo" name="texlive-repo" caption="A mirror of the TeX Live repository" />
+  <package key="texlive-source" name="TeX Live source tree" caption="Sources of the TeX Live distribution" />
+  <package key="texliveonfly" name="texliveonfly" caption="On-the-fly download of missing TeX live packages" />
+  <package key="texlog-extract" name="texlog-extract" caption="Extract errors and warnings from TeX logs" />
+  <package key="texloganalyser" name="texloganalyser" caption="Analyse TeX logs" />
+  <package key="texlogfilter" name="texlogfilter" caption="Filter LaTeX engines output or log file" />
+  <package key="texlogos" name="texlogos" caption="Ready-to-use LaTeX logos" />
+  <package key="texlogsieve" name="texlogsieve" caption="Filter and summarize LaTeX log files" />
+  <package key="texmacs" name="TeXmacs" caption="Structured text editor for TeX" />
+  <package key="texmalli" name="texmalli" caption="A quick Finnish introduction to using LaTeX" />
+  <package key="texmate" name="TeXmate" caption="Comprehensive chess annotation in LaTeX" />
+  <package key="texments" name="texments" caption="Using the Pygments highlighter in LaTeX" />
+  <package key="texmuse" name="TeXmuse" caption="Music typesetting system using TeX and Metafont" />
+  <package key="texnegar" name="texnegar" caption="Kashida justification in XeLaTeX and LuaLaTeX" />
+  <package key="texniccenter" name="TeXnicCenter" caption="An IDE for LaTeX on MSWindows" />
+  <package key="texonly" name="texonly" caption="A sample document in Plain TeX" />
+  <package key="texosquery" name="texosquery" caption="Cross-platform Java application to query OS information" />
+  <package key="texpack" name="texpack" caption="Create documented LaTeX classes, packages and docs in a Unix environment" />
+  <package key="texperf" name="texperf" caption="A WordPerfect to LaTeX translator" />
+  <package key="texpict" name="texpict" caption="Create drawings for LaTeX" />
+  <package key="texpictex" name="texpictex" caption="Use tpic special commands in PiCTeX" />
+  <package key="texplate" name="texplate" caption="A tool for creating document structures based on templates" />
+  <package key="texpower" name="texpower" caption="Create dynamic online presentations with LaTeX" />
+  <package key="texproject" name="TeXProject" caption="A package for project management" />
+  <package key="texproposal" name="TeXProposal" caption="A proposal prototype for LaTeX promotion in Chinese universities" />
+  <package key="texref" name="texref" caption="Find cross-references in a LaTeX file" />
+  <package key="texshade" name="texshade" caption="Package for setting nucleotide and peptide alignments" />
+  <package key="texshell" name="TeXshell" caption="X-Window Shell for TeX" />
+  <package key="texshell32" name="texshell32" caption="A free TeXShell for MS-Windows 95 and NT" />
+  <package key="texshop" name="texshop" caption="TeX front end for use on MacOS X" />
+  <package key="texsis" name="TeXsis" caption="Plain TeX macros for Physicists" />
+  <package key="texsketch" name="texsketch" caption="A drawing package for OS/2" />
+  <package key="texsort" name="texsort" caption="Sort/compress numerical lists" />
+  <package key="texspell" name="texspell" caption="A LaTeX spelling checker" />
+  <package key="texsurgery" name="texsurgery" caption="A LaTeX companion to the &#8220;texsurgery&#8221; python project" />
+  <package key="text1" name="TeX T1" caption="TeX format from Washington State University" />
+  <package key="text2bib" name="text2bib" caption="A PHP script to convert references to BibTeX" />
+  <package key="textarea" name="textarea" caption="Control the text area dynamically" />
+  <package key="textcase" name="textcase" caption="Case conversion ignoring mathematics, etc" />
+  <package key="textcomp" name="textcomp" caption="LaTeX support for the Text Companion fonts" />
+  <package key="textcsc" name="textcsc" caption="Simple commands for caps-to-small-caps text" />
+  <package key="textfit" name="textfit" caption="Fit text to a desired size" />
+  <package key="textglos" name="textglos" caption="Typeset and index linguistic gloss abbreviations" />
+  <package key="textgreek" name="textgreek" caption="Upright greek letters in text" />
+  <package key="textmerg" name="textmerg" caption="Merge text in TeX and LaTeX" />
+  <package key="textool" name="textool" caption="A SunOS DVI viewer" />
+  <package key="textoolspro" name="textoolspro" caption="Tools for documentation written in LaTeX" />
+  <package key="textopo" name="textopo" caption="Annotated membrane protein topology plots" />
+  <package key="textpath" name="textpath" caption="Setting text along a path with MetaPost" />
+  <package key="textpos" name="textpos" caption="Place boxes at arbitrary positions on the LaTeX page" />
+  <package key="textualicomma" name="textualicomma" caption="Use the textual comma character as decimal separator in math mode" />
+  <package key="textures-metrics" name="textures-metrics" caption="Adobe font metrics, converted for use with Textures" />
+  <package key="texvc" name="texvc" caption="Use MediaWiki LaTeX commands" />
+  <package key="texware" name="texware" caption="Utility programs for use with TeX" />
+  <package key="tfmpk" name="tfmpk" caption="A viewer for tfm and pk font files" />
+  <package key="tfmpktest" name="TFMPKtest" caption="Check and correct checksums of TFM and PK files" />
+  <package key="tfrupee" name="tfrupee" caption="A font offering the new (Indian) Rupee symbol" />
+  <package key="tgothic" name="tgothic" caption="Gothic Textura Quadrata manuscript book-hand font" />
+  <package key="tgrind" name="tgrind" caption="Produce beautiful program listings using plain TeX" />
+  <package key="tgrind209" name="tgrind209" caption="Support tgrind in LaTeX 2.09" />
+  <package key="thai-rmit" name="thai-rmit" caption="A font for Thai script" />
+  <package key="thai-usl" name="thai-usl" caption="A font for Thai script" />
+  <package key="thaienum" name="thaienum" caption="Thai labels in enumerate environments" />
+  <package key="thaifonts-arundina" name="thaifonts-arundina" caption="DejaVu-compatible Thai fonts" />
+  <package key="thailatex" name="ThaiLaTeX" caption="Typeset Thai texts with standard LaTeX classes" />
+  <package key="thaispec" name="thaispec" caption="Thai Language Typesetting in XeLaTeX" />
+  <package key="thalie" name="thalie" caption="Typeset drama plays" />
+  <package key="theanodidot" name="theanodidot" caption="TheanoDidot fonts with LaTeX support" />
+  <package key="theanomodern" name="theanomodern" caption="Theano Modern fonts with LaTeX support" />
+  <package key="theanooldstyle" name="theanooldstyle" caption="Theano OldStyle fonts with LaTeX support" />
+  <package key="theapa" name="theapa" caption="APA (American Psychology Association) Reference Citation for LaTeX" />
+  <package key="theatre" name="theatre" caption="A sophisticated package for typesetting stage plays" />
+  <package key="theorem" name="theorem" caption="Manipulate theorem environments" />
+  <package key="theoremref" name="theoremref" caption="References with automatic theorem names" />
+  <package key="thepdfnumber" name="thepdfnumber" caption="Print PDF numbers with minimal digits" />
+  <package key="thermodynamics" name="thermodynamics" caption="Macros for multicomponent thermodynamics documents" />
+  <package key="these" name="these" caption="Bibliography style for French theses" />
+  <package key="thesis" name="thesis" caption="Typeset thesis" />
+  <package key="thesis-ekf" name="thesis-ekf" caption="Thesis class for Eszterh&#225;zy K&#225;roly Catholic University" />
+  <package key="thesis-gwu" name="thesis-gwu" caption="Thesis class for George Washington University School of Engineering and Applied Science" />
+  <package key="thesis-qom" name="thesis-qom" caption="Thesis style of the University of Qom, Iran" />
+  <package key="thesis-titlepage-fhac" name="thesis-titlepage-fhac" caption="Little style to create a standard titlepage for diploma thesis" />
+  <package key="thinsp" name="thinsp" caption="A stretchable \thinspace for LaTeX" />
+  <package key="thirteen" name="thirteen" caption="Print dates of Friday 13th days" />
+  <package key="thmbox" name="thmbox" caption="Decorate theorem statements" />
+  <package key="thmtools" name="thmtools" caption="Extensions to theorem environments" />
+  <package key="thorshammer" name="thorshammer" caption="Assessment based on AcroTeX quizzes" />
+  <package key="threadcol" name="threadcol" caption="Organize document columns into PDF &#8220;article thread&#8221;" />
+  <package key="threecol" name="threecol" caption="Three-column newsletter output" />
+  <package key="threecolumn" name="threecolumn" caption="LaTeX output in three columns" />
+  <package key="threeddice" name="threeddice" caption="Create images of dice with one, two, or three faces showing, using MetaPost" />
+  <package key="threedldf" name="3DLDF" caption="Three-dimensional drawing with MetaPost output" />
+  <package key="threeparttable" name="threeparttable" caption="Tables with captions and notes all the same width" />
+  <package key="threeparttablex" name="threeparttablex" caption="Notes in longtables" />
+  <package key="thrmappendix" name="thrmappendix" caption="Theorems, lemmas, etc., in appendix" />
+  <package key="thsmc" name="thsmc" caption="Metrics and LaTeX support for Sans Mono Condensed Font" />
+  <package key="thuaslogos" name="thuaslogos" caption="Logos for The Hague University of Applied Sciences (THUAS)" />
+  <package key="thubeamer" name="thubeamer" caption="A beamer theme for Tsinghua University" />
+  <package key="thucoursework" name="thucoursework" caption="Coursework template for Tsinghua University" />
+  <package key="thumb" name="thumb" caption="Thumb marks in documents" />
+  <package key="thumbpdf" name="thumbpdf" caption="Thumbnails for pdfTeX and dvips/ps2pdf" />
+  <package key="thumbs" name="thumbs" caption="Create thumb indexes" />
+  <package key="thumby" name="thumby" caption="Create thumb indexes for printed books" />
+  <package key="thuthesis" name="thuthesis" caption="Thesis template for Tsinghua University" />
+  <package key="tib" name="tib" caption="A bibliographic preprocessor" />
+  <package key="tibetan" name="tibetan" caption="An early LaTeX Tibetan package" />
+  <package key="ticket" name="ticket" caption="Make labels, visiting-cards, pins with LaTeX" />
+  <package key="ticollege" name="ticollege" caption="Graphical representation of keys on a standard scientific calculator" />
+  <package key="tidyres" name="tidyres" caption="Create formal resumes easily" />
+  <package key="tie" name="tie" caption="Allow multiple web change files" />
+  <package key="tif2eps" name="tif2eps" caption="A PostScript program for converting TIFF files to EPS" />
+  <package key="tiff" name="tiff" caption="The tiff graphics package" />
+  <package key="tikz-3dplot" name="tikz-3dplot" caption="Coordinate transformation styles for 3d plotting in TikZ" />
+  <package key="tikz-among-us" name="tikz-among-us" caption="Create some AmongUs characters in TikZ environments" />
+  <package key="tikz-bagua" name="TikZ-Bagua" caption="Draw Bagua symbols in Yijing" />
+  <package key="tikz-bayesnet" name="tikz-bayesnet" caption="Draw Bayesian networks, graphical models and directed factor graphs" />
+  <package key="tikz-bbox" name="tikz-bbox" caption="Precise determination of bounding boxes in TikZ" />
+  <package key="tikz-cd" name="tikz-cd" caption="Create commutative diagrams with TikZ" />
+  <package key="tikz-dependency" name="tikz-dependency" caption="A library for drawing dependency graphs" />
+  <package key="tikz-dimline" name="tikz-dimline" caption="Technical dimension lines using PGF/TikZ" />
+  <package key="tikz-ext" name="tikz-ext" caption="A collection of libraries for PGF/TikZ" />
+  <package key="tikz-feynhand" name="TikZ-FeynHand" caption="Feynman diagrams with TikZ" />
+  <package key="tikz-feynman" name="tikz-feynman" caption="Feynman diagrams with TikZ" />
+  <package key="tikz-imagelabels" name="tikz-imagelabels" caption="Put labels on images using TikZ" />
+  <package key="tikz-inet" name="tikz-inet" caption="Draw interaction nets with TikZ" />
+  <package key="tikz-kalender" name="tikz-kalender" caption="A LaTeX based calendar using TikZ" />
+  <package key="tikz-karnaugh" name="tikz-karnaugh" caption="Typeset Karnaugh maps using TikZ" />
+  <package key="tikz-ladder" name="tikz-ladder" caption="Draw ladder diagrams using TikZ" />
+  <package key="tikz-lake-fig" name="tikz-lake-fig" caption="Schematic diagrams of lakes" />
+  <package key="tikz-layers" name="tikz-layers" caption="TikZ provides graphical layers on TikZ: &quot;behind&quot;, &quot;above&quot; and &quot;glass&quot; " />
+  <package key="tikz-mirror-lens" name="tikz-mirror-lens" caption="Spherical mirrors and lenses in TikZ" />
+  <package key="tikz-nef" name="tikz-nef" caption="Create diagrams for neural networks constructed with the methods of the Neural Engineering Framework (NEF)" />
+  <package key="tikz-network" name="tikz-network" caption="Draw networks with TikZ" />
+  <package key="tikz-nfold" name="tikz-nfold" caption="Triple, quadruple, and n-fold paths with TikZ" />
+  <package key="tikz-opm" name="tikz-opm" caption=" Typeset OPM diagrams" />
+  <package key="tikz-optics" name="tikz-optics" caption="A library for drawing optical setups with TikZ" />
+  <package key="tikz-page" name="tikz-page" caption=" Small macro to help building nice and complex layout materials" />
+  <package key="tikz-palattice" name="tikz-palattice" caption="Draw particle accelerator lattices with TikZ" />
+  <package key="tikz-planets" name="TikZ-planets" caption="Illustrate celestial mechanics and the solar system" />
+  <package key="tikz-qtree" name="tikz-qtree" caption="Use existing qtree syntax for trees in TikZ" />
+  <package key="tikz-relay" name="tikz-relay" caption="TikZ library for typesetting electrical diagrams " />
+  <package key="tikz-sfc" name="tikz-sfc" caption="Symbols collection for typesetting Sequential Function Chart (SFC) diagrams (PLC programs)" />
+  <package key="tikz-swigs" name="tikz-swigs" caption="Horizontally and vertically split elliptical nodes" />
+  <package key="tikz-timing" name="tikz-timing" caption="Easy generation of timing diagrams as TikZ pictures" />
+  <package key="tikz-trackschematic" name="tikz-trackschematic" caption="A TikZ library for creating track diagrams in railways" />
+  <package key="tikz-truchet" name="tikz-truchet" caption="Draw Truchet tiles" />
+  <package key="tikz2d-fr" name="tikz2d-fr" caption="Work with some 2D TikZ commands (French)" />
+  <package key="tikz3d-fr" name="tikz3d-fr" caption="Work with some 3D figures" />
+  <package key="tikzbricks" name="TikZbricks" caption="Drawing bricks with TikZ" />
+  <package key="tikzcodeblocks" name="tikzcodeblocks" caption="Helps to draw codeblocks like scratch, NEPO and PXT in TikZ" />
+  <package key="tikzducks" name="TikZducks" caption="A little fun package for using rubber ducks in TikZ" />
+  <package key="tikzfill" name="tikzfill" caption="TikZ libraries for filling with images and patterns" />
+  <package key="tikzinclude" name="tikzinclude" caption="Import TikZ images from colletions" />
+  <package key="tikzlings" name="TikZlings" caption="A collection of cute little animals and similar creatures" />
+  <package key="tikzmark" name="tikzmark" caption="Use TikZ&apos;s method of remembering a position on a page" />
+  <package key="tikzmarmots" name="TikZmarmots" caption="Drawing little marmots in TikZ" />
+  <package key="tikzorbital" name="tikzorbital" caption="Atomic and molecular orbitals using TikZ" />
+  <package key="tikzpackets" name="tikzpackets" caption="Display network packets" />
+  <package key="tikzpagenodes" name="tikzpagenodes" caption="A single TikZ node for the whole page" />
+  <package key="tikzpeople" name="tikzpeople" caption="Draw people-shaped nodes in TikZ" />
+  <package key="tikzpfeile" name="tikzpfeile" caption="Draw arrows using PGF/TikZ" />
+  <package key="tikzpingus" name="Tikzpingus" caption="Penguins with TikZ" />
+  <package key="tikzposter" name="tikzposter" caption="Create scientific posters using TikZ" />
+  <package key="tikzscale" name="tikzscale" caption="Resize pictures while respecting text size" />
+  <package key="tikzsymbols" name="tikzsymbols" caption="Some symbols created using TikZ" />
+  <package key="tikztosvg" name="tikztosvg" caption="A utility for rendering TikZ diagrams to SVG" />
+  <package key="tikzviolinplots" name="tikzviolinplots" caption="Draws violin plots from data" />
+  <package key="tile-graphic" name="tile-graphic" caption="Create tiles of a graphical file" />
+  <package key="tilings" name="tilings" caption="A TikZ library for drawing tiles and tilings" />
+  <package key="timbreicmc" name="timbreicmc" caption="Typeset documents with ICMC/USP watermarks" />
+  <package key="time" name="time" caption="Defines a macro \now to print the current time" />
+  <package key="time-gen" name="time-gen" caption="Print the time (12-hour clock)" />
+  <package key="timeline" name="timeline" caption="Typeset time-lines, for planning, etc" />
+  <package key="times" name="times" caption="Select Adobe Times Roman (or equivalent) as default font" />
+  <package key="timetab" name="timetab" caption="Typeset timetables" />
+  <package key="timetable" name="timetable" caption="Generate timetables" />
+  <package key="timing" name="timing" caption="Fonts and macro package for drawing timing diagrams" />
+  <package key="timing-diagrams" name="timing-diagrams" caption="Draw timing diagrams" />
+  <package key="tinos" name="tinos" caption="Tinos fonts with LaTeX support" />
+  <package key="tinyc2l" name="tinyc2l" caption="Pretty print C/C++/Java source code using LaTeX" />
+  <package key="tip" name="tip" caption="Macro examples from &#8220;TeX in Practice&#8221;" />
+  <package key="tipa" name="tipa" caption="Fonts and macros for IPA phonetics characters" />
+  <package key="tipa-de" name="tipa-de" caption="German translation of tipa documentation" />
+  <package key="tipauni" name="tipauni" caption="Producing Unicode characters with TIPA commands" />
+  <package key="tipfr" name="tipfr" caption="Produces calculator&apos;s keys with the help of TikZ" />
+  <package key="tipos" name="tipos" caption="Description of fonts for TeX, in Spanish" />
+  <package key="tiscreen" name="tiscreen" caption="Mimic the screen of older Texas Instruments calculators" />
+  <package key="titlecaps" name="titlecaps" caption="Setting rich-text input into Titling Caps" />
+  <package key="titlefoot" name="titlefoot" caption="Add special material to footer of title page" />
+  <package key="titlepage-uni-dortmund" name="titlepage-uni-dortmund" caption="Titlepage for University of Dortmund (Germany)" />
+  <package key="titlepages" name="titlepages" caption="Sample titlepages, and how to code them" />
+  <package key="titlepic" name="titlepic" caption="Add picture to title page of a document" />
+  <package key="titleps" name="titleps" caption="Page style control" />
+  <package key="titleref" name="titleref" caption="A &quot;\titleref&quot; command to cross-reference section titles" />
+  <package key="titles" name="titles" caption="Titles of books, articles, etc. in LaTeX" />
+  <package key="titlesec" name="titlesec" caption="Select alternative section titles" />
+  <package key="titletoc" name="titletoc" caption="Alternative headings for toc/lof/lot" />
+  <package key="titling" name="titling" caption="Control over the typesetting of the \maketitle command" />
+  <package key="tkbibtex" name="tkbibtex" caption="A portable editor and browser for BibTeX files" />
+  <package key="tkdvi" name="tkdvi" caption="DVI previewer built with the Tcl/Tk toolkit" />
+  <package key="tkhyph" name="tkhyph" caption="Hyphenation patterns for Turkish" />
+  <package key="tktexcad" name="tktexcad" caption="Generate LaTeX picture environments" />
+  <package key="tkz-base" name="tkz-base" caption="Tools for drawing with a cartesian coordinate system" />
+  <package key="tkz-berge" name="tkz-berge" caption="Macros for drawing graphs of graph theory" />
+  <package key="tkz-doc" name="tkz-doc" caption="Documentation macros for the TKZ series of packages" />
+  <package key="tkz-euclide" name="tkz-euclide" caption="Tools for drawing Euclidean geometry" />
+  <package key="tkz-fct" name="tkz-fct" caption="Tools for drawing graphs of functions" />
+  <package key="tkz-graph" name="tkz-graph" caption="Draw graph-theory graphs" />
+  <package key="tkz-kiviat" name="tkz-kiviat" caption="Draw Kiviat graphs" />
+  <package key="tkz-linknodes" name="tkz-linknodes" caption="Link nodes in mathematical environments" />
+  <package key="tkz-orm" name="tkz-orm" caption="Create Object-Role Model (ORM) diagrams" />
+  <package key="tkz-tab" name="tkz-tab" caption="Tables of signs and variations using PGF/TikZ" />
+  <package key="tkzexample" name="tkzexample" caption="Package for the documentation of all tkz-* packages" />
+  <package key="tlaunch" name="tlaunch" caption="A Windows GUI to run a networked TeX Live as if installed locally" />
+  <package key="tlc-article" name="tlc-article" caption="A LaTeX document class for formal documents" />
+  <package key="tlc2-errata" name="tlc2-errata" caption="Errata list for The LaTeX Companion, Second Edition" />
+  <package key="tlc2-examples" name="tlc2-examples" caption="Examples from &#8220;The LaTeX Companion&#8221;, second edition" />
+  <package key="tlc3-examples" name="tlc3-examples" caption="All examples from &#8220;The LaTeX Companion&#8221;, third edition" />
+  <package key="tlcockpit" name="TLCockpit" caption="A GUI frontend to TeX Live Manager (tlmgr)" />
+  <package key="tlg2latex" name="tlg2latex" caption="Prepare LaTeX from the Thesaurus Linguae Graecae" />
+  <package key="tlmgr-intro-zh-cn" name="tlmgr-intro-zh-cn" caption="A short tutorial on using tlmgr in Chinese" />
+  <package key="tlmgrbasics" name="tlmgrBasics" caption="A simplified documentation for tlmgr" />
+  <package key="tmmath" name="tmmath" caption="Support for using the Micropress TM-Math fonts" />
+  <package key="tmmath-fonts" name="tmmath-fonts" caption="Bitmap versions of the Micropress TM-Math fonts (Times Maths)" />
+  <package key="tmview" name="tmview" caption="A DVI previewer for SVGA displays" />
+  <package key="to-be-determined" name="to-be-determined" caption="Highlight text passages that need further work" />
+  <package key="toc" name="toc" caption="Table of contents macros for Plain TeX" />
+  <package key="toc-zar" name="toc-zar" caption="Plain TeX table of contents macros" />
+  <package key="tocbasic" name="tocbasic" caption="Management of tables/lists of contents (and the like)" />
+  <package key="tocbibind" name="tocbibind" caption="Add bibliography/index/contents to Table of Contents" />
+  <package key="tocdata" name="tocdata" caption="Adds names to chapters, sections, figures in the TOC and LOF" />
+  <package key="tocenter" name="tocenter" caption="Centring (and other) Page Layout" />
+  <package key="tocloft" name="tocloft" caption="Control table of contents, figures, etc" />
+  <package key="tocstyle" name="tocstyle" caption="Define style of Table of contents (etc) files" />
+  <package key="tocvsec2" name="tocvsec2" caption="Section numbering and table of contents control" />
+  <package key="todo" name="todo" caption="Make a to-do list for a document" />
+  <package key="todonotes" name="todonotes" caption="Marking things to do in a LaTeX document" />
+  <package key="toil" name="toil" caption="An installer of PostScript fonts for TeX" />
+  <package key="tokcycle" name="tokcycle" caption="Build tools to process tokens from an input stream" />
+  <package key="tokenizer" name="tokenizer" caption="A tokenizer" />
+  <package key="tolkienfonts" name="tolkienfonts" caption="Use TTF &quot;Tolkien&quot; fonts from the WWW with pdfTeX" />
+  <package key="tonevalue" name="toneval" caption="Tool for linguists and phoneticians to visualize tone value patterns" />
+  <package key="toolbox" name="toolbox" caption="Tool macros" />
+  <package key="topcapt" name="topcapt" caption="Place captions above figures or tables" />
+  <package key="topfloat" name="topfloat" caption="Move floats to the top of the page" />
+  <package key="topiclongtable" name="topiclongtable" caption="Extend&#160;longtable&#160;with cells that merge hierarchically" />
+  <package key="topletter" name="TOPletter" caption="Letter class for the Politecnico di Torino" />
+  <package key="topsection" name="topsection" caption="An un-numbered top level section" />
+  <package key="toptesi" name="TOPtesi" caption="Bundle for typesetting multilanguage theses" />
+  <package key="totalcount" name="totalcount" caption="Commands for typesetting total values of counters" />
+  <package key="totcount" name="totcount" caption="Find the last value of a counter" />
+  <package key="totpages" name="totpages" caption="Count pages in a document, and report last page number" />
+  <package key="tpcmfont" name="tpcmfont" caption="Computer modern fonts in &quot;true point sizes&quot;" />
+  <package key="tpic2pdftex" name="tpic2pdftex" caption="Use tpic commands in pdfTeX" />
+  <package key="tpslifonts" name="tpslifonts" caption="A LaTeX package for configuring presentation fonts" />
+  <package key="tpx" name="TpX" caption="A drawing tool for Windows" />
+  <package key="tqft" name="tqft" caption="Drawing TQFT diagrams with TikZ/PGF" />
+  <package key="tr2latex" name="tr2latex" caption="Translate troff source to LaTeX" />
+  <package key="trace" name="trace" caption="Make sensible use of TeX tracing in LaTeX" />
+  <package key="tracking" name="tracking" caption="Adjust tracking of strings" />
+  <package key="tracklang" name="tracklang" caption="Language and dialect tracker" />
+  <package key="trademarks" name="trademarks" caption="A collection of trademarks and the like" />
+  <package key="trajan" name="trajan" caption="Fonts from the Trajan column in Rome" />
+  <package key="tram" name="tram" caption="Typeset tram boxes in LaTeX" />
+  <package key="tramlines" name="tramlines" caption="A package for creating tramlines (lines above and below a title used
+    by lawyers in the UK)" />
+  <package key="trans" name="trans" caption="A simple TeX macro package for PostScript transformations" />
+  <package key="transfig" name="transfig" caption="Transform xfig pictures into many other formats" />
+  <package key="translation-array-fr" name="translation-array-fr" caption="French translation of the documentation of array" />
+  <package key="translation-arsclassica-de" name="translation-arsclassica-de" caption="German version of arsclassica" />
+  <package key="translation-biblatex-de" name="translation-biblatex-de" caption="German translation of the User Guide for BibLaTeX" />
+  <package key="translation-booktabs-fr" name="translation-booktabs-fr" caption="French translation of the documentation of booktabs" />
+  <package key="translation-chemsym-de" name="translation-chemsym-de" caption="German version of chemsym" />
+  <package key="translation-dcolumn-fr" name="translation-dcolumn-fr" caption="French translation of the documentation of dcolumn" />
+  <package key="translation-ecv-de" name="translation-ecv-de" caption="Ecv documentation, in German" />
+  <package key="translation-enumitem-de" name="translation-enumitem-de" caption="Enumitem documentation, in German" />
+  <package key="translation-europecv-de" name="translation-europecv-de" caption="German version of europecv" />
+  <package key="translation-filecontents-de" name="translation-filecontents-de" caption="German version of filecontents" />
+  <package key="translation-footmisc-de" name="translation-footmisc-de" caption="A German translation of the documentation of footmisc" />
+  <package key="translation-moreverb-de" name="translation-moreverb-de" caption="German version of moreverb" />
+  <package key="translation-natbib-fr" name="translation-natbib-fr" caption="French translation of the documentation of natbib" />
+  <package key="translation-pst-jtree-de" name="translation-pst-jtree-de" caption="A German translation of the documentation of pst-jtree" />
+  <package key="translation-tabbing-fr" name="translation-tabbing-fr" caption="French translation of the documentation of Tabbing" />
+  <package key="translations" name="translations" caption="Internationalisation of LaTeX2e packages" />
+  <package key="translator" name="translator" caption="Easy translation of strings in LaTeX" />
+  <package key="transparent" name="transparent" caption="Using a color stack for transparency with pdfTeX" />
+  <package key="transparent-io" name="Transparent-IO" caption="Show for approval the filenames used in \input, \openin, or \openout" />
+  <package key="tree-dvips" name="tree-dvips" caption="Trees and other linguists&apos; macros" />
+  <package key="treedef" name="treedef" caption="Macros to typeset trees in Plain TeX" />
+  <package key="treesvr" name="treesvr" caption="Tree macros" />
+  <package key="treetex-ltx209" name="treetex-ltx209" caption="Draw horizontally- or vertically-oriented trees" />
+  <package key="treetex-plain" name="treetex-plain" caption="Draw trees" />
+  <package key="trfsigns" name="trfsigns" caption="Typeset transform signs" />
+  <package key="trig" name="trig" caption="Simple trigonometric functions" />
+  <package key="trigonometry" name="trigonometry" caption="Demonstration code for cos and sin in TeX macros" />
+  <package key="trimspaces" name="trimspaces" caption="Trim spaces around an argument or within a macro" />
+  <package key="trivfloat" name="trivfloat" caption="Quick float definitions in LaTeX" />
+  <package key="trsym" name="trsym" caption="Symbols for transformations" />
+  <package key="truchet" name="truchet" caption="Truchet tiling in MetaPost" />
+  <package key="truecols" name="truecols" caption="Colour facilities for SliTeX" />
+  <package key="truetypemetrics" name="truetypemetrics" caption="Metrics for some TrueType font families" />
+  <package key="truetypetotype42" name="TrueTypeToType42" caption="Generate a Type 42 font from a TrueType font" />
+  <package key="truncate" name="truncate" caption="Truncate text to a specified width" />
+  <package key="truthtable" name="truthtable" caption="Automatically generate truth tables for given variables and statements" />
+  <package key="try" name="TrY" caption="Automation of TeX/LaTeX compilation" />
+  <package key="tsconfig" name="tsconfig" caption="Setup support for TeXshell" />
+  <package key="tsemlines" name="tsemlines" caption="Support for the ancient \emline macro" />
+  <package key="tsipa" name="tsipa" caption="Macros and fonts to produce IPA typesetting" />
+  <package key="tsvtemplate" name="tsvtemplate" caption="Apply a template to a tsv file" />
+  <package key="tt2001" name="tt2001" caption="Type 1 EC fonts generated by TeXtrace" />
+  <package key="ttf-howto" name="ttf-howto" caption="Using TrueType fonts with TeX systems" />
+  <package key="ttf2mf" name="ttf2mf" caption="Convert True Type fonts to Metafont" />
+  <package key="ttf2pfb" name="ttf2pfb" caption="Make an Adobe Type 1 version of a TrueType font" />
+  <package key="ttf2pt1" name="ttf2pt1" caption="Convert TrueType fonts to Adobe Type 1 format" />
+  <package key="ttf2tex" name="ttf2tex" caption="Use TrueType fonts with teTeX" />
+  <package key="ttftogf" name="ttftogf" caption="Convert True Type fonts to GF format" />
+  <package key="tth" name="tth" caption="A TeX to HTML translator" />
+  <package key="ttn" name="ttn" caption="TeX and TUG news archive" />
+  <package key="ttt" name="ttt" caption="A Tibetan Transcript Transliterator for LaTeX" />
+  <package key="tucv" name="tucv" caption="Support for typesetting a CV or r&#233;sume&#233;" />
+  <package key="tuda-ci" name="tuda-ci" caption="LaTeX templates of Technische Universit&#228;t Darmstadt" />
+  <package key="tudscr" name="tudscr" caption="Corporate Design of Technische Universit&#228;t Dresden" />
+  <package key="tufte-latex" name="tufte-latex" caption="Document classes inspired by the work of Edward Tufte" />
+  <package key="tugboat" name="tugboat" caption="LaTeX macros for TUGboat articles" />
+  <package key="tugboat-plain" name="tugboat-plain" caption="Plain TeX macros for TUGboat" />
+  <package key="tugboat-toc" name="tugboat-toc" caption="An accumulation of TUGboat tables of contents" />
+  <package key="tui" name="tui" caption="Thesis style for the University of the Andes, Colombia" />
+  <package key="turabian" name="turabian" caption="Create Turabian-formatted material using LaTeX" />
+  <package key="turabian-formatting" name="turabian-formatting" caption="Formatting based on Turabian&apos;s Manual" />
+  <package key="turkish" name="turkish" caption="LaTeX Support for Typesetting Turkish" />
+  <package key="turkishintro" name="turkishintro" caption="An introduction to LaTeX, in Turkish" />
+  <package key="turkmen" name="turkmen" caption="Babel support for Turkmen" />
+  <package key="turnstile" name="turnstile" caption="Typeset the (logic) turnstile notation" />
+  <package key="turnthepage" name="turnthepage" caption="Provide &quot;turn page&quot; instructions" />
+  <package key="tvs" name="TVS" caption="TeX Versioning System" />
+  <package key="twcal" name="twcal" caption="Calligraphic font for typesetting handwriting" />
+  <package key="tweb" name="tweb" caption="A web system for TeX macro sources" />
+  <package key="twemoji-colr" name="twemoji-colr" caption="Twemoji font in COLR/CPAL layered format" />
+  <package key="twemojis" name="twemojis" caption="Use Twitter&#8217;s open source emojis through LaTeX commands" />
+  <package key="twocolumns" name="twocolumns" caption="Knuth&apos;s two-column output macros" />
+  <package key="twoinone" name="2in1" caption="Print two pages on a single page" />
+  <package key="twoopt" name="twoopt" caption="Definitions with two optional arguments" />
+  <package key="twoside" name="twoside" caption="Two-side typesetting in Plain TeX" />
+  <package key="twoup-gen" name="twoup-gen" caption="Macros to print two-up" />
+  <package key="twoupltx" name="twoupltx" caption="Print two virtual pages on each physical page" />
+  <package key="txfonts" name="txfonts" caption="Times-like fonts in support of mathematics" />
+  <package key="txfontsb" name="txfontsb" caption="Extensions to txfonts, using GNU Freefont" />
+  <package key="txgreeks" name="txgreeks" caption="Shape selection for TX fonts Greek letters" />
+  <package key="txp" name="txp" caption="Draw text along a path" />
+  <package key="txt" name="txt" caption="Output documents via terminals, line printers, etc" />
+  <package key="txt2latex" name="txt2latex" caption="Convert text by fixing special chars and quote marks" />
+  <package key="txt2tex" name="txt2tex" caption="Add LaTeX markup to plain text" />
+  <package key="txuprcal" name="TXUprCal" caption="Upright calligraphic font based on TX calligraphic" />
+  <package key="type1cm" name="type1cm" caption="Arbitrary size font selection in LaTeX" />
+  <package key="type1ec" name="type1ec" caption="Permit EC, TC and LH fonts at arbitrary sizes" />
+  <package key="typearea" name="typearea" caption="Set page margins" />
+  <package key="typed-checklist" name="typed-checklist" caption="Typesetting tasks, goals, milestones, artifacts, and more in LaTeX" />
+  <package key="typedref" name="typedref" caption="Eliminate errors by enforcing the types of labels" />
+  <package key="typeface" name="typeface" caption="Select a balanced set of fonts" />
+  <package key="typehtml" name="typehtml" caption="Typeset HTML directly from LaTeX" />
+  <package key="typeoutfileinfo" name="typeoutfileinfo" caption="Display class/package/file information" />
+  <package key="typespec" name="typespec" caption="Create font samplers" />
+  <package key="typewriter" name="typewriter" caption="Typeset with a randomly variable monospace font" />
+  <package key="typicons" name="typicons" caption="Font containing a set of web-related icons" />
+  <package key="typoaid" name="typoaid" caption="Macros for font diagnostics" />
+  <package key="typografie" name="typografie" caption="A tutorial on typography" />
+  <package key="typogrid" name="typogrid" caption="Print a typographic grid" />
+  <package key="tzplot" name="tzplot" caption="Plot graphs with TikZ abbreviations" />
+  <package key="u8tex" name="u8tex" caption="Input Unicode characters in TeX notation, in emacs" />
+  <package key="uaclasses" name="uaclasses" caption="University of Arizona thesis and dissertation format" />
+  <package key="uafthesis" name="uafthesis" caption="Document class for theses at University of Alaska Fairbanks" />
+  <package key="uantwerpendocs" name="uantwerpendocs" caption="Course texts, master theses, and exams in University of Antwerp style" />
+  <package key="uassign" name="uassign" caption="Environments and options for typesetting university assignments" />
+  <package key="ucalgmthesis" name="ucalgmthesis" caption="LaTeX thesis class for University of Calgary Faculty of Graduate Studies" />
+  <package key="ucbthesis" name="ucbthesis" caption="Thesis and dissertation class supporting UCB requirements" />
+  <package key="ucdavisthesis" name="ucdavisthesis" caption="A thesis/dissertation class for University of California at Davis" />
+  <package key="ucharcat" name="ucharcat" caption="Implementation of the (new in 2015) XeTeX \Ucharcat command in lua, for LuaTeX" />
+  <package key="ucharclasses" name="ucharclasses" caption="Font actions in XeTeX according to what is being processed" />
+  <package key="ucs" name="ucs" caption="Extended UTF-8 input encoding support for LaTeX" />
+  <package key="ucsmonograph" name="ucsmonograph" caption="Typesetting academic documents from the University of Caxias do Sul" />
+  <package key="ucthesis" name="ucthesis" caption="University of California thesis format" />
+  <package key="ucthesis209" name="ucthesis209" caption="LaTeX 2.09 document style for UC Theses" />
+  <package key="udes-genie-these" name="udes-genie-these" caption=" A thesis class file for the Facult&#233; de g&#233;nie at the Universit&#233; de Sherbrooke" />
+  <package key="udesoftec" name="udesoftec" caption="Thesis class for the University of Duisburg-Essen" />
+  <package key="uebungsblatt" name="uebungsblatt" caption="A LaTeX class for writing exercise sheets" />
+  <package key="uestcthesis" name="uestcthesis" caption="Thesis class for UESTC" />
+  <package key="ufrgscca" name="ufrgscca" caption="A bundle for undergraduate students final work/report (tcc) at UFRGS/EE" />
+  <package key="ugarite" name="ugarite" caption="Fonts for Ugaritic cuneiform script" />
+  <package key="ugaritic" name="ugaritic" caption="A font for Ugaritic" />
+  <package key="uhc" name="uhc" caption="Fonts for the Korean language" />
+  <package key="uhhassignment" name="uhhassignment" caption="A document class for typesetting homework assignments" />
+  <package key="uhrzeit" name="uhrzeit" caption="Time printing, in German" />
+  <package key="uhthesis" name="uhthesis" caption="University of Houston thesis document style" />
+  <package key="uiucredborder" name="uiucredborder" caption="Class for UIUC thesis red-bordered forms" />
+  <package key="uiucthesis" name="uiucthesis" caption="UIUC thesis class" />
+  <package key="ukbill" name="ukbill" caption="A class for typesetting UK legislation" />
+  <package key="ukdate" name="ukdate" caption="Typeset date in a UK-ish form" />
+  <package key="ukhyph" name="ukhyph" caption="Hyphenation patterns for British English" />
+  <package key="ukrhyph" name="ukrhyph" caption="Hyphenation Patterns for Ukrainian" />
+  <package key="uktex" name="UK-TeX" caption="The UK TeX digest" />
+  <package key="uktug-bask" name="uktug-bask" caption="Old copies and sources of Baskerville" />
+  <package key="ulem" name="ulem" caption="Package for underlining" />
+  <package key="ulqda" name="ulqda" caption="Support of Qualitative Data Analysis" />
+  <package key="ulsy" name="ulsy" caption="Extra mathematical characters" />
+  <package key="ulsy-ps" name="ulsy-ps" caption="Extra mathematical characters in Adobe Type 1 format" />
+  <package key="ulthese" name="ulthese" caption="Thesis class and templates for Universit&#233; Laval" />
+  <package key="ultratex" name="Ultra-TeX" caption="An emacs TeX mode with &quot;lightning completion&apos;" />
+  <package key="umbclegislation" name="umbclegislation" caption="A LaTeX class for building legislation files for UMBC Student
+    Government Association Bills" />
+  <package key="umich-thesis" name="umich-thesis" caption="University of Michigan Thesis LaTeX class" />
+  <package key="uml" name="UML" caption="UML diagrams in LaTeX" />
+  <package key="umlaute" name="umlaute" caption="German input encodings in LaTeX" />
+  <package key="umoline" name="umoline" caption="Underline text allowing line breaking" />
+  <package key="umrand" name="umrand" caption="Package for fancy box frames" />
+  <package key="umthesis" name="umthesis" caption="Dissertations at the University of Michigan" />
+  <package key="umtypewriter" name="umtypewriter" caption="Fonts to typeset with the xgreek package" />
+  <package key="unam-thesis" name="unam-thesis" caption="Create documents according to the UNAM guidelines" />
+  <package key="unamth-template" name="unamth-template" caption="UNAM Thesis LaTeX Template" />
+  <package key="unamthesis" name="unamthesis" caption="Style for Universidad Nacional Autonoma de Mexico theses" />
+  <package key="unbtex" name="UnBTeX" caption="A class for theses at University of Brasilia (UnB)" />
+  <package key="uncial" name="uncial" caption="Uncial manuscript book-hand font" />
+  <package key="undergradmath" name="undergradmath" caption="LaTeX Math for Undergraduates cheat sheet" />
+  <package key="underlin" name="underlin" caption="Underlined running heads" />
+  <package key="underlin-gen" name="underlin-generic" caption="Multi-word underlining" />
+  <package key="underoverlap" name="underoverlap" caption="Position decorations over and under expressions" />
+  <package key="underscore" name="underscore" caption="Control the behaviour of &quot;_&quot; in text" />
+  <package key="undertilde" name="undertilde" caption="Typeset a tilde under one (or many) maths symbols" />
+  <package key="undertilde-gen" name="undertilde-gen" caption="A simple macro for placing a tilde under a character" />
+  <package key="undolabl" name="undolabl" caption="Override existing labels" />
+  <package key="undump" name="undump" caption="Make a new executable with format loaded" />
+  <package key="unfinished" name="unfinished" caption="Mark unfinished parts of a document" />
+  <package key="unfonts-core" name="unfonts-core" caption="TrueType version of Un-fonts" />
+  <package key="unfonts-extra" name="unfonts-extra" caption="TrueType version of Un-fonts" />
+  <package key="uni-titlepage" name="uni-titlepage" caption="Universal titlepages with configuration options and predefined styles" />
+  <package key="uni-wtal-ger" name="uni-wtal-ger" caption="Citation style for literary studies at the University of Wuppertal" />
+  <package key="uni-wtal-lin" name="uni-wtal-lin" caption="Citation style for linguistic studies at the University of Wuppertal" />
+  <package key="unicode" name="unicode" caption="Extended UTF-8 input encoding for LaTeX" />
+  <package key="unicode-alphabets" name="unicode-alphabets" caption="Macros for using characters from Unicode&#8217;s Private Use Area" />
+  <package key="unicode-bidi" name="unicode-bidi" caption="Experimental unicode bidi package for XeTeX" />
+  <package key="unicode-data" name="unicode-data" caption="Unicode data and loaders for TeX" />
+  <package key="unicode-math" name="unicode-math" caption="Unicode mathematics support for XeTeX and LuaTeX" />
+  <package key="unicode-math-input" name="unicode-math-input" caption="Allow entering Unicode symbols in math formulas" />
+  <package key="unicodefonttable" name="unicodefonttable" caption="A Unicode font table generator" />
+  <package key="unifith" name="UniFiTh" caption="Typeset theses for University of Florence (Italy)" />
+  <package key="unifront" name="unifront" caption="Give notes a unique front page for every chapter and section" />
+  <package key="unigrazpub" name="unigrazpub" caption="LaTeX templates for University of Graz Library Publishing Services" />
+  <package key="unimath-plain-xetex" name="unimath-plain-xetex" caption="OpenType math support in (plain) XeTeX" />
+  <package key="uninormalize" name="uninormalize" caption="Unicode normalization support" />
+  <package key="uniquecounter" name="uniquecounter" caption="Provides unlimited unique counter" />
+  <package key="unisc" name="unisc" caption="Unicode small caps with Lua/XeLaTeX" />
+  <package key="unisugar" name="unisugar" caption="Define syntactic sugar for Unicode LaTeX" />
+  <package key="unitconv" name="unitconv" caption="Convert a length into one with another unit" />
+  <package key="unitipa" name="unitipa" caption="TIPA typefaces with Unicode characters as input" />
+  <package key="unitn-bimrep" name="unitn-bimrep" caption="A bimonthly report class for the PhD School of Materials, Mechatronics and System Engineering" />
+  <package key="units" name="units" caption="Typeset units" />
+  <package key="unitsdef" name="unitsdef" caption="Typesetting units in LaTeX" />
+  <package key="universa" name="universa" caption="Herbert Bayer&#8217;s &#8216;universal&#8217; font" />
+  <package key="universalis" name="universalis" caption="Universalis font, with support" />
+  <package key="univie-ling" name="univie-ling" caption="Papers, theses and research proposals in (Applied) Linguistics at Vienna University" />
+  <package key="unixman" name="unixman" caption="Typeset to look like Unix man output" />
+  <package key="unizgklasa" name="unizgklasa" caption="A LaTeX class for theses at the Faculty Of Graphic Arts in Zagreb" />
+  <package key="unouter" name="unouter" caption="Suppress \outer flags in Plain TeX" />
+  <package key="unpacked" name="unpacked" caption="Unpacked copy of the LaTeX sources" />
+  <package key="unravel" name="unravel" caption="Watching TeX digest tokens" />
+  <package key="unswcover" name="unswcover" caption="Typeset a dissertation cover page following UNSW guidelines" />
+  <package key="unswthesis" name="unswthesis" caption="UNSW theses" />
+  <package key="untex" name="untex" caption="Strip (La)TeX commands from source file" />
+  <package key="uol-physics-report" name="uol-physics-report" caption="A LaTeX document class for writing lab reports" />
+  <package key="uothesis" name="uothesis" caption="Class for dissertations and theses at the University of Oregon" />
+  <package key="uowthesis" name="uowthesis" caption="Document class for dissertations at the University of Wollongong" />
+  <package key="uowthesistitlepage" name="uowthesistitlepage" caption="Title page for dissertations at the University of Wollongong" />
+  <package key="upca" name="upca" caption="Print UPC-A barcodes" />
+  <package key="upgreek" name="upgreek" caption="Upright Greek letters" />
+  <package key="uplatex" name="uplatex" caption="pLaTeX2e and miscellaneous macros for upTeX" />
+  <package key="upmendex" name="upmendex" caption="Multilingual index processor" />
+  <package key="upmethodology" name="UPmethodology" caption="Writing specifications such as for UP-based methodologies" />
+  <package key="uppunctlm" name="uppunctlm" caption="Always keep upright shape for some punctuation marks and Arabic numerals" />
+  <package key="upquote" name="upquote" caption="Show &quot;realistic&quot; quotes in verbatim" />
+  <package key="upref" name="upref" caption="Ensure references are upright" />
+  <package key="uptex" name="uptex" caption="Unicode version of pTeX" />
+  <package key="uptex-base" name="uptex-base" caption="Plain TeX formats and documents for upTeX" />
+  <package key="uptex-fonts" name="uptex-fonts" caption="Fonts for use with upTeX" />
+  <package key="upzhkinsoku" name="upzhkinsoku" caption="Supplementary Chinese kinsoku for Unicode *pTeX" />
+  <package key="urcls" name="urcls" caption="
+    Beamer and scrlttr2 classes and styles
+    for the University of Regensburg
+  " />
+  <package key="uri" name="uri" caption="Hyperlinks for a wide range of URIs" />
+  <package key="url" name="url" caption="Verbatim with URL-sensitive line breaks" />
+  <package key="urlbst" name="urlbst" caption="Web support for BibTeX" />
+  <package key="urw" name="urw" caption="URW free font support" />
+  <package key="urw-antiqua" name="urw-antiqua" caption="URW Antiqua condensed font, for use with TeX" />
+  <package key="urw-arial" name="urw-arial" caption="URW Arial font pack for use with LaTeX" />
+  <package key="urw-base35" name="URW-base35" caption="URW &#8216;Base 35&#8217; font pack for LaTeX" />
+  <package key="urw-garamond" name="urw-garamond" caption="URW Garamond No8 Adobe Type 1 fonts" />
+  <package key="urw-grotesq" name="URW-Grotesq" caption="URW Grotesq font pack for LaTeX" />
+  <package key="urwchancal" name="urwchancal" caption="Use URW&apos;s clone of Zapf Chancery as a maths alphabet" />
+  <package key="urwvf" name="urwvf" caption="Support for use of free URW fonts" />
+  <package key="uscthesis" name="uscthesis" caption="USC thesis style for LaTeX 2.09" />
+  <package key="usebib" name="usebib" caption="A simple bibliography processor" />
+  <package key="usenix" name="usenix" caption="Style option to do Usenix conference proceedings" />
+  <package key="ushort" name="ushort" caption="Shorter (and longer) underlines and underbars" />
+  <package key="ushyph" name="ushyph" caption="US hyphenation patterns" />
+  <package key="uspace" name="uspace" caption="Giving meaning to various Unicode space characters" />
+  <package key="uspatent" name="uspatent" caption="U.S. Patent Application Tools for LaTeX and LyX" />
+  <package key="usrguide" name="usrguide" caption="User-mode documentation for LaTeX" />
+  <package key="ut-backref" name="ut-backref" caption="Modified backref" />
+  <package key="ut-thesis" name="ut-thesis" caption="University of Toronto thesis style" />
+  <package key="utexasthesis" name="utexasthesis" caption="University of Texas at Austin graduate thesis style" />
+  <package key="utf2any" name="utf2any" caption="Converting Unicoded text to LaTeX, HTML, etc" />
+  <package key="utf8add" name="utf8add" caption="Additional support for UTF-8 encoded LaTeX input" />
+  <package key="utf8mex" name="utf8mex" caption="Tools to produce formats that read Polish language input" />
+  <package key="utfsym" name="utfsym" caption="Provides various Unicode symbols" />
+  <package key="util-half" name="util-half" caption="A half-tone font" />
+  <package key="utopia" name="utopia" caption="Adobe Utopia fonts" />
+  <package key="utorontothesis" name="utorontothesis" caption="A thesis class definition for University of Toronto" />
+  <package key="utthesis" name="utthesis" caption="Thesis package for the University of Texas at Austin" />
+  <package key="uvaletter" name="uvaletter" caption="Unofficial letterhead template for the University of Amsterdam" />
+  <package key="uwa-colours" name="uwa-colours" caption="The colour palette of The University of Western Australia" />
+  <package key="uwa-letterhead" name="uwa-letterhead" caption="The letterhead of the University of Western Australia" />
+  <package key="uwa-pcf" name="uwa-pcf" caption="A Participant Consent Form (PCF) for a human research protocol at the University of Western Australia" />
+  <package key="uwa-pif" name="uwa-pif" caption="A Participant Information Form (PIF) for a human research protocol at the University of Western Australia" />
+  <package key="uwmslide" name="uwmslide" caption="Slides with a simple Power Point like appearance" />
+  <package key="uwthesis" name="uwthesis" caption="University of Washington thesis class" />
+  <package key="uwthesis209" name="uwthesis209" caption="LaTeX 2.09 style for University of Washington theses" />
+  <package key="va" name="va" caption="Handwriting fonts" />
+  <package key="vak" name="vak" caption="BibTeX style for Russian Theses, books, etc" />
+  <package key="vancouver" name="Vancouver" caption="Bibliographic style file for Biomedical Journals" />
+  <package key="variablelm" name="variablelm" caption="Font definitions for the variable Latin Modern fonts" />
+  <package key="variations" name="variations" caption="Typeset tables of variations of functions" />
+  <package key="varindent" name="varindent" caption="Make paragraph indentation match the length of the line above" />
+  <package key="varindex" name="varindex" caption="Luxury frontend to the \index command" />
+  <package key="varioref" name="varioref" caption="Intelligent page references" />
+  <package key="varisize" name="varisize" caption="Change font size in Plain TeX" />
+  <package key="varsects" name="varsects" caption="A simple package for controlling headings" />
+  <package key="varsfromjobname" name="varsfromjobname" caption="Extract variables from the name of the LaTeX file" />
+  <package key="varwidth" name="varwidth" caption="A variable-width minipage" />
+  <package key="vaucanson-g" name="vaucanson-g" caption="PSTricks macros for drawing automata" />
+  <package key="vc" name="vc" caption="The vc (version control) bundle" />
+  <package key="vcell" name="vcell" caption="Vertical alignment of content inside table cells" />
+  <package key="vdm" name="vdm" caption="Typesetting VDM schemas" />
+  <package key="vdmlisting" name="vdmlisting" caption="Typesetting VDM in ASCII syntax" />
+  <package key="vector" name="vector" caption="LaTeX macros for vectors" />
+  <package key="venn" name="venn" caption="Creating Venn diagrams with MetaPost" />
+  <package key="venndiagram" name="venndiagram" caption="Creating Venn diagrams with TikZ" />
+  <package key="venturisadf" name="venturisADF" caption="Venturis ADF fonts collection" />
+  <package key="verbasef" name="verbasef" caption="VERBatim Automatic Splitting of External Files" />
+  <package key="verbatim" name="verbatim" caption="Reimplementation of and extensions to LaTeX verbatim" />
+  <package key="verbatim-gen" name="verbatim-gen" caption="Generic macros for setting text verbatim" />
+  <package key="verbatim-pln" name="verbatim-pln" caption="Define new verbatim &quot;environments&quot; in Plain TeX" />
+  <package key="verbatim-tub" name="verbatim-tub" caption="Plain TeX macros for verbatim" />
+  <package key="verbatimbox" name="verbatimbox" caption="Deposit verbatim text in a box" />
+  <package key="verbatimcopy" name="verbatimcopy" caption="Make copies of text documents from within LaTeX" />
+  <package key="verbdef" name="verbdef" caption="Define commands which expand to verbatim text" />
+  <package key="verbinp" name="verbinp" caption="&quot;8-bit&quot; verbatim" />
+  <package key="verbments" name="verbments" caption="Syntax highlighting of source code in LaTeX documents" />
+  <package key="verbtext" name="verbtext" caption="Verbatim, interpreting non-ascii text" />
+  <package key="verbtim2" name="verbtim2" caption="Verbatim listings in Plain TeX" />
+  <package key="verdana" name="verdana" caption="Macros and metrics for using Verdana with LaTeX" />
+  <package key="verifica" name="verifica" caption="Typeset (Italian high school) exercises" />
+  <package key="verifiche" name="verifiche" caption="A LaTeX package to typeset (Italian) high school tests" />
+  <package key="verse" name="verse" caption="Aids for typesetting simple verse" />
+  <package key="version" name="version" caption="Conditionally include text" />
+  <package key="versions" name="versions" caption="Optionally omit pieces of text" />
+  <package key="versonotes" name="versonotes" caption="Display brief notes on verso pages" />
+  <package key="vertbars" name="vertbars" caption="Mark vertical rules in margin of text" />
+  <package key="vertex" name="vertex" caption="Styles for economics working papers and journals" />
+  <package key="vf-howto" name="vf-howto" caption="Tutorial on creating virtual fonts" />
+  <package key="vf-knuth" name="vf-knuth" caption="Knuth on virtual fonts" />
+  <package key="vfcomb" name="vfcomb" caption="VF author support" />
+  <package key="vfinst" name="vfinst" caption="Virtual font installation support" />
+  <package key="vfware" name="vfware" caption="Tools for virtual font metrics" />
+  <package key="vgrid" name="vgrid" caption="Overlay a grid on the printed page" />
+  <package key="vhistory" name="vhistory" caption="Support for creating a change log" />
+  <package key="vicentino" name="vicentino" caption="Vicentino fonts" />
+  <package key="vietnet" name="vietnet" caption="Preprocessor and macros for Vietnamese" />
+  <package key="viiptart" name="viiptart" caption="7pt-article class" />
+  <package key="viking" name="viking" caption="Scandinavian runic alphabet as used by the Vikings" />
+  <package key="vispeech" name="vispeech" caption="Using Bell&apos;s Visible Speech alphabet" />
+  <package key="visualfaq" name="visualFAQ" caption="A Visual LaTeX FAQ" />
+  <package key="visualfaq-fr" name="visualFAQ-fr" caption="FAQ LaTeX visuelle francophone" />
+  <package key="visualpstricks" name="VisualPSTricks" caption="Visual help for PSTricks based on images with minimum text" />
+  <package key="visualtex" name="visualtex" caption="A TeX-oriented visual editor for Windows platforms" />
+  <package key="visualtikz" name="VisualTikZ" caption="Visual help for TikZ based on images with minimum text" />
+  <package key="vita" name="vita" caption="Configurable class for curricula vitarum" />
+  <package key="vita209" name="vita209" caption="A Curriculum Vitae style" />
+  <package key="vmargin" name="vmargin" caption="Set various page dimensions" />
+  <package key="vmspell" name="vmspell" caption="A spell-checker for VMS systems" />
+  <package key="vmsps" name="vmsps" caption="Metrics for using Type 1 fonts available in VMS" />
+  <package key="vntex" name="vntex" caption="Support for Vietnamese" />
+  <package key="vntex-nonfree" name="vntex-nonfree" caption="URW Classico and URW Garamond extended for Vietnamese" />
+  <package key="vocaltract" name="vocaltract" caption="Visualise the vocal tract using LaTeX and PSTricks" />
+  <package key="volumes" name="volumes" caption="Typeset only parts of a document, with complete indexes etc" />
+  <package key="voss-mathcol" name="voss-mathcol" caption="Typesetting mathematics in colour, in (La)TeX" />
+  <package key="voss-mathmode" name="voss-mathmode" caption="A comprehensive review of mathematics in (La)TeX" />
+  <package key="vowel" name="vowel" caption="Draw vowel charts for phonetic research" />
+  <package key="vpage" name="vpage" caption="Set page sizes" />
+  <package key="vpe" name="vpe" caption="Source specials for PDF output" />
+  <package key="vplutils" name="vplutils" caption="Manipulate (virtual) property lists" />
+  <package key="vpp" name="vpp" caption="View and (selectively) Print PDF and PostScript" />
+  <package key="vrb" name="vrb" caption="Verbatim macros in plain TeX" />
+  <package key="vrbexin" name="vrbexin" caption="Verbatim input support" />
+  <package key="vrsion" name="vrsion" caption="Add version number to a DVI file" />
+  <package key="vruler" name="vruler" caption="Numbering text" />
+  <package key="vslitex" name="VSliTeX" caption="Virtual invisible fonts for use with LaTeX Slides class" />
+  <package key="vtable" name="vtable" caption="Vertical alignement of table cells" />
+  <package key="vtex-free" name="VTeX/Free" caption="TeX system and PDF support for Linux and OS/2" />
+  <package key="vutex" name="vutex" caption="View TeX output on an ASCII-only terminal" />
+  <package key="vvcode" name="vvcode" caption="Reliable encoder for binary files via email" />
+  <package key="vwcol" name="vwcol" caption="Variable-width multiple text columns" />
+  <package key="vxu" name="vxu" caption="Document classes for Vaxjo University" />
+  <package key="w-a-schmidt" name="w-a-schmidt" caption="A collection of metrics for commercial fonts" />
+  <package key="w32tex" name="w32tex" caption="A comprehensive TeX system for Windows" />
+  <package key="wadalab" name="wadalab" caption="Wadalab (Japanese) font packages" />
+  <package key="wallcalendar" name="wallcalendar" caption="A wall calendar class with custom layouts" />
+  <package key="wallpaper" name="wallpaper" caption="Easy addition of wallpapers (background images) to LaTeX documents, including tiling" />
+  <package key="wargame" name="wargame" caption="A LaTeX package to prepare hex&apos;n&apos;counter wargames" />
+  <package key="warning" name="warning" caption="Global warnings at the end of the logfile" />
+  <package key="warpcol" name="warpcol" caption="Relative alignment of rows in numeric columns in tabulars" />
+  <package key="was" name="was" caption="A collection of small packages by Walter Schmidt" />
+  <package key="wasy" name="wasy" caption="The wasy fonts (Waldi symbol fonts)" />
+  <package key="wasy-type1" name="wasy-type1" caption="Type 1 versions of wasy fonts" />
+  <package key="wasysym" name="wasysym" caption="LaTeX support for the wasy fonts" />
+  <package key="watermark" name="watermark" caption="Draw &#8220;watermarks&#8221; on the output page" />
+  <package key="weave" name="weave" caption="Generate TeX source from web" />
+  <package key="web" name="web" caption="The original literate programming system" />
+  <package key="web2c" name="Web2C" caption="Conversion programs and supporting code to compile TeX in C" />
+  <package key="web2w" name="web2w" caption="Converting TeX from WEB to cweb" />
+  <package key="web9pt" name="web9pt" caption="Nine-point web listings" />
+  <package key="webcomp-errata" name="webcomp-errata" caption="Errata list for The LaTeX Web Companion" />
+  <package key="webfiles" name="webfiles" caption="Include CWEB and/or Spidery WEB LaTeX" />
+  <package key="webguide" name="webguide" caption="Brief Guide to LaTeX Tools for Web publishing" />
+  <package key="webmacss" name="webmacss" caption="Use sans serif font in Web listings" />
+  <package key="webomints" name="webomints" caption="Webomints font support" />
+  <package key="webquiz" name="WebQuiz" caption="Write interactive web based quizzes" />
+  <package key="weekday" name="weekday" caption="Generate &quot;day of week&quot;" />
+  <package key="wheelchart" name="wheelchart" caption="Draw wheelcharts with TikZ" />
+  <package key="wheretotrim" name="wheretotrim" caption="Assist in reducing LaTeX document page counts" />
+  <package key="wichura-table" name="wichura-table" caption="Table macros for plain TeX (and LaTeX)" />
+  <package key="widetable" name="widetable" caption="An environment for typesetting tables of specified width" />
+  <package key="widows-and-orphans" name="widows-and-orphans" caption="Identify (typographic) widows and orphans" />
+  <package key="wiggly" name="wiggly" caption="Draw wiggly lines under text" />
+  <package key="wiki" name="wiki" caption="Use Wiki-style markup in a LaTeX document" />
+  <package key="williams" name="williams" caption="Miscellaneous macros by Peter Williams" />
+  <package key="willowtreebook" name="willowtreebook" caption="Easy basic book class, built on memoir" />
+  <package key="win32-emacs-auctex" name="win32-emacs-auctex" caption="Ready-to-use Emacs and AucTeX for Windows" />
+  <package key="window" name="window" caption="Create windows in paragraphs" />
+  <package key="windvi" name="windvi" caption="MS-Windows DVI viewer" />
+  <package key="windycity" name="windycity" caption="A Chicago style for BibLaTeX" />
+  <package key="winedt" name="WinEdt" caption="MS-Windows shell and editor for TeX" />
+  <package key="winemtex" name="winemtex" caption="EmTeX for windows" />
+  <package key="winfonts" name="Winfonts" caption="Use fonts distributed with Windows XP" />
+  <package key="winlatex" name="winlatex" caption="FrontEnd for TeX, Win98/NT, needs Microsoft VisualBasic-DLLs" />
+  <package key="winshell" name="winshell" caption="A MS-Windows32 user interface for TeX" />
+  <package key="wintex2000" name="WinTeX XP" caption="A Win32 TeX Editor with the MS Office look and feel" />
+  <package key="withargs" name="withargs" caption="In-place argument substitution" />
+  <package key="witharrows" name="witharrows" caption="&#8220;Aligned&#8221; math environments with arrows for comments" />
+  <package key="withesis" name="withesis" caption="University of Wisconsin-Madison Thesis LaTeX Class" />
+  <package key="wmaainf" name="wmaainf" caption="BibTeX style for Abteilung f&#252;r Angewandte Informatik" />
+  <package key="wmf2eps" name="wmf2eps" caption="Windows metafile conversion" />
+  <package key="wmf2epsc" name="wmf2epsc" caption="Windows metafile conversion" />
+  <package key="wncyr" name="wncyr" caption="University of Washington cyrillic fonts" />
+  <package key="wnri" name="wnri" caption="Ridgeway&apos;s fonts" />
+  <package key="wnri-latex" name="wnri-latex" caption="LaTeX support for wnri fonts" />
+  <package key="wntamil" name="wntamil" caption="Tamil to TeX converter" />
+  <package key="wochtag" name="wochtag" caption="Generate the German weekday name for a date" />
+  <package key="woff2ot" name="Woff2OT" caption="Woff to OpenType converter" />
+  <package key="word2latex" name="word2latex" caption="A translator from MS Word to LaTeX documents" />
+  <package key="word2tex" name="word2tex" caption="Convert TeX/MSWord to LaTeX" />
+  <package key="word2x" name="word2x" caption="Word 6 format converter" />
+  <package key="wordcloud" name="wordcloud" caption="Drawing wordclouds with MetaPost and Lua" />
+  <package key="wordcount" name="wordcount" caption="Estimate the number of words in a LaTeX document" />
+  <package key="wordle" name="wordle" caption="Create wordle grids" />
+  <package key="wordlike" name="wordlike" caption="Simulating word processor layout" />
+  <package key="wordml2latex" name="WordML2LaTeX" caption="XSLT to transform a WordML file to a LaTeX2e source" />
+  <package key="wordweb" name="wordweb" caption="Literate programming using Microsoft Word" />
+  <package key="worksheet" name="worksheet" caption="Easy creation of worksheets" />
+  <package key="worldflags" name="worldflags" caption="Drawing flags with TikZ" />
+  <package key="wotree" name="wotree" caption="Draw Warnier/Orr diagrams" />
+  <package key="wp2latex" name="WP2LaTeX" caption="Convert WordPerfect documents to LaTeX" />
+  <package key="wrapfig" name="wrapfig" caption="Produces figures which text can flow around" />
+  <package key="wrapfig2" name="wrapfig2" caption="Wrap text around figures" />
+  <package key="wrapstuff" name="wrapstuff" caption="Wrapping text around stuff" />
+  <package key="wright" name="wright" caption="Define commands with optional arguments" />
+  <package key="writeongrid" name="WriteOnGrid" caption="Write on grid lines" />
+  <package key="wrtfile" name="wrtfile" caption="Write TeX files from a TeX document" />
+  <package key="wsemclassic" name="wsemclassic" caption="LaTeX class for Bavarian school w-seminar papers" />
+  <package key="wsuipa" name="wsuipa" caption="International Phonetic Alphabet fonts" />
+  <package key="wsuipa2tipa" name="wsuipa2tipa" caption="Translate wsuipa font commands into tipa font commands" />
+  <package key="wtref" name="WTRef" caption="Extend LaTeX&#8217;s cross-reference system" />
+  <package key="xargs" name="xargs" caption="Define commands with many optional arguments" />
+  <package key="xarticle" name="xarticle" caption="A LaTeX 2.09 document style with 7pt, 8pt and 9pt options" />
+  <package key="xassoccnt" name="xassoccnt" caption="Associated counters stepping simultaneously" />
+  <package key="xbibfile" name="xbibfile" caption="Create and search BibTeX databases" />
+  <package key="xbibtex" name="xbibtex" caption="An X-Windows utility for adding to a BibTeX database" />
+  <package key="xbmks" name="xbmks" caption="Create a cross-document bookmark tree" />
+  <package key="xcharter" name="XCharter" caption="Extension of Bitstream Charter fonts" />
+  <package key="xcharter-math" name="xcharter-math" caption="XCharter-based OpenType Math font for LuaTeX and XeTeX" />
+  <package key="xcite" name="xcite" caption="Use citation keys from a different document" />
+  <package key="xcjk2uni" name="xcjk2uni" caption="Convert CJK characters to Unicode, in pdfTeX" />
+  <package key="xcmr" name="xcmr" caption="A crossed-out version of Computer Modern" />
+  <package key="xcntperchap" name="xcntperchap" caption="Track the number of subsections etc. that occur in a specified tracklevel" />
+  <package key="xcoffins" name="xcoffins" caption="Rich boxed material for LaTeX 3" />
+  <package key="xcolor" name="xcolor" caption="Driver-independent color extensions for LaTeX and pdfLaTeX" />
+  <package key="xcolor-material" name="xcolor-material" caption="Defines the 256 colors from Google Material Color Palette" />
+  <package key="xcolor-solarized" name="xcolor-solarized" caption="Defines the 16 colors from Ethan Schoonover&#8217;s Solarized palette" />
+  <package key="xcomment" name="xcomment" caption="Allows selected environments to be included/excluded" />
+  <package key="xcookybooky" name="xcookybooky" caption="Typeset (potentially long) recipes" />
+  <package key="xcpdftips" name="xcpdftips" caption="Natbib citations with PDF tooltips" />
+  <package key="xdoc" name="xdoc" caption="Extending the LaTeX doc system" />
+  <package key="xduthesis" name="xduthesis" caption="XeLaTeX template for writing Xidian University Thesis" />
+  <package key="xduts" name="xduts" caption="Xidian University TeX Suite" />
+  <package key="xdvi" name="xdvi" caption="A DVI previewer for the X Window System" />
+  <package key="xebaposter" name="xebaposter" caption="Create beautiful scientific Persian/Latin posters using TikZ" />
+  <package key="xechangebar" name="xechangebar" caption="An extension of package changebar that can be used with XeLaTeX" />
+  <package key="xecjk" name="xecjk" caption="Support for CJK documents in XeLaTeX" />
+  <package key="xecolor" name="xecolor" caption="Support for color in XeLaTeX" />
+  <package key="xecolour" name="xecolour" caption="Support for colour in XeLaTeX" />
+  <package key="xecyr" name="xecyr" caption="Using Cyrillic languages in XeTeX" />
+  <package key="xecyrmongolian" name="xecyrmongolian" caption=" Basic support for the typesetting of Cyrillic Mongolian
+      documents using (Xe|Lua)LaTeX" />
+  <package key="xeindex" name="xeindex" caption="Automatic index generation for XeLaTeX" />
+  <package key="xellipsis" name="xellipsis" caption="Extremely configurable ellipses with formats for various style manuals" />
+  <package key="xepersian" name="XePersian" caption="Persian for LaTeX, using XeTeX" />
+  <package key="xepersian-hm" name="xepersian-hm" caption="Fixes kashida feature in xepersian package" />
+  <package key="xesearch" name="xesearch" caption="A string finder for XeTeX" />
+  <package key="xesoul" name="xesoul" caption="Use the soul package with XeLaTeX" />
+  <package key="xespotcolor" name="xespotcolor" caption="Spot colours support for XeLaTeX" />
+  <package key="xet-tex" name="XeT-TeX" caption="A bi-directional version of TeX" />
+  <package key="xetal" name="xetal" caption="Strip TeX constructs from a file" />
+  <package key="xetex" name="xetex" caption="An extended variant of TeX for use with Unicode sources" />
+  <package key="xetex-def" name="xetex-def" caption="Colour and graphics support for XeTeX" />
+  <package key="xetex-devanagari" name="xetex-devanagari" caption="XeTeX input map for Unicode Devanagari" />
+  <package key="xetex-greek" name="xetex-greek" caption="Hyphenation for different variants of Greek, under XeTeX" />
+  <package key="xetex-itrans" name="xetex-itrans" caption="Itrans input maps for use with XeLaTeX" />
+  <package key="xetex-pstricks" name="xetex-pstricks" caption="Running PSTricks under XeTeX" />
+  <package key="xetex-tibetan" name="xetex-tibetan" caption="XeTeX input maps for Unicode Tibetan" />
+  <package key="xetexfontinfo" name="xetexfontinfo" caption="Report font features in XeTeX" />
+  <package key="xetexko" name="xetexko" caption="Typeset Korean with Xe(La)TeX" />
+  <package key="xetexref" name="XeTeXref" caption="Reference documentation of XeTeX" />
+  <package key="xevlna" name="xevlna" caption="Insert non-breakable spaces using XeTeX" />
+  <package key="xfakebold" name="xfakebold" caption="Fake a regular font for bold characters" />
+  <package key="xfig" name="xfig" caption="XWindows vector drawing program" />
+  <package key="xfor" name="xfor" caption="A reimplementation of the LaTeX for-loop macro" />
+  <package key="xfp" name="xfp" caption="Interface to the LaTeX3 floating point unit" />
+  <package key="xfrac" name="xfrac" caption="Split-level fractions in LaTeX2e*" />
+  <package key="xgalley" name="xgalley" caption="Control text feeding onto the page" />
+  <package key="xgreek" name="xgreek" caption="Greek Language Support for XeLaTeX and LuaLaTeX" />
+  <package key="xhfill" name="xhfill" caption="Extending \hrulefill" />
+  <package key="xifthen" name="xifthen" caption="Extended conditional commands" />
+  <package key="xii" name="xii" caption="Christmas silliness (English)" />
+  <package key="xii-lat" name="xii-lat" caption="Christmas silliness (Latin)" />
+  <package key="xindex" name="xindex" caption="Unicode-compatible index generation" />
+  <package key="xindy" name="xindy" caption="A general-purpose index processor" />
+  <package key="xindy-persian" name="xindy-persian" caption="Support for the Persian language in xindy" />
+  <package key="xint" name="xint" caption="Expandable operations on long numbers" />
+  <package key="xintsession" name="xintsession" caption="Interactive computing sessions (fractions, floating points, polynomials)" />
+  <package key="xistercian" name="xistercian" caption="Cistercian numerals in LaTeX" />
+  <package key="xits" name="xits" caption="A Scientific Times-like font with support for mathematical typesetting" />
+  <package key="xkcdcolors" name="xkcdcolors" caption="xkcd names of colors" />
+  <package key="xkeyval" name="xkeyval" caption="Extension of the keyval package" />
+  <package key="xkvltxp" name="xkvltxp" caption="Provision for expandable macros in package options" />
+  <package key="xkvview" name="xkvview" caption="Xkeyval viewer" />
+  <package key="xl2latex" name="xl2latex" caption="Convert Excel (97 and above) tables to LaTeX tabulars" />
+  <package key="xlatex" name="xlatex" caption="A TeX/LaTeX shell for X-windows" />
+  <package key="xlop" name="xlop" caption="Calculates and displays arithmetic operations" />
+  <package key="xltabular" name="xltabular" caption="Longtable support with possible X-column specifier" />
+  <package key="xltxtra" name="xltxtra" caption="&#8220;Extras&#8221; for LaTeX users of XeTeX" />
+  <package key="xml2pmx" name="xml2pmx" caption="Convert MusicXML to PMX and MusiXTeX" />
+  <package key="xmlplay" name="xmlplay" caption="Typeset Shakespeare&#8217;s plays as marked up by Bosak" />
+  <package key="xmltex" name="xmltex" caption="Support for parsing XML documents" />
+  <package key="xmpincl" name="xmpincl" caption="Include eXtensible Metadata Platform data in pdfLaTeX" />
+  <package key="xmuthesis" name="xmuthesis" caption="XMU thesis style" />
+  <package key="xnewcommand" name="xnewcommand" caption="Define \global and \protected commands with \newcommand" />
+  <package key="xoptarg" name="xoptarg" caption="Expandable macros that take an optional argument" />
+  <package key="xparse" name="xparse" caption="A generic document command parser" />
+  <package key="xpatch" name="xpatch" caption="Extending etoolbox patching commands" />
+  <package key="xpdf" name="xpdf" caption="Viewing and manipulating PDF files" />
+  <package key="xpdfopen" name="xpdfopen" caption="Commands to control PDF readers, under X11" />
+  <package key="xpeek" name="xpeek" caption="Define commands that peek ahead in the input stream" />
+  <package key="xpiano" name="xpiano" caption="An extension of the piano package" />
+  <package key="xpicture" name="xpicture" caption="Extensions of LaTeX picture drawing" />
+  <package key="xpinyin" name="xpinyin" caption="Automatically add pinyin to Chinese characters" />
+  <package key="xprintlen" name="xprintlen" caption="Print TeX lengths in a variety of units" />
+  <package key="xpunctuate" name="xpunctuate" caption="Process trailing punctuation which may be redundant" />
+  <package key="xq" name="xq" caption="Support for writing about xiangqi" />
+  <package key="xr" name="xr" caption="References to other LaTeX documents" />
+  <package key="xr-hyper" name="xr-hyper" caption="Inter-document hyper-references" />
+  <package key="xrefwarn" name="xrefwarn" caption="Only one warning for an undefined citation" />
+  <package key="xsavebox" name="xsavebox" caption="Saveboxes for repeating content without code replication, based on PDF Form XObjects" />
+  <package key="xsim" name="xsim" caption="eXercise Sheets IMproved" />
+  <package key="xskak" name="xskak" caption="An extension to the skak package for chess typesetting" />
+  <package key="xspace" name="xspace" caption="Define commands that appear not to eat spaces" />
+  <package key="xstring" name="xstring" caption="String manipulation for (La)TeX" />
+  <package key="xtab" name="xtab" caption="Break tables across pages" />
+  <package key="xtcapts" name="xtcapts" caption="Defining language-dependent text macros" />
+  <package key="xtem" name="xtem" caption="An X11 TeX menu built on Tcl/Tk" />
+  <package key="xtemplate" name="xtemplate" caption="A high-level interface for declaring document commands" />
+  <package key="xtexcad" name="xtexcad" caption="Simple drawing program for LaTeX use" />
+  <package key="xtexshell" name="XteXShell" caption="A shell/editor" />
+  <package key="xtrcode" name="xtrcode" caption="Extract contents of LaTeX environments" />
+  <package key="xtuthesis" name="xtuthesis" caption="XTU thesis template" />
+  <package key="xunicode" name="xunicode" caption="Generate Unicode characters from accented glyphs" />
+  <package key="xurl" name="xurl" caption="Allow URL breaks at any alphanumerical character" />
+  <package key="xwatermark" name="xwatermark" caption="Graphics and text watermarks on selected pages" />
+  <package key="xwpick" name="xwpick" caption="Pick an image from an X display" />
+  <package key="xyling" name="xyling" caption="Draw syntactic trees, etc., for linguistics literature, using xy-pic" />
+  <package key="xymatrix" name="xymatrix" caption="Commutative diagrams using XY-pic" />
+  <package key="xymtex" name="xymtex" caption="Typesetting chemical structures" />
+  <package key="xypic" name="xypic" caption="Flexible diagramming macros" />
+  <package key="xypic-tut-pt" name="xypic-tut-pt" caption="A tutorial for XY-pic, in Portuguese" />
+  <package key="xytree" name="xytree" caption="Tree macros using XY-Pic" />
+  <package key="yacco2" name="yacco2" caption="Multi-threaded LR(1) compiler/compiler that emits literate grammar documents" />
+  <package key="yafoot" name="yafoot" caption="A bundle of miscellaneous footnote packages" />
+  <package key="yagusylo" name="yagusylo" caption="A symbol loader" />
+  <package key="yaletter" name="yaletter" caption="Extremely flexible macros for letters, envelopes, and label sheets" />
+  <package key="yamlvars" name="YAMLvars" caption="A YAML parser and tool for easy LaTeX definition creation" />
+  <package key="yandy" name="yandy" caption="TUG release of Y and Y&#8217;s TeX distribution" />
+  <package key="yannisgr" name="yannisgr" caption="Greek fonts by Yannis Haralambous" />
+  <package key="yathesis" name="yathesis" caption="A LaTeX class for writing a thesis following French rules" />
+  <package key="yax" name="yax" caption="Yet Another Key System" />
+  <package key="yazd-thesis" name="yazd-thesis" caption="A template for the Yazd University" />
+  <package key="yb-book" name="yb-book" caption="Template for YB Branded Books" />
+  <package key="ycbook" name="ycbook" caption="A versatile book class" />
+  <package key="ydoc" name="ydoc" caption="Macros for documentation of LaTeX classes and packages" />
+  <package key="yet-another-guide-latex2e" name="Yet-Another-Guide-LaTeX2e" caption="A short guide to using LaTeX2e to typeset high quality documents" />
+  <package key="yfonts" name="yfonts" caption="Support for old German fonts" />
+  <package key="yfonts-otf" name="yfonts-otf" caption="OpenType version of the Old German fonts designed by Yannis Haralambous" />
+  <package key="yfonts-t1" name="yfonts-t1" caption="Old German-style fonts, in Adobe type 1 format" />
+  <package key="yfrak" name="yfrak" caption="Old German Fraktur font" />
+  <package key="ygoth" name="ygoth" caption="Old German Gothic font" />
+  <package key="yhmath" name="yhmath" caption="Extended maths fonts for LaTeX" />
+  <package key="yi4latex" name="yi4latex" caption="Yi (Southern Chinese) support" />
+  <package key="yinit" name="yinit" caption="Old German decorative initials" />
+  <package key="yinit-as" name="yinit-as" caption="Additions to Yannis Haralambous&apos; Old German decorative initials" />
+  <package key="yinit-otf" name="yinit-otf" caption="OTF conversion of Yannis Haralambous&apos; Old German decorative initials" />
+  <package key="york-thesis" name="york-thesis" caption="A thesis class file for York University, Toronto" />
+  <package key="young" name="young" caption="Young tableaux" />
+  <package key="youngtab" name="youngtab" caption="Typeset Young-Tableaux" />
+  <package key="yplan" name="yplan" caption="Daily planner type calendar" />
+  <package key="yquant" name="yquant" caption="Typesetting quantum circuits in a human-readable language" />
+  <package key="yswab" name="yswab" caption="Old German Schwabacher font" />
+  <package key="yt4pdf" name="yt4pdf" caption="Play YouTube videos in a PDF" />
+  <package key="ytableau" name="ytableau" caption="Many-featured Young tableaux and Young diagrams" />
+  <package key="ytex" name="ytex" caption="Macro package developed at MIT" />
+  <package key="zaccone" name="zaccone" caption="Different configuration for different captions" />
+  <package key="zahl2string" name="zahl2string" caption="Format numbers as German words" />
+  <package key="zblbuild" name="zblbuild" caption="Help with the choice of a BibLaTeX style and options" />
+  <package key="zbmath-review-template" name="zbmath-review-template" caption="Template for a zbMATH Open review" />
+  <package key="zebra-goodies" name="zebra-goodies" caption="A collection of handy macros for paper writing" />
+  <package key="zed" name="zed" caption="Typeset Z specifications" />
+  <package key="zed-csp" name="zed-csp" caption="Typesetting Z and CSP format specifications" />
+  <package key="zefonts" name="zefonts" caption="Virtual fonts to provide T1 encoding from existing fonts" />
+  <package key="zennote" name="zennote" caption="Streamline your note-taking process!" />
+  <package key="zero" name="zero" caption="Start list (etc.) numbering at zero" />
+  <package key="zhlineskip" name="zhlineskip" caption="Line spacing for CJK documents" />
+  <package key="zhlipsum" name="zhlipsum" caption="Chinese dummy text" />
+  <package key="zhmakeindex" name="zhmakeindex" caption="Makeindex replacement for Chinese users" />
+  <package key="zhmcjk" name="zhmCJK" caption="Simplify configuration of CJK installations for Chinese" />
+  <package key="zhmetrics" name="zhmetrics" caption="TFM subfont files for using Chinese fonts in 8-bit TeX" />
+  <package key="zhmetrics-uptex" name="zhmetrics-uptex" caption="Chinese font metrics for upTeX" />
+  <package key="zhnumber" name="zhnumber" caption="Typeset Chinese representations of numbers" />
+  <package key="zhspacing" name="zhspacing" caption="Spacing for mixed CJK-English documents in XeTeX" />
+  <package key="ziffer" name="ziffer" caption="Conversion of punctuation in maths mode" />
+  <package key="zigaretten" name="zigaretten" caption="Propaganda and mind-numbing for cigarette addicts" />
+  <package key="zip" name="zip" caption="Barcodes for USA ZIP code" />
+  <package key="zitie" name="zitie" caption="Create CJK character calligraphy practicing sheets" />
+  <package key="zlmtt" name="zlmtt" caption="Use Latin Modern Typewriter fonts" />
+  <package key="zootaxa-bst" name="zootaxa-bst" caption="A BibTeX style for the journal Zootaxa" />
+  <package key="zref" name="zref" caption="A new reference scheme for LaTeX" />
+  <package key="zref-check" name="zref-check" caption="Flexible cross-references with contextual checks based on zref" />
+  <package key="zref-clever" name="zref-clever" caption="Clever LaTeX cross-references based on zref" />
+  <package key="zref-vario" name="zref-vario" caption="Extended LaTeX page cross-references with varioref and zref-clever" />
+  <package key="zwgetfdate" name="zwgetfdate" caption="Get package or file date" />
+  <package key="zwpagelayout" name="zwpagelayout" caption="Page layout and crop-marks" />
+  <package key="zx-calculus" name="zx-calculus" caption="A library to typeset ZX Calculus diagrams" />
+  <package key="zxjafbfont" name="zxjafbfont" caption="Fallback CJK font support for xeCJK" />
+  <package key="zxjafont" name="ZXjafont" caption="Set up Japanese font families for XeLaTeX" />
+  <package key="zxjatype" name="ZXjatype" caption="Standard conforming typesetting of Japanese, for XeLaTeX" />
+  <package key="zztex" name="ZzTeX" caption="A full-featured TeX macro package for producing books, journals, and manuals" />
+</packages>


### PR DESCRIPTION
- use package list from CTAN
- show package list as a table
- regExp search filter for package names
- add a button which opens CTAN package doc
- fix enabled open button while testing whether texdoc is available