### PR TITLE
Fix scrolling to top line shouldn’t depend on cursor position

### DIFF
--- a/src/qcodeedit/lib/qeditor.cpp
+++ b/src/qcodeedit/lib/qeditor.cpp
@@ -5815,15 +5815,7 @@ void QEditor::scrollToFirstLine(int l){
 
     const qreal ls = document()->getLineSpacing();
     const qreal ypos = m_doc->y(l-1);
-    const qreal yval = verticalOffset();
-    const int ylen = viewport()->height();
-    const qreal yend = ypos + ylen;
-
-	if ( ypos < yval )
-        verticalScrollBar()->setValue(qFloor(ypos / ls));
-	else if ( yend > (yval + ylen) )
-        verticalScrollBar()->setValue(qFloor(1. + (yend - ylen) / ls));
-
+    verticalScrollBar()->setValue(qRound(ypos / ls));
 }
 
 void QEditor::setCursorSurroundingLines(int s){

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -3598,8 +3598,8 @@ void Texstudio::restoreSession(const Session &s, bool showProgress, bool warnMis
                     col = 0;
                 }
             }
-            edView->editor->setCursorPosition(line, col);
-            edView->editor->scrollToFirstLine(f.firstLine);
+            edView->editor->setCursorPosition(line, col, false);
+            edView->editor->scrollToFirstLine(f.firstLine+1);
             edView->document->foldLines(f.foldedLines);
             editors->moveToTabGroup(edView, f.editorGroup, -1);
         } else {


### PR DESCRIPTION
Txs remembers the top line visible in the editor and cursor position when txs is closed (while tab isn’t closed). Thus, txs should be able to reopen the editor with the same line at top and the cursor at the same position. But sometimes this is not the case (s. footnote of #3361). We start our analysis with an editor where line number 300 is the first line visible while line number 1 holds the cursor (s. status bar):

![image](https://github.com/texstudio-org/texstudio/assets/102688820/a333d188-edc8-4579-96d3-73e57bf1e63e)

After closing txs a look into the session file reveals:
```
"FirstLine": 299,
"Line": 0	
```
Obviously `FirstLine` is the line index counting from zero. Surprisingly, after starting txs again we see a shift in the line numbers:

![image](https://github.com/texstudio-org/texstudio/assets/102688820/a27ee154-9d46-4a40-b311-b9a03294d9f4)

After closing txs we find:
```
"FirstLine": 298,
"Line": 0
```
Scrolling to `FirstLine` is done by `edView->editor->scrollToFirstLine(f.firstLine)` (s. texstudio.cpp). But `scrollToFirstLine` subtracts 1 from the line parameter (s. below), e.g. a line number is expected, not a line index. Thus using `edView->editor->scrollToFirstLine(f.firstLine+1)` should fix the issue. But why not in all cases?

Before scrolling to `FirstLine` the cursor is set using `edView->editor->setCursorPosition(line, col)`. There is an optional 3rd parameter that is true by default, which means it should be scrolled such that the cursor line gets visible. This is useless since we scroll to `FirstLine` anyway. Therefor we will let the 3rd parameter be false.
We have a closer look at:
```
void QEditor::scrollToFirstLine(int l){
    const qreal ls = document()->getLineSpacing();
    const qreal ypos = m_doc->y(l-1);
    const qreal yval = verticalOffset();
    const int ylen = viewport()->height();
    const qreal yend = ypos + ylen;

    if ( ypos < yval )
        verticalScrollBar()->setValue(qFloor(ypos / ls));
    else if ( yend > (yval + ylen) )
        verticalScrollBar()->setValue(qFloor(1. + (yend - ylen) / ls));
}
```
We do some calculations using the definitions: From `yend = ypos + ylen` follows `yend – ylen = ypos`. From `yend > yval + ylen` follows `yend – ylen > yval`. Hence, `ypos > yval`. So, the code could be written as:
```
    if ( ypos < yval )
        verticalScrollBar()->setValue(qFloor(ypos / ls));
    else if ( ypos > yval )
        verticalScrollBar()->setValue(qFloor(1. + ypos / ls));
```
Since `yvar` is 0 in our first example the scrollbar is set to `1 + ypos/ls`. Without the first fix this gives the expected index of 299. To take the fix into account we must omit the addition of 1. By this the code gets symmetric. Would target position `ypos` be less than indicated by the scrollbar value `yval` then the value would be set to `ypos/ls` which equals 299, due to the first fix. Note that the quotient `ypos/ls` is an integer since `ypos` is an integer multiple of `ls`. Instead of `qFloor` we use `qRound` to be bullet proof and get:
```
    verticalScrollBar()->setValue(qRound(ypos / ls));
```
