### PR TITLE
faster search of a visible page for the pdf viewer

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -2174,10 +2174,19 @@ int PDFWidget::visiblePages() const
 	if (pages.isEmpty()) return 0;
 	int firstPage = pages.first();
 	int lastPage = pages.last();
+	int page = lastPage;
 	int visibleHeight = getScrollArea()->viewport()->height() - this->y();
-	while (lastPage > firstPage && pageRect(lastPage).top() >= visibleHeight)
-		lastPage--;
-	return lastPage - firstPage + 1;
+	int lowerBound=firstPage+gridx;
+	while (page > firstPage && pageRect(page).top() >= visibleHeight) {
+		if (page>=lowerBound)
+			page-=gridx;
+		else
+			page=firstPage;
+	}
+	int po=getPageOffset();
+	page+=(gridx-1)-(page+po)%gridx;	// page at right end of the same row
+	page=qMin(page,lastPage);
+	return page - firstPage + 1;
 }
 
 int PDFWidget::pseudoNumPages()  const


### PR DESCRIPTION
This PR improves the algorithm of how the visible page with the highest page index is found. It should be nearly a factor of gridx faster. The algorithm uses the fact that all pages of the same row have the same vertical position, i.e. they are aligned vertically. So, instead of checking all pages of each row, the algorithm checks one page per row only. For this pages in the same column are checked (and the first page of the grid if necessary).