### PR TITLE
cwl: add `\theH<counter>` to latex-dev.cwl

### DIFF
--- a/completion/class-book.cwl
+++ b/completion/class-book.cwl
@@ -31,6 +31,7 @@ openbib
 \frontmatter#n
 \mainmatter#n
 \backmatter#n
+\theHchapter#*
 \thechapter#*
 \chaptername#n
 \bibname#n

--- a/completion/class-report.cwl
+++ b/completion/class-report.cwl
@@ -27,6 +27,7 @@ fleqn
 openbib
 #endkeyvals
 
+\theHchapter#*
 \thechapter#*
 \chaptername#n
 \bibname#n

--- a/completion/hyperref.cwl
+++ b/completion/hyperref.cwl
@@ -393,26 +393,13 @@ width=##L
 \subsectionautorefname#*
 \subsubsectionautorefname#*
 \tableautorefname#*
+# most \theH<counter> are now in the format
 \theHchapter#*
-\theHenumi#*
-\theHenumii#*
-\theHenumiii#*
-\theHenumiv#*
-\theHequation#*
-\theHfigure#*
 \theHHfootnote#*
 \theHHmpfootnote#*
 \theHItem#*
-\theHmpfootnote#*
-\theHparagraph#*
-\theHpart#*
-\theHsection#*
-\theHsubparagraph#*
-\theHsubsection#*
-\theHsubsubsection#*
-\theHtable#*
 \theHtheorem#*
-\theHthm#* 
+\theHthm#*
 \theoremautorefname#*
 \unichar{char num}#*
 \XeTeXLinkBox{contents}#*

--- a/completion/latex-dev.cwl
+++ b/completion/latex-dev.cwl
@@ -445,6 +445,25 @@ debug={%<options%>}
 \thetable#*
 \thetotalpages#*
 
+\theHenumi#*
+\theHenumii#*
+\theHenumiii#*
+\theHenumiv#*
+\theHequation#*
+\theHfigure#*
+\theHfootnote#*
+# \theHmpfn#*
+\theHmpfootnote#*
+# \theHpage#*
+\theHparagraph#*
+\theHpart#*
+\theHsection#*
+\theHsubparagraph#*
+\theHsubsection#*
+\theHsubsubsection#*
+\theHtable#*
+# \theHtotalpages#*
+
 # boxes
 \savebox{box}[width][position]{text}#*
 \savebox{box}[width]{text}#*


### PR DESCRIPTION
For now `\theHchapter` is only added to the standard `report` and `book` classes, and kept in `hyperref.cwl`.

Not sure if it's wanted to add all `\theH<counter>` for all new counters defined by `\newcounter` in packages and classes. If so that would take some effort.