### PR TITLE
cwl: add starred variants of `\VerbatimInput` and friends

### DIFF
--- a/completion/fancyvrb.cwl
+++ b/completion/fancyvrb.cwl
@@ -80,10 +80,16 @@ aftersave={%<code%>}
 # writing and reading verbatim files
 \VerbatimInput{file}
 \VerbatimInput[options%keyvals]{file}
+\VerbatimInput*{file}
+\VerbatimInput*[options%keyvals]{file}
 \BVerbatimInput{file}
 \BVerbatimInput[options%keyvals]{file}
+\BVerbatimInput*{file}
+\BVerbatimInput*[options%keyvals]{file}
 \LVerbatimInput{file}
 \LVerbatimInput[options%keyvals]{file}
+\LVerbatimInput*{file}
+\LVerbatimInput*[options%keyvals]{file}
 \begin{VerbatimOut}{file name%file}#V
 \end{VerbatimOut}
 


### PR DESCRIPTION
These starred variants have been supported for a long time, but not explicitly documented until `fancyvrb` v4.5c (2024-01-20), see changes of `fancyvrb` package manual.