### PR TITLE
pdf-viewer: fix Custom Grid preset values

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -3800,8 +3800,8 @@ void PDFDocument::setGrid()
 	QString gs = sender()->property("grid").toString();
 	if (gs == "xx") {
 		UniversalInputDialog d;
-        int x = pdfWidget->gridCols();
-        int y = pdfWidget->gridRows();
+        int x = pdfWidget->gridCols(true);
+        int y = pdfWidget->gridRows(true);
 		d.addVariable(&x , "X-Grid:");
 		d.addVariable(&y , "Y-Grid:");
 		if (d.exec()) {


### PR DESCRIPTION
since continuous mode changes current values the dialog needs to be preset with the original (config) values