### PR TITLE
Edit Macros dialog: Don't add the macro type to the first line of the editor field

### DIFF
--- a/src/usermacro.h
+++ b/src/usermacro.h
@@ -41,11 +41,14 @@ public:
 
     bool isEmpty() const;
 
+    QString getTag();
+    void setTag(const QString &ntag);
     void setShortcut(const QString &sc);
     void setTrigger(const QString &newTrigger);
 
 	QString typedTag() const;
-    void setTypedTag(const QString &m_tag);
+	void setTypedTag(const QString &m_tag);
+	void setType(const Macro::Type &ntype);
 	static QString parseTypedTag(QString typedTag, Macro::Type &retType);
 
 	void parseTriggerLanguage(QLanguageFactory *langFactory);

--- a/src/usermenudialog.h
+++ b/src/usermenudialog.h
@@ -38,7 +38,7 @@ public:
     bool getLineWrap();
 
 private:
-	void setLanguageFromText(void);
+	void setLanguageFromType(QTreeWidgetItem *current);
     QTreeWidgetItem* findCreateFolder(const QString &menu);
     QTreeWidgetItem* findCreateFolder(QTreeWidgetItem *parent, QStringList folders);
 
@@ -53,12 +53,12 @@ signals:
 	void execMacro(const Macro &macro);
 
 private slots:
-    void change(QTreeWidgetItem *current,QTreeWidgetItem *previous);
+	void change(QTreeWidgetItem *current,QTreeWidgetItem *previous);
 	void slotOk();
 	void slotExecMacro();
 	void slotAdd();
 	void slotRemove();
-    void slotAddFolder();
+	void slotAddFolder();
 	void slotMoveUp();
 	void slotMoveDown();
     void importMacro();
@@ -72,9 +72,7 @@ private slots:
 	void abbrevChanged();
 	void triggerChanged();
 	void showTooltip();
-	void changeTypeToNormal();
-	void changeTypeToEnvironment();
-	void changeTypeToScript();
+	void changeType();
 };
 
 #endif // USERMENUDIALOG_H


### PR DESCRIPTION
This PR eliminates the confusing interaction between the radio buttons for selecting the type of the macro and the first line of the macro, at the beginning of which the type is encoded. What makes things even more difficult is that Normal type macros are coded without a type at all. When entering the first line, unexpected effects occur if you want to start with a comment. The comment character % is recognized as code for the Environment type and changes the radio buttons to Environment. It is not clear a priori that the character loses this meaning through duplication, but ultimately the type changes back to normal. If the type is changed using the radio buttons, the coding in the first line changes. Multiple changes of type may be irreversible. From the user's point of view as well as that of the technical implementation, the duplicate type in the editor is unnecessary.

Solution: Use radio buttons only to select the type. The type must be saved in the macro object and when exporting to the Json file. Old files (format version 1) will be migrated on import.

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/83518cd2-4a3b-49d7-81d2-e15f93b1403a) <-- old vs. new --> ![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/b13bad5b-28eb-4a0d-a884-735d654ee653)

Json Example:
```json
{
    "abbrev": "",
    "description": [
        "Transposes the two characters to the left and right of the cursor."
    ],
    "formatVersion": 2,
    "menu": "",
    "name": "Transpose Characters",
    "shortcut": "Alt+X",
    "tag": [
        "/* V1.1 2022-04-18 by octaeder */",
        "cursor.beginEditBlock();",
        "cursor.movePosition(1,cursorEnums.Left,cursorEnums.KeepAnchor);",
        "leftchar = cursor.selectedText();",
        "cursor.removeSelectedText();",
        "cursor.movePosition(1,cursorEnums.Right,cursorEnums.KeepAnchor);",
        "rightchar = cursor.selectedText();",
        "cursor.removeSelectedText();",
        "editor.write(rightchar + leftchar);",
        "cursor.movePosition(1,cursorEnums.Left);",
        "cursor.endEditBlock();"
    ],
    "trigger": "",
    "type": "Script"
}
```