### PR TITLE
pdf-viewer: Closing fullscreen window with ESC keeps toolbar removed in case ESC doesn't end fullscreen first

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -3898,6 +3898,7 @@ bool PDFDocument::closeElement()
 	else if (dwOverview && dwOverview->isVisible()) dwOverview->hide();
 	else if (configManager->useEscForClosingEmbeddedViewer && isVisible()) {
 		// Note: avoid crash on osx where esc key is passed to hidden window
+		toggleFullScreen(false);
 		actionClose->trigger();
 	} else {
 		return false;  // nothing to close


### PR DESCRIPTION
This PR resolves following issue:
Uncheck option "ESC closes fullscreen mode" in Shortcut config.
Start windowed pdf-viewer and ensure that toolbar is visible.
Start fullscreen window mode (Ctrl+Shift+F).
Press ESC, thus the pdf-viewer window is closed immediately (but internally fullscreen mode is not ended!).
Start again windowed pdf-viewer and observe that toolbar keeps invisible as it was in fullscreen mode. But it should be visible.
