### PR TITLE
Improve gitignore rule ignoring `build` directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,9 @@ cov-int/
 # ignore macOS compiling result
 git_revision.o
 texstudio.app/
-build*
+build/
+utilities/manual/build/
+!utilities/manual/build/html
 symbols-ng/gesymb-ng
 symbols-ng/gesymb-ng.o
 CMakeLists.txt.user

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,7 @@ cov-int/
 # ignore macOS compiling result
 git_revision.o
 texstudio.app/
-build/
-utilities/manual/build/
+build*/
 !utilities/manual/build/html
 symbols-ng/gesymb-ng
 symbols-ng/gesymb-ng.o


### PR DESCRIPTION
Old rule `build*` also ignores files like `./src/buildmanager.cpp`, which will influence other tools respecting gitignore, such as ripgrep.