### PR TITLE
Cwl: minor improvements for `\numberwithin` and `\counter(within|without)`

### DIFF
--- a/completion/amsmath.cwl
+++ b/completion/amsmath.cwl
@@ -135,8 +135,8 @@ alignedleftspaceyesifneg
 \multlinetaggap#*
 \nobreakdash
 \notag#m
-\numberwithin{env}{counter}
-\numberwithin[format]{env}{counter}
+\numberwithin{counter}{within-counter}
+\numberwithin[format]{counter}{within-counter}
 \overleftrightarrow{argument}#m
 \overset{superscript}{argument}#m
 \overunderset{superscript}{subscript}{argument}#m

--- a/completion/latex-dev.cwl
+++ b/completion/latex-dev.cwl
@@ -636,7 +636,11 @@ debug={%<options%>}
 \allocationnumber#*
 \bfdefault#*
 \counterwithin{counter}{within-counter}#*
+\counterwithin[format]{counter}{within-counter}#*
+\counterwithin*{counter}{within-counter}#*
 \counterwithout{counter}{within-counter}#*
+\counterwithout[format]{counter}{within-counter}#*
+\counterwithout*{counter}{within-counter}#*
 \emforce#*
 \eminnershape#*
 \emreset#*


### PR DESCRIPTION
- The two mandatory arguments that `\numberwithin` from `amsmath` takes are both counter names, not one env and one counter.
  See `texdoc amsmath`, sec. 3.11.1 "Numbering hierarchy"
  ![image](https://github.com/texstudio-org/texstudio/assets/6376638/136d03cd-b3bf-45ab-9f39-311c79dbe411)
- Both `\counterwithin` and `\counterwithout` in the LaTeX2e kernel take an optional star and an optional argument since LaTeX2e 2021-11-15.
  See `texdoc ltnews34`, sec. "New argument for `\counterwithin`/`without`"
  ![image](https://github.com/texstudio-org/texstudio/assets/6376638/1cba4d67-755d-44fe-8deb-1ecfd86f64c2)
  The forms where two optional arguments are present, like `\counterwithin*[format]{counter}{within-counter}`, have no real use case so I didn't add them.