### PR TITLE
Add show the currently opened .tex document in file explorer (#1752)

### DIFF
--- a/src/editors.cpp
+++ b/src/editors.cpp
@@ -404,8 +404,16 @@ void Editors::tabBarContextMenu(const QPoint &point)
 
 	act = menu.addAction((splitter->orientation() == Qt::Horizontal) ? tr("Split Vertically") : tr("Split Horizontally"));
 	connect(act, SIGNAL(triggered()), SLOT(changeSplitOrientation()));
+    menu.addSeparator();
 
 	if (editorUnderCursor) {
+        act = menu.addAction(tr("Copy file path"));
+        act->setData(QVariant::fromValue<LatexDocument *>(editorUnderCursor->getDocument()));
+        connect(act, SIGNAL(triggered()), SLOT(copyFilePath()));
+        // Open the containing folder of the currently opened document.
+        act = menu.addAction(msgGraphicalShellAction());
+        act->setData(QVariant::fromValue<LatexDocument *>(editorUnderCursor->getDocument()));
+        connect(act, SIGNAL(triggered()), SLOT(showInGraphicalShell_()));
 		menu.addSeparator();
 		QString text = tr("Set Read-Only");
 		if (editorUnderCursor->editor->isReadOnly())
@@ -430,6 +438,37 @@ void Editors::onEditorChangeByTabClick(LatexEditorView *from, LatexEditorView *t
 	// the original event comes from a tab widget. from is the previously selected tab in that widget
 	// which has not been the current one one if the tab widget has not been the current
 	emit editorAboutToChangeByTabClick(currentEditor(), to);
+}
+
+
+/*!
+ * \brief copy file path of document to clipboard
+ *
+ * Called from the tab's context menu of the currently opened document
+ */
+void Editors::copyFilePath()
+{
+    QAction *action = qobject_cast<QAction *>(sender());
+    if (!action) return;
+    LatexDocument *document = qvariant_cast<LatexDocument *>(action->data());
+    if (!document) return;
+    QClipboard* clipboard = QGuiApplication::clipboard();
+    if (!clipboard) return;
+    clipboard->setText(document->getFileInfo().absoluteFilePath());
+}
+/*!
+ * \brief open directory in external explorer
+ *
+ * Called from the tab's context menu of the currently opened document
+ */
+
+void Editors::showInGraphicalShell_()
+{
+    QAction *action = qobject_cast<QAction *>(sender());
+    if (!action) return;
+    LatexDocument *document = qvariant_cast<LatexDocument *>(action->data());
+    if (!document) return;
+    showInGraphicalShell(this, document->getFileName());
 }
 
 /*!

--- a/src/editors.h
+++ b/src/editors.h
@@ -63,6 +63,8 @@ protected slots:
 	void moveAllToOtherTabGroup();
 	void moveAllOthersToOtherTabGroup();
 	void moveToTabGroup(LatexEditorView *edView, TxsTabWidget *target, int targetIndex);
+    void showInGraphicalShell_();
+    void copyFilePath();
 
 protected:
 	TxsTabWidget *tabWidgetFromEditor(LatexEditorView *edView) const;


### PR DESCRIPTION
This PR includes an addition of two menu items  to the tab's context menu of the current document being edited (see below).
Now it's possible to copy the document's file path, and show the document in its containing folder from the tab editor's context menu.

![image](https://github.com/user-attachments/assets/7aebb8b6-caf8-4cde-87dc-4712784d0c4c)

This PR resolves: #1752  
