### PR TITLE
ci: bump GeekyEggo/delete-artifact to v5

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -375,7 +375,6 @@ jobs:
         files: ./*
 
     - name: Delete temp artifacts
-      uses: GeekyEggo/delete-artifact@v4
+      uses: GeekyEggo/delete-artifact@v5
       with:
         name: release-*
-        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
See https://github.com/GeekyEggo/delete-artifact/releases/tag/v5.0.0.

Also remove unneeded and deprecated `token` input.