### PR TITLE
cwl: Add LaTeX commands \obeyedline and \obeyedspace

### DIFF
--- a/completion/latex-dev.cwl
+++ b/completion/latex-dev.cwl
@@ -218,6 +218,8 @@
 \NextLinkTarget{target name}#*
 \OmitIndent#*
 \OptionNotUsed#*
+\obeyedline#*
+\obeyedspace#*
 \PackageError{package name}{error text%text}{help text%text}#*
 \PackageInfo{package name}{info text%text}#*
 \PackageNote{package name}{note text%text}#*


### PR DESCRIPTION
They were introduced in LaTeX2e 2022-06-01, see ltnews35.

Relevant description in ltnews35, on pages 78 to 79 of `texdoc ltnews`:
![image](https://github.com/texstudio-org/texstudio/assets/6376638/a06690d6-7bbc-4aae-b363-b1cfab55a18e)
![image](https://github.com/texstudio-org/texstudio/assets/6376638/a912b617-d635-4ff8-870c-440c50bbc79e)
