### PR TITLE
preview with xelatex

### DIFF
--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1428,7 +1428,7 @@ void BuildManager::readSettings(QSettings &settings)
 
 	int md = dvi2pngMode;
 #ifdef NO_POPPLER_PREVIEW
-	if (md == DPM_EMBEDDED_PDF || md == DPM_LUA_EMBEDDED_PDF)
+	if (md == DPM_EMBEDDED_PDF || md == DPM_LUA_EMBEDDED_PDF || md == DPM_XE_EMBEDDED_PDF)
 		md = -1;
 #endif
 	if (md < 0) {
@@ -1811,6 +1811,8 @@ void BuildManager::preview(const QString &preamble, const PreviewSource &source,
                     p = newProcessInternal(QString("%1 -interaction=nonstopmode -ini \"&pdflatex %2 \\dump\"").arg(getCommandInfo(CMD_PDFLATEX).getProgramName(),preambleFormatFile), QFileInfo(tf->fileName())); //no delete! goes automatically
 				} else if (dvi2pngMode == DPM_LUA_EMBEDDED_PDF) {
                     p = newProcessInternal(QString("%1 -interaction=nonstopmode -ini \"&lualatex %2 \\dump\"").arg(getCommandInfo(CMD_LUALATEX).getProgramName(),preambleFormatFile), QFileInfo(tf->fileName())); //no delete! goes automatically
+				} else if (dvi2pngMode == DPM_XE_EMBEDDED_PDF) {
+                    p = newProcessInternal(QString("%1 -interaction=nonstopmode -ini \"&xelatex %2 \\dump\"").arg(getCommandInfo(CMD_XELATEX).getProgramName(),preambleFormatFile), QFileInfo(tf->fileName())); //no delete! goes automatically
 				} else {
                     p = newProcessInternal(QString("%1 -interaction=nonstopmode -ini \"&latex %2 \\dump\"").arg(getCommandInfo(CMD_LATEX).getProgramName(),preambleFormatFile), QFileInfo(tf->fileName())); //no delete! goes automatically
 				}
@@ -1877,6 +1879,15 @@ void BuildManager::preview(const QString &preamble, const PreviewSource &source,
 		QString command = getCommandInfo(CMD_LUALATEX).commandLine;
 		if (preambleFormatFile != "") {
 			QString pgm = getCommandInfo(CMD_LUALATEX).getProgramName();
+			command = command.insert(pgm.length(), " -fmt=" + preambleFormatFile);
+		}
+		p1 = firstProcessOfDirectExpansion(command, QFileInfo(ffn)); //no delete! goes automatically
+	} else if (dvi2pngMode == DPM_XE_EMBEDDED_PDF) {
+		// start conversion
+		// tex -> pdf
+		QString command = getCommandInfo(CMD_XELATEX).commandLine;
+		if (preambleFormatFile != "") {
+			QString pgm = getCommandInfo(CMD_XELATEX).getProgramName();
 			command = command.insert(pgm.length(), " -fmt=" + preambleFormatFile);
 		}
 		p1 = firstProcessOfDirectExpansion(command, QFileInfo(ffn)); //no delete! goes automatically
@@ -2098,6 +2109,20 @@ void BuildManager::latexPreviewCompleted(int status)
 		}
 	}
 	if (dvi2pngMode == DPM_LUA_EMBEDDED_PDF) {
+		ProcessX *p1 = qobject_cast<ProcessX *> (sender());
+		if (!p1) return;
+		QString processedFile = p1->getFile();
+		if (processedFile.endsWith(".tex"))
+            processedFile = QDir::fromNativeSeparators(parseExtendedCommandLine("?am.tex", QFileInfo(processedFile)).constFirst());
+			// TODO: fromNativeSeparators is a workaround to fix bug
+			// yields different dir separators depending on the context. This should be fixed (which direction?).
+			// Test (on win): switch preview between dvipng and pdflatex
+        QString fn = parseExtendedCommandLine("?am).pdf", QFileInfo(processedFile)).constFirst();
+        if (QFileInfo::exists(fn)) {
+			emit previewAvailable(fn, previewFileNameToSource[processedFile]);
+		}
+	}
+	if (dvi2pngMode == DPM_XE_EMBEDDED_PDF) {
 		ProcessX *p1 = qobject_cast<ProcessX *> (sender());
 		if (!p1) return;
 		QString processedFile = p1->getFile();

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -180,7 +180,7 @@ public:
 	int deprecatedQuickmode;
 	QStringList deprecatedUserToolCommands, deprecatedUserToolNames;
 	QStringList userToolOrder, userToolDisplayNames;
-	enum Dvi2PngMode { DPM_DVIPNG, DPM_DVIPNG_FOLLOW, DPM_DVIPS_GHOSTSCRIPT, DPM_EMBEDDED_PDF, DPM_LUA_EMBEDDED_PDF};
+	enum Dvi2PngMode { DPM_DVIPNG, DPM_DVIPNG_FOLLOW, DPM_DVIPS_GHOSTSCRIPT, DPM_EMBEDDED_PDF, DPM_LUA_EMBEDDED_PDF, DPM_XE_EMBEDDED_PDF};
 	Dvi2PngMode dvi2pngMode;
 	enum SaveFilesBeforeCompiling {SFBC_ALWAYS, SFBC_ONLY_CURRENT_OR_NAMED, SFBC_ONLY_NAMED};
 	SaveFilesBeforeCompiling saveFilesBeforeCompiling;

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -4024,6 +4024,11 @@ them here.</string>
                       <string>Preview with lualatex</string>
                      </property>
                     </item>
+                    <item>
+                     <property name="text">
+                      <string>Preview with xelatex</string>
+                     </property>
+                    </item>
                    </widget>
                   </item>
                   <item row="1" column="0">

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -1749,7 +1749,7 @@ bool ConfigManager::execConfigDialog(QWidget *parentToDialog)
         previewMode = static_cast<PreviewMode>(confDlg->ui.comboBoxPreviewMode->currentIndex());
         buildManager->dvi2pngMode = static_cast<BuildManager::Dvi2PngMode>(confDlg->ui.comboBoxDvi2PngMode->currentIndex());
 #ifdef NO_POPPLER_PREVIEW
-		if (buildManager->dvi2pngMode == BuildManager::DPM_EMBEDDED_PDF || buildManager->dvi2pngMode == BuildManager::DPM_LUA_EMBEDDED_PDF) {
+		if (buildManager->dvi2pngMode == BuildManager::DPM_EMBEDDED_PDF || buildManager->dvi2pngMode == BuildManager::DPM_LUA_EMBEDDED_PDF || buildManager->dvi2pngMode == BuildManager::DPM_XE_EMBEDDED_PDF) {
 			buildManager->dvi2pngMode = BuildManager::DPM_DVIPNG; //fallback when poppler is not included
 		}
 #endif

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -8830,7 +8830,7 @@ void Texstudio::showPreview(const QString &text)
 	QStringList header;
 	for (int l = 0; l < m_endingLine; l++)
 		header << edView->editor->document()->line(l).text();
-	if (buildManager.dvi2pngMode == BuildManager::DPM_EMBEDDED_PDF || buildManager.dvi2pngMode == BuildManager::DPM_LUA_EMBEDDED_PDF) {
+	if (buildManager.dvi2pngMode == BuildManager::DPM_EMBEDDED_PDF || buildManager.dvi2pngMode == BuildManager::DPM_LUA_EMBEDDED_PDF || buildManager.dvi2pngMode == BuildManager::DPM_XE_EMBEDDED_PDF) {
 		header << "\\usepackage[active,tightpage]{preview}"
 		       << "\\usepackage{varwidth}"
 		       << "\\AtBeginDocument{\\begin{preview}\\begin{varwidth}{\\linewidth}}"
@@ -8930,7 +8930,7 @@ QStringList Texstudio::makePreviewHeader(const LatexDocument *rootDoc)
 			header << newLine;
 		}
 	}
-	if ((buildManager.dvi2pngMode == BuildManager::DPM_EMBEDDED_PDF || buildManager.dvi2pngMode == BuildManager::DPM_LUA_EMBEDDED_PDF)
+	if ((buildManager.dvi2pngMode == BuildManager::DPM_EMBEDDED_PDF || buildManager.dvi2pngMode == BuildManager::DPM_LUA_EMBEDDED_PDF || buildManager.dvi2pngMode == BuildManager::DPM_XE_EMBEDDED_PDF)
 			&& configManager.previewMode != ConfigManager::PM_EMBEDDED) {
 		header << "\\usepackage[active,tightpage]{preview}"
 			<< "\\usepackage{varwidth}"


### PR DESCRIPTION
This PR adds Preview with Xelatex (s. Config, Preview option _Command:_). Resolves #3621.

Citation regarding precompile of preamble:
years later, most large packages end up loading something related to fontspec (Koma script classes do, tikz does, unicode-math and fontspec and polyglossia do of course, etc.). As a result dumping isn't very effective at all for LuaLaTeX and XeTeX. – 
by Clément [Dec 15, 2021 at 1:10](https://tex.stackexchange.com/questions/49295/precompile-header-with-xelatex#comment1563009_65357)