### PR TITLE
Fix incorrect file opening from structure with master doc present

### DIFF
--- a/src/latexdocument.cpp
+++ b/src/latexdocument.cpp
@@ -943,6 +943,7 @@ void LatexDocument::interpretCommandArguments(QDocumentLineHandle *dlh, const in
             newInclude->level = parent && !parent->indentIncludesInStructure ? 0 : lp->structureDepth() - 1;
             fn = removeQuote(fn);
             newInclude->title = fn;
+            newInclude->tooltip = getAbsoluteFilePath(fn,".tex", QStringList(), true);
             QString name=fn;
             name.replace("\\string~",QDir::homePath());
             QString fname = findFileName(name);
@@ -2263,10 +2264,10 @@ QString LatexDocuments::getLogFileName() const
 	}
 }
 
-QString LatexDocuments::getAbsoluteFilePath(const QString &relName, const QString &extension, const QStringList &additionalSearchPaths) const
+QString LatexDocuments::getAbsoluteFilePath(const QString &relName, const QString &extension, const QStringList &additionalSearchPaths, bool ignore_root) const
 {
 	if (!currentDocument) return relName;
-	return currentDocument->getAbsoluteFilePath(relName, extension, additionalSearchPaths);
+	return currentDocument->getAbsoluteFilePath(relName, extension, additionalSearchPaths, ignore_root);
 }
 
 LatexDocument *LatexDocuments::findDocumentFromName(const QString &fileName) const
@@ -3154,10 +3155,10 @@ LatexDocument *LatexDocuments::getRootDocumentForDoc(LatexDocument *doc,bool bre
     return const_cast<LatexDocument *>(current->getRootDocument(nullptr,breakAtSubfileRoot));
 }
 
-QString LatexDocument::getAbsoluteFilePath(const QString &relName, const QString &extension, const QStringList &additionalSearchPaths) const
+QString LatexDocument::getAbsoluteFilePath(const QString &relName, const QString &extension, const QStringList &additionalSearchPaths, bool ignore_root) const
 {
 	QStringList searchPaths;
-    const LatexDocument *rootDoc = getRootDocument(nullptr,true);
+    const LatexDocument *rootDoc = ignore_root ? this : getRootDocument(nullptr,true);
 	QString compileFileName = rootDoc->getFileName();
 	if (compileFileName.isEmpty()) compileFileName = rootDoc->getTemporaryFileName();
 	QString fallbackPath;

--- a/src/latexdocument.h
+++ b/src/latexdocument.h
@@ -137,7 +137,7 @@ public:
 	Q_INVOKABLE QString getTemporaryFileName() const;
 	Q_INVOKABLE QString getFileNameOrTemporaryFileName() const;
 	Q_INVOKABLE QFileInfo getTemporaryFileInfo() const;
-	Q_INVOKABLE QString getAbsoluteFilePath(const QString &relName, const QString &extension, const QStringList &additionalSearchPaths = QStringList()) const;
+	Q_INVOKABLE QString getAbsoluteFilePath(const QString &relName, const QString &extension, const QStringList &additionalSearchPaths = QStringList(), bool ignore_root = false) const;
 
 	void setMasterDocument(LatexDocument *doc, bool recheck = true);
 	void addChild(LatexDocument *doc);
@@ -355,7 +355,7 @@ public:
 	Q_INVOKABLE QString getCompileFileName() const; ///< returns the absolute file name of the file to be compiled (master or current)
 	Q_INVOKABLE QString getTemporaryCompileFileName() const; ///< returns the absolute file name of the file to be compiled (master or current)
 	Q_INVOKABLE QString getLogFileName() const;
-	Q_INVOKABLE QString getAbsoluteFilePath(const QString &relName, const QString &extension = "", const QStringList &additionalSearchPaths = QStringList()) const;
+	Q_INVOKABLE QString getAbsoluteFilePath(const QString &relName, const QString &extension = "", const QStringList &additionalSearchPaths = QStringList(), bool ignore_root = false) const;
 
 	Q_INVOKABLE LatexDocument *findDocument(const QString &fileName, bool checkTemporaryNames = false) const;
 	Q_INVOKABLE LatexDocument *findDocument(const QDocument *qDoc) const;


### PR DESCRIPTION
This PR fixes an issue which occurs when a master document is set.

If there are two open documents and both documents have an include of the same name (say Version1/a.tex -> Version1/b.tex and Version2/a.tex -> Version2/b.tex, with Version1/a.tex as master), I cannot open Version2/b.tex from the structure because it always interprets the path relative to the root. 

In this case, this makes no sense, as the user explicitly said relative to which document the path should be interpreted. 

Checked that the fix also works when opening a non-existing document. Previously, it was created relative to the root document, now it's created at the correct location.

However, I did not get the red color to disappear. The previous code was wrong (it reinterpreted only the current cursor position, but the parent document doesn't even need to be the active tab, but I haven't figured out a replacement.

Also added full paths to the tooltips of sub-items in the structure.