### PR TITLE
always highlight log lines with Process started

### DIFF
--- a/src/loghighlighter.cpp
+++ b/src/loghighlighter.cpp
@@ -35,7 +35,7 @@ void LogHighlighter::highlightBlock(const QString &text)
 		setFormat(0, text.length(), LatexLogEntry::textColor(LT_WARNING));
     } else if (text.startsWith(". ") || text.indexOf(rxOnlyDots)==0) {
 		setFormat(0, text.length(), LatexLogEntry::textColor(LT_INFO));
-	} else if (text.indexOf(".tex", 0) != -1 && !text.startsWith("Error:")) {
+	} else if ( ( text.indexOf(".tex", 0) != -1 || text.indexOf(tr("Process started:"), 0) != -1 ) && !text.startsWith("Error:")) {
 		setFormat(0, text.length(), ColorFile);
 	}
 }


### PR DESCRIPTION
This PR aims to improve highlighting of the message log. When you start a LaTeX compile the log shows a green line with the build command. This is because the line contains `.tex` from the file name given (including extension):

![grafik](https://github.com/user-attachments/assets/dedbd1b5-6cc8-41ca-a4a2-700a321a9b82)

But not in all cases a command uses the file name including extension. For example, when you run Biber all log lines are black:

![grafik](https://github.com/user-attachments/assets/129da477-47c0-4fca-b398-e273ebe924cf)

So this PR will change the color to green for all lines, which would be black under the same conditions, but contain `Process started:`:

![grafik](https://github.com/user-attachments/assets/7bb1018a-6420-4f38-87c1-f84f295d201f)

This helps finding quickly the start of the next process.