### PR TITLE
fix font weight

### DIFF
--- a/src/qcodeedit/lib/qformat.cpp
+++ b/src/qcodeedit/lib/qformat.cpp
@@ -39,7 +39,11 @@ QString QFormat::toCSS(bool simplifyCSS) const {
 	if ( italic )
 		result += "font-style: italic;";
 	if ( weight && (weight != QFont::Normal))
-		result += QString("font-weight: %1;").arg(weight);
+#if QT_VERSION_MAJOR<6
+		result += QString("font-weight: %1;").arg(weight*12-200);   // map weight values from 0 to 99 onto -200 to 988
+#else
+		result += QString("font-weight: %1;").arg(weight);          // weight values from 1 to 1000
+#endif
 	if ( simplifyCSS ) {
 		if ( overline || underline || strikeout || waveUnderline )
 			result += QString("text-decoration: %1 %2 %3;").arg(overline?"overline":"").arg(strikeout?"line-through":"").arg(underline?"underline":"");

--- a/src/qcodeedit/lib/qformat.cpp
+++ b/src/qcodeedit/lib/qformat.cpp
@@ -39,7 +39,7 @@ QString QFormat::toCSS(bool simplifyCSS) const {
 	if ( italic )
 		result += "font-style: italic;";
 	if ( weight && (weight != QFont::Normal))
-		result += QString("font-weight: %1;").arg(weight*12-200);
+		result += QString("font-weight: %1;").arg(weight);
 	if ( simplifyCSS ) {
 		if ( overline || underline || strikeout || waveUnderline )
 			result += QString("text-decoration: %1 %2 %3;").arg(overline?"overline":"").arg(strikeout?"line-through":"").arg(underline?"underline":"");


### PR DESCRIPTION
This PR fixes #3366. The list below (s. `QFormatScheme::exportAsCSS`) shows the fonts noted in the issue. As stated there fmt20 and fmt31 are known to be responsible for message `QFont::setWeight: Weight must be between 1 and 1000, attempted to set  1001`. As one can readily see fonts fmt23, fmt26, fmt28, fmt32, fmt58, fmt66, fmt67, fmt73, and fmt76 also have a font-weight of 8200. Please read note below.

#### Reason
The value is calculated with `weight*12-200`. Since weight is 700 (`QFont::Bold`), the result is obviously 8200. It seems that the formula had been introduced to scale the values from Qt5, but there was a change with Qt6. While Qt5 uses values from 0 to 99, Qt6 uses values from 1 to 1000 (s. error message). See following links:

`enum QFont::Weight` [Qt5](https://doc.qt.io/qt-5/qfont.html#Weight-enum)
`enum QFont::Weight` [Qt6](https://doc.qt.io/qt-6/qfont.html#Weight-enum)

#### Note
The formula maps range 0 to 99 onto -200 to 988 (negative values for 0 to 16). When you want to map 0 to 99 onto 1 to 1000 you need to use `111/11*weight+1`. Using `10*weight+1` maps onto 1 to 991, so this would be a good approximation.

So which formula should we use in case of Qt5?

#### Examples
Following two examples show tooltips with the fix (Qt6):

![image](https://github.com/texstudio-org/texstudio/assets/102688820/5ecbd130-8e2d-4808-a973-dc81b539f967)

![image](https://github.com/texstudio-org/texstudio/assets/102688820/099d6502-f585-4859-aecc-f2ff38214a6e)

The above message no longer appears.

#### List of fonts
```
".fmt0 {  } /* normal */\n"
".fmt1 {  } /* background */\n"
".fmt2 { background-color: #ffcabf; } /* line:error */\n"
".fmt3 { background-color: #fffbbf; } /* line:warning */\n"
".fmt4 { background-color: #bfd6ff; } /* line:badbox */\n"
".fmt5 {  } /* line:bookmark */\n"
".fmt6 {  } /* line:bookmark0 */\n"
".fmt7 {  } /* line:bookmark1 */\n"
".fmt8 {  } /* line:bookmark2 */\n"
".fmt9 {  } /* line:bookmark3 */\n"
".fmt10 {  } /* line:bookmark4 */\n"
".fmt11 {  } /* line:bookmark5 */\n"
".fmt12 {  } /* line:bookmark6 */\n"
".fmt13 {  } /* line:bookmark7 */\n"
".fmt14 {  } /* line:bookmark8 */\n"
".fmt15 {  } /* line:bookmark9 */\n"
".fmt16 { color: #555580; } /* magicComment */\n"
".fmt17 { background-color: #a8cf83; } /* commentTodo */\n"
".fmt18 { color: #808080; } /* comment */\n"
".fmt19 { color: #800000; } /* keyword */\n"
".fmt20 { font-weight: 8200;color: #0095ff; } /* extra-keyword */\n"
".fmt21 { color: #808000; } /* math-keyword */\n"
".fmt22 { text-decoration:   underline;color: #0000ff; } /* link */\n"
".fmt23 { font-weight: 8200;color: #0055ff; } /* align-ampersand */\n"
".fmt24 { color: #008080; } /* verbatim */\n"
".fmt25 { color: #800000; } /* sweave-block */\n"
".fmt26 { font-weight: 8200;color: #0095ff; } /* sweave-delimiter */\n"
".fmt27 { color: #800000; } /* pweave-block */\n"
".fmt28 { font-weight: 8200;color: #0095ff; } /* pweave-delimiter */\n"
".fmt29 { color: #804000; } /* picture */\n"
".fmt30 { color: #c06000; } /* picture-keyword */\n"
".fmt31 { font-weight: 8200;background-color: #ffff7f; } /* braceMatch */\n"
".fmt32 { font-weight: 8200;color: #ffff7f;background-color: #c00000; } /* braceMismatch */\n"
".fmt33 { color: #000000;background-color: #ffef0b; } /* search */\n"
".fmt34 { color: #008000; } /* numbers */\n"
".fmt35 { color: #509600; } /* math-delimiter */\n"
".fmt36 { color: #202000; } /* math-text */\n"
".fmt37 { color: #ff0000; } /* text */\n"
".fmt38 { color: #ff0088; } /* escapeseq */\n"
".fmt39 { text-decoration:   ; } /* spellingMistake */\n"
".fmt40 { text-decoration:   ; } /* wordRepetition */\n"
".fmt41 { text-decoration:   ; } /* wordRepetitionLongRange */\n"
".fmt42 { text-decoration:  line-through ; } /* badWord */\n"
".fmt43 { text-decoration:   ; } /* grammarMistake */\n"
".fmt44 { background-color: #00ffa0; } /* grammarMistakeSpecial1 */\n"
".fmt45 { background-color: #00c0ff; } /* grammarMistakeSpecial2 */\n"
".fmt46 { background-color: #00ff00; } /* grammarMistakeSpecial3 */\n"
".fmt47 { background-color: #c8ff61; } /* grammarMistakeSpecial4 */\n"
".fmt48 { background-color: #ffbf9f; } /* latexSyntaxMistake */\n"
".fmt49 { font-style: italic;color: #0000ff; } /* temporaryCodeCompletion */\n"
".fmt50 { color: #000080; } /* environment */\n"
".fmt51 { color: #008000; } /* referencePresent */\n"
".fmt52 { text-decoration:   ;color: #008000; } /* referenceMissing */\n"
".fmt53 { text-decoration:   ;color: #800080; } /* referenceMultiple */\n"
".fmt54 { color: #008000; } /* citationPresent */\n"
".fmt55 { text-decoration:   ;color: #008000; } /* citationMissing */\n"
".fmt56 { color: #008000; } /* packagePresent */\n"
".fmt57 { text-decoration:   ;color: #008000; } /* packageMissing */\n"
".fmt58 { font-weight: 8200;color: #000000; } /* structure */\n"
".fmt59 { background-color: #eeeeff; } /* current */\n"
".fmt60 { background-color: #b2d8ff; } /* selection */\n"
".fmt61 { background-color: #ffaaaa; } /* replacement */\n"
".fmt62 { text-decoration:  line-through ;background-color: #ffaaaa; } /* diffDelete */\n"
".fmt63 { background-color: #aaffaa; } /* diffAdd */\n"
".fmt64 { background-color: #ffff50; } /* diffReplace */\n"
".fmt65 { background-color: #ddffcc; } /* previewSelection */\n"
".fmt66 { font-weight: 8200;color: #0095ff; } /* txs-test */\n"
".fmt67 { font-weight: 8200; } /* txs-test-summary */\n"
".fmt68 { color: #008000; } /* txs-test-pass */\n"
".fmt69 { color: #c00000; } /* txs-test-fail */\n"
".fmt70 { color: #ea8800; } /* txs-test-warn */\n"
".fmt71 { color: #808000; } /* txs-test-qdebug */\n"
".fmt72 { color: #ffa500; } /* dtx:guard */\n"
".fmt73 { font-weight: 8200;color: #006400; } /* dtx:macro */\n"
".fmt74 { color: #008080; } /* dtx:verbatim */\n"
".fmt75 { color: #cc8100; } /* dtx:specialchar */\n"
".fmt76 { font-weight: 8200;color: #10c010; } /* dtx:commands */\n"
".fmt77 { color: #b200ff; } /* lua:keyword */\n"
".fmt78 { color: #808080; } /* lua:comment */\n"
".fmt79 { color: #804000; } /* asymptote:block */\n"
".fmt80 { color: #800080; } /* asymptote:keyword */\n"
".fmt81 { color: #808000; } /* asymptote:type */\n"
".fmt82 { color: #008000; } /* asymptote:numbers */\n"
".fmt83 { color: #000080; } /* asymptote:string */\n"
".fmt84 { color: #808080; } /* asymptote:comment */\n"
".fmt85 { color: #808080; } /* qtscript:comment */\n"
".fmt86 { color: #008000; } /* qtscript:string */\n"
".fmt87 { color: #000080; } /* qtscript:number */\n"
".fmt88 { color: #808000; } /* qtscript:keyword */\n"
".fmt89 { color: #800000; } /* qtscript:txs-variable */\n"
".fmt90 { font-style: italic; } /* qtscript:txs-function */\n"
".fmt91 { background-color: #ffff7f; } /* preedit */\n"
```
