### PR TITLE
cwl: reclassify \ExplLoaderFileDate to "all" tab

### DIFF
--- a/completion/latex-dev.cwl
+++ b/completion/latex-dev.cwl
@@ -323,7 +323,7 @@ ypos
 
 # expl3 commands
 \ExplFileDate#S
-\ExplLoaderFileDate#S
+\ExplLoaderFileDate#*
 \ProvidesExplFile{name}{date}{version}{description}#*
 \ProvidesExplClass{name}{date}{version}{description}#*
 \ProvidesExplPackage{name}{date}{version}{description}#*


### PR DESCRIPTION
`\ExplLoaderFileDate` provided by `expl3` (aka `l3kernel`) is indeed a user command and may be used in minimal working examples. See its doc in `texdoc expl3.pdf` (2024-02-20), sec. 9.
![image](https://github.com/texstudio-org/texstudio/assets/6376638/b6e0a10b-d1af-4847-accf-52143c50bc16)
