### PR TITLE
fix line number visibility in Orion dark

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -3714,12 +3714,12 @@ retryNow:
 			pdfWidget->setFocus();
 
 		// set page viewer only once
-        int maxDigits = 1 + qFloor(log10(pdfWidget->realNumPages()));
-		//if (maxDigits < 2) maxDigits = 2;
+		int maxDigits = 1 + qFloor(log10(pdfWidget->realNumPages()));
 		leCurrentPage->setMaxLength(maxDigits);
-        leCurrentPage->setFixedWidth(UtilsUi::getFmWidth(leCurrentPage->fontMetrics(), QString(maxDigits + 1, '#')));
+		int numWidth = UtilsUi::getFmWidth(leCurrentPage->fontMetrics(), QString(maxDigits, '#')) + 8;
+		leCurrentPage->setFixedWidth(numWidth);
 		leCurrentPageValidator->setTop(pdfWidget->realNumPages());
-        //qDebug() << pdfWidget->realNumPages() << maxDigits << UtilsUi::getFmWidth(leCurrentPage->fontMetrics(), QString(maxDigits + 1, '#'))<<QString(maxDigits + 1, '#');
+		// qDebug() << pdfWidget->realNumPages() << maxDigits << numWidth;
 
 		loadSyncData();
 		if (fillCache) {

--- a/utilities/stylesheet_francesco.qss
+++ b/utilities/stylesheet_francesco.qss
@@ -270,7 +270,7 @@ QSlider:focus {
 
 QLineEdit {
     background-color: #232629;
-    padding: 5px;
+    padding: 2px;
     border-style: solid;
     border: 1px solid #76797C;
     border-radius: 2px;


### PR DESCRIPTION
and alignment QLineEdit vs. QTextEdit. This PR resolves #2186, #3046, #3048, and #3222.

#### Details:
Image shows misalignment (ex. from macro browser):

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/7f5f866f-acb1-4156-94a1-f04921068ed1)
old (left) vs. new

Reducing size of padding helps solving the line number issue. Here is a line up of state before fix for several styles (per row), each with a document of 25 pages (at left) and a document of 100.001 pages (at right):

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/320ea82d-276d-4d7e-9572-e798a2795d83)
Be aware of the line number issue with Orion.

With the fix it looks like this:

![grafik](https://github.com/texstudio-org/texstudio/assets/102688820/ffc7b230-110d-47d4-9abf-351ab61709fd)

Note: The extra amount of space needed for the width of leCurrentPage should be constant (width of borders, paddings) and not depend on the width of the characters of the font. Therefore I changed the formula.