### PR TITLE
pdf-viewer: fix continuous mode is set even so it wasn't set before

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -4455,7 +4455,7 @@ void PDFDocument::toggleFullScreen(bool fullscreen)
 	bool presentation = false;
 	if (fullscreen) {
 		// entering full-screen mode
-		wasContinuous = actionContinuous->isChecked() == true;
+		wasContinuous = actionContinuous->isChecked();
 		statusBar()->hide();
 		toolBar->hide();
 		globalConfig->windowMaximized = isMaximized();

--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -4455,6 +4455,7 @@ void PDFDocument::toggleFullScreen(bool fullscreen)
 	bool presentation = false;
 	if (fullscreen) {
 		// entering full-screen mode
+		wasContinuous = actionContinuous->isChecked() == true;
 		statusBar()->hide();
 		toolBar->hide();
 		globalConfig->windowMaximized = isMaximized();
@@ -4479,17 +4480,13 @@ void PDFDocument::toggleFullScreen(bool fullscreen)
 			dwInfo->hide();
 			dwOverview->hide();
 			presentation = true;
-			if (actionContinuous->isChecked()) {
-				actionContinuous->setChecked(false);
-				wasContinuous = true;
-			} else wasContinuous = false;
+			if (wasContinuous) actionContinuous->setChecked(false);
 		} else
 			actionFull_Screen->setChecked(true);
-
-		//actionFull_Screen->setChecked(true);
 	} else {
 		// exiting full-screen mode
 		statusBar()->show();
+		if (wasContinuous) actionContinuous->setChecked(true);
 		toolBar->show();
 		if (globalConfig->windowMaximized)
 			showMaximized();
@@ -4505,9 +4502,8 @@ void PDFDocument::toggleFullScreen(bool fullscreen)
 		pdfWidget->setContextMenuPolicy(Qt::DefaultContextMenu);
 		if (exitFullscreen) {
 			delete exitFullscreen;
-            exitFullscreen = nullptr;
+			exitFullscreen = nullptr;
 		}
-		if (wasContinuous) actionContinuous->setChecked(true);
 	}
 }
 


### PR DESCRIPTION
This PR fixes following issue:

Start windowed pdf-viewer.
Set continuous page mode (menu) in normal window mode.
Start presentation window mode (F5), then return to normal window mode (ESC).
Deactivate continuous page mode, then start fullscreen window mode (Ctrl+Shift+F).
Return to normal window mode (ESC).
Now continuous page mode is set even so it had been unset previously.