### PR TITLE
pdf-viewer: fix wrong scaling on return from fullscreen when page mode is fit to window

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -4455,11 +4455,11 @@ void PDFDocument::toggleFullScreen(bool fullscreen)
 	bool presentation = false;
 	if (fullscreen) {
 		// entering full-screen mode
+		pdfWidget->saveState();
 		statusBar()->hide();
 		toolBar->hide();
 		globalConfig->windowMaximized = isMaximized();
 		showFullScreen();
-		pdfWidget->saveState();
 		pdfWidget->fitWindow(true);
 		dwVisOutline = dwOutline->isVisible();
 		dwVisOverview = dwOverview->isVisible();


### PR DESCRIPTION
This PR fixes following issue:
Start windowed pdf-viewer.
Set page mode to fit to window.
Switch to fullscreen window mode (Ctrl+Shift+F).
End fullscreen mode with ESC.
Now scaling is wrong because when starting fullscreen mode the settings to be restored are saved after some internal changes on the UI.