### PR TITLE
fix issues with windowed pdf-viewer

### DIFF
--- a/src/pdfviewer/PDFDocument.h
+++ b/src/pdfviewer/PDFDocument.h
@@ -242,6 +242,9 @@ protected slots: //not private, so scripts have access
 	void goBack();
 	void doPageDialog();
 
+	void magnifierClicked();
+	void scrollClicked();
+
 	void fitWidth(bool checked = true);
 	void fitTextWidth(bool checked = true);
 	void zoomIn();
@@ -705,6 +708,8 @@ private:
 	PDFDock *dwClock, *dwOutline, *dwFonts, *dwInfo, *dwOverview;
 	bool dwVisOutline, dwVisFonts, dwVisInfo, dwVisSearch, dwVisOverview;
 	bool wasContinuous;
+	bool wasShowToolBar;
+	bool wasFullScreen;
 	PDFSearchDock *dwSearch;
 
 	PDFSearchResult lastSearchResult;

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## TeXstudio 4.7.2
 
 - fix duplicate shortcut in 'Additional Shortcut' column is not removed [#3408](https://github.com/texstudio-org/texstudio/pull/3408)
+- fix some minor issues in the windowed internal pdf-viewer [#3419](https://github.com/texstudio-org/texstudio/pull/3419)
 
 ## TeXstudio 4.7.1
 


### PR DESCRIPTION
This PR solves following issues found in the UI of the internal windowed pdf-viewer:

- When running fullscreen window mode and directly switching to presentation window mode (with F5) results in restoring the settings of the fullscreen window mode on returning to normal window mode. Thus the toolbar is missing and page mode is set to fit to window (what  might not be the original value from normal mode).
- When changing toolbar visibility or continuous page mode while in fullscreen window mode then these values are used on returning to normal window mode, not the ones used previously.

