### PR TITLE
improve TeXdoc dialog

### DIFF
--- a/src/texdocdialog.cpp
+++ b/src/texdocdialog.cpp
@@ -25,7 +25,7 @@ TexdocDialog::TexdocDialog(QWidget *parent,Help *obj) :
 	connect(ui->tbPackages, SIGNAL(currentItemChanged(QTableWidgetItem *, QTableWidgetItem *)), SLOT(itemChanged(QTableWidgetItem *)));
 	connect(help, SIGNAL(texdocAvailableReply(QString, bool, QString)), SLOT(updateDocAvailableInfo(QString, bool, QString)));
 	connect(ui->buttonCTAN, SIGNAL(clicked()), SLOT(openCtanUrl()));
-    connect(ui->cbShowAllPackages,&QCheckBox::stateChanged,this,&TexdocDialog::regenerateTable);
+	connect(ui->cbShowAllPackages,&QCheckBox::stateChanged,this,&TexdocDialog::regenerateTable);
 
 	updateDocAvailableInfo("", false); // initially disable warning message
 	ui->buttonCTAN->setEnabled(false);
@@ -87,11 +87,11 @@ void TexdocDialog::regenerateTable(int state)
 }
 
 void TexdocDialog::tableSearchTermChanged(QString term) {
-	QTableWidget *tb = ui->tbPackages;
-	int rows = tb->rowCount();
+    QTableWidget *tb = ui->tbPackages;
+    int rows = tb->rowCount();
     uint foundLevel = 0;
-	for (int i=0; i<rows; i++) {
-		QTableWidgetItem *itemPkgName = tb->item(i,0);
+    for (int i=0; i<rows; i++) {
+        QTableWidgetItem *itemPkgName = tb->item(i,0);
         bool match = itemPkgName->text().contains(term,Qt::CaseInsensitive);
         if (match){
             if(foundLevel<1){
@@ -112,12 +112,12 @@ void TexdocDialog::tableSearchTermChanged(QString term) {
             QTableWidgetItem *itemPkgName = tb->item(i,1);
             match = itemPkgName->text().contains(term,Qt::CaseInsensitive);
         }
-		tb->setRowHidden(i,!match);
-	}
+        tb->setRowHidden(i,!match);
+    }
     if (foundLevel==0 && rows>0) {
-		QTableWidgetItem *itemPkgName = tb->item(0,0);
-		tb->setCurrentItem(itemPkgName);
-	}
+        QTableWidgetItem *itemPkgName = tb->item(0,0);
+        tb->setCurrentItem(itemPkgName);
+    }
 }
 
 void TexdocDialog::itemChanged(QTableWidgetItem* item)
@@ -176,7 +176,7 @@ void TexdocDialog::delayedCheckDocAvailable(const QString &package)
 void TexdocDialog::checkDockAvailable()
 {
     if (lastDocRequest.isEmpty()){
-		updateDocAvailableInfo("", false);
+        updateDocAvailableInfo("", false);
     } else {
         help->texdocAvailableRequest(lastDocRequest);
     }

--- a/src/texdocdialog.cpp
+++ b/src/texdocdialog.cpp
@@ -89,35 +89,37 @@ void TexdocDialog::regenerateTable(int state)
 void TexdocDialog::tableSearchTermChanged(QString term) {
     QTableWidget *tb = ui->tbPackages;
     int rows = tb->rowCount();
+    QTableWidgetItem *currentItem = nullptr;
     uint foundLevel = 0;
     for (int i=0; i<rows; i++) {
         QTableWidgetItem *itemPkgName = tb->item(i,0);
         bool match = itemPkgName->text().contains(term,Qt::CaseInsensitive);
         if (match){
             if(foundLevel<1){
-                tb->setCurrentItem(itemPkgName);
+                currentItem = itemPkgName;
                 foundLevel=1;
             }
             if(foundLevel<2 && itemPkgName->text().startsWith(term,Qt::CaseInsensitive)){
-                tb->setCurrentItem(itemPkgName);
+                currentItem = itemPkgName;
                 foundLevel=2;
             }
             if(foundLevel<3 && itemPkgName->text().startsWith(term)){
-                tb->setCurrentItem(itemPkgName);
+                currentItem = itemPkgName;
                 foundLevel=3;
             }
-		}
+        }
         if(!match){
             // check description
             QTableWidgetItem *itemPkgName = tb->item(i,1);
             match = itemPkgName->text().contains(term,Qt::CaseInsensitive);
+            if (match) currentItem = itemPkgName;
         }
         tb->setRowHidden(i,!match);
     }
     if (foundLevel==0 && rows>0) {
-        QTableWidgetItem *itemPkgName = tb->item(0,0);
-        tb->setCurrentItem(itemPkgName);
+        currentItem = tb->item(0,0);
     }
+    tb->setCurrentItem(currentItem);
 }
 
 void TexdocDialog::itemChanged(QTableWidgetItem* item)

--- a/src/texdocdialog.cpp
+++ b/src/texdocdialog.cpp
@@ -91,6 +91,7 @@ void TexdocDialog::tableSearchTermChanged(QString term) {
     int rows = tb->rowCount();
     QTableWidgetItem *currentItem = nullptr;
     uint foundLevel = 0;
+    int n = 0;
     for (int i=0; i<rows; i++) {
         QTableWidgetItem *itemPkgName = tb->item(i,0);
         bool match = itemPkgName->text().contains(term,Qt::CaseInsensitive);
@@ -112,8 +113,9 @@ void TexdocDialog::tableSearchTermChanged(QString term) {
             // check description
             QTableWidgetItem *itemPkgName = tb->item(i,1);
             match = itemPkgName->text().contains(term,Qt::CaseInsensitive);
-            if (match) currentItem = itemPkgName;
+            if (n==0 && match) currentItem = itemPkgName;
         }
+        if (match) n++;
         tb->setRowHidden(i,!match);
     }
     if (foundLevel==0 && rows>0) {


### PR DESCRIPTION
This PR mainly addresses a matching issue for Captions: For example, when you enter `longtables` no match can be found in the first column (Package) but in the second one (Caption). But none of the rows shown is selected (i.e. not set as current row).

Also enabling/disabling of buttons/fields not worked correctly in all cases.