### PR TITLE
fix del closing brace

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -4014,10 +4014,10 @@ void Texstudio::editEraseWordCmdEnv()
                 if (cursor.nextChar() == QChar('{')) {
                     QDocumentCursor orig, to;
                     cursor.getMatchingPair(orig, to, false);
-                    cursor.deleteChar();
                     if (orig.isValid() && to.isValid()){
                         to.removeSelectedText();
                     }
+                    cursor.deleteChar();
                 }
                 currentEditorView()->editor->document()->endMacro();
             }


### PR DESCRIPTION
This fixes #3535.
orig and to are to large by 1 when deleting opening brace after determining orig and to when in same line. thus delete from right to left.