### PR TITLE
packageHelp: improved printing of package.version

### DIFF
--- a/src/latexrepository.cpp
+++ b/src/latexrepository.cpp
@@ -157,7 +157,8 @@ QString LatexRepository::packageInfo(LatexPackageInfo package)
     Info += tr("- Name : ")+package.name+"\n";
     Info += tr("- Caption : ")+package.caption+"\n";
     Info += tr("- Authors : \n")+package.authorsFullName()+"\n";
-    Info += tr("- Version : ")+package.version.number+", "+package.version.date.toString()+"\n";
+    QString delim = ( package.version.number.isEmpty() || !package.version.date.isValid() ? "" : ", " );
+    Info += tr("- Version : ")+package.version.number+delim+package.version.date.toString()+"\n";
     Info += tr("- Documentation : \n")+package.showAllDocumentation()+"\n";
     Info += tr("- Copyright : \n")+package.showAllCopyrights()+"\n";
     Info += tr("- License : \n")+package.showAllLicenses()+"\n";


### PR DESCRIPTION
small visual improvement, because often not both of version.number and version.date are available:

current:

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/6951c249-6f5a-45ce-b57e-7711a1b49720)

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/a5c15a05-5022-4ee2-8013-232c9538353f)

fixed:

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/bc73d435-1e5a-4d68-9aed-bef755abbb90)

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/51de47bb-80ac-469a-bae2-0ccd590470b6)

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/cbb837b1-f4af-4005-8dd5-0207e4ddee3f)


