### PR TITLE
insertGraphicsDlg: avoid qt.svg: Cannot open file ':/images/up-arrow-circle-silver.svg', because: No such file or directory

### DIFF
--- a/src/insertgraphics.ui
+++ b/src/insertgraphics.ui
@@ -312,7 +312,7 @@
           </property>
           <property name="icon">
            <iconset resource="../texstudio.qrc">
-            <normaloff>:/images/up-arrow-circle-silver.svg</normaloff>:/images/up-arrow-circle-silver.svg</iconset>
+            <normaloff>:/images/up-arrow-circle-silver.png</normaloff>:/images/up-arrow-circle-silver.png</iconset>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
When debugging, above message shows twice when starting InsertGraphics dialog.
The image available in the given path has file extension `.png`.