### PR TITLE
hide first toolbar separator for embedded pdf viewer

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -2930,7 +2930,7 @@ void PDFDocument::setupToolBar(){
     connect(toolBarTimer, SIGNAL(timeout()), this, SLOT(showToolbars()));
 
     toolBar->addAction(actionTypeset);
-    toolBar->addSeparator();
+    separatorAfterTypeset = toolBar->addSeparator();
     toolBar->addAction(actionExternalViewer);
     toolBar->addSeparator();
     toolBar->addAction(actionMagnify);
@@ -3171,6 +3171,7 @@ void PDFDocument::init(bool embedded)
 	actionExternalViewer->setIcon(getRealIcon("acroread"));
 	if (embedded) {
 		actionTypeset->setVisible(false);
+		separatorAfterTypeset->setVisible(false);
 		actionShrinkViewer->setVisible(false);
 	} else {
 		actionClose->setVisible(false);

--- a/src/pdfviewer/PDFDocument.h
+++ b/src/pdfviewer/PDFDocument.h
@@ -616,6 +616,7 @@ private:
     QAction *actionPaste;
     QAction *actionClear;
     QAction *actionTypeset;
+    QAction *separatorAfterTypeset;
     QAction *actionExternalViewer;
     QAction *actionPreferences;
     QAction *actionStack;


### PR DESCRIPTION
The embedded pdf viewer has no build action in the toolbar, while the windowed pdf viewer's toolbar shows this action followed by a separator followed by the external viewer action. Thus the toolbars begins respectively as follows:

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/0e8eab5a-3787-4b38-b19b-7b3ea8725235) embedded
![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/519e704f-b60a-4cca-b663-9b0736b38d5e) windowed

This leads to a different behavior when you move the mouse pointer further to the left. In the second case the size all cursor
![cursor-sizeall](https://github.com/texstudio-org/texstudio/assets/102688820/b916ce55-957f-473f-8e38-3c3d498d4633) appears immediately indicating that the toolbar can be moved. In the first case the arrow pointer doesn't change even so the cursor leaves the box of the external viewer's button, because the cursor moves over the separator:

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/aadc42bd-d639-4822-9af8-778678533446)

So, in the embedded case the build button and the separator must be hidden:

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/da424056-9f40-4d9b-9642-fd2efc617070)

