### PR TITLE
pdf-viewer: make actions scroll and magnify checkable

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -2809,6 +2809,18 @@ void PDFWidget::restoreState()
 	emit changedScaleOption(scaleOption);
 }
 
+void PDFWidget::magnifierClicked()
+{
+	setTool(kMagnifier);
+	updateCursor();
+}
+
+void PDFWidget::scrollClicked()
+{
+	setTool(kScroll);
+	updateCursor();
+}
+
 PDFScrollArea *PDFWidget::getScrollArea() const
 {
 	QWidget *parent = parentWidget();
@@ -3000,8 +3012,14 @@ void PDFDocument::setupMenus(bool embedded)
     actionGrayscale=configManager->newManagedAction(menuroot,menuEdit, "grayscale", tr("Grayscale"), pdfWidget, SLOT(update()), QList<QKeySequence>());
     actionGrayscale->setCheckable(true);
 
-    actionMagnify=configManager->newManagedAction(menuroot,menuView, "magnify", tr("&Magnify"), this, "", QList<QKeySequence>(),"magnifier-button");
-    actionScroll=configManager->newManagedAction(menuroot,menuView, "scroll", tr("&Scroll"), this, "", QList<QKeySequence>(),"hand");
+    QActionGroup *toolGroup = new QActionGroup(this);
+    actionMagnify=configManager->newManagedAction(menuroot,menuView, "magnify", tr("&Magnify"), pdfWidget, SLOT(magnifierClicked()), QList<QKeySequence>(),"magnifier-button");
+    actionMagnify->setCheckable(true);
+    toolGroup->addAction(actionMagnify);
+    actionScroll=configManager->newManagedAction(menuroot,menuView, "scroll", tr("&Scroll"), pdfWidget, SLOT(scrollClicked()), QList<QKeySequence>(),"hand");
+    actionScroll->setCheckable(true);
+    toolGroup->addAction(actionScroll);
+
     menuView->addSeparator();
     actionFirst_Page=configManager->newManagedAction(menuroot,menuView, "firstPage", tr("&First Page"), pdfWidget, SLOT(goFirst()), QList<QKeySequence>()<<Qt::Key_Home<<QKeySequence(Qt::ControlModifier | Qt::Key_Home),"go-first");
     actionBack=configManager->newManagedAction(menuroot,menuView, "back", tr("Back"), pdfWidget, SLOT(goBack()), QList<QKeySequence>()<< QKeySequence(Qt::AltModifier | Qt::Key_L),"back");

--- a/src/pdfviewer/PDFDocument.h
+++ b/src/pdfviewer/PDFDocument.h
@@ -242,6 +242,9 @@ protected slots: //not private, so scripts have access
 	void goBack();
 	void doPageDialog();
 
+	void magnifierClicked();
+	void scrollClicked();
+
 	void fitWidth(bool checked = true);
 	void fitTextWidth(bool checked = true);
 	void zoomIn();


### PR DESCRIPTION
Make actions for scroll and magnify tools (s. menu and toolbar icons) checkable for a consistent UI. This fixes the bug (due to a negative toolid) that returning to normal window mode from fullscreen or presentation mode resulted in a wrong arrow mouse cursor.