### PR TITLE
cwl: use arg name `basename` and disable syntax check for most `basename` args

### DIFF
--- a/completion/aeb_pro.cwl
+++ b/completion/aeb_pro.cwl
@@ -188,7 +188,7 @@ true
 false
 print#true,false
 #endkeyvals
-\DeclareAnime{basename}{speed}{nframes}
+\DeclareAnime{basename%definition}{speed}{nframes}
 \animeBld
 \animeBld[options%keyvals]
 \backAnimeBtn{width}{height}
@@ -309,7 +309,7 @@ true
 false
 print#true,false
 #endkeyvals
-\DeclareAnime{basename}{speed}{nframes}
+\DeclareAnime{basename%definition}{speed}{nframes}
 \animeBld
 \animeBld[options%keyvals]
 \backAnimeBtn{width}{height}

--- a/completion/animate.cwl
+++ b/completion/animate.cwl
@@ -50,8 +50,8 @@ poster=#first,last,none,%<number%>
 alttext=#none,%<alt description%>
 #endkeyvals
 
-\animategraphics{frame rate}{file basename}{first}{last}
-\animategraphics[options%keyvals]{frame rate}{file basename}{first}{last}
+\animategraphics{frame rate}{file basename%definition}{first}{last}
+\animategraphics[options%keyvals]{frame rate}{file basename%definition}{first}{last}
 
 \begin{animateinline}{frame rate}
 \begin{animateinline}[options%keyvals]{frame rate}

--- a/completion/clipboard.cwl
+++ b/completion/clipboard.cwl
@@ -1,8 +1,8 @@
 # clipboard package
 # Matthew Bertucci 1/21/2022 for v0.3
 
-\newclipboard{basename}
-\openclipboard{basename}
+\newclipboard{basename%definition}
+\openclipboard{basename%definition}
 \clipboard{key%plain}{content%text}#*
 \Copy{key%plain}{content%text}
 \Paste{key%plain}

--- a/completion/filesdo.cwl
+++ b/completion/filesdo.cwl
@@ -3,5 +3,5 @@
 
 #include:commado
 
-\DoWithExtBases{cmd}{ext}{basenames}
-\DoWithBasesExts{cmd}{basenames}{exts}
+\DoWithExtBases{cmd}{ext}{basenames%definition}
+\DoWithBasesExts{cmd}{basenames%definition}{exts}

--- a/completion/glossaries-extra.cwl
+++ b/completion/glossaries-extra.cwl
@@ -2556,8 +2556,8 @@ topicmcols
 \glsifcategoryattributehasitem{category}{attribute}{item}{true}{false}#*
 
 ### 11 bib2gls: Managing Reference Databases ###
-\glsxtrresourcefile{filename%file}
-\glsxtrresourcefile[options%keyvals]{filename%file}
+\glsxtrresourcefile{basename}
+\glsxtrresourcefile[options%keyvals]{basename}
 \GlsXtrLoadResources
 \GlsXtrLoadResources[options%keyvals]
 

--- a/completion/glossaries-extra.cwl
+++ b/completion/glossaries-extra.cwl
@@ -1022,7 +1022,7 @@ showtargets=#left,right,innerleft,innerright,annoteleft,annoteright
 
 \glsxtrundeftag#*
 \glsxtrundefaction{message}{additional help}#*
-\glsxtrsetbibglsaux{basename}#*
+\glsxtrsetbibglsaux{basename%definition}#*
 \thewrglossary#*
 \glsxtrwrglossmark#*
 \glsxtrwrglosscountermark{number}#*
@@ -2556,8 +2556,8 @@ topicmcols
 \glsifcategoryattributehasitem{category}{attribute}{item}{true}{false}#*
 
 ### 11 bib2gls: Managing Reference Databases ###
-\glsxtrresourcefile{basename}
-\glsxtrresourcefile[options%keyvals]{basename}
+\glsxtrresourcefile{basename%definition}
+\glsxtrresourcefile[options%keyvals]{basename%definition}
 \GlsXtrLoadResources
 \GlsXtrLoadResources[options%keyvals]
 


### PR DESCRIPTION
`\glsxtrresourcefile` in `glossaries-extra` takes a basename without file extension as its mandatory argument. For example, `\glsxtrresourcefile{\jobname}` specifies `\jobname.glstex` as the resource file.

See `glossaries-extra` package manual (v1.52, 2023-06-28), sec. 11. `bib2gls`: Managing Reference Databases
- ![image](https://github.com/texstudio-org/texstudio/assets/6376638/3bb330c7-a699-4af4-8bbd-cb94c587716c)
- ![image](https://github.com/texstudio-org/texstudio/assets/6376638/6f49c5dc-0365-4c9c-bb22-8e54fea072f2)
