### PR TITLE
fix #3190

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -2857,7 +2857,7 @@ PDFDocument::PDFDocument(PDFDocumentConfig *const pdfConfig, bool embedded)
         int &h = globalConfig->windowHeight;
         QRect screen = UtilsUi::getAvailableGeometryAt(QPoint(x, y));
         // add some tolerance, as fullscreen seems to have negative coordinate (KDE, Win7 ...)
-        screen.adjust(-8, -8, +8, +8);
+//        screen.adjust(-8, -8, +8, +8);
         if (!screen.contains(x, y)) {
             // top left is not on screen
             x = screen.x() + screen.width() * 2 / 3;
@@ -2865,13 +2865,13 @@ PDFDocument::PDFDocument(PDFDocumentConfig *const pdfConfig, bool embedded)
             if (x + w > screen.right()) w = screen.width() / 3 - 26;
             if (y + h > screen.height()) h = screen.height() - 100;
         }
+        resize(w, h); //important to first resize then move then maximize
+        move(x, y);
         if (globalConfig->windowMaximized)
             showMaximized();
         else
             setWindowState(Qt::WindowNoState);
 
-        resize(w, h); //important to first resize then move
-        move(x, y);
         if (!globalConfig->windowState.isEmpty()) restoreState(globalConfig->windowState);
         toolBar->setVisible(globalConfig->toolbarVisible);
         statusbar->setVisible(true);
@@ -4298,10 +4298,12 @@ PDFDocument *PDFDocument::findDocument(const QString &fileName)
 
 void PDFDocument::saveGeometryToConfig()
 {
-	globalConfig->windowLeft = x();
-	globalConfig->windowTop = y();
-	globalConfig->windowWidth = width();
-	globalConfig->windowHeight = height();
+	if (!isMaximized() && !isFullScreen()) {
+		globalConfig->windowLeft = x();
+		globalConfig->windowTop = y();
+		globalConfig->windowWidth = width();
+		globalConfig->windowHeight = height();
+	}
 	globalConfig->windowMaximized = isMaximized();
 	globalConfig->windowState = saveState();
 	globalConfig->toolbarVisible = toolBar->isVisible();

--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -4298,13 +4298,15 @@ PDFDocument *PDFDocument::findDocument(const QString &fileName)
 
 void PDFDocument::saveGeometryToConfig()
 {
-	if (!isMaximized() && !isFullScreen()) {
-		globalConfig->windowLeft = x();
-		globalConfig->windowTop = y();
-		globalConfig->windowWidth = width();
-		globalConfig->windowHeight = height();
+	if (!embeddedMode) {
+		if (!isMaximized() && !isFullScreen()) {
+			globalConfig->windowLeft = x();
+			globalConfig->windowTop = y();
+			globalConfig->windowWidth = width();
+			globalConfig->windowHeight = height();
+		}
+		globalConfig->windowMaximized = isMaximized();
 	}
-	globalConfig->windowMaximized = isMaximized();
 	globalConfig->windowState = saveState();
 	globalConfig->toolbarVisible = toolBar->isVisible();
 	globalConfig->annotationPanelVisible = annotationPanel->isVisible();

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -4,6 +4,7 @@
 - First line of macro editor no longer uses macro type, use buttons to set type. Macro format changes slightly. For details s. [#3458](https://github.com/texstudio-org/texstudio/pull/3458)
 - add export of all macros in Edit Macros dialog
 - fix missing connection error message when browsing macro repository [#3448](https://github.com/texstudio-org/texstudio/pull/3448)
+- fix pdf viewer window can be restored to maximized window from embedded state or start of txs [#3190](https://github.com/texstudio-org/texstudio/issues/3190)
 
 ## TeXstudio 4.7.2
 


### PR DESCRIPTION
This PR fixes #3190.  Pdf-viewer window now can be restored to maximized window from embedded state.
Main reasons for the issue are: Resize and move after setting to maximized. Bad coordinates appear because they were retrieved and stored while in maximized state. But maximizing a window is solely achieved by setting appropriate attributes not by window coordinates.

