### PR TITLE
Replace user tags in side panel

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -589,12 +589,18 @@ void Texstudio::addTagList(const QString &id, const QString &iconName, const QSt
 {
 	XmlTagsListWidget *list = qobject_cast<XmlTagsListWidget *>(leftPanel->widget(id));
 	if (!list) {
-		list = new XmlTagsListWidget(this, ":/tags/" + tagFile);
+		// check for user tags
+		QString configBaseDir = configManager.configBaseDir;
+		QString pathPrefix=joinPath(configBaseDir,"tags/");
+		QFileInfo userTagFile(pathPrefix+tagFile);
+		if(!QFileInfo::exists(pathPrefix+tagFile) || !userTagFile.isReadable()) {
+			pathPrefix = ":/tags/";
+		}
+		list = new XmlTagsListWidget(this, pathPrefix + tagFile);
 		list->setObjectName("tags/" + tagFile.left(tagFile.indexOf("_tags.xml")));
 		UtilsUi::enableTouchScrolling(list);
 		connect(list, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(insertXmlTag(QListWidgetItem*)));
 		leftPanel->addWidget(list, id, text, iconName);
-		//(*list)->setProperty("mType",2);
 	} else {
 		leftPanel->setWidgetText(list, text);
 		leftPanel->setWidgetIcon(list,iconName);

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -592,13 +592,13 @@ void Texstudio::addTagList(const QString &id, const QString &iconName, const QSt
 		list = new XmlTagsListWidget(this, ":/tags/" + tagFile);
 		list->setObjectName("tags/" + tagFile.left(tagFile.indexOf("_tags.xml")));
 		UtilsUi::enableTouchScrolling(list);
-        connect(list, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(insertXmlTag(QListWidgetItem*)));
+		connect(list, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(insertXmlTag(QListWidgetItem*)));
 		leftPanel->addWidget(list, id, text, iconName);
 		//(*list)->setProperty("mType",2);
-    } else {
-        leftPanel->setWidgetText(list, text);
-        leftPanel->setWidgetIcon(list,iconName);
-    }
+	} else {
+		leftPanel->setWidgetText(list, text);
+		leftPanel->setWidgetIcon(list,iconName);
+	}
 }
 
 /*!

--- a/src/texstudio.h
+++ b/src/texstudio.h
@@ -104,21 +104,21 @@ protected:
 	//these are just wrappers around configManager so we don't have to type so much (todo??? move them to configmanager.h and use a singleton design???)
 	Q_INVOKABLE inline QMenu *newManagedMenu(const QString &id, const QString &text) { return configManager.newManagedMenu(id, text); }
 	Q_INVOKABLE inline QMenu *newManagedMenu(QMenu *menu, const QString &id, const QString &text) { return configManager.newManagedMenu(menu, id, text); }
-    Q_INVOKABLE QAction *newManagedAction(QWidget *menu, const QString &id, const QString &text, const char *slotName = nullptr, const QKeySequence &shortCut = 0, const QString &iconFile = "", const QList<QVariant> &args = QList<QVariant>());
+	Q_INVOKABLE QAction *newManagedAction(QWidget *menu, const QString &id, const QString &text, const char *slotName = nullptr, const QKeySequence &shortCut = 0, const QString &iconFile = "", const QList<QVariant> &args = QList<QVariant>());
 	Q_INVOKABLE QAction *newManagedAction(QWidget *menu, const QString &id, const QString &text, const char *slotName, const QList<QKeySequence> &shortCuts, const QString &iconFile = "", const QList<QVariant> &args = QList<QVariant>());
-    Q_INVOKABLE QAction *newManagedEditorAction(QWidget *menu, const QString &id, const QString &text, const char *slotName = nullptr, const QKeySequence &shortCut = 0, const QString &iconFile = "", const QList<QVariant> &args = QList<QVariant>());
+	Q_INVOKABLE QAction *newManagedEditorAction(QWidget *menu, const QString &id, const QString &text, const char *slotName = nullptr, const QKeySequence &shortCut = 0, const QString &iconFile = "", const QList<QVariant> &args = QList<QVariant>());
 	Q_INVOKABLE QAction *newManagedEditorAction(QWidget *menu, const QString &id, const QString &text, const char *slotName, const QList<QKeySequence> &shortCuts, const QString &iconFile = "", const QList<QVariant> &args = QList<QVariant>());
 	Q_INVOKABLE inline QAction *newManagedAction(QWidget *menu, const QString &id, QAction *act) { return configManager.newManagedAction(menu, id, act); }
 	Q_INVOKABLE inline QMenu *getManagedMenu(const QString &id) { return configManager.getManagedMenu(id); }
 	Q_INVOKABLE inline QAction *getManagedAction(const QString &id) { return configManager.getManagedAction(id); }
 	Q_INVOKABLE inline QList<QAction *> getManagedActions(const QStringList &ids, const QString &commonPrefix = "") { return configManager.getManagedActions(ids, commonPrefix); }
-    Q_INVOKABLE QAction *insertManagedAction(QAction *before, const QString &id, const QString &text, const char *slotName = nullptr, const QKeySequence &shortCut = 0, const QString &iconFile = "");
-    Q_INVOKABLE void loadManagedMenu(const QString &fn);
+	Q_INVOKABLE QAction *insertManagedAction(QAction *before, const QString &id, const QString &text, const char *slotName = nullptr, const QKeySequence &shortCut = 0, const QString &iconFile = "");
+	Q_INVOKABLE void loadManagedMenu(const QString &fn);
 
-    Q_INVOKABLE void setupToolBars();
+	Q_INVOKABLE void setupToolBars();
 
 	void addTagList(const QString &id, const QString &iconName, const QString &text, const QString &tagFile);
-    void addMacrosAsTagList();
+	void addMacrosAsTagList();
 
 private slots:
 	void updateToolBarMenu(const QString &menuName);


### PR DESCRIPTION
The tag lists in the side panel for brackets, pstricks, metapost, tikz, asymptote, beamer, and xymatrix are fixed so the user can't change or add things needed.
This PR resolves #3561 by enhancing txs such that each of those lists can be replaced by new tag lists provided by the user in the user profile (say %appdata% for win).

Note: Description changed because adding new groups has been changed to replacing tag list of existing groups like beamer (s. comment below).

#### Example
The author of #3561 describes that some items should be added to the Beamer Commands. To do so, the user may [download here](https://github.com/texstudio-org/texstudio/tree/master/tags) the xml and change it. In this case four more tags are added:

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/41794095-b364-4456-8296-0b282bdb7223)

#### Description
To the left of the image above you can see the standard version of the Beamer Commands tags. To the right there is an extended version shown that txs loaded from user profile. For this you have to add a folder named `tags` to the user profile. There you have to place a file with the xml containing the description of the tags. For the example given I downloaded and changed the file `beamer_tags.xml`. The name must not be changed.