### PR TITLE
ProcessX::startCommand(): Prepend `flatpak-spawn --host` to build com…

### DIFF
--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -2394,12 +2394,16 @@ void ProcessX::startCommand()
 				QString executable_path = texlive_flatpak_dir.filePath(executable);
 
 				// Check if the executable exists
+				qDebug() << "checking if " << executable_path << " exists";
 				QFileInfo fileInfo(executable_path);
-				if (fileInfo.isFile()) {
+				if (fileInfo.isFile() and executable.indexOf("/") == -1) {
+					qDebug() << "executable exists in /app/texlive/bin";
 					// don't change cmd
 				} else {
 					cmd = "flatpak-spawn --host "+cmd;
 				}
+			} else {
+				qDebug() << "cmd is empty";
 			}
 		}
 	}

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -2394,16 +2394,12 @@ void ProcessX::startCommand()
 				QString executable_path = texlive_flatpak_dir.filePath(executable);
 
 				// Check if the executable exists
-				qDebug() << "checking if " << executable_path << " exists";
 				QFileInfo fileInfo(executable_path);
 				if (fileInfo.isFile() and executable.indexOf("/") == -1) {
-					qDebug() << "executable exists in /app/texlive/bin";
 					// don't change cmd
 				} else {
 					cmd = "flatpak-spawn --host "+cmd;
 				}
-			} else {
-				qDebug() << "cmd is empty";
 			}
 		}
 	}

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -2384,19 +2384,22 @@ void ProcessX::startCommand()
 
 	// Check if FLATPAK_SANDBOX_DIR is set
 	if (env.contains("FLATPAK_SANDBOX_DIR")) {
-		QStringList cmd_elements = cmd.split(" ");
+		if (!cmd.startsWith("flatpak-spawn")) {
+			QStringList cmd_elements = cmd.split(" ");
 
-		if (!cmd_elements.isEmpty()) {
-			QDir texlive_flatpak_dir("/app/texlive/bin");
-			QString executable = cmd_elements.first();
-			QString executable_path = texlive_flatpak_dir.filePath(executable);
+			if (!cmd_elements.isEmpty()) {
+				QDir texlive_flatpak_dir("/app/texlive/bin");
+				QString executable = cmd_elements.first();
 
-			// Check if the executable exists
-			QFileInfo fileInfo(executable_path);
-			if (fileInfo.isFile()) {
-				// don't change cmd
-			} else {
-				cmd = "flatpak-spawn --host "+cmd;
+				QString executable_path = texlive_flatpak_dir.filePath(executable);
+
+				// Check if the executable exists
+				QFileInfo fileInfo(executable_path);
+				if (fileInfo.isFile()) {
+					// don't change cmd
+				} else {
+					cmd = "flatpak-spawn --host "+cmd;
+				}
 			}
 		}
 	}

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -2372,11 +2372,35 @@ void ProcessX::startCommand()
 		emit finished(0, NormalExit);
 		return;
 	}
+
 	if (stdoutEnabled || stdoutBuffer)
 		connect(this, SIGNAL(readyReadStandardOutput()), this, SLOT(readFromStandardOutput()));
 	if (stderrEnabled)
 		connect(this, SIGNAL(readyReadStandardError()), this, SLOT(readFromStandardError()));
 
+#ifdef Q_OS_LINUX
+	// Retrieve the environment variables
+	QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+
+	// Check if FLATPAK_SANDBOX_DIR is set
+	if (env.contains("FLATPAK_SANDBOX_DIR")) {
+		QStringList cmd_elements = cmd.split(" ");
+
+		if (!cmd_elements.isEmpty()) {
+			QDir texlive_flatpak_dir("/app/texlive/bin");
+			QString executable = cmd_elements.first();
+			QString executable_path = texlive_flatpak_dir.filePath(executable);
+
+			// Check if the executable exists
+			QFileInfo fileInfo(executable_path);
+			if (fileInfo.isFile()) {
+				// don't change cmd
+			} else {
+				cmd = "flatpak-spawn --host "+cmd;
+			}
+		}
+	}
+#endif
 	ExecProgram execProgram(cmd, BuildManager::resolvePaths(BuildManager::additionalSearchPaths));
 	execProgram.execAndNoWait(*this);
 


### PR DESCRIPTION
…mands if TeXstudio is run inside a Flatpak sandbox and the executable does not exist in /app/texlive/bin

Here's a test build: https://github.com/flathub/org.texstudio.TeXstudio/pull/190