### PR TITLE
TexDoc dialog: check all packages option without packages present

### DIFF
--- a/src/help.cpp
+++ b/src/help.cpp
@@ -18,17 +18,25 @@ Help::Help(QObject *parent): QObject(parent),texDocSystem(0)
  */
 void Help::execTexdocDialog(const QStringList &packages, const QString &defaultPackage)
 {
-    TexdocDialog dialog(nullptr,this);
+	bool lastState;
+	lastState = mShowAllPackages;
+	TexdocDialog dialog(nullptr,this);
 	dialog.setPackageNames(packages);
+	if (packages.count()==0) {
+		mShowAllPackages = true;
+	}
+	dialog.setShowAllPackages(mShowAllPackages);
 	if (!defaultPackage.isEmpty()) {
 		dialog.setPreferredPackage(defaultPackage);
-    }else{
-        dialog.setShowAllPackages(mShowAllPackages);
-    }
+	}
 	if (dialog.exec()) {
 		viewTexdoc(dialog.selectedPackage());
 	}
-    mShowAllPackages=dialog.showAllPackages();
+	if (packages.count()>0) {
+		mShowAllPackages = dialog.showAllPackages();
+	} else {
+		mShowAllPackages = lastState;
+	}
 }
 /*!
  * \brief run texdoc --view package

--- a/src/texdocdialog.cpp
+++ b/src/texdocdialog.cpp
@@ -182,9 +182,7 @@ void TexdocDialog::itemChanged(QTableWidgetItem* item)
 void TexdocDialog::setPackageNames(const QStringList &packages)
 {
     m_packages=packages;
-    if (m_packages.count()==0){
-        ui->cbShowAllPackages->setChecked(true); // regenerateTable will be called by the stateChanged signal
-    }else{
+    if (m_packages.count()>0){
         regenerateTable();
     }
 }


### PR DESCRIPTION
This PR brings back following functionality (discussion https://github.com/texstudio-org/texstudio/pull/3478#issuecomment-1915874683, lost by 277e8c87850b01deab0c7ebb8062a1ae8aacf434): When txs starts without any documents the Package help (TexDoc) dialog should automatically check option `all packages`. Otherwise you have to do so manually before you can search anything. As a side effect this fixes that the packages list is emtpy although the documentation of a0poster is presented.