### PR TITLE
pdf-viewer: restore settings from normal window mode after switching from fullscreen to presentation mode

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -3378,6 +3378,7 @@ void PDFDocument::init(bool embedded)
     //connect(actionZoom_Out, SIGNAL(triggered()), pdfWidget, SLOT(zoomOut()));
     //connect(actionFull_Screen, SIGNAL(triggered(bool)), this, SLOT(toggleFullScreen(bool)));
     //connect(actionPresentation, SIGNAL(triggered(bool)), this, SLOT(toggleFullScreen(bool)));
+	wasFullScreen = false;
 	connect(pdfWidget, SIGNAL(changedZoom(qreal)), this, SLOT(enableZoomActions(qreal)));
 	connect(pdfWidget, SIGNAL(changedScaleOption(autoScaleOption)), this, SLOT(adjustScaleActions(autoScaleOption)));
     connect(pdfWidget, SIGNAL(syncClick(int,const QPointF&,bool)), this, SLOT(syncClick(int,const QPointF&,bool)));
@@ -4473,10 +4474,12 @@ void PDFDocument::toggleFullScreen(bool fullscreen)
 {
 	bool presentation = false;
 	if (fullscreen) {
-		// entering full-screen mode
-		wasContinuous = actionContinuous->isChecked();
-		wasShowToolBar = toolBar->isVisible();
-		pdfWidget->saveState();
+		// entering full-screen mode (maybe a second time when switching from fullscreen to presentation)
+		if (!wasFullScreen) {
+			wasContinuous = actionContinuous->isChecked();
+			wasShowToolBar = toolBar->isVisible();
+			pdfWidget->saveState();
+		}
 		statusBar()->hide();
 		toolBar->hide();
 		globalConfig->windowMaximized = isMaximized();
@@ -4525,6 +4528,7 @@ void PDFDocument::toggleFullScreen(bool fullscreen)
 			exitFullscreen = nullptr;
 		}
 	}
+	wasFullScreen = fullscreen;
 }
 
 void PDFDocument::zoomFromAction()

--- a/src/pdfviewer/PDFDocument.h
+++ b/src/pdfviewer/PDFDocument.h
@@ -709,6 +709,7 @@ private:
 	bool dwVisOutline, dwVisFonts, dwVisInfo, dwVisSearch, dwVisOverview;
 	bool wasContinuous;
 	bool wasShowToolBar;
+	bool wasFullScreen;
 	PDFSearchDock *dwSearch;
 
 	PDFSearchResult lastSearchResult;


### PR DESCRIPTION
This PR fixes following issue:

When running fullscreen window mode (Ctrl+Shift+F) and then directly switching to presentation window mode (with F5) results in restoring the settings of the fullscreen mode on returning to normal window mode. Thus the toolbar is missing and page mode is set to fit to window (what might not be the original value from normal mode).