### PR TITLE
cwl: mark \DeclareExpandableDocumentCommand as xparse/ltcmd command

### DIFF
--- a/completion/latex-dev.cwl
+++ b/completion/latex-dev.cwl
@@ -71,7 +71,7 @@
 \DeclareEncodingSubset{encoding}{family}{subset number}#*
 \DeclareEnvironmentCopy{envname}{copied envname}#N
 \DeclareErrorFont{encoding}{family}{series}{shape}{size}#*
-\DeclareExpandableDocumentCommand{cmd}{args}{def}#*d
+\DeclareExpandableDocumentCommand{cmd}{xargs}{def}#*d
 \DeclareFixedFont{cmd}{encoding}{family}{series}{shape}{size}#*d
 \DeclareFontEncoding{encoding}{text-settings}{math-settings}#*
 \DeclareFontEncodingDefaults{text-settings}{math-settings}#*

--- a/completion/xparse.cwl
+++ b/completion/xparse.cwl
@@ -1,4 +1,4 @@
-### this package is deprecated. All but the commands below are provided are in the format (see latex-dev.cwl)
+### this package is deprecated. All but the commands below are provided in the format (see latex-dev.cwl)
 
 \ArgumentSpecification#S
 \GetDocumentCommandArgSpec{cmd}#S


### PR DESCRIPTION
All other commands were already marked in commit 051fc9b3 (support xparse command defintion, 2022-01-22).