### PR TITLE
txs restores wrong top line with folded lines

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -3599,8 +3599,8 @@ void Texstudio::restoreSession(const Session &s, bool showProgress, bool warnMis
                 }
             }
             edView->editor->setCursorPosition(line, col, false);
-            edView->editor->scrollToFirstLine(f.firstLine+1);
             edView->document->foldLines(f.foldedLines);
+            edView->editor->scrollToFirstLine(f.firstLine+1);
             editors->moveToTabGroup(edView, f.editorGroup, -1);
         } else {
             missingFiles.append(f.fileName);


### PR DESCRIPTION
Fold 13 lines (i.e. they are hidden) as shown here:

![image](https://github.com/texstudio-org/texstudio/assets/102688820/bfaf055e-5f00-4ae2-bac3-4a56e151ebda)

Then scroll down (down is the important information here) to line 253 such that this line is at top of the editor:

![image](https://github.com/texstudio-org/texstudio/assets/102688820/48db2368-2022-4db6-997b-70554a182961)

Close txs (but not the editor) and find their indices in the session file:
```
"FirstLine": 252,
"FoldedLines": "227",
```
Starting txs the editor shows at top line:

![image](https://github.com/texstudio-org/texstudio/assets/102688820/fbea9ef6-7866-45e5-9733-99f458a9c4d2)

But we expect to see line 253 at top.

Txs calculates the position of `FirstLine` before lines are folded. Since 13 lines are hidden by folding, line 253+13=263 moves to top of the editor. S. `QDocument::y(…)` used in `scrollToFirstLine`, which respects folded and wrapped lines by calling `visualLine`.
To fix this the order of position calculation and folding need to be reversed.
