### PR TITLE
Cwls

### DIFF
--- a/completion.qrc
+++ b/completion.qrc
@@ -319,6 +319,7 @@
 <file>completion/beamerthemeTUDa.cwl</file>
 <file>completion/beamerthemeVerona.cwl</file>
 <file>completion/beamerthemeXiaoshan.cwl</file>
+<file>completion/beamertools.cwl</file>
 <file>completion/bearwear.cwl</file>
 <file>completion/begingreek.cwl</file>
 <file>completion/begriff.cwl</file>
@@ -523,6 +524,7 @@
 <file>completion/CascadiaCodePL.cwl</file>
 <file>completion/CascadiaMono.cwl</file>
 <file>completion/CascadiaMonoPL.cwl</file>
+<file>completion/cascadiamono-otf.cwl</file>
 <file>completion/cas-common.cwl</file>
 <file>completion/cases.cwl</file>
 <file>completion/casiofont.cwl</file>
@@ -1563,6 +1565,7 @@
 <file>completion/filemod.cwl</file>
 <file>completion/filemod-expmin.cwl</file>
 <file>completion/filesdo.cwl</file>
+<file>completion/fillpages.cwl</file>
 <file>completion/fillwith.cwl</file>
 <file>completion/finstrut.cwl</file>
 <file>completion/firamath-otf.cwl</file>
@@ -1695,6 +1698,7 @@
 <file>completion/gensymb.cwl</file>
 <file>completion/gentiumbook.cwl</file>
 <file>completion/gentium.cwl</file>
+<file>completion/gentium-otf.cwl</file>
 <file>completion/gentombow.cwl</file>
 <file>completion/geometry.cwl</file>
 <file>completion/german.cwl</file>
@@ -1985,6 +1989,7 @@
 <file>completion/iwonamath.cwl</file>
 <file>completion/jamtimes.cwl</file>
 <file>completion/javascripthttp.cwl</file>
+<file>completion/jetbrainsmono-otf.cwl</file>
 <file>completion/JeuxCartes.cwl</file>
 <file>completion/jiazhu.cwl</file>
 <file>completion/jigsaw.cwl</file>

--- a/completion/beamertools.cwl
+++ b/completion/beamertools.cwl
@@ -1,0 +1,15 @@
+# beamertools package
+# Matthew Bertucci 2025/01/13 for v0.1
+
+\redefbeamertemplate<mode specification>*{element name}{predefined option}[argument number][default optional argument]{predefined text}[action]{action command}
+\redefbeamertemplate<mode specification>*{element name}{predefined option}[default optional argument]{predefined text}[action]{action command}
+\redefbeamertemplate<mode specification>*{element name}{predefined option}{predefined text}[action]{action command}
+\redefbeamertemplate<mode specification>*{element name}{predefined option}[argument number][default optional argument]{predefined text}
+\redefbeamertemplate<mode specification>*{element name}{predefined option}[argument number]{predefined text}
+\redefbeamertemplate<mode specification>*{element name}{predefined option}{predefined text}
+\redefbeamertemplate{element name}{predefined option}[argument number][default optional argument]{predefined text}[action]{action command}
+\redefbeamertemplate{element name}{predefined option}[default optional argument]{predefined text}[action]{action command}
+\redefbeamertemplate{element name}{predefined option}{predefined text}[action]{action command}
+\redefbeamertemplate{element name}{predefined option}[argument number][default optional argument]{predefined text}
+\redefbeamertemplate{element name}{predefined option}[argument number]{predefined text}
+\redefbeamertemplate{element name}{predefined option}{predefined text}

--- a/completion/cascadiamono-otf.cwl
+++ b/completion/cascadiamono-otf.cwl
@@ -1,0 +1,14 @@
+# cascadiamono-otf package
+# Matthew Bertucci 2025/01/13 for v0.3
+
+#include:xkeyval
+#include:fontspec
+
+\cascadiamono
+\cascadiamonosemilight
+\cascadiamonolight
+\cascadiamonoextralight
+\cascadiacode
+\cascadiacodesemilight
+\cascadiacodelight
+\cascadiacodeextralight

--- a/completion/class-elsarticle.cwl
+++ b/completion/class-elsarticle.cwl
@@ -1,5 +1,5 @@
 # elsarticle class
-# Matthew Bertucci 3/22/2022 for v3.3
+# Matthew Bertucci 2025/01/12 for v3.4c
 
 #include:etoolbox
 #include:graphicx
@@ -263,7 +263,6 @@ abstract
 \stmexpandonce{arg}#*
 \textmarker{color}{text}#*
 \theaffn#*
-\theauthor#*
 \thecnote#*
 \theead#*
 \thefnote#*

--- a/completion/class-xdupgthesis.cwl
+++ b/completion/class-xdupgthesis.cwl
@@ -1,5 +1,5 @@
 # xdupgthesis class
-# Matthew Bertucci 2023/03/05 for v6.1.0.1
+# Matthew Bertucci 2025/01/13 for v6.2.3.1
 
 #include:l3keys2e
 #include:class-ctexbook
@@ -102,7 +102,6 @@ info/supv-ent-title*={%<校外导师职称英文名称%>}
 info/student-id={%<作者学号%>}
 info/clc={%<中图分类号%>}
 info/secret-level=#秘密,公开
-info/secret-year={%<保密年限%>}
 info/submit-date={%<yyyy-mm%>}
 info/statement-scan={%<学位论文独创性声明和关于论文使用授权的说明页扫描文件路径%>}
 info/statement-sign={%<文件路径1,文件路径2,文件路径3,文件路径4,文件路径5,文件路径6%>}

--- a/completion/fillpages.cwl
+++ b/completion/fillpages.cwl
@@ -1,0 +1,7 @@
+# fillpages package
+# Matthew Bertucci 2025/01/13 for v1.0.1
+
+\pagesDivisibleBy{number}
+\pagesDivisibleBy{number}[offset]
+\setFillPage{number}{content%text}
+\insertFillPages

--- a/completion/gentium-otf.cwl
+++ b/completion/gentium-otf.cwl
@@ -1,0 +1,46 @@
+# gentium-otf package
+# Matthew Bertucci 2025/01/13 for v0.01
+
+#include:iftex
+#include:xkeyval
+#include:fontspec
+
+#keyvals:\usepackage/gentium-otf#c
+book
+ScaleRM=%<factor%>
+math=%<font name%>
+mathFeatures={%<fontspec features%>}
+sans=%<font name%>
+sansFeatures={%<fontspec features%>}
+mono=%<font name%>
+monoFeatures={%<fontspec features%>}
+defaultfeatures={%<fontspec features%>}
+#endkeyvals
+
+\Lctosc{text}
+\LCtoSC-
+\LCtoSC+
+\Lctosmcp{text}
+\LCtoSMCP-
+\LCtoSMCP+
+\Lliga{text}
+\LLIGA-
+\LLIGA+
+\Lss{num1}{num2}{text}
+\LSS{num1}{num2}
+\Lcv{num1}{num2}{text}
+\LCV{num1}{num2}
+\Lcv[opt]{num1}{num2}{text}
+\LCV[opt]{num1}{num2} 
+\Lsup{text}
+\LSUP-
+\LSUP+
+\Lsub{text}
+\LSUB-
+\LSUB+
+\Lfrac{fraction}
+\LFRAC-
+\LFRAC+
+
+# not documented
+\Llang{arg}#S

--- a/completion/jetbrainsmono-otf.cwl
+++ b/completion/jetbrainsmono-otf.cwl
@@ -1,0 +1,16 @@
+# jetbrainsmono-otf package
+# Matthew Bertucci 2025/01/13 for v0.1
+
+#include:xkeyval
+#include:fontspec
+
+\jetbrainsmono
+\jetbrainsmonoextralight
+\jetbrainsmonolight
+\jetbrainsmonomedium
+\jetbrainsmonothin
+\jetbrainscode
+\jetbrainscodeextralight
+\jetbrainscodelight
+\jetbrainscodemedium
+\jetbrainscodethin

--- a/completion/jsonparse.cwl
+++ b/completion/jsonparse.cwl
@@ -1,5 +1,5 @@
 # jsonparse package
-# Matthew Bertucci 2024/11/29 for v0.9.8
+# Matthew Bertucci 2025/01/16 for v0.9.11
 
 \JSONParse{token variable%cmd}{JSON string}#d
 \JSONParse[options%keyvals]{token variable%cmd}{JSON string}#d
@@ -32,6 +32,8 @@
 \JSONParseArrayKey
 \JSONParseArrayValue
 \JSONParseArrayCount{token variable}{key%plain}
+\JSONParseSetArrayCount{token variable%cmd}{token variable}{key%plain}#d
+\JSONParseArrayMapInline{token variable}{key%plain}{inline function}
 \JSONParseSet{keyvals}
 
 ## global

--- a/completion/libertinus-type1.cwl
+++ b/completion/libertinus-type1.cwl
@@ -1,5 +1,5 @@
 # libertinus-type1 package
-# Matthew Bertucci 2024/09/23
+# Matthew Bertucci 2025/01/13
 
 #include:ifxetex
 #include:ifluatex
@@ -44,6 +44,7 @@ ScaleTT=%<factor%>
 \LibertinusSansLF
 \LibertinusMono
 \LibertinusKeyboard
+\libertinusDisplay
 \libertinusseriflgr#*
 \libertinussanslgr#*
 \sufigures

--- a/completion/plantuml.cwl
+++ b/completion/plantuml.cwl
@@ -1,5 +1,5 @@
 # plantuml package
-# Matthew Bertucci 2024/09/18 for v0.4.0
+# Matthew Bertucci 2025/01/13 for v0.5.0
 
 #include:adjustbox
 #include:fancyvrb
@@ -12,6 +12,7 @@
 \begin{plantuml}
 \end{plantuml}
 
+\CurrentDirectory#S
 \PlantUMLJobname#S
 \PlantUmlMode#S
 \maxwidth{width}#S

--- a/completion/schooldocs.cwl
+++ b/completion/schooldocs.cwl
@@ -1,10 +1,10 @@
 # schooldocs package
-# Matthew Bertucci 2024/02/01 for v1.5
+# Matthew Bertucci 2025/01/16 for v1.6
 
 #include:geometry
 #include:fancyhdr
 #include:ifthen
-#include:lastpage
+#include:totpages
 #include:fancybox
 #include:xcolor
 #include:translations

--- a/completion/simpleicons.cwl
+++ b/completion/simpleicons.cwl
@@ -1,5 +1,5 @@
 # simpleicons package
-# Matthew Bertucci 2024/12/28 for v14.0.0
+# Matthew Bertucci 2025/01/13 for v14.1.0
 
 #include:iftex
 
@@ -613,6 +613,7 @@ comma
 commerzbank
 commitlint
 commodore
+commonlisp
 commonworkflowlanguage
 compilerexplorer
 composer
@@ -1900,6 +1901,7 @@ nextflow
 nextra
 nextui
 nexusmods
+nfcore
 nfc
 nginx
 nginxproxymanager

--- a/completion/skeldoc.cwl
+++ b/completion/skeldoc.cwl
@@ -1,5 +1,5 @@
 # skeldoc package
-# Matthew Bertucci 2022/07/20 for v0.1.2
+# Matthew Bertucci 2025/01/16 for v0.1.3
 
 #include:xcolor
 #include:tabularx
@@ -45,6 +45,8 @@ bib-item-lines=%<integer%>
 pseudo-lines=%<integer%>
 pseudo-head=
 pseudo-newlines={%<cmd1,cmd2,...%>}
+hide-notes#true,false
+hide-all
 #endkeyvals
 
 \skelline


### PR DESCRIPTION
New cwls for `beamertools`, `cascadiamono-otf`, `fillpages`, `gentium-otf`, and `jetbrainsmono-otf`. Several updated cwls