### PR TITLE
check checkbox Show all packages when package list would be empty on startup

### DIFF
--- a/src/texdocdialog.cpp
+++ b/src/texdocdialog.cpp
@@ -182,7 +182,10 @@ void TexdocDialog::itemChanged(QTableWidgetItem* item)
 void TexdocDialog::setPackageNames(const QStringList &packages)
 {
     m_packages=packages;
-    regenerateTable();
+    bool checked = false;
+    if (m_packages.count()==0) checked = true;
+    ui->cbShowAllPackages->setChecked(checked);
+    regenerateTable(checked);
 }
 
 void TexdocDialog::setPreferredPackage(const QString &package)


### PR DESCRIPTION
When the package list of Package Help dialog would be empty then start the dialog with checkbox _Show all packages_ checked.
This resolves https://github.com/texstudio-org/texstudio/pull/3478#issuecomment-1915874683