### PR TITLE
clear additional shortcut field when necessary

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -249,7 +249,10 @@ void ShortcutDelegate::setModelData(QWidget *editor, QAbstractItemModel *model,
 				if (UtilsUi::txsConfirmWarning(QString(ConfigDialog::tr("The shortcut <%1> is already assigned to the command:")).arg(value) + "\n" + duplicate + "\n\n" + ConfigDialog::tr("Do you wish to remove the old assignment and bind the shortcut to the new command?"))) {
 					//model->setData(mil[0],"",Qt::DisplayRole);
 					foreach (QTreeWidgetItem *twi, li) {
-						if (twi && twi->text(2) == value) twi->setText(2, "");
+						if (twi) {
+							if (twi->text(2) == value) twi->setText(2, "");
+							else if (twi->text(3) == value) twi->setText(3, "");
+						}
 					}
 				} else {
 					return;

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -1,7 +1,8 @@
 # CHANGELOG
+
 ## TeXstudio 4.7.2
 
-- 
+- fix duplicate shortcut in 'Additional Shortcut' column is not removed [#3408](https://github.com/texstudio-org/texstudio/pull/3408)
 
 ## TeXstudio 4.7.1
 


### PR DESCRIPTION
This PR fixes a small issue in the shortcut config. After confirming to remove an already existing shortcut the field in the list is cleared, but the latter only happens for the _Current Shortcut_ column, but not for the _Additional Shortcut_ column. Following animated gif shows in 5 pictures (7sec each) what happens when you want to move `Ctrl+Tab` from `View/Next Document/Additional Shortcut` to `View/List Of Open Documents/Current Shortcut` and the other way round:

![RemoveKey](https://github.com/texstudio-org/texstudio/assets/102688820/2ef6a462-4021-4387-8787-9fbb8abff0c2)

In addition `Ctrl+Tab` doesn't work at all instead of opening the List Of Open Documents, accompanied by debug messages:

``QAction::event: Ambiguous shortcut overload: Ctrl+Tab``

You need to remove the definition in the _Additional Shortcut_ column.
