### PR TITLE
Fixing single-instance not working with Qt5 ?

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -731,12 +731,15 @@ void Texstudio::setupDockWidgets()
     if(!dock){
         fileView=new QTreeView();
         fileExplorerModel = new QFileSystemModel(this);
-        //fileExplorerModel->setRootPath(QDir::currentPath());
+		QString rootDir = QDir::currentPath();
+		if (rootDir == "/tmp")
+			rootDir = "/";
+        fileExplorerModel->setRootPath(rootDir);
         fileView->setModel(fileExplorerModel);
         fileView->setColumnHidden(1,true);
         fileView->setColumnHidden(2,true);
         fileView->setColumnHidden(3,true);
-        fileView->setRootIndex(fileExplorerModel->index(QDir::currentPath()));
+        fileView->setRootIndex(fileExplorerModel->index(rootDir));
         QAction *act=new QAction();
         act->setText(tr("Insert filename"));
         connect(act,&QAction::triggered,this,&Texstudio::insertFromExplorer);
@@ -1910,8 +1913,10 @@ void Texstudio::currentEditorChanged()
     // set dock file explorer to current file, root to root document folder
     LatexDocument *doc=edView->getDocument();
     QFileInfo fi=doc->getFileInfo();
-    const QString rootDir=fi.absoluteDir().path();
-    //fileExplorerModel->setRootPath(rootDir);
+    QString rootDir=fi.absoluteDir().path();
+	if (rootDir == "/tmp")
+		rootDir = "/";
+    fileExplorerModel->setRootPath(rootDir);
     fileView->setRootIndex(fileExplorerModel->index(rootDir));
 }
 

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -731,7 +731,7 @@ void Texstudio::setupDockWidgets()
     if(!dock){
         fileView=new QTreeView();
         fileExplorerModel = new QFileSystemModel(this);
-        fileExplorerModel->setRootPath(QDir::currentPath());
+        //fileExplorerModel->setRootPath(QDir::currentPath());
         fileView->setModel(fileExplorerModel);
         fileView->setColumnHidden(1,true);
         fileView->setColumnHidden(2,true);
@@ -1911,7 +1911,7 @@ void Texstudio::currentEditorChanged()
     LatexDocument *doc=edView->getDocument();
     QFileInfo fi=doc->getFileInfo();
     const QString rootDir=fi.absoluteDir().path();
-    fileExplorerModel->setRootPath(rootDir);
+    //fileExplorerModel->setRootPath(rootDir);
     fileView->setRootIndex(fileExplorerModel->index(rootDir));
 }
 


### PR DESCRIPTION
For some reason, any of these two lines confuses the single-instance mechanism and makes TXS open each file in a new instance when invoked from the desktop environment on a file or via CLI ``texstudio somefile.tex``.

I tried to say ``new QFileSystemModel()`` instead of ``new QFileSystemModel(this)`` on line 733, but to no avail.

(insert picture of dog in front a a keyboard with caption "I have no idea what I am doing")

Would fix #3743.