### PR TITLE
ci: upload to uniquely named artifacts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          name: release
+          name: release-win
           path: |
             texstudio-${{ steps.package.outputs.GIT_VERSION }}-win-qt6.exe
             texstudio-${{ steps.package.outputs.GIT_VERSION }}-win-portable-qt6.zip
@@ -143,7 +143,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        name: release
+        name: release-linux
         path: texstudio-${{ steps.package.outputs.GIT_VERSION }}-x86_64.AppImage
 
 
@@ -230,7 +230,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        name: release
+        name: release-osx
         path: texstudio-${{ steps.package.outputs.GIT_VERSION }}-osx.dmg
 
   release:
@@ -241,10 +241,20 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-    - name: Download temp artifact
+    - name: Download Windows release asset(s)
       uses: actions/download-artifact@v4
       with:
-        name: release
+        name: release-win
+
+    - name: Download Linux release asset(s)
+      uses: actions/download-artifact@v4
+      with:
+        name: release-linux
+
+    - name: Download OS X release asset(s)
+      uses: actions/download-artifact@v4
+      with:
+        name: release-osx
 
     - name: Calculate hashes
       run: |


### PR DESCRIPTION
`actions/download-artifact@v4` disables uploading to same named artifact multiple times.

See
- https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/
- https://github.com/actions/toolkit/tree/68f22927e727a60caff909aaaec1ab7267b39f75/packages/artifact

Unfortunately this change is only tested when a tag is pushed.

Currently `actions/download-artifact@v4` only supports [downloading all artifacts](https://github.com/actions/download-artifact/tree/v4/?tab=readme-ov-file#download-all-artifacts), but not a list of selected ones (see https://github.com/actions/download-artifact/issues/216), hence three `actions/download-artifact@v4` steps are used.

See also
- https://github.com/actions/upload-artifact/issues/472