### PR TITLE
cwl: drop LaTeX toc commands from tocloft.cwl

### DIFF
--- a/completion/tocloft.cwl
+++ b/completion/tocloft.cwl
@@ -8,13 +8,7 @@ subfigure
 titles
 #endkeyvals
 
-\addcontentsline{file}{kind}{title}#n
-\contentsline{kind}{title}{page}#n
-\addtocontents{file}{text}#n
-
 \tocloftpagestyle{style}#n
-
-\addtocontents{file}{text}
 
 \cftmarktoc#n
 \cftmarklof#n


### PR DESCRIPTION
They are already provided in latex-dev.cwl.

Also the syntax of `\contentsline` entry in `tocloft.cwl` is outdated. It takes four argument since LaTeX 2021-11-16, see `texdoc ltnews`, Issue 32, Oct 2020 (https://github.com/latex3/latex2e/commit/2ef798bee3511cff40b09ce26f0fcf98cb731e56) and Issue 34, Nov 2021 (https://github.com/latex3/latex2e/commit/0b7a68ea80ecfe405577131789e2d34d20f2ac67).