### PR TITLE
add maximize button to packages help dialog

### DIFF
--- a/src/texdocdialog.cpp
+++ b/src/texdocdialog.cpp
@@ -3,7 +3,7 @@
 #include "utilsUI.h"
 
 TexdocDialog::TexdocDialog(QWidget *parent,Help *obj) :
-	QDialog(parent),
+	QDialog(parent,Qt::Dialog|Qt::WindowMaximizeButtonHint|Qt::WindowCloseButtonHint),
 	ui(new Ui::TexdocDialog),
     openButton(nullptr),
     help(obj)


### PR DESCRIPTION
@tmelorc mentioned this as a wish [here](https://github.com/texstudio-org/texstudio/pull/3478#issuecomment-1897383484)

![grafik](https://github.com/user-attachments/assets/aef5db35-bdeb-499c-ae01-35eda868eb6c)

I didn't made the Minimize Button available, since you can't switch to the main txs window. So this could prevent some confusion.