### PR TITLE
enhance retrieving packages and captions for tooltips

### DIFF
--- a/src/latexeditorview.cpp
+++ b/src/latexeditorview.cpp
@@ -2696,15 +2696,15 @@ void LatexEditorView::mouseHovered(QPoint pos)
 				type = tr("Beamer Theme");
 				type.replace(' ', "&nbsp;");
 			}
-            QString text = QString("%1:&nbsp;<b>%2</b>").arg(type,value);
-            if (latexPackageList->find(preambel + value) != latexPackageList->end()) {
+			QString text = QString("%1:&nbsp;<b>%2</b>").arg(type,value);
+			if (LatexRepository::instance()->packageExists(value)
+				|| latexPackageList->find(preambel + value) != latexPackageList->end()) {
 				QString description = LatexRepository::instance()->shortDescription(value);
 				if (!description.isEmpty()) text += "<br>" + description;
-				QToolTip::showText(editor->mapToGlobal(editor->mapFromFrame(pos)), text);
 			} else {
 				text += "<br><b>(" + tr("not found") + ")";
-				QToolTip::showText(editor->mapToGlobal(editor->mapFromFrame(pos)), text);
 			}
+			QToolTip::showText(editor->mapToGlobal(editor->mapFromFrame(pos)), text);
 		}
 		if (config->imageToolTip && tk.subtype == Token::color) {
             handled=true;


### PR DESCRIPTION
This PR addresses following: Editor shows tool tips on hovering the mouse over arguments of commands like \documentclass and \usepackage. Currently not all arguments are found at all or the package description can't be retrieved:

\documentclass:

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/46e093d8-14d6-426f-812b-8309953cfa74)

The Koma class is not found. With the fix a package with the same name is found and the caption can be shown from the ctan list introduced recently:

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/02bc86c3-1ff9-4889-8556-dc05b9052216)

\usepackage:

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/30b56166-f14d-4dfb-b21f-87490b26254a)

After fix package and caption are found:

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/1b4a5746-66dd-4adc-8af4-3b3e6b4395f4)

This affects many packages in my test.