### PR TITLE
Messages Pane: Add action to menu to copy any data of all issues to clipboard

### DIFF
--- a/src/latexlogwidget.h
+++ b/src/latexlogwidget.h
@@ -39,8 +39,8 @@ private slots:
 	void clickedOnLogModelIndex(const QModelIndex &index);
 	void gotoLogEntry(int logEntryNumber);
 	void gotoLogLine(int logLine);
-	void copyMessage();
-	void copyAllMessages();
+	void copyRow();
+	void copyAllRows();
 	void copyAllMessagesWithLineNumbers();
 	void setWidgetVisibleFromAction(bool visible);
 	void setInfo(const QString &message);
@@ -56,6 +56,8 @@ private:
 	LogEditor *log;
 	QLabel *infoLabel;
 	QAction *displayTableAction, *displayLogAction, *filterErrorAction, *filterWarningAction, *filterBadBoxAction;
+
+	void copyRowsWithColumnRange(int firstRow, int rows, int first, int last);
 };
 
 #endif // LATEXLOGWIDGET_H


### PR DESCRIPTION
This PR adds new action `Copy All Rows And Columns` retrieving all data needed for multi document projects.
Name could be changed to `Copy Table` or action could replace action `Copy All`, s. discussion below.

Discuss with me before merging (nothing of this is currently done):

- Mnemonics are all the same (&Copy) and are not visible. This could be improved.
- `Copy` and `Copy All` actions: Why should one simply copy one or all messages without further data? Since all columns of a row are selected (model behavior) the names suggest that
    - `Copy` copies complete row -> change code to do so
    - `Copy All` copies all rows (i.e. all table data) ->  remove or change to behavior of new action (to keep action name)
- `Copy All With Line Numbers` -> unchanged
