### PR TITLE
cwl: \standardstatesymbol should be \standardstate

### DIFF
--- a/completion/chemmacros.cwl
+++ b/completion/chemmacros.cwl
@@ -224,7 +224,7 @@ pos=#side,sub
 ## symbols-module
 # loads amstext package
 \transitionstatesymbol
-\standardstatesymbol
+\standardstate
 \changestate
 
 ## formula-module


### PR DESCRIPTION
See source code in `chemmacros` package
https://github.com/cgnieder/chemmacros/blob/05e767ac4a9d50a134a228f4aabdd952f6296765/code/chemmacros.symbols.code.tex#L36-L40