### PR TITLE
execute any type of macro from Macro Dialog

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -5603,7 +5603,7 @@ void Texstudio::editMacros()
         userMacroDialog->selectFirst();
         connect(userMacroDialog, SIGNAL(accepted()), SLOT(macroDialogAccepted()));
         connect(userMacroDialog, SIGNAL(rejected()), SLOT(macroDialogRejected()));
-        connect(userMacroDialog, SIGNAL(runScript(QString)), SLOT(runScript(QString)));
+        connect(userMacroDialog, SIGNAL(execMacro(Macro)), SLOT(execMacro(Macro)));
         // persistent setting like wrap
         userMacroDialog->setLineWrap(configManager.macroEditorUsesLineWrap);
     }

--- a/src/usermenudialog.cpp
+++ b/src/usermenudialog.cpp
@@ -37,7 +37,7 @@ UserMenuDialog::UserMenuDialog(QWidget *parent,  QString name, QLanguageFactory 
 
 	connect(ui.okButton, SIGNAL(clicked()), SLOT(slotOk()));
 
-	connect(ui.runScriptButton, SIGNAL(clicked()), SLOT(slotRunScript()));
+	connect(ui.runScriptButton, SIGNAL(clicked()), SLOT(slotExecMacro()));
 
 	connect(ui.pushButtonAdd, SIGNAL(clicked()), SLOT(slotAdd()));
     connect(ui.pushButtonAddFolder, SIGNAL(clicked()), SLOT(slotAddFolder()));
@@ -314,12 +314,15 @@ void UserMenuDialog::slotOk()
 {
 	accept();
 }
-void UserMenuDialog::slotRunScript()
+void UserMenuDialog::slotExecMacro()
 {
-	QString script = codeedit->editor()->text();
-	if (script.startsWith("%SCRIPT\n"))
-		script = script.mid(8);
-	emit runScript(script);
+    QTreeWidgetItem *item=ui.treeWidget->currentItem();
+    if (item==nullptr) return;
+    QVariant v = item->data(0,Qt::UserRole);
+    if (v.isValid()){
+        Macro m = v.value<Macro>();
+        emit execMacro(m);
+    }
 }
 
 void UserMenuDialog::slotAdd()

--- a/src/usermenudialog.h
+++ b/src/usermenudialog.h
@@ -50,12 +50,12 @@ protected:
     virtual void keyPressEvent(QKeyEvent *e) override;
 
 signals:
-	void runScript(const QString &script);
+	void execMacro(const Macro &macro);
 
 private slots:
     void change(QTreeWidgetItem *current,QTreeWidgetItem *previous);
 	void slotOk();
-	void slotRunScript();
+	void slotExecMacro();
 	void slotAdd();
 	void slotRemove();
     void slotAddFolder();

--- a/src/usermenudialog.ui
+++ b/src/usermenudialog.ui
@@ -443,10 +443,10 @@ p, li { white-space: pre-wrap; }
          <item>
           <widget class="QPushButton" name="runScriptButton">
            <property name="enabled">
-            <bool>false</bool>
+            <bool>true</bool>
            </property>
            <property name="text">
-            <string>Run Script</string>
+            <string>Exec Macro</string>
            </property>
           </widget>
          </item>
@@ -585,22 +585,6 @@ p, li { white-space: pre-wrap; }
   <include location="../images.qrc"/>
  </resources>
  <connections>
-  <connection>
-   <sender>radioButtonScript</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>runScriptButton</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>824</x>
-     <y>128</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>686</x>
-     <y>330</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>cancelButton</sender>
    <signal>clicked()</signal>


### PR DESCRIPTION
This PR enhances User Menu Dialog (Macro Dialog). Currently you can execute macros by pressing button `Run Script` only for type `Script`. For any other type (Snippet or Environment) the button isn't enabled, so the only thing you can do is editing the macro.