### PR TITLE
fix open online template location

### DIFF
--- a/src/templateselector.cpp
+++ b/src/templateselector.cpp
@@ -629,7 +629,17 @@ void TemplateSelector::removeTemplate()
 void TemplateSelector::openTemplateLocation()
 {
 	TemplateHandle th = selectedTemplate();
-	QString url = "file:///" + QFileInfo(th.file()).absolutePath();
+	QString url = th.file();
+	QString proto = url;
+	proto.truncate(8);
+	if (proto=="https://") {
+		url.replace(0, QString( "https://raw.githubusercontent.com/texstudio-org/texstudio-template/main").size(),
+								"https://github.com/texstudio-org/texstudio-template/tree/main");
+		url.truncate(url.lastIndexOf("/"));
+	}
+	else {
+		url = "file:///" + QFileInfo(th.file()).absolutePath();
+	}
 	if (!QDesktopServices::openUrl(QUrl(url))) {
 		UtilsUi::txsCritical(tr("Could not open location:") + QString("\n%1").arg(url));
 	}


### PR DESCRIPTION
before change: Action gives an error:

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/f8b69a04-e701-4444-8a4a-11e2e1aa1a3a)

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/f560dc0b-6a7e-449d-b92f-cc1eb1aac497)

after change: Following link is opened in the browser:
[https://github.com/texstudio-org/texstudio-template/tree/main/Letters](https://github.com/texstudio-org/texstudio-template/tree/main/Letters)