### PR TITLE
Add grid actions in case of embedded PDF-Viewer

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -3346,27 +3346,27 @@ void PDFDocument::init(bool embedded)
 		pdfWidget->setGridSize(globalConfig->gridx, globalConfig->gridy, true);
 		conf->registerOption("Preview/PageOffset", &globalConfig->pageOffset, 0);
 		pdfWidget->setPageOffset(globalConfig->pageOffset, true);
-        // set grid menu entry checked
-        QString gs=QString("%1x%2").arg(globalConfig->gridx).arg(globalConfig->gridy);
-        bool found=false;
-        for(QAction *a:actionGroupGrid->actions()){
-            if(a->property("grid").toString()==gs){
-                a->setChecked(true);
-                found=true;
-                break;
-            }
-        }
-        if(!found){
-            // if no other grid action fits, use custom
-            actionCustom->setChecked(true);
-        }
+		// set grid menu entry checked
+		QString gs=QString("%1x%2").arg(globalConfig->gridx).arg(globalConfig->gridy);
+		bool found=false;
+		for(QAction *a:actionGroupGrid->actions()){
+			if(a->property("grid").toString()==gs){
+				a->setChecked(true);
+				found=true;
+				break;
+			}
+		}
+		if(!found){
+			// if no other grid action fits, use custom
+			actionCustom->setChecked(true);
+		}
 
-        //connect(actionSinglePageStep, SIGNAL(toggled(bool)), pdfWidget, SLOT(setSinglePageStep(bool)));
+		//connect(actionSinglePageStep, SIGNAL(toggled(bool)), pdfWidget, SLOT(setSinglePageStep(bool)));
 		conf->registerOption("Preview/Single Page Step", &globalConfig->singlepagestep, true);
-        conf->linkOptionToObject(&globalConfig->singlepagestep, actionSinglePageStep, LO_NONE);
-        connect(actionContinuous, SIGNAL(toggled(bool)), scrollArea, SLOT(setContinuous(bool)));
+		conf->linkOptionToObject(&globalConfig->singlepagestep, actionSinglePageStep, LO_NONE);
+		connect(actionContinuous, SIGNAL(toggled(bool)), scrollArea, SLOT(setContinuous(bool)));
 		conf->registerOption("Preview/Continuous", &globalConfig->continuous, true);
-        conf->linkOptionToObject(&globalConfig->continuous, actionContinuous, LO_NONE);
+		conf->linkOptionToObject(&globalConfig->continuous, actionContinuous, LO_NONE);
 	} else {
 		pdfWidget->setGridSize(1, 1, true);
 		pdfWidget->setPageOffset(0, true);


### PR DESCRIPTION
This PR resolves #222. For this the context menu of the embedded (not the windowed) PDF-viewer integrates some of the actions known from the View menu of the windowed viewer.

#### 2x1 grid, non continuous
![image](https://github.com/texstudio-org/texstudio/assets/102688820/74e89180-0f15-49f8-b785-033073939f74)

#### context menu of embedded viewer
![image](https://github.com/texstudio-org/texstudio/assets/102688820/17384bb6-7f4b-42ee-9a25-e685bb2c1fd8)

This looks similar to the View menu:

![image](https://github.com/texstudio-org/texstudio/assets/102688820/4a468940-bcff-47a3-ad66-17b405d5a61d)
