### PR TITLE
make grid options and two others available to the embedded pdf-viewer

### DIFF
--- a/src/pdfviewer/PDFDocument.h
+++ b/src/pdfviewer/PDFDocument.h
@@ -182,7 +182,7 @@ public:
 	explicit PDFWidget(bool embedded = false);
 	virtual ~PDFWidget();
 
-	void setDocument(const QSharedPointer<Poppler::Document> &doc);
+	void setDocument(const QSharedPointer<Poppler::Document> &doc, bool embedded);
 	void setPDFDocument(PDFDocument *docu);
 
 	void saveState(); // used when toggling full screen mode
@@ -232,6 +232,14 @@ public:
 	Q_INVOKABLE void zoom(qreal scale);
 
 	virtual void wheelEvent(QWheelEvent *event);
+	int getGridxEmbedded() {return gridxEmbedded;};
+	int getGridyEmbedded() {return gridyEmbedded;};
+	int getPageOffsetEmbedded() {return pageOffsetEmbedded;};
+	bool getSinglePageStepEmbedded() {return singlePageStepEmbedded;};
+	void setGridxEmbedded(int x) {gridxEmbedded=x;};
+	void setGridyEmbedded(int y) {gridyEmbedded=y;};
+	void setPageOffsetEmbedded(int o) {pageOffsetEmbedded=o;};
+	void setSinglePageStepEmbedded(bool s) {singlePageStepEmbedded=s;};
 
 protected slots: //not private, so scripts have access
 	void goFirst();
@@ -324,7 +332,6 @@ private:
 	QSharedPointer<Poppler::Document> document;
 	QMutex textwidthCalculationMutex;
 
-	//QList<int> pages;
 	QSharedPointer<Poppler::Link> clickedLink;
 	QSharedPointer<Poppler::Annotation> clickedAnnotation;
 
@@ -363,9 +370,10 @@ private:
 #endif
 	int		currentTool;	// the current tool selected in the toolbar
 	int		usingTool;	// the tool actually being used in an ongoing mouse drag
-	bool		singlePageStep;
+	bool	singlePageStep, singlePageStepEmbedded;
 
 	int gridx, gridy, pageOffset;
+	int gridxEmbedded, gridyEmbedded, pageOffsetEmbedded;
 
 	bool forceUpdate;
 
@@ -561,8 +569,8 @@ signals:
 
 private:
 	void init(bool embedded = false);
-    void setupMenus(bool embedded);
-    void setupToolBar();
+	void setupMenus(bool embedded);
+	void setupToolBar(bool embedded);
 	void setCurrentFile(const QString &fileName);
 	void loadSyncData();
 
@@ -675,6 +683,7 @@ private:
 
     QStatusBar *statusbar;
     QToolBar *toolBar;
+    QToolBar *tbPdfView;
     QTimer *toolBarTimer;
 public:
 	QMenu *menuShow;


### PR DESCRIPTION
Happy new year!

This PR resolves #222 (enhancement request). The changes add tool button `Grid` to the tool bar of the embedded pdf-viewer. The tool button offers known options from the main menu `View` of the windowed pdf-viewer. The button menu looks like this:

![grafik](https://github.com/user-attachments/assets/1e4c6d7b-f965-4755-9b6f-8aaa94f1661e)

This may often allow working without the windowed pdf-viewer. For example, you could choose grid `2x1` and option `Fit to Window`. If you want to take a closer look at the pdf, you can expand the viewer to the left (and later on shrink it to the right) with the button Enlarge Viewer ![grafik](https://github.com/user-attachments/assets/fb929dde-e85e-4836-8337-1d0f41827dd1) to the right of the tool bar. On large screens it may suffice to enlarge the texstudio window.

![gridAnimation](https://github.com/user-attachments/assets/d2b4d394-d6aa-449b-bad9-b689ef1c3d15)

![Grid4x1continuous](https://github.com/user-attachments/assets/329ae9b1-689f-4537-99b9-4919086ab860)

Following assertions hold:

1. A new embedded viewer (or a windowed viewer getting embedded) always sets the options as shown in the image (including Fit to Width).  These are the ones used before this PR (c.f. [#3554#issuecomment-2001989472](https://github.com/texstudio-org/texstudio/pull/3554#issuecomment-2001989472)).
2. Only the windowed viewer saves and restores previously set options.
3. These options of embedded and windowed viewer do not interfere.

Previous PR is #3554.
