### PR TITLE
changing frametitle syntax

### DIFF
--- a/templates/template_Beamer.tex
+++ b/templates/template_Beamer.tex
@@ -7,6 +7,7 @@
 \begin{frame}[plain]
     \maketitle
 \end{frame}
-\begin{frame}{Frame Title}
+\begin{frame}
+\frametitle{Frame Title}
 \end{frame}
 \end{document}


### PR DESCRIPTION
While `\begin{frame}{...}` is valid beamer syntax, it involves a lot of dirty hacks behind the scenes. `\frametitle` is not only more robust, but also more powerful as it allows users to do things like `\frametitle<2->{Another Title}`. 

For users who just learn beamer, I think it would be much better if they see the `\frametitle` syntax and don't get into the habit of using `\begin{frame}{...}`.