### PR TITLE
add menu action Idefix/Show Preview on Formulas

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -1090,6 +1090,9 @@ void Texstudio::setupMenus()
 	menu->addSeparator();
     newManagedAction(menu, "previewLatex", tr("Pre&view Selection/Parentheses"), SLOT(previewLatex()), Qt::ALT | Qt::Key_P);
 	newManagedAction(menu, "removePreviewLatex", tr("C&lear Inline Preview"), SLOT(clearPreview()));
+	act = newManagedAction(menu, "toggleToolTipPreview", tr("Show Preview on &Formulas"), SLOT(setToolTipPreview()));
+	act->setCheckable(true);
+	setCheckedToolTipPreviewAction();
 
 	submenu = newManagedMenu(menu, "previewMode", tr("Preview Dis&play Mode"));
 	QActionGroup *previewModeGroup = new QActionGroup(this);
@@ -1491,6 +1494,22 @@ void Texstudio::setupMenus()
 
 	configManager.modifyMenuContents();
 	configManager.modifyManagedShortcuts();
+}
+/* \brief slot for menu action Idefix/Show preview on formulas (toggles same config option)
+ */
+void Texstudio::setToolTipPreview()
+{
+	QAction *act = qobject_cast<QAction *>(sender());
+	if (act) {
+		configManager.editorConfig->toolTipPreview = act->isChecked();
+	}
+}
+/* \brief (un)checks menu action Idefix/Show preview on formulas
+ */
+void Texstudio::setCheckedToolTipPreviewAction()
+{
+	bool status = configManager.editorConfig->toolTipPreview;
+	getManagedAction("main/edit2/toggleToolTipPreview")->setChecked(status);
 }
 /*! \brief slot for actions from Menu Preview Display Mode
  */
@@ -6871,6 +6890,8 @@ void Texstudio::generalOptions()
         delete pdfviewerWindow;
     }
 #endif
+    // update Menu Idefix/Show Preview on Formulas
+    setCheckedToolTipPreviewAction();
     // update Menu Idefix/Preview Display Mode
     setCheckedPreviewModeAction();
 #ifdef INTERNAL_TERMINAL

--- a/src/texstudio.h
+++ b/src/texstudio.h
@@ -139,6 +139,7 @@ private:
     void setStructureSectionIcons();
     void updateStatusBarIcons();
     void updatePDFIcons();
+	void setCheckedToolTipPreviewAction();
 	void setCheckedPreviewModeAction();
 
 	void updateUserMacros(bool updateMenu = true);
@@ -378,6 +379,7 @@ protected slots:
 	void editSpell();
 	void editThesaurus(int line = -1, int col = -1);
 	void editChangeLineEnding();
+	void setToolTipPreview();
 	void setPreviewMode();
 	void editSetupEncoding();
 	void editInsertUnicode(); ///< open dialog to insert a unicode character


### PR DESCRIPTION
This PR enables changing the same config option from the Idefix Menu:

![image](https://github.com/texstudio-org/texstudio/assets/102688820/34f3ca7c-f259-4fbe-92d2-a4c4fe1bd1b1)

Reasons for this change are similar to those for integrating sub menu Preview Display Mode (s. image).
By this change the _set of important preview config settings_ is quickly available in the Idefix menu with just a few key strokes. Less advanced users don't have to search through dozens of options in the config dialog which also has a clear start delay. While Show Preview on Formulas is often needed, it is difficult to prevent preview creation when the mouse pointer hovers over a text cluttered with formulas and math envs. Even more when Preview Display Mode is set to Preview Panel or Pdf Viewer (with unlimited viewing time) an already existing preview can be replaced with a new one by accident. With both options, Preview Display Mode (already there) and Show Preview on Formulas, one can organize work much easier and faster. Viewing previews of formulas and tikzpictures at the same time is often useful and you don't need do read the complex latex code. For doing so you need quick access to both options mentioned.