### PR TITLE
fix pages/grid after switching single page step

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -2265,7 +2265,8 @@ void PDFWidget::setSinglePageStep(bool step)
 		return;
 	singlePageStep = step;
 	getScrollArea()->goToPage(realPageIndex);
-    delayedUpdate();
+	reloadPage();
+	getScrollArea()->updateScrollBars();
 }
 
 void PDFWidget::goFirst()

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -12,6 +12,7 @@
 - fix pdf-viewer's scrollbar with Fit to Width/Window and changing Continuous mode [#3928](https://github.com/texstudio-org/texstudio/pull/3928)
 - fix pdf-viewer's Custom Grid dialog not preset with current Grid settings in Continuous mode [#3929](https://github.com/texstudio-org/texstudio/pull/3929)
 - fix pfd-viewer's page display in non continuous mode [3952](https://github.com/texstudio-org/texstudio/pull/3952)
+- fix pdf-viewer has a small issue when activating single page step [3957](https://github.com/texstudio-org/texstudio/pull/3957)
 - add maximize button to Packages Help (Texdoc) dialog [#3911](https://github.com/texstudio-org/texstudio/pull/3911)
 - fix option 'all packages' no longer checked in Packages Help with no tex documents opened [#3917](https://github.com/texstudio-org/texstudio/pull/3917)
 - when context menu of a package name is used to open the Packages Help dialog then preset search filter with the name [#3918](https://github.com/texstudio-org/texstudio/pull/3918)


### PR DESCRIPTION
The PR fixes following two cases (alway start with non singlePageOffset). Left half of the images from master, right half fixed (s. details in txs window title).

1. Set non continuous, pageOffset>0. Scroll to top. Now setting singlePageStep moves pages and leaves empty grid faces at lower right of the grid:

    ![grafik](https://github.com/user-attachments/assets/dcde4750-c33b-4b03-85af-2cbbda5c3e46)
    click to enlarge

    ![grafik](https://github.com/user-attachments/assets/66aae6b3-0b0f-48db-8831-7cbc612a4d49)
    click to enlarge

    This issue is a direct consequence of fixing calculation of visible pages/pages list #3952. This is fixed with `reloadPage`.

3. Set continuous, pageOffset>0 and last grid row has at most pageOffset many pages (f.ex. gridx=3 and 11 pages). Scroll to end. Then setting singlePageStep moves last pages to previous line and last grid row is empty. Have a close look at the different scrollbars to the left and right. To the left you can sroll down to the empty row. But overscroll should't be possible with continuous. Also, returning back works with fixed version: Switching to non singlePageStep brings back the row on the right side:

    ![grafik](https://github.com/user-attachments/assets/7196d01d-d069-40f4-8981-5a82fc0229ad)
    click to enlarge

    ![grafik](https://github.com/user-attachments/assets/0a41e34b-6d87-43f8-b963-de9dd9903950)
    click to enlarge

    This is fixd with `updateScrollBars`. I see no difference when removing `delayedUpdate`.

