### PR TITLE
insertGraphicsDlg: prevent elements from moving

### DIFF
--- a/src/insertgraphics.cpp
+++ b/src/insertgraphics.cpp
@@ -480,13 +480,13 @@ void InsertGraphics::updateLabel(const QString &fname)
 void InsertGraphics::togglePlacementCheckboxes(bool forceHide)
 {
 	if (ui.placementCheckboxes->isVisible() || forceHide) {
-		ui.placementCheckboxes->hide();
 		ui.pbPlaceExpand->setIcon(getRealIcon("down-arrow-circle-silver"));
-		resize(width(), height() - (ui.placementCheckboxes->height() + ui.gridLayout->verticalSpacing()));
+		resize(width(), height() - (ui.placementCheckboxes->height() - ui.gridLayout->verticalSpacing()));
+		ui.placementCheckboxes->hide();
 	} else {
-		resize(width(), height() + (ui.placementCheckboxes->height() + ui.gridLayout->verticalSpacing()));
 		ui.pbPlaceExpand->setIcon(getRealIcon("up-arrow-circle-silver"));
 		ui.placementCheckboxes->show();
+		resize(width(), height() + (ui.placementCheckboxes->height() - ui.gridLayout->verticalSpacing()));
 	}
 }
 


### PR DESCRIPTION
Current behavior may prevent that you can click push button to expand and collapse position/placement details:

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/bfadbf4e-5ac8-4bcd-9bb3-7675be981eee)
1: started dialog 2: expand 3: collapse, after this repeat 2 and 3 (click to enlarge)

Fixed behavior:

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/0ddd85d0-92eb-433d-a861-325b80430c9f)
1: started dialog 2: expand, after this repeat 1 and 2 (click to enlarge)