### PR TITLE
mathassistant: No such signal QProcess::error(QProcess::ProcessError)

### DIFF
--- a/src/mathassistant.cpp
+++ b/src/mathassistant.cpp
@@ -7,7 +7,7 @@ MathAssistant *MathAssistant::m_Instance = nullptr;
 MathAssistant::MathAssistant() :
 	QObject()
 {
-	connect(&process, SIGNAL(error(QProcess::ProcessError)), this, SLOT(processError(QProcess::ProcessError)));
+	connect(&process, SIGNAL(errorOccurred(QProcess::ProcessError)), this, SLOT(processError(QProcess::ProcessError)));
 	connect(&process, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(processFinished(int, QProcess::ExitStatus)));
 }
 


### PR DESCRIPTION
`qt.core.qobject.connect: QObject::connect: No such signal QProcess::error(QProcess::ProcessError)`

correct name is `errorOccurred`, s. [Qt6 online](https://doc.qt.io/qt-6/qprocess.html#signals), same for Qt5

To reproduce: Start txs with debug. Select `Wizards/Math Assistant...` when it is not installed.

Note: buildmanager l. 2339 uses correct name `errorOccurred`