### PR TITLE
Template Selector: Add a description for top item Online Repository

### DIFF
--- a/src/templateselector.cpp
+++ b/src/templateselector.cpp
@@ -130,7 +130,7 @@ void TemplateSelector::addOnlineRepository()
     QFont ft = topitem->font(0);
     ft.setBold(true);
     topitem->setFont(0, ft);
-    topitem->setData(0, ResourceRole, tr("Online available templates"));
+    topitem->setData(0, ResourceRole, tr("Online available template files"));
     topitem->setData(0, UrlRole, QString("https://api.github.com/repos/texstudio-org/texstudio-template/contents"));
     topitem->setData(0, PathRole, QString(""));
     ui.templatesTree->addTopLevelItem(topitem);

--- a/src/templateselector.cpp
+++ b/src/templateselector.cpp
@@ -127,10 +127,10 @@ void TemplateSelector::addResource(AbstractTemplateResource *res)
 void TemplateSelector::addOnlineRepository()
 {
     QTreeWidgetItem *topitem = new QTreeWidgetItem(QStringList() << tr("Online Repository"));
-    //topitem->setIcon(0, res->icon());
     QFont ft = topitem->font(0);
     ft.setBold(true);
     topitem->setFont(0, ft);
+    topitem->setData(0, ResourceRole, tr("Online available templates"));
     topitem->setData(0, UrlRole, QString("https://api.github.com/repos/texstudio-org/texstudio-template/contents"));
     topitem->setData(0, PathRole, QString(""));
     ui.templatesTree->addTopLevelItem(topitem);
@@ -505,6 +505,16 @@ void TemplateSelector::showInfo(QTreeWidgetItem *currentItem, QTreeWidgetItem *p
             QString path=currentItem->data(0,PathRole).toString();
             QString url=currentItem->data(0,UrlRole).toString();
             QString downloadUrl=currentItem->data(0,DownloadRole).toString();
+            if (currentItem->data(0,ResourceRole).isValid()) {
+                QString topDescription = currentItem->data(0,ResourceRole).toString();
+                ui.lbName->setText(currentItem->text(0));
+                ui.lbDescription->setText(topDescription);
+                ui.lbAuthor->setText("");
+                ui.lbDate->setText("");
+                ui.lbVersion->setText("");
+                ui.lbLicense->setText("");
+                ui.lbAuthorTag->setVisible(false);
+            }
             if(!downloadUrl.isEmpty()){
                 makeRequest(downloadUrl,path,currentItem,true);
             }


### PR DESCRIPTION
similar to
![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/75d0372e-4094-4f16-ac30-4f0810dab5e0)
![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/061253c3-8f9e-4832-a00b-be4d9cdc5f52)
Since Online Repo doesn't set the data you will see old data, which is misleading.
we now have
![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/a731998c-50a7-4c15-9032-6761e56f7760)
