### PR TITLE
menu LaTeX/AMS packages

### DIFF
--- a/uiconfig.xml
+++ b/uiconfig.xml
@@ -2,7 +2,7 @@
 <menu id="main/latex" text="&amp;LaTeX">
   <insert id="documentclass" text="\documentclass" insert="\documentclass[%&lt;options%|%>]{%&lt;class%>}"/>
   <insert id="usepackage" text="\usepackage{}" insert="\usepackage[%&lt;options%>]{%&lt;package%|%>}"/>
-  <insert id="amspackages" text="AMS packages" insert="\usepackage{amsmath}%\\usepackage{amssymb}" info="The main American Mathematical Society packages"/>
+  <insert id="amspackages" text="AMS packages" insert="\usepackage{mathtools}%\\usepackage{amssymb}%\\usepackage{amsthm}" info="The main American Mathematical Society packages"/>
   <insert id="document" text="\begin{document}" insert="\begin{document}%\%|%\\end{document}" info="Text is allowed only between \begin{document} and \end{document}."/>
   <insert id="title" text="\title{}" insert="\title{%&lt;title%|%>}" info="The \title command declares text to be the title."/>
   <insert id="author" text="\author{}" insert="\author{%&lt;names%|%>}" info="The \author command declares the author(s), where names is a list of authors separated by \and commands."/>


### PR DESCRIPTION
This PR resolves #3798. The changed menu action will add package mathtools instead of amsmath, and will also add amsthm. Package `amssymb` will still be present (no change).