### PR TITLE
Typos

### DIFF
--- a/cmake/ECMFindModuleHelpersStub.cmake
+++ b/cmake/ECMFindModuleHelpersStub.cmake
@@ -68,7 +68,7 @@
 # If SKIP_DEPENDENCY_HANDLING is not set, the INTERFACE_LINK_LIBRARIES property
 # of the imported target for <component> will be set to contain the imported
 # targets for the components listed in <name>_<component>_component_deps.
-# <component>_FOUND will also be set to false if any of the compoments in
+# <component>_FOUND will also be set to false if any of the components in
 # <name>_<component>_component_deps are not found.  This requires the components
 # in <name>_<component>_component_deps to be listed before <component> in the
 # COMPONENTS argument.

--- a/cmake/FindQTermWidget.cmake
+++ b/cmake/FindQTermWidget.cmake
@@ -1,5 +1,5 @@
 # - Try to find QTermWidget5
-# cmake varaint fails on ubuntu for missing libutf8proc.so
+# cmake variant fails on ubuntu for missing libutf8proc.so
 # Once done this will define
 #
 #  QTERMWIDGET_FOUND - system has QTermWidget5

--- a/src/aichatassistant.cpp
+++ b/src/aichatassistant.cpp
@@ -425,7 +425,7 @@ void AIChatAssistant::onTreeViewClicked(const QModelIndex &index)
         ja_messages=obj["messages"].toArray();
         QString responseText=getConversationForBrowser();
         textBrowser->setHtml(responseText);
-        // prepare last repsonse
+        // prepare last response
         QJsonObject ja_message=ja_messages.last().toObject();
         m_response=ja_message["content"].toString();
         // check if macro, then execute instead of insert

--- a/utilities/manual/build/html/CHANGELOG.html
+++ b/utilities/manual/build/html/CHANGELOG.html
@@ -7,8 +7,8 @@
 <meta property="og:type" content="website" />
 <meta property="og:url" content="CHANGELOG.html" />
 <meta property="og:site_name" content="TeXstudio" />
-<meta property="og:description" content="TeXstudio 4.8.1:. TeXstudio 4.8.0: AI chat assistant added, use moveable/ splitable docks for sidepanel, extended search can now also search in all files in one folder, add basic syntax highlightin..." />
-<meta name="description" content="TeXstudio 4.8.1:. TeXstudio 4.8.0: AI chat assistant added, use moveable/ splitable docks for sidepanel, extended search can now also search in all files in one folder, add basic syntax highlightin..." />
+<meta property="og:description" content="TeXstudio 4.8.1:. TeXstudio 4.8.0: AI chat assistant added, use moveable/ splitable docks for sidepanel, extended search can now also search in all files in one folder, add basic syntax highlighting..." />
+<meta name="description" content="TeXstudio 4.8.1:. TeXstudio 4.8.0: AI chat assistant added, use moveable/ splitable docks for sidepanel, extended search can now also search in all files in one folder, add basic syntax highlighting..." />
 <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="prev" title="Background information" href="background.html" />
 
     <link rel="shortcut icon" href="_static/texstudio.ico"/><!-- Generated with Sphinx 5.3.0 and Furo 2022.12.07 -->
@@ -328,7 +328,7 @@
 <li><p>when the mouse cursor hovers over a spin/combo box, the wheel scrolls through the configuration page instead of changing values (<a class="reference external" href="https://github.com/texstudio-org/texstudio/issues/2977">#2977</a>)</p></li>
 <li><p>copy some details (icons, separators) to menu item list in combo box (<a class="reference external" href="https://github.com/texstudio-org/texstudio/issues/3025">#3025</a>)</p></li>
 <li><p>support toggling comment on folded lines (<a class="reference external" href="https://github.com/texstudio-org/texstudio/issues/2912">#2912</a>)</p></li>
-<li><p>don’t show pointing hand cursor over hyperlinks when magnifier is activ (<a class="reference external" href="https://github.com/texstudio-org/texstudio/pull/2982">#2982</a>)</p></li>
+<li><p>don’t show pointing hand cursor over hyperlinks when magnifier is active (<a class="reference external" href="https://github.com/texstudio-org/texstudio/pull/2982">#2982</a>)</p></li>
 <li><p>improve usage of tab key and enter key in QuickStart Wizard (<a class="reference external" href="https://github.com/texstudio-org/texstudio/pull/3014">#3014</a>)</p></li>
 <li><p>add \maketitle to the document created by QuickStart Wizard if appropriate (<a class="reference external" href="https://github.com/texstudio-org/texstudio/pull/3015">#3015</a>)</p></li>
 <li><p>pos1 (home) key now sets cursor to start or to first non-blank character of editor lines (<a class="reference external" href="https://github.com/texstudio-org/texstudio/issues/3012">#3012</a>)</p></li>
@@ -419,7 +419,7 @@
 <li><p>fix stuck to save unsaved document (only in explicit root mode and with a new unsaved document,<a class="reference external" href="https://github.com/texstudio-org/texstudio/issues/2153">#2153</a>)</p></li>
 <li><p>xindex engine added</p></li>
 <li><p>fix math highlighting in keyvals (<a class="reference external" href="https://github.com/texstudio-org/texstudio/issues/2138">#2138</a>)</p></li>
-<li><p>add context menu in embbeded pdf viewer to invert pdf colors</p></li>
+<li><p>add context menu in embedded pdf viewer to invert pdf colors</p></li>
 <li><p>remember window state (maximized/normal) of config dialog</p></li>
 <li><p>fix (and speed-up) miktex package detection</p></li>
 <li><p>fix handling apostrophed words better in spellchecker (<a class="reference external" href="https://github.com/texstudio-org/texstudio/issues/2179">#2179</a>)</p></li>
@@ -517,7 +517,7 @@
 <li><p>fix pdfviewer page display</p></li>
 <li><p>build OSX with QT6.2, fix special characters entry (alt+n + n , etc.) (<a class="reference external" href="https://github.com/texstudio-org/texstudio/issues/1770">#1770</a>)</p></li>
 <li><p>activate crash handler on win again</p></li>
-<li><p>fix strcuture detection for included files</p></li>
+<li><p>fix structure detection for included files</p></li>
 </ul>
 </section>
 <section id="texstudio-4-0-0">
@@ -529,7 +529,7 @@
 <li><p>more and updated completion word lists thanks to mbertucci47</p></li>
 <li><p>handle text (e.g. \text{text}) in mathenv as text with spell checking</p></li>
 <li><p>performance improvement for large files with large number of labels and/or large number of includes</p></li>
-<li><p>fix that search options are persistant</p></li>
+<li><p>fix that search options are persistent</p></li>
 <li><p>automatic structure scrolling can be turned off (<a class="reference external" href="https://github.com/texstudio-org/texstudio/issues/1742">#1742</a>)</p></li>
 <li><p>some bug fixes</p></li>
 </ul>
@@ -645,7 +645,7 @@
 <h2>TeXstudio 2.12.16<a class="headerlink" href="#texstudio-2-12-16" title="Permalink to this heading">#</a></h2>
 <ul class="simple">
 <li><p>bug fixes</p></li>
-<li><p>somes fixes for tool-tip preview by MeanSquaredError</p></li>
+<li><p>some fixes for tool-tip preview by MeanSquaredError</p></li>
 </ul>
 </section>
 <section id="texstudio-2-12-14">
@@ -713,7 +713,7 @@
 <li><p>tags for beamer</p></li>
 <li><p>change preview default to embedded pdf</p></li>
 <li><p>handle preview failures more gracefully, i.e. no warning pop-ups</p></li>
-<li><p>repect preview settings (panel,etc) also for hover preview</p></li>
+<li><p>respect preview settings (panel,etc) also for hover preview</p></li>
 <li><p>show hover preview as tooltip in case of inline-mode</p></li>
 <li><p>warn if compiler commands are actually a command list</p></li>
 <li><p>several improvements to the latex parser</p></li>
@@ -769,7 +769,7 @@
 <li><p>fix highlighting of current section in structure (bug 2103)</p></li>
 <li><p>fix delays when typing _abc</p></li>
 <li><p>fix bug in log parser: wrong filename if empty brackets () occur in text</p></li>
-<li><p>fix word repetition erro on non-breaking space (~)</p></li>
+<li><p>fix word repetition error on non-breaking space (~)</p></li>
 <li><p>fix file detection in latex/include file</p></li>
 <li><p>fix width of side panel not saved (bug 2083)</p></li>
 <li><p>fix ampersand in in recent session names</p></li>
@@ -926,7 +926,7 @@ before changing to windowed mode (Bug #1876)</p></li>
 <li><p>do not parse for structure in non-LaTeX-like languages</p></li>
 <li><p>make preview work with \input in preamble (files get rewritten to absolute paths for the temporary compilation)</p></li>
 <li><p>use QSaveFile for file saving instead of our custom file saving strategy if available (Qt5 only)</p></li>
-<li><p>eneable left/right shortcuts for embedded viewer</p></li>
+<li><p>enable left/right shortcuts for embedded viewer</p></li>
 <li><p>remove multiple default values for latexmk (fixes bug 1694)</p></li>
 <li><p>support environment variables in additional search paths</p></li>
 <li><p>support [txs-app-dir] and [txs-settings-dir] in additional search paths for log and pdf</p></li>
@@ -936,7 +936,7 @@ before changing to windowed mode (Bug #1876)</p></li>
 <li><p>make pasting into cursor mirrors a single undo block</p></li>
 <li><p>do not remove cursor mirrors on undo</p></li>
 <li><p>select text of current item in Packages Help to allow easier overwriting (feature request 1063)</p></li>
-<li><p>select search/replace texts when switchting there using Tab / Backtab (feature request 1064)</p></li>
+<li><p>select search/replace texts when switching there using Tab / Backtab (feature request 1064)</p></li>
 <li><p>added optional workingDirectory argument to script function system()</p></li>
 <li><p>added editor-&gt;insertSnippet() to scripting environment</p></li>
 <li><p>added option to choose log encoding</p></li>
@@ -970,7 +970,7 @@ before changing to windowed mode (Bug #1876)</p></li>
 <li><p>fix line breaks for cursor mirrors</p></li>
 <li><p>fix auto paren completion for cursor mirrors</p></li>
 <li><p>fix line operations to work with cursor mirrors</p></li>
-<li><p>fix sychronize text of placeholder mirror when inserting an environment on a selection (Ctrl+E)</p></li>
+<li><p>fix synchronize text of placeholder mirror when inserting an environment on a selection (Ctrl+E)</p></li>
 <li><p>fix font in pdf viewer status bar did not scale</p></li>
 <li><p>fix loading of badword lists</p></li>
 <li><p>fix LanguageTool startup</p></li>
@@ -1026,7 +1026,7 @@ before changing to windowed mode (Bug #1876)</p></li>
 <li><p>fix: context help for \documentclass</p></li>
 <li><p>fix: treat minted as verboten environment</p></li>
 <li><p>fix: correctly handle files with uppercase extension .TEX as tex files</p></li>
-<li><p>fix: workaround for pasting from LibreOffice (priorize text over image)</p></li>
+<li><p>fix: workaround for pasting from LibreOffice (prioritize text over image)</p></li>
 <li><p>updates to translations</p></li>
 <li><p>updates to the manual</p></li>
 <li><p>updates to cwl files</p></li>
@@ -1108,7 +1108,7 @@ before changing to windowed mode (Bug #1876)</p></li>
 <li><p>user-visible list of hidden documents</p></li>
 <li><p>added –foreground and –no-foreground options to pdf viewer</p></li>
 <li><p>make format for magicComment editable in Options -&gt; Highlighting</p></li>
-<li><p>added line operation “Delete from start of line”, more constent naming of line operations, adaption for OSX default shortcuts</p></li>
+<li><p>added line operation “Delete from start of line”, more consistent naming of line operations, adaption for OSX default shortcuts</p></li>
 <li><p>improved support for output redirection of commands</p></li>
 <li><p>support shell-style literal quotes (”) in commands</p></li>
 <li><p>new selection actions “Expand Selection to Word”, “Expand Selection to Line”</p></li>
@@ -1381,7 +1381,7 @@ before changing to windowed mode (Bug #1876)</p></li>
 <section id="texstudio-2-6-4">
 <h2>TeXstudio 2.6.4<a class="headerlink" href="#texstudio-2-6-4" title="Permalink to this heading">#</a></h2>
 <ul class="simple">
-<li><p>package scanner: queries the tex istallation for installed packages and highlights missing packages</p></li>
+<li><p>package scanner: queries the tex installation for installed packages and highlights missing packages</p></li>
 <li><p>package completion</p></li>
 <li><p>basic annotation support in internal pdf viewer</p></li>
 <li><p>improved render speed, especially on mac</p></li>

--- a/utilities/manual/build/html/CHANGELOG.html
+++ b/utilities/manual/build/html/CHANGELOG.html
@@ -7,8 +7,8 @@
 <meta property="og:type" content="website" />
 <meta property="og:url" content="CHANGELOG.html" />
 <meta property="og:site_name" content="TeXstudio" />
-<meta property="og:description" content="TeXstudio 4.8.1:. TeXstudio 4.8.0: AI chat assistant added, use moveable/ splitable docks for sidepanel, extended search can now also search in all files in one folder, add basic syntax highlighting..." />
-<meta name="description" content="TeXstudio 4.8.1:. TeXstudio 4.8.0: AI chat assistant added, use moveable/ splitable docks for sidepanel, extended search can now also search in all files in one folder, add basic syntax highlighting..." />
+<meta property="og:description" content="TeXstudio 4.8.1: allow hiding of sidepanel docks via view/show, reduce number on visible dock on OSX due to qt osx style weakness, fix raised dock after hiding/showing sidepanel#3653, fallback to s..." />
+<meta name="description" content="TeXstudio 4.8.1: allow hiding of sidepanel docks via view/show, reduce number on visible dock on OSX due to qt osx style weakness, fix raised dock after hiding/showing sidepanel#3653, fallback to s..." />
 <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="prev" title="Background information" href="background.html" />
 
     <link rel="shortcut icon" href="_static/texstudio.ico"/><!-- Generated with Sphinx 5.3.0 and Furo 2022.12.07 -->

--- a/utilities/manual/build/html/background.html
+++ b/utilities/manual/build/html/background.html
@@ -398,7 +398,7 @@ classification</p></li>
 <h3>Command format<a class="headerlink" href="#command-format" title="Permalink to this heading">#</a></h3>
 <p>In its simplest form the command is just a valid LaTeX expression as you
 find it in the documentation, e.g. <code class="docutils literal notranslate"><span class="pre">\section{title}</span></code>. By default, every
-option is treated as a placeholder. Alteratively, you may either just
+option is treated as a placeholder. Alternatively, you may either just
 define a stop position for the cursor by <code class="docutils literal notranslate"><span class="pre">%|</span></code> (Example:
 <code class="docutils literal notranslate"><span class="pre">\left(%|\right)</span></code>) or use <code class="docutils literal notranslate"><span class="pre">%&lt;</span> <span class="pre">%&gt;</span></code> to mark only part of an option as
 placeholder (Example: <code class="docutils literal notranslate"><span class="pre">\includegraphics[scale=%&lt;1%&gt;]{file}</span></code>). New lines

--- a/utilities/manual/build/html/configuration.html
+++ b/utilities/manual/build/html/configuration.html
@@ -327,9 +327,9 @@ Or hard line wrapping after a number of characters can be selected. This inserts
 <dl class="simple myst">
 <dt>Special commands</dt><dd><p>Are special commands which do not add cell content and need to handled specially, e.g. <code class="docutils literal notranslate"><span class="pre">\hline</span></code> at the end of a row.</p>
 </dd>
-<dt>Special commands position</dt><dd><p>where to place them when reformating a table.</p>
+<dt>Special commands position</dt><dd><p>where to place them when reformatting a table.</p>
 </dd>
-<dt>One line per cell</dt><dd><p>when reformating a table, just put each cell in an individual line</p>
+<dt>One line per cell</dt><dd><p>when reformatting a table, just put each cell in an individual line</p>
 </dd>
 </dl>
 <p><img alt="Configure Editor advanced: table autoformatting" src="_images/conf_tableautoformating.png" /></p>

--- a/utilities/manual/build/html/editing.html
+++ b/utilities/manual/build/html/editing.html
@@ -488,7 +488,7 @@ A number of templates are predefined by txs:</p>
 <li><p>plain_tabularx</p></li>
 <li><p>rowcolors_tabular</p></li>
 </ul>
-<p>By selecting the first entry, the table is reformated to:</p>
+<p>By selecting the first entry, the table is reformatted to:</p>
 <div class="highlight-latex notranslate"><div class="highlight"><pre><span></span><span class="k">\begin</span><span class="nb">{</span>tabular<span class="nb">}{</span>|l|l|<span class="nb">}</span>
 <span class="k">\hline</span>
 <span class="k">\textbf</span><span class="nb">{</span>a<span class="nb">}&amp;</span><span class="k">\textbf</span><span class="nb">{</span>b<span class="nb">}</span><span class="k">\\</span> <span class="k">\hline</span>

--- a/utilities/manual/build/html/getting_started.html
+++ b/utilities/manual/build/html/getting_started.html
@@ -229,7 +229,7 @@ The central toolbar offers access to some common latex commands as we will see.<
 </section>
 <section id="create-a-first-document">
 <h2>Create a first document<a class="headerlink" href="#create-a-first-document" title="Permalink to this heading">#</a></h2>
-<p>LaTeX needs some configuartion code in the document. The <a class="reference internal" href="editing.html#setting-the-preamble-of-a-tex-document"><span class="std std-doc">Quick Start Wizard</span></a> offers an easy way to set up a typical document.</p>
+<p>LaTeX needs some configuration code in the document. The <a class="reference internal" href="editing.html#setting-the-preamble-of-a-tex-document"><span class="std std-doc">Quick Start Wizard</span></a> offers an easy way to set up a typical document.</p>
 <p><img alt="Quick start wizard" src="_images/txs_wizard.png" /></p>
 <p>Select <code class="docutils literal notranslate"><span class="pre">Wizards/Quick</span> <span class="pre">Start...</span></code> and confirm the dialog with <code class="docutils literal notranslate"><span class="pre">OK</span></code>.
 This will lead to this basic document:</p>

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -95,7 +95,7 @@
 - when the mouse cursor hovers over a spin/combo box, the wheel scrolls through the configuration page instead of changing values ([#2977](https://github.com/texstudio-org/texstudio/issues/2977))
 - copy some details (icons, separators) to menu item list in combo box ([#3025](https://github.com/texstudio-org/texstudio/issues/3025))
 - support toggling comment on folded lines ([#2912](https://github.com/texstudio-org/texstudio/issues/2912))
-- don't show pointing hand cursor over hyperlinks when magnifier is activ ([#2982](https://github.com/texstudio-org/texstudio/pull/2982))
+- don't show pointing hand cursor over hyperlinks when magnifier is active ([#2982](https://github.com/texstudio-org/texstudio/pull/2982))
 - improve usage of tab key and enter key in QuickStart Wizard ([#3014](https://github.com/texstudio-org/texstudio/pull/3014))
 - add \maketitle to the document created by QuickStart Wizard if appropriate ([#3015](https://github.com/texstudio-org/texstudio/pull/3015))
 - pos1 (home) key now sets cursor to start or to first non-blank character of editor lines ([#3012](https://github.com/texstudio-org/texstudio/issues/3012))
@@ -174,7 +174,7 @@
 - fix stuck to save unsaved document (only in explicit root mode and with a new unsaved document,[#2153](https://github.com/texstudio-org/texstudio/issues/2153)) 
 - xindex engine added
 - fix math highlighting in keyvals ([#2138](https://github.com/texstudio-org/texstudio/issues/2138))
-- add context menu in embbeded pdf viewer to invert pdf colors
+- add context menu in embedded pdf viewer to invert pdf colors
 - remember window state (maximized/normal) of config dialog
 - fix (and speed-up) miktex package detection
 - fix handling apostrophed words better in spellchecker ([#2179](https://github.com/texstudio-org/texstudio/issues/2179))
@@ -254,7 +254,7 @@
 - fix pdfviewer page display
 - build OSX with QT6.2, fix special characters entry (alt+n + n , etc.) ([#1770](https://github.com/texstudio-org/texstudio/issues/1770))
 - activate crash handler on win again
-- fix strcuture detection for included files
+- fix structure detection for included files
  
 
 ## TeXstudio 4.0.0
@@ -265,7 +265,7 @@
 - more and updated completion word lists thanks to mbertucci47
 - handle text (e.g. \text{text}) in mathenv as text with spell checking
 - performance improvement for large files with large number of labels and/or large number of includes
-- fix that search options are persistant
+- fix that search options are persistent
 - automatic structure scrolling can be turned off ([#1742](https://github.com/texstudio-org/texstudio/issues/1742))
 - some bug fixes
 
@@ -359,7 +359,7 @@
 ## TeXstudio 2.12.16
 
 - bug fixes
-- somes fixes for tool-tip preview by MeanSquaredError
+- some fixes for tool-tip preview by MeanSquaredError
 
 ## TeXstudio 2.12.14
 
@@ -417,7 +417,7 @@
 - tags for beamer
 - change preview default to embedded pdf
 - handle preview failures more gracefully, i.e. no warning pop-ups
-- repect preview settings (panel,etc) also for hover preview
+- respect preview settings (panel,etc) also for hover preview
 - show hover preview as tooltip in case of inline-mode
 - warn if compiler commands are actually a command list
 - several improvements to the latex parser
@@ -472,7 +472,7 @@
 - fix highlighting of current section in structure (bug 2103)
 - fix delays when typing _abc
 - fix bug in log parser: wrong filename if empty brackets () occur in text
-- fix word repetition erro on non-breaking space (~)
+- fix word repetition error on non-breaking space (~)
 - fix file detection in latex/include file
 - fix width of side panel not saved (bug 2083)
 - fix ampersand in in recent session names
@@ -625,7 +625,7 @@ before changing to windowed mode (Bug #1876)
 - do not parse for structure in non-LaTeX-like languages
 - make preview work with \input in preamble (files get rewritten to absolute paths for the temporary compilation)
 - use QSaveFile for file saving instead of our custom file saving strategy if available (Qt5 only)
-- eneable left/right shortcuts for embedded viewer
+- enable left/right shortcuts for embedded viewer
 - remove multiple default values for latexmk (fixes bug 1694)
 - support environment variables in additional search paths
 - support [txs-app-dir] and [txs-settings-dir] in additional search paths for log and pdf
@@ -635,7 +635,7 @@ before changing to windowed mode (Bug #1876)
 - make pasting into cursor mirrors a single undo block
 - do not remove cursor mirrors on undo
 - select text of current item in Packages Help to allow easier overwriting (feature request 1063)
-- select search/replace texts when switchting there using Tab / Backtab (feature request 1064)
+- select search/replace texts when switching there using Tab / Backtab (feature request 1064)
 - added optional workingDirectory argument to script function system()
 - added editor->insertSnippet() to scripting environment
 - added option to choose log encoding
@@ -669,7 +669,7 @@ before changing to windowed mode (Bug #1876)
 - fix line breaks for cursor mirrors
 - fix auto paren completion for cursor mirrors
 - fix line operations to work with cursor mirrors
-- fix sychronize text of placeholder mirror when inserting an environment on a selection (Ctrl+E)
+- fix synchronize text of placeholder mirror when inserting an environment on a selection (Ctrl+E)
 - fix font in pdf viewer status bar did not scale
 - fix loading of badword lists
 - fix LanguageTool startup
@@ -723,7 +723,7 @@ before changing to windowed mode (Bug #1876)
 - fix: context help for \documentclass
 - fix: treat minted as verboten environment
 - fix: correctly handle files with uppercase extension .TEX as tex files
-- fix: workaround for pasting from LibreOffice (priorize text over image)
+- fix: workaround for pasting from LibreOffice (prioritize text over image)
 - updates to translations
 - updates to the manual
 - updates to cwl files
@@ -802,7 +802,7 @@ before changing to windowed mode (Bug #1876)
 - user-visible list of hidden documents
 - added --foreground and --no-foreground options to pdf viewer
 - make format for magicComment editable in Options -> Highlighting
-- added line operation "Delete from start of line", more constent naming of line operations, adaption for OSX default shortcuts
+- added line operation "Delete from start of line", more consistent naming of line operations, adaption for OSX default shortcuts
 - improved support for output redirection of commands
 - support shell-style literal quotes (\") in commands
 - new selection actions "Expand Selection to Word", "Expand Selection to Line"
@@ -1063,7 +1063,7 @@ before changing to windowed mode (Bug #1876)
 
 ## TeXstudio 2.6.4
 
-- package scanner: queries the tex istallation for installed packages and highlights missing packages
+- package scanner: queries the tex installation for installed packages and highlights missing packages
 - package completion
 - basic annotation support in internal pdf viewer
 - improved render speed, especially on mac

--- a/utilities/manual/source/background.md
+++ b/utilities/manual/source/background.md
@@ -150,7 +150,7 @@ cwl files should be encoded as UTF-8.
 
 In its simplest form the command is just a valid LaTeX expression as you
 find it in the documentation, e.g. `\section{title}`. By default, every
-option is treated as a placeholder. Alteratively, you may either just
+option is treated as a placeholder. Alternatively, you may either just
 define a stop position for the cursor by `%|` (Example:
 `\left(%|\right)`) or use `%< %>` to mark only part of an option as
 placeholder (Example: `\includegraphics[scale=%<1%>]{file}`). New lines

--- a/utilities/manual/source/configuration.md
+++ b/utilities/manual/source/configuration.md
@@ -141,10 +141,10 @@ Special commands
 :   Are special commands which do not add cell content and need to handled specially, e.g. `\hline` at the end of a row.
 
 Special commands position
-:   where to place them when reformating a table.
+:   where to place them when reformatting a table.
 
 One line per cell
-:   when reformating a table, just put each cell in an individual line
+:   when reformatting a table, just put each cell in an individual line
 
 ![Configure Editor advanced: table autoformatting](images/conf_tableautoformating.png)
 

--- a/utilities/manual/source/editing.md
+++ b/utilities/manual/source/editing.md
@@ -290,7 +290,7 @@ A number of templates are predefined by txs:
 -   plain\_tabularx
 -   rowcolors\_tabular
 
-By selecting the first entry, the table is reformated to:
+By selecting the first entry, the table is reformatted to:
 
 ```latex
 \begin{tabular}{|l|l|}

--- a/utilities/manual/source/getting_started.md
+++ b/utilities/manual/source/getting_started.md
@@ -18,7 +18,7 @@ On the lower right you see the *messages panel* which can be switched to the [*l
 The central toolbar offers access to some common latex commands as we will see.
 
 ## Create a first document
-LaTeX needs some configuartion code in the document. The [Quick Start Wizard](editing.md#setting-the-preamble-of-a-tex-document) offers an easy way to set up a typical document.
+LaTeX needs some configuration code in the document. The [Quick Start Wizard](editing.md#setting-the-preamble-of-a-tex-document) offers an easy way to set up a typical document.
 
 ![Quick start wizard](images/txs_wizard.png)
 

--- a/utilities/manual/usermanual_en.html
+++ b/utilities/manual/usermanual_en.html
@@ -163,7 +163,7 @@ This needs to be refined
 </figure>
 <p>The main window is divided into three parts (blue): On the left we have a "side panel" (currently showing an empty Structure) that provides many different functions. On the lower right you see a <em>messages panel</em>. You can switch to the <a href="#the-log-files">log panel</a>, the <em>preview panel</em>, or the <em>search results panel</em> there. The third area is left to the editor. You can have multiple editors open, which you select using tabs. You may increase the area for editors by turning off the side panel or the messages panel. This can be done easily via the two icons in the lower left corner (marked orange). They are in the status bar, which can be hidden (s. menu View/Show).</p>
 <h2 id="create-a-first-document"><span class="header-section-number">1.3</span> Create a first document</h2>
-<p>LaTeX needs some configuartion code in the document. The <a href="#setting-the-preamble-of-a-tex-document">Quick Start Wizard</a> offers an easy way to set up an typical document.</p>
+<p>LaTeX needs some configuration code in the document. The <a href="#setting-the-preamble-of-a-tex-document">Quick Start Wizard</a> offers an easy way to set up an typical document.</p>
 <figure>
 <img src="txs_wizard.png" alt="Quick start wizard" style="width:100.0%" /><figcaption>Quick start wizard</figcaption>
 </figure>
@@ -284,7 +284,7 @@ This option is available for all the environments indicated by "[selection]" in 
 <li>To Titlecase (strict)</li>
 <li>To Titlecase (smart)</li>
 </ul>
-<p>Both variants of "To Titlecase" leave small words like a, the, of etc. in lowercase. Additionally, "To Titlecase (smart)" does not convert any words containing capital letters, assuming they are acronymes which require a fixed capitalization (e.g. "TeXstudio").</p>
+<p>Both variants of "To Titlecase" leave small words like a, the, of etc. in lowercase. Additionally, "To Titlecase (smart)" does not convert any words containing capital letters, assuming they are acronyms which require a fixed capitalization (e.g. "TeXstudio").</p>
 <h3 id="escaping-reserved-characters"><span class="header-section-number">2.4.2</span> Escaping reserved characters</h3>
 <p>If you have text containing reserved TeX characters and want the text to appear literally in your document, you have to escape the reserved characters to prevent LaTeX from interpreting them. The following functions take care of that (Menu: Idefix)</p>
 <ul>
@@ -385,7 +385,7 @@ The completer has several operation modes which are shown in the tabs below the 
 <figure>
 <img src="thesaurus.png" alt="Thesaurus" /><figcaption>Thesaurus</figcaption>
 </figure>
-<p>The first line to the left contains the word, for which a synonym is searched for. The list below gives a list of word classes. The can be chosen to reduce the number of suggestions. The column to the right contains the list of suggested synonyms. A selected word from this list apears in the first line to the right as proposition for replacement of the text. This word can be changed manually. It is also used to do further investigations for words and their synonyms which "start with" or "contain" that word. With "lookup" it can be directly used to look for a synonym for that word.</p>
+<p>The first line to the left contains the word, for which a synonym is searched for. The list below gives a list of word classes. The can be chosen to reduce the number of suggestions. The column to the right contains the list of suggested synonyms. A selected word from this list appears in the first line to the right as proposition for replacement of the text. This word can be changed manually. It is also used to do further investigations for words and their synonyms which "start with" or "contain" that word. With "lookup" it can be directly used to look for a synonym for that word.</p>
 <h2 id="special-commands"><span class="header-section-number">2.14</span> Special Commands</h2>
 <h3 id="delete-wordcommandenvironment"><span class="header-section-number">2.14.1</span> Delete word/command/environment</h3>
 <p>With the shortcut Alt+Del, the word under the cursor is deleted. If it is a command, the command is deleted including opening and closing braces. E.g. "\textbf{text}" leave "text". If it is an environment, the enclosing begin/end are removed.</p>
@@ -403,21 +403,21 @@ Note : the "Clean" command in the "Tools menu" allows you to erase the files (dv
 </figure>
 <p><strong>Warning:</strong> all your files must have an extension.</p>
 <h2 id="the-log-files"><span class="header-section-number">3.2</span> The log files</h2>
-<p>The log panel gives you insight to all the informations output to the log file by the command processing your LaTeX file. This panel can show the log file in two ways: First the log file, highlighted at important messages, and second as a table, that extracts the error and warning messages aswell as messages for bad boxes from the log file for easier overview. The buttons <em>Log File</em> and <em>Issues</em> let you show or hide the two representations (but you can't hide both at the same time). If you choose to show both of them then the log panel will be split vertically into two parts.</p>
+<p>The log panel gives you insight to all the information output to the log file by the command processing your LaTeX file. This panel can show the log file in two ways: First the log file, highlighted at important messages, and second as a table, that extracts the error and warning messages as well as messages for bad boxes from the log file for easier overview. The buttons <em>Log File</em> and <em>Issues</em> let you show or hide the two representations (but you can't hide both at the same time). If you choose to show both of them then the log panel will be split vertically into two parts.</p>
 <figure>
 <img src="errorlog.png" alt="Display of Error Log" /><figcaption>Display of Error Log</figcaption>
 </figure>
 <p>Use the buttons <em>Show Error</em>, <em>Show Warning</em>, <em>Show BadBox</em> (see tooltips) to choose whether error messages (red), warning messages (yellow) or messages for bad boxes (blue) will be shown or hidden. Use the button <em>Show Log Markers</em> to display or hide log marker icons left to the lines in the editor. The tooltips for the log markers show message details.</p>
 <p>In case that the log file contains error messages the log panel is opened automatically (check option <em>Show log in case of compile error</em>, s. Build settings) and log markers are activated. The editor's cursor will be placed in the first line which has an error marker (check option <em>Go to error when displaying log</em>, s. Adv. Editor settings).</p>
 <p>You may use the buttons <em>Previous Error</em> and <em>Next Error</em> to jump back or forth to the previous or next error. The shortcuts for this are Ctrl+Shift+Up/Down, accordingly Ctrl+Alt+Up/Down (these you have to set up on your own, s. Shortcut options for actions in menu Idefix/Go to) and Alt+Shift+Up/Down are used for warnings and bad boxes respectively. You can jump between markers of any type with Ctrl+Up/Down.</p>
-<p>When you select an entry in the table then the editor (and the log file) scrolls to the corresponding location. The log markers will be activated (check option <em>Show log markers when clicking log entry</em>, s. Adv. Editor settings). The log file informations can be shown or hidden by clicking on the Log File button. The Issues button offers a similar function for the table with the messages.</p>
+<p>When you select an entry in the table then the editor (and the log file) scrolls to the corresponding location. The log markers will be activated (check option <em>Show log markers when clicking log entry</em>, s. Adv. Editor settings). The log file information can be shown or hidden by clicking on the Log File button. The Issues button offers a similar function for the table with the messages.</p>
 <h1 id="viewing-a-document-pdf"><span class="header-section-number">4</span> Viewing a document (pdf)</h1>
 <!--
 **TODO** internal/external 
 -->
 <h2 id="internal-pdf-viewer"><span class="header-section-number">4.1</span> Internal pdf viewer</h2>
 <p>TeXstudio has an internal (built-in) pdf viewer that lets you view your pdf documents. The viewer can be embedded or window-based (in a separate window). The former uses an area to the right of the editor, the latter uses its own window and gives the user more options. The viewer can be opened by clicking the View button or by pressing the F7 key.</p>
-<p>You may want to change otions in the config dialog (s. Internal PDF Viewer). For forward and inverse searching, scrolling follows cursor, and cursor follows scrolling see <a href="#forward-and-inverse-searching">Forward and Inverse searching</a>.</p>
+<p>You may want to change options in the config dialog (s. Internal PDF Viewer). For forward and inverse searching, scrolling follows cursor, and cursor follows scrolling see <a href="#forward-and-inverse-searching">Forward and Inverse searching</a>.</p>
 <h3 id="modes-and-mouse-actions"><span class="header-section-number">4.1.1</span> Modes and mouse actions</h3>
 <p>You can choose main mode <em>Magnify</em> or <em>Scroll</em> from the toolbar. The mouse cursor used is a magnifier glass, or an open hand. These offer following actions:</p>
 <p>Magnify mode only</p>
@@ -496,7 +496,7 @@ Now you can select a template which defines the formatting of the table. A numbe
 <li>plain_tabularx</li>
 <li>rowcolors_tabular</li>
 </ul>
-<p>By selecting the first entry, the table is reformated to:</p>
+<p>By selecting the first entry, the table is reformatted to:</p>
 <pre><code>\begin{tabular}{|l|l|}
 \hline
 \textbf{a}&amp;\textbf{b}\\ \hline
@@ -1737,7 +1737,7 @@ Concerning auto completion, TeXstudio allows one to adapt the behaviour to your 
 <p>As a last resort, you may set an <em>explicit root document</em> via <code>Options -&gt; Root Document -&gt; Set Current Document As Explicit Root</code>. This setting takes absolute precedence. All the commands of the "Tools" menu will be called on this document (to be more precise, the build system will expand the placeholder <code>%</code> to the root document), no matter which document is active in the editor. Additionally, labels and usercommands which are defined in any open document, can be used for completion in any open document.</p>
 <p>In earlier versions, the <em>explicit root document</em> was somewhat misleadingly called <em>master document</em>.</p>
 <h3 id="loaded-documents"><span class="header-section-number">7.1.2</span> Loaded Documents</h3>
-<p>Obviously, TeXstudio can only use information (defined commands, labels, document hirachy, etc.) that it is aware of. We use the information in all opened files, but if a label in a multi-file document is defined in a not-loaded files, TeXstudio does not know about it and will mark it as missing in references. To remedy this, you can just open the corresponding file as well.</p>
+<p>Obviously, TeXstudio can only use information (defined commands, labels, document hierarchy, etc.) that it is aware of. We use the information in all opened files, but if a label in a multi-file document is defined in a not-loaded files, TeXstudio does not know about it and will mark it as missing in references. To remedy this, you can just open the corresponding file as well.</p>
 <p>More recent versions of TeXstudio have an advanced option <code>Editor -&gt; Automatically load included files</code>. It's disabled by default for performance reasons with older systems. When you enable this option, TeXstudio will automatically load and parse all files of multi-file-documents as soon as one of the files is opened. You may have to set the magic comment <code>% !TeX root = root-filename</code> if you do not have the root document open. With this option enabled TeXstudio will always know about your complete document and act accordingly when performing highlighting or completion.</p>
 <h2 id="overview-of-texstudio-command-line-options"><span class="header-section-number">7.2</span> Overview of TeXstudio command-line options</h2>
 <p><code>texstudio file [--config DIR] [--root] [--line xx[:cc]] [--insert-cite citation] [--start-always] [--pdf-viewer-only] [--page yy] [--no-session]</code></p>
@@ -1853,7 +1853,7 @@ If ##l is added to a key, the argument is defining a label. (see listings.cwl)<b
 </ul>
 <p>cwl files should be encoded as UTF-8.</p>
 <h3 id="command-format"><span class="header-section-number">7.3.2</span> Command format</h3>
-<p>In its simplest form the command is just a valid LaTeX expression as you find it in the documentation, e.g. <code>\section{title}</code>. By default, every option is treated as a placeholder. Alteratively, you may either just define a stop position for the cursor by <code>%|</code> (Example: <code>\left(%|\right)</code>) or use <code>%&lt; %&gt;</code> to mark only part of an option as placeholder (Example: <code>\includegraphics[scale=%&lt;1%&gt;]{file}</code>). New lines can be included in a command by <code>%\</code>.</p>
+<p>In its simplest form the command is just a valid LaTeX expression as you find it in the documentation, e.g. <code>\section{title}</code>. By default, every option is treated as a placeholder. Alternatively, you may either just define a stop position for the cursor by <code>%|</code> (Example: <code>\left(%|\right)</code>) or use <code>%&lt; %&gt;</code> to mark only part of an option as placeholder (Example: <code>\includegraphics[scale=%&lt;1%&gt;]{file}</code>). New lines can be included in a command by <code>%\</code>.</p>
 <h4 id="argument-names"><span class="header-section-number">7.3.2.1</span> Argument Names</h4>
 <p>The argument names are visible in the completer window and after completion as placeholders in the editor. In general, you are free to name the arguments as you like. We encurage to provide meaningful names e.g. <code>\parbox[position]{width}{text}</code> instead of <code>\parbox[arg1]{arg2}{arg3}</code>.</p>
 <p>There are a few argument names that have special meaning:</p>


### PR DESCRIPTION
Fixes a few typos, mostly from the manual and changelog. Found with [codespell](https://pypi.org/project/codespell/).