### PR TITLE
set editor with all line numbers as default

### DIFF
--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -519,7 +519,7 @@ ConfigManager::ConfigManager(QObject *parent): QObject (parent),
 	registerOption("Editor/WrapLineWidth", &editorConfig->lineWidth, 80, &pseudoDialog->spinBoxWrapLineWidth);
 	registerOption("Editor/Parentheses Matching", &editorConfig->parenmatch, true); //TODO: checkbox?
 	registerOption("Editor/Parentheses Completion", &editorConfig->parenComplete, true, &pseudoDialog->checkBoxAutoCompleteParens);
-	registerOption("Editor/Line Number Multiples", &editorConfig->showlinemultiples, 0);
+	registerOption("Editor/Line Number Multiples", &editorConfig->showlinemultiples, 1);
 	registerOption("Editor/Cursor Surrounding Lines", &editorConfig->cursorSurroundLines, 5);
 	registerOption("Editor/BoldCursor", &editorConfig->boldCursor, true, &pseudoDialog->checkBoxBoldCursor);
     registerOption("Editor/CenterDocumentInEditor", &editorConfig->centerDocumentInEditor, false, &pseudoDialog->checkBoxCenterDocumentInEditor);


### PR DESCRIPTION
this PR resolves #3617
this changes the default of no line numbers to all line numbers (s. Editor options)