### PR TITLE
Suppress Homebrew "already installed" warnings

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -276,8 +276,8 @@ jobs:
         wget https://github.com/sunderme/homebrew-qt6-modules/releases/download/${{ env.OSX_QT_VERSION }}/QuaZip-${{ env.OSX_QUAZIP_VERSION }}-Darwin.tar.xz
         sudo tar xvf ./QuaZip-${{ env.OSX_QUAZIP_VERSION }}-Darwin.tar.xz -C /usr/local --strip-components=1
         rm QuaZip-${{ env.OSX_QUAZIP_VERSION }}-Darwin.tar.xz
-        brew install cairo fontconfig freetype gettext jpeg libpng libtiff little-cms2 openjpeg
-        brew install ninja pkg-config
+        brew install --quiet cairo fontconfig freetype gettext jpeg libpng libtiff little-cms2 openjpeg
+        brew install --quiet ninja pkg-config
 
     - name: Configure
       run: |
@@ -371,8 +371,8 @@ jobs:
         wget https://github.com/sunderme/homebrew-qt6-modules/releases/download/${{ env.OSX_QT_VERSION }}/QuaZip-${{ env.OSX_QUAZIP_VERSION }}-Darwin-M1.tar.xz
         sudo tar xvf ./QuaZip-${{ env.OSX_QUAZIP_VERSION }}-Darwin-M1.tar.xz -C /usr/local --strip-components=1
         rm QuaZip-${{ env.OSX_QUAZIP_VERSION }}-Darwin-M1.tar.xz
-        brew install cairo fontconfig freetype gettext jpeg libpng libtiff little-cms2 openjpeg
-        brew install ninja pkg-config
+        brew install --quiet cairo fontconfig freetype gettext jpeg libpng libtiff little-cms2 openjpeg
+        brew install --quiet ninja pkg-config
 
     - name: Configure
       run: |


### PR DESCRIPTION
To make the Annotations list less distracted, this PR suppresses 17 Homebrew warnings which all look like
```
cairo 1.18.0 is already installed and up-to-date. To reinstall 1.18.0, run: brew reinstall cairo
```
raised by `cd.yml` workflow runs.

Example runs
- Before, 17 warnings and possibly 1 notice added by #3752
  ![image](https://github.com/user-attachments/assets/d1ca2af4-9716-4376-a485-17efd0dec8a3)
  https://github.com/texstudio-org/texstudio/actions/runs/10260913774
- After, 0 warnings and possibly 1 notice
  ![image](https://github.com/user-attachments/assets/ef0dc0be-898a-47f3-bfef-f7ad98971f64)
  https://github.com/muzimuzhi/texstudio/actions/runs/10261136172