### PR TITLE
Add missing files in sources.pri

### DIFF
--- a/src/sources.pri
+++ b/src/sources.pri
@@ -3,6 +3,8 @@ DEPENDPATH += $$PWD
 
 HEADERS += \
     $$PWD/aboutdialog.h \
+    $$PWD/aichatassistant.h \
+    $$PWD/aiquerystoragemodel.h \
     $$PWD/arraydialog.h \
     $$PWD/bibtexdialog.h \
     $$PWD/bibtexparser.h \
@@ -111,6 +113,8 @@ HEADERS += \
 SOURCES += \
     $$PWD/aboutdialog.cpp \
     $$PWD/additionaltranslations.cpp \
+    $$PWD/aichatassistant.cpp \
+    $$PWD/aiquerystoragemodel.cpp \
     $$PWD/arraydialog.cpp \
     $$PWD/bibtexdialog.cpp \
     $$PWD/bibtexparser.cpp \


### PR DESCRIPTION

    This fixes the following linking error while building with qmake.
    
    ld.lld: error: undefined symbol: AIChatAssistant::AIChatAssistant(QWidget*)
     referenced by texstudio.cpp
     .obj/texstudio.o:(Texstudio::aiChat())
