### PR TITLE
fix pdf-viewer scroll bar

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -2149,6 +2149,7 @@ void PDFWidget::setGridSize(int gx, int gy, bool setAsDefault)
 	getScrollArea()->goToPage(realPageIndex);
 	if (pi == realPageIndex)
 		reloadPage();
+	emit changedScaleOption(scaleOption);
 	//update();
 }
 
@@ -4465,8 +4466,14 @@ void PDFDocument::adjustScaleActions(autoScaleOption scaleOption)
 	} else if (scaleOption == kFitWindow) {
 		if (scrollArea->horizontalScrollBarPolicy() != Qt::ScrollBarAlwaysOff)
 			scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-		if (scrollArea->verticalScrollBarPolicy() != Qt::ScrollBarAlwaysOff)
-			scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+		if (scrollArea->getContinuous()) {
+			if (scrollArea->verticalScrollBarPolicy() != Qt::ScrollBarAlwaysOn)
+				scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+		}
+		else {
+			if (scrollArea->verticalScrollBarPolicy() != Qt::ScrollBarAlwaysOff)
+				scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+		}
 	} else {
 		if (scrollArea->horizontalScrollBarPolicy() != Qt::ScrollBarAsNeeded)
 			scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);


### PR DESCRIPTION
This fixes following (and may also resolve #2463):

1.	Start windowed viewer showing a pdf with 5 or more pages
2.	Set checked 100%
3.	Clear continuous
4.	Set checked fit to width
5.	Choose window size such that no vertical scroll bar is necessary:
    ![grafik](https://github.com/user-attachments/assets/9c567a54-1e67-4cd2-b733-cd46f88697b0)
6.	Set checked continuous, as expected a vert. scroll bar appears:
    ![grafik](https://github.com/user-attachments/assets/d36b42ea-4359-4e22-b717-94a0786f1df9)
7.	Clear continuous, other than expected the scroll bar isn’t removed:
    ![grafik](https://github.com/user-attachments/assets/32bf15fb-beeb-44f6-92fb-c682e4ecfb8e)
8.	Clear fit to width, size doesn’t fit exactly (but as expected):
    ![grafik](https://github.com/user-attachments/assets/1dc37688-5dde-49d9-899a-6a2824dd2fe0)
9.	Set checked fit to width, now result is as expected in 7.:
    ![grafik](https://github.com/user-attachments/assets/6ed0a37e-a01d-4c72-8fc6-7f176f0611ef)

Repeating the procedure from 1. to 8. but using fit to window instead of fit to width is even worth:
At 6., 7. and 8. no vert. scroll bar appears (but size always fits). Skip 9.

10. Set checked  continuous, scroll bar appears:
     ![grafik](https://github.com/user-attachments/assets/b4377a58-e8c0-4f55-8f4c-138f086c3a7e)
11. Set checked fit to window, some resizing happens:
     ![grafik](https://github.com/user-attachments/assets/8c37311e-dbed-4711-8280-3016933154bf)
12. Clear continuous, other than expected the scroll bar isn’t removed:
     ![grafik](https://github.com/user-attachments/assets/df0bf79b-75ef-4eb8-a6b2-798138d6e87b)
13. Same as 8.
14. Same as 9.
