### PR TITLE
make menu entries Show embedded PDF large/small consistent

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -2880,7 +2880,10 @@ PDFDocument::PDFDocument(PDFDocumentConfig *const pdfConfig, bool embedded)
     if (embeddedMode && globalConfig->autoHideToolbars) {
         setAutoHideToolbars(true);
     }
-
+    ConfigManager *configManager=dynamic_cast<ConfigManager *>(ConfigManager::getInstance());
+    if(!configManager) return;
+    bool enlarged=configManager->viewerEnlarged;
+    setVisibleMenuEntriesEnlargeShrink(embeddedMode && !enlarged, embeddedMode && enlarged);
 }
 
 PDFDocument::~PDFDocument()
@@ -2890,6 +2893,10 @@ PDFDocument::~PDFDocument()
     ConfigManager *configManager=dynamic_cast<ConfigManager *>(ConfigManager::getInstance());
 
     if(configManager){
+        if (embeddedMode) {
+            QAction *act=configManager->getManagedAction("main/view/enlargePDF");
+            setVisibleMenuEntriesEnlargeShrink(false, false);
+        }
 #if (QT_VERSION > 0x050000) && (QT_VERSION <= 0x050700) && (defined(Q_OS_MAC))
         QList<QKeySequence> keys=configManager->specialShortcuts.keys();
         foreach(QKeySequence key,keys){
@@ -3774,6 +3781,10 @@ void PDFDocument::runInternalViewer()
 
 void PDFDocument::toggleEmbedded()
 {
+	ConfigManager *configManager=dynamic_cast<ConfigManager *>(ConfigManager::getInstance());
+	if(!configManager) return;
+	bool enlarged=configManager->viewerEnlarged;
+	setVisibleMenuEntriesEnlargeShrink(!embeddedMode && !enlarged, !embeddedMode && enlarged);
 	if (embeddedMode)
 		emit runCommand("txs:///view-pdf-internal --windowed --close-embedded", masterFile, QFileInfo(lastSyncPoint.filename), lastSyncPoint.line);
 	else
@@ -3855,6 +3866,7 @@ void PDFDocument::setStateEnlarged(bool state)
 {
     actionEnlargeViewer->setVisible(!state);
     actionShrinkViewer->setVisible(state);
+    setVisibleMenuEntriesEnlargeShrink(!state, state);
 }
 
 /*!
@@ -4876,6 +4888,16 @@ void PDFDocument::splitMergeTool()
     PDFSplitMergeTool *psmt = new PDFSplitMergeTool(nullptr, fileName());
     connect(psmt, SIGNAL(runCommand(QString,QFileInfo,QFileInfo,int)), SIGNAL(runCommand(QString,QFileInfo,QFileInfo,int)));
 	psmt->show();
+}
+
+void PDFDocument::setVisibleMenuEntriesEnlargeShrink(bool visibleEnlarge, bool visibleShrink)
+{
+    ConfigManager *configManager=dynamic_cast<ConfigManager *>(ConfigManager::getInstance());
+    if(!configManager) return;
+    QAction *act=configManager->getManagedAction("main/view/enlargePDF");
+    act->setVisible(visibleEnlarge);
+    act=configManager->getManagedAction("main/view/shrinkPDF");
+    act->setVisible(visibleShrink);
 }
 
 #endif  // ndef NO_POPPLER_PREVIEW

--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -2880,10 +2880,6 @@ PDFDocument::PDFDocument(PDFDocumentConfig *const pdfConfig, bool embedded)
     if (embeddedMode && globalConfig->autoHideToolbars) {
         setAutoHideToolbars(true);
     }
-    ConfigManager *configManager=dynamic_cast<ConfigManager *>(ConfigManager::getInstance());
-    if(!configManager) return;
-    bool enlarged=configManager->viewerEnlarged;
-    setVisibleMenuEntriesEnlargeShrink(embeddedMode && !enlarged, embeddedMode && enlarged);
 }
 
 PDFDocument::~PDFDocument()
@@ -2893,10 +2889,6 @@ PDFDocument::~PDFDocument()
     ConfigManager *configManager=dynamic_cast<ConfigManager *>(ConfigManager::getInstance());
 
     if(configManager){
-        if (embeddedMode) {
-            QAction *act=configManager->getManagedAction("main/view/enlargePDF");
-            setVisibleMenuEntriesEnlargeShrink(false, false);
-        }
 #if (QT_VERSION > 0x050000) && (QT_VERSION <= 0x050700) && (defined(Q_OS_MAC))
         QList<QKeySequence> keys=configManager->specialShortcuts.keys();
         foreach(QKeySequence key,keys){
@@ -3781,10 +3773,6 @@ void PDFDocument::runInternalViewer()
 
 void PDFDocument::toggleEmbedded()
 {
-	ConfigManager *configManager=dynamic_cast<ConfigManager *>(ConfigManager::getInstance());
-	if(!configManager) return;
-	bool enlarged=configManager->viewerEnlarged;
-	setVisibleMenuEntriesEnlargeShrink(!embeddedMode && !enlarged, !embeddedMode && enlarged);
 	if (embeddedMode)
 		emit runCommand("txs:///view-pdf-internal --windowed --close-embedded", masterFile, QFileInfo(lastSyncPoint.filename), lastSyncPoint.line);
 	else
@@ -3866,7 +3854,6 @@ void PDFDocument::setStateEnlarged(bool state)
 {
     actionEnlargeViewer->setVisible(!state);
     actionShrinkViewer->setVisible(state);
-    setVisibleMenuEntriesEnlargeShrink(!state, state);
 }
 
 /*!
@@ -4888,16 +4875,6 @@ void PDFDocument::splitMergeTool()
     PDFSplitMergeTool *psmt = new PDFSplitMergeTool(nullptr, fileName());
     connect(psmt, SIGNAL(runCommand(QString,QFileInfo,QFileInfo,int)), SIGNAL(runCommand(QString,QFileInfo,QFileInfo,int)));
 	psmt->show();
-}
-
-void PDFDocument::setVisibleMenuEntriesEnlargeShrink(bool visibleEnlarge, bool visibleShrink)
-{
-    ConfigManager *configManager=dynamic_cast<ConfigManager *>(ConfigManager::getInstance());
-    if(!configManager) return;
-    QAction *act=configManager->getManagedAction("main/view/enlargePDF");
-    act->setVisible(visibleEnlarge);
-    act=configManager->getManagedAction("main/view/shrinkPDF");
-    act->setVisible(visibleShrink);
 }
 
 #endif  // ndef NO_POPPLER_PREVIEW

--- a/src/pdfviewer/PDFDocument.h
+++ b/src/pdfviewer/PDFDocument.h
@@ -565,6 +565,7 @@ private:
     void setupToolBar();
 	void setCurrentFile(const QString &fileName);
 	void loadSyncData();
+	void setVisibleMenuEntriesEnlargeShrink(bool visibleEnlarge, bool visibleShrink);
 
 	qreal zoomSliderPosToScale(int pos);
 	int scaleToZoomSliderPos(qreal scale);

--- a/src/pdfviewer/PDFDocument.h
+++ b/src/pdfviewer/PDFDocument.h
@@ -565,7 +565,6 @@ private:
     void setupToolBar();
 	void setCurrentFile(const QString &fileName);
 	void loadSyncData();
-	void setVisibleMenuEntriesEnlargeShrink(bool visibleEnlarge, bool visibleShrink);
 
 	qreal zoomSliderPosToScale(int pos);
 	int scaleToZoomSliderPos(qreal scale);

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -1403,9 +1403,8 @@ void Texstudio::setupMenus()
         }
     }
 
-	newManagedAction(menu, "enlargePDF", tr("Show embedded PDF large"), SLOT(enlargeEmbeddedPDFViewer()));
-	newManagedAction(menu, "shrinkPDF", tr("Show embedded PDF small"), SLOT(shrinkEmbeddedPDFViewer()));
-
+	newManagedAction(menu, "enlargePDF", tr("Show embedded PDF large"), SLOT(enlargeEmbeddedPDFViewer()))->setVisible(false);
+	newManagedAction(menu, "shrinkPDF", tr("Show embedded PDF small"), SLOT(shrinkEmbeddedPDFViewer()))->setVisible(false);
 	newManagedAction(menu, "closeelement", tr("Close Element"), SLOT(viewCloseElement()), Qt::Key_Escape);
 
 	menu->addSeparator();

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -1404,9 +1404,9 @@ void Texstudio::setupMenus()
     }
 
 	act=newManagedAction(menu, "enlargePDF", tr("Show embedded PDF large"), SLOT(enlargeEmbeddedPDFViewer()));
-	act->setVisible(false);
+	act->setEnabled(false);
 	act=newManagedAction(menu, "shrinkPDF", tr("Show embedded PDF small"), SLOT(shrinkEmbeddedPDFViewer()));
-	act->setVisible(false);
+	act->setEnabled(false);
 	newManagedAction(menu, "closeelement", tr("Close Element"), SLOT(viewCloseElement()), Qt::Key_Escape);
 
 	menu->addSeparator();
@@ -6216,6 +6216,7 @@ void Texstudio::runInternalPdfViewer(const QFileInfo &master, const QString &opt
 			viewer->setStateEnlarged(true);
             centralVSplitter->hide();
 		}
+		setEnabledMenusEnlargeShrink(viewer->embeddedMode && !configManager.viewerEnlarged, viewer->embeddedMode && configManager.viewerEnlarged);
 
 		if (preserveDuplicates) break;
 	}
@@ -7740,6 +7741,7 @@ void Texstudio::pdfClosed()
 	PDFDocument *from = qobject_cast<PDFDocument *>(sender());
 	if (from) {
 		if (from->embeddedMode) {
+			setEnabledMenusEnlargeShrink(false, false);
 			shrinkEmbeddedPDFViewer(true);
 			QList<int> sz = mainHSplitter->sizes(); // set widths to 50%, eventually restore user setting
 			int sum = 0;
@@ -11380,6 +11382,7 @@ void Texstudio::enlargeEmbeddedPDFViewer()
 	enlargedViewer=true;
 	pdfConfig->followFromScroll=false;
 	viewer->setStateEnlarged(true);
+	setEnabledMenusEnlargeShrink(false, true);
 #endif
 }
 /*!
@@ -11404,9 +11407,18 @@ void Texstudio::shrinkEmbeddedPDFViewer(bool preserveConfig)
 		enlargedViewer=false;
 	}
 	viewer->setStateEnlarged(false);
+	setEnabledMenusEnlargeShrink(true, false);
 #else
 	Q_UNUSED(preserveConfig)
 #endif
+}
+
+void Texstudio::setEnabledMenusEnlargeShrink(bool enabledEnlarge, bool enabledShrink)
+{
+	QAction *act=configManager.getManagedAction("main/view/enlargePDF");
+	act->setEnabled(enabledEnlarge);
+	act=configManager.getManagedAction("main/view/shrinkPDF");
+	act->setEnabled(enabledShrink);
 }
 
 void Texstudio::showStatusbar()

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -1403,8 +1403,10 @@ void Texstudio::setupMenus()
         }
     }
 
-	newManagedAction(menu, "enlargePDF", tr("Show embedded PDF large"), SLOT(enlargeEmbeddedPDFViewer()))->setVisible(false);
-	newManagedAction(menu, "shrinkPDF", tr("Show embedded PDF small"), SLOT(shrinkEmbeddedPDFViewer()))->setVisible(false);
+	act=newManagedAction(menu, "enlargePDF", tr("Show embedded PDF large"), SLOT(enlargeEmbeddedPDFViewer()));
+	act->setVisible(false);
+	act=newManagedAction(menu, "shrinkPDF", tr("Show embedded PDF small"), SLOT(shrinkEmbeddedPDFViewer()));
+	act->setVisible(false);
 	newManagedAction(menu, "closeelement", tr("Close Element"), SLOT(viewCloseElement()), Qt::Key_Escape);
 
 	menu->addSeparator();

--- a/src/texstudio.h
+++ b/src/texstudio.h
@@ -560,6 +560,7 @@ protected slots:
 	void focusViewer();
 	void enlargeEmbeddedPDFViewer();
 	void shrinkEmbeddedPDFViewer(bool preserveConfig = false);
+	void setEnabledMenusEnlargeShrink(bool enabledEnlarge, bool enabledShrink);
 
 	void showStatusbar();
 	void viewCloseElement();


### PR DESCRIPTION
This PR adresses following two menu entries:

![grafik](https://github.com/user-attachments/assets/ce5a032e-b372-4b53-903f-0891b2a29a4a)

Both actions are always enabled even when there is no pdf-viewer at all or the viewer is not embedded. When the viewer is emedded exactly one of the entries should be enabled. So we have three cases:

+ no (embedded) viewer:
  ![grafik](https://github.com/user-attachments/assets/0213eeb6-0f44-4869-bb53-2ebd0a6c6e83)
+ small embedded viewer:
  ![grafik](https://github.com/user-attachments/assets/66d2fb30-ee24-4199-81cd-7567e9bf9de0)
+ large embedded viewer
  ![grafik](https://github.com/user-attachments/assets/f330e199-1885-4699-913e-69ff7f1db486)


