### PR TITLE
activate expl3 syntax highlighting for `\ProvidesExplPackage` packages

### DIFF
--- a/src/syntaxcheck.cpp
+++ b/src/syntaxcheck.cpp
@@ -1053,7 +1053,8 @@ void SyntaxCheck::checkLine(const QString &line, Ranges &newRanges, StackEnviron
 					word = word + line.mid(tkEnvName.start, tkEnvName.length);
 				}
 			}
-            // special treatment for \ExplSyntaxOn and \ExplSyntaxOff
+            // special treatment for \ExplSyntaxOn, \ExplSyntaxOff
+            // \ProvidesExplPackage and \ProvidesExplClass
             // activate latex3 mode which ignores _ in commandnames
             if(word=="\\ExplSyntaxOn" || word=="\\ProvidesExplPackage" || word=="\\ProvidesExplClass" ){
                 Environment env;

--- a/src/syntaxcheck.cpp
+++ b/src/syntaxcheck.cpp
@@ -1056,7 +1056,7 @@ void SyntaxCheck::checkLine(const QString &line, Ranges &newRanges, StackEnviron
             // special treatment for \ExplSyntaxOn, \ExplSyntaxOff
             // \ProvidesExplPackage and \ProvidesExplClass
             // activate latex3 mode which ignores _ in commandnames
-            if(word=="\\ExplSyntaxOn" || word=="\\ProvidesExplPackage" || word=="\\ProvidesExplClass" ){
+            if(word=="\\ExplSyntaxOn" || word=="\\ProvidesExplPackage" || word=="\\ProvidesExplClass"){
                 Environment env;
                 env.name = "expl3";
                 env.id = 1; // to be changed
@@ -1067,7 +1067,7 @@ void SyntaxCheck::checkLine(const QString &line, Ranges &newRanges, StackEnviron
                 activeEnv.push(env);
                 continue;
             }
-                        
+
             // special treatment for & in math
             if(word=="&" && containsEnv("math", activeEnv)){
                 Error elem;

--- a/src/syntaxcheck.cpp
+++ b/src/syntaxcheck.cpp
@@ -1054,9 +1054,9 @@ void SyntaxCheck::checkLine(const QString &line, Ranges &newRanges, StackEnviron
 				}
 			}
             // special treatment for \ExplSyntaxOn, \ExplSyntaxOff
-            // \ProvidesExplPackage and \ProvidesExplClass
+            // \ProvidesExplPackage, \ProvidesExplClass and \ProvidesExplFile
             // activate latex3 mode which ignores _ in commandnames
-            if(word=="\\ExplSyntaxOn" || word=="\\ProvidesExplPackage" || word=="\\ProvidesExplClass"){
+            if(word=="\\ExplSyntaxOn" || word=="\\ProvidesExplPackage" || word=="\\ProvidesExplClass" || word=="\\ProvidesExplFile"){
                 Environment env;
                 env.name = "expl3";
                 env.id = 1; // to be changed

--- a/src/syntaxcheck.cpp
+++ b/src/syntaxcheck.cpp
@@ -1055,7 +1055,7 @@ void SyntaxCheck::checkLine(const QString &line, Ranges &newRanges, StackEnviron
 			}
             // special treatment for \ExplSyntaxOn and \ExplSyntaxOff
             // activate latex3 mode which ignores _ in commandnames
-            if(word=="\\ExplSyntaxOn"){
+            if(word=="\\ExplSyntaxOn" || word=="\\ProvidesExplPackage"){
                 Environment env;
                 env.name = "expl3";
                 env.id = 1; // to be changed
@@ -1066,7 +1066,7 @@ void SyntaxCheck::checkLine(const QString &line, Ranges &newRanges, StackEnviron
                 activeEnv.push(env);
                 continue;
             }
-
+                        
             // special treatment for & in math
             if(word=="&" && containsEnv("math", activeEnv)){
                 Error elem;

--- a/src/syntaxcheck.cpp
+++ b/src/syntaxcheck.cpp
@@ -1055,7 +1055,7 @@ void SyntaxCheck::checkLine(const QString &line, Ranges &newRanges, StackEnviron
 			}
             // special treatment for \ExplSyntaxOn and \ExplSyntaxOff
             // activate latex3 mode which ignores _ in commandnames
-            if(word=="\\ExplSyntaxOn" || word=="\\ProvidesExplPackage"){
+            if(word=="\\ExplSyntaxOn" || word=="\\ProvidesExplPackage" || word=="\\ProvidesExplClass" ){
                 Environment env;
                 env.name = "expl3";
                 env.id = 1; // to be changed


### PR DESCRIPTION
The new l3 syntax highlighting from your recent commit https://github.com/texstudio-org/texstudio/commit/f14060826c6fa2847761fd3e3ff9e7cfa81f9841 seems to work great for code within `\ExplSyntaxOn ... \ExplSyntaxOff`.

It would be nice to have the same syntax highlighting for l3 packages (they can be recognised by the `\ProvidesExplPackage` instead of `\ProvidesPackage`). If you need an example for testing, `siunitx.sty` is one such package.

My naive attempt is to just use

```
 if(word=="\\ExplSyntaxOn" || word=="\\ProvidesExplPackage"){
```

in `syntaxcheck.cpp`. This seems to work, but I don't know if there is a better solution...

![Screenshot 2024-04-18 at 11 33 57](https://github.com/texstudio-org/texstudio/assets/43832342/aba074d8-917f-450c-ae8f-5a0578e3a4b4)

