### PR TITLE
pdf-viewer: On return from fullscreen/presentation show toolbar only when it had been present before

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -4475,6 +4475,7 @@ void PDFDocument::toggleFullScreen(bool fullscreen)
 	if (fullscreen) {
 		// entering full-screen mode
 		wasContinuous = actionContinuous->isChecked();
+		wasShowToolBar = toolBar->isVisible();
 		pdfWidget->saveState();
 		statusBar()->hide();
 		toolBar->hide();
@@ -4506,7 +4507,7 @@ void PDFDocument::toggleFullScreen(bool fullscreen)
 		// exiting full-screen mode
 		statusBar()->show();
 		if (wasContinuous) actionContinuous->setChecked(true);
-		toolBar->show();
+		if (wasShowToolBar) toolBar->show();
 		if (globalConfig->windowMaximized)
 			showMaximized();
 		else

--- a/src/pdfviewer/PDFDocument.h
+++ b/src/pdfviewer/PDFDocument.h
@@ -708,6 +708,7 @@ private:
 	PDFDock *dwClock, *dwOutline, *dwFonts, *dwInfo, *dwOverview;
 	bool dwVisOutline, dwVisFonts, dwVisInfo, dwVisSearch, dwVisOverview;
 	bool wasContinuous;
+	bool wasShowToolBar;
 	PDFSearchDock *dwSearch;
 
 	PDFSearchResult lastSearchResult;


### PR DESCRIPTION
This PR enhances toolbar handling for users having toolbar disabled:

Open windowed pdf-viewer, disable toolbar.
Start and end fullscreen (or presentation) window mode. In this case toolbar becomes disabled.
On returning to normal window mode toolbar is restored in any case.
This makes it necessary to disable toolbar again for those who want to have a pdv preview as large as possible in normal mode.
