### PR TITLE
add colibre icon for windowed pdf-viewer

### DIFF
--- a/images-ng/colibre/embedded-viewer.svg
+++ b/images-ng/colibre/embedded-viewer.svg
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16px"
+   height="16px"
+   id="svg3827"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   enable-background="new"
+   inkscape:export-filename="C:\Users\Tim\Documents\texstudio\svn6\images\section.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   sodipodi:docname="embedded-viewer.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3829">
+    <linearGradient
+       id="linearGradient3853">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3855" />
+      <stop
+         id="stop3861"
+         offset="0.5"
+         style="stop-color:#e3e3e3;stop-opacity:0.39664805;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3857" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3853"
+       id="linearGradient3859"
+       x1="8.8297024"
+       y1="9.8282175"
+       x2="3.1985149"
+       y2="2.7103961"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       id="filter3863"
+       x="0"
+       y="-inf"
+       width="1.0106281"
+       height="inf">
+      <feBlend
+         inkscape:collect="always"
+         mode="multiply"
+         in2="BackgroundImage"
+         id="feBlend3865" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3853"
+       id="linearGradient3763"
+       gradientUnits="userSpaceOnUse"
+       x1="8.8297024"
+       y1="9.8282175"
+       x2="3.1985149"
+       y2="2.7103961" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3853"
+       id="linearGradient3784"
+       gradientUnits="userSpaceOnUse"
+       x1="8.8297024"
+       y1="9.8282175"
+       x2="3.1985149"
+       y2="2.7103961" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3853"
+       id="linearGradient3787"
+       gradientUnits="userSpaceOnUse"
+       x1="8.8297024"
+       y1="9.8282175"
+       x2="3.1985149"
+       y2="2.7103961" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3853"
+       id="linearGradient3793"
+       gradientUnits="userSpaceOnUse"
+       x1="8.8297024"
+       y1="9.8282175"
+       x2="3.1985149"
+       y2="2.7103961"
+       gradientTransform="translate(17.137624,4.0356436)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3853"
+       id="linearGradient3814"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.0126241,0.00439366)"
+       x1="8.8297024"
+       y1="9.8282175"
+       x2="3.1985149"
+       y2="2.7103961" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="19.3125"
+     inkscape:cx="-15.404531"
+     inkscape:cy="8.4142395"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1137"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata3832">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/3.0/" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Tim Hoffmann</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/3.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     style="filter:url(#filter3863)">
+    <rect
+       y="2.5"
+       x="1.5"
+       height="10"
+       width="13"
+       id="rect4177"
+       style="fill:none;fill-opacity:1;stroke:#e0e0e0;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#e0e0e0;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 1.5,3.4304214 13,0"
+       id="path4148"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#202020;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter3863)"
+       d="m -32.545308,5.9029126 13,0"
+       id="path4148-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path4165"
+       d="M 8,3 8,13"
+       style="fill:none;fill-rule:evenodd;stroke:#e0e0e0;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/images.qrc
+++ b/images.qrc
@@ -402,6 +402,7 @@
 <file>images-ng/colibre/edit-redo.svg</file>
 <file>images-ng/colibre/edit-undo_dm.svg</file>
 <file>images-ng/colibre/edit-undo.svg</file>
+<file>images-ng/colibre/embedded-viewer.svg</file>
 <file>images-ng/colibre/enlarge-viewer_dm.svg</file>
 <file>images-ng/colibre/enlarge-viewer.svg</file>
 <file>images-ng/colibre/enumerate_dm.svg</file>


### PR DESCRIPTION
This PR fixes #3660

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/ea390272-8f0e-4684-9be8-6332a1967dda)

### Note
First, I used the image from source folder `images-ng` but the icon remained invisible. Then, I used "save as" from Inkscape (version 1.3.2) to save the file again. Now the icon is visible, even so it contains a filter with a blending[^1] section:

<details>
<summary>show XML</summary>

```
    <filter
       inkscape:collect="always"
       id="filter3863"
       x="0"
       y="-inf"
       width="1.0106281"
       height="inf">
      <feBlend
         inkscape:collect="always"
         mode="multiply"
         in2="BackgroundImage"
         id="feBlend3865" />
    </filter>
```

</details>

[^1]: s. [QTBUG-124374](https://bugreports.qt.io/browse/QTBUG-124374)
