### PR TITLE
ci: batch download temp artifacts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -241,20 +241,11 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-    - name: Download Windows release asset(s)
+    - name: Download temp artifacts
       uses: actions/download-artifact@v4
       with:
-        name: release-win
-
-    - name: Download Linux release asset(s)
-      uses: actions/download-artifact@v4
-      with:
-        name: release-linux
-
-    - name: Download OS X release asset(s)
-      uses: actions/download-artifact@v4
-      with:
-        name: release-osx
+        pattern: release-*
+        merge-multiple: true
 
     - name: Calculate hashes
       run: |


### PR DESCRIPTION
Use new `actions/download-artifact@v4` inputs `pattern` and `merge-multiple`, introduced in v4.1.0.

See
- https://github.com/actions/download-artifact/releases/tag/v4.1.0
- https://github.com/actions/download-artifact/tree/v4.1.0?tab=readme-ov-file#download-multiple-filtered-artifacts-to-the-same-directory

Tested with a fake tag `4.7.2rc10` on my forked repo, see
- workflow run https://github.com/muzimuzhi/texstudio/actions/runs/7281579257
- release https://github.com/muzimuzhi/texstudio/releases/tag/4.7.2rc10