### PR TITLE
check rc after loading macro from Json

### DIFF
--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -1066,8 +1066,9 @@ QSettings *ConfigManager::readSettings(bool reread)
                 QString fileName=joinPath(configBaseDir,"macro",QString("Macro_%1.txsMacro").arg(i));
                 if(QFile(fileName).exists()){
                     Macro macro;
-                    macro.load(fileName);
-                    completerConfig->userMacros.append(macro);
+                    if (macro.load(fileName)) {
+                        completerConfig->userMacros.append(macro);
+                    }
                 }else{
                     break;
                 }

--- a/src/usermacro.cpp
+++ b/src/usermacro.cpp
@@ -7,6 +7,7 @@
 #include "latexdocument.h"
 #include <QJsonDocument>
 #include <QJsonArray>
+#include <QMessageBox>
 
 Macro::Macro() : type(Snippet), triggerLookBehind(false), document(nullptr)
 {
@@ -273,10 +274,10 @@ bool Macro::load(const QString &fileName){
     in.setCodec("UTF-8");
 #endif
     QString text=in.readAll();
-    return loadFromText(text);
+    return loadFromText(text,fileName);
 }
 
-bool Macro::loadFromText(const QString &text)
+bool Macro::loadFromText(const QString &text,const QString &fileName)
 {
     QHash<QString,QString>rawData;
     QJsonParseError parseError;
@@ -311,6 +312,10 @@ bool Macro::loadFromText(const QString &text)
     }else{
         //old format
         qDebug()<<"support for old macro format was removed!";
+        QString message = QObject::tr("Support for old macro format was removed!");
+        if (fileName!="")  // macrobrowser has no file name
+            message = message + "\n" + QObject::tr("Make a backup of file %1 before continuing. File will be deleted!").arg(fileName);
+        QMessageBox::warning(nullptr, QObject::tr("Error"), message);
         return false;
     }
 

--- a/src/usermacro.h
+++ b/src/usermacro.h
@@ -54,7 +54,7 @@ public:
 	bool isActiveForFormat(int format) const;
 
     bool load(const QString &fileName);
-    bool loadFromText(const QString &text);
+    bool loadFromText(const QString &text,const QString &fileName=QString());
     bool save(const QString &fileName) const;
 
 	LatexDocument *document;

--- a/src/usermenudialog.cpp
+++ b/src/usermenudialog.cpp
@@ -429,8 +429,9 @@ void UserMenuDialog::importMacro()
     QStringList fileNames = QFileDialog::getOpenFileNames(this,tr("Import macros"), "", tr("txs macro files (*.txsMacro)"));
     for(const QString &fileName:fileNames){
         Macro m;
-        m.load(fileName);
-        addMacro(m,true);
+        if (m.load(fileName)) {
+            addMacro(m,true);
+        }
     }
 }
 


### PR DESCRIPTION
This PR tries to prevent situations where a macro can't be imported/loaded and thus will be replaced in the macro editor by an empty macro without warning. This happens when an old macro is loaded where the JSon has no formatVersion tag. The empty macro is also listed in the tree of macros (without name, ..., so barely visible). When the macro editor or txs is closed the file will overwritten with the empty macro. This could be very harmful to the user. The change will not create an empty member but presents a warning for the user in this case. As a consequence the file will not be overwritten as described before, but deleted.

To reproduce remove the tag from the Json and import the file (manually or by starting txs).

Note:
Current code may detect that Json parsing may not work. This case should probably handled in the same way.