### PR TITLE
make `grayscale` options available for embedded viewer users

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -3382,6 +3382,7 @@ void PDFDocument::init(bool embedded)
     //connect(actionInvertColors, SIGNAL(triggered()), pdfWidget, SLOT(update()));
 	conf->registerOption("Preview/Grayscale", &globalConfig->grayscale, false);
 	conf->linkOptionToObject(&globalConfig->grayscale, actionGrayscale);
+    pdfWidget->addAction(actionGrayscale); // add grayscale to widget context menu
     //connect(actionGrayscale, SIGNAL(triggered()), pdfWidget, SLOT(update()));
 
     if(!embedded){


### PR DESCRIPTION
For users of the embedded pdf viewer, options like "Grayscale", "Scrolling follows cursor", "Cursor follows scrolling" or "Synchronize multiple views" were not easily accessible (and even harder to discover). 

If they were listed in the right-click context menu, such users could use them more easily.

(inspired by this question https://tex.stackexchange.com/q/700072/36296)