### PR TITLE
reorder buttons in Edit Macros dialog

### DIFF
--- a/src/usermenudialog.cpp
+++ b/src/usermenudialog.cpp
@@ -54,7 +54,6 @@ UserMenuDialog::UserMenuDialog(QWidget *parent,  QString name, QLanguageFactory 
     connect(ui.pbImport,SIGNAL(clicked()), SLOT(importMacro()));
     connect(ui.pbBrowse,SIGNAL(clicked()), SLOT(browseMacrosOnRepository()));
 
-
 	connect(ui.radioButtonNormal, SIGNAL(clicked()), SLOT(changeTypeToNormal()));
 	connect(ui.radioButtonEnvironment, SIGNAL(clicked()), SLOT(changeTypeToEnvironment()));
 	connect(ui.radioButtonScript, SIGNAL(clicked()), SLOT(changeTypeToScript()));
@@ -127,6 +126,8 @@ UserMenuDialog::UserMenuDialog(QWidget *parent,  QString name, QLanguageFactory 
 	connect(ui.triggerHelp, SIGNAL(linkActivated(QString)), SLOT(showTooltip()));
 
     codeedit->editor()->clearFocus();
+    ui.pbBrowse->setFocus();
+
 }
 
 UserMenuDialog::~UserMenuDialog()

--- a/src/usermenudialog.ui
+++ b/src/usermenudialog.ui
@@ -93,16 +93,6 @@
           </spacer>
          </item>
          <item>
-          <widget class="QPushButton" name="pbBrowse">
-           <property name="toolTip">
-            <string>Browse offered macros on txs site.</string>
-           </property>
-           <property name="text">
-            <string>Browse</string>
-           </property>
-          </widget>
-         </item>
-         <item>
           <widget class="QToolButton" name="tbExport">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -115,6 +105,9 @@
              <width>100</width>
              <height>0</height>
             </size>
+           </property>
+           <property name="toolTip">
+            <string>Export macro(s) to file(s)</string>
            </property>
            <property name="text">
             <string>Export</string>
@@ -137,6 +130,16 @@
            </property>
            <property name="text">
             <string>Import</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pbBrowse">
+           <property name="toolTip">
+            <string>Browse offered macros on txs site.</string>
+           </property>
+           <property name="text">
+            <string>Browse</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
As mentioned in my PR #3451 reordering the buttons from Browse, Export, Import to Export, Import, Browse gives better alignment of the buttons and brings Import and Browse together, which are basically the same function.

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/a3cf772c-238b-4872-a694-c98327f73995)
