### PR TITLE
add "Start Column" to pdfContext/Grid

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -1601,7 +1601,8 @@ void PDFWidget::contextMenuEvent(QContextMenuEvent *event)
 		doZoom(event->pos(), 1);
 	else if (action == ctxZoomOutAction)
 		doZoom(event->pos(), -1);
-
+	else if (action == pdfDoc->actionSetPageOffsetMenu)
+		setPageOffsetClick(event->pos());
 }
 
 bool PDFWidget::event(QEvent *event)
@@ -3114,6 +3115,8 @@ void PDFDocument::setupMenus(bool embedded)
     actionSinglePageStep=configManager->newManagedAction(menuroot,menuGrid, "singlePageStep", tr("Single Page Step"), pdfWidget, SLOT(setSinglePageStep(bool)), QList<QKeySequence>());
     menuGridContext->addAction(actionSinglePageStep);
     menuGridContext->addAction(actionContinuous);
+    menuGridContext->addSeparator();
+    actionSetPageOffsetMenu=configManager->newManagedAction(menuroot,menuGridContext, "setPageOffset", tr("Start Column"), this, "", QList<QKeySequence>());
     menuWindow->addAction(menuShow->menuAction());
 #if (QT_VERSION > 0x050a00) && (defined(Q_OS_MAC))
     actionCloseElement=configManager->newManagedAction(menuroot,menuWindow, "closeElement", tr("&Close something"), this, SLOT(closeElement()), QList<QKeySequence>()); // osx work around

--- a/src/pdfviewer/PDFDocument.h
+++ b/src/pdfviewer/PDFDocument.h
@@ -678,6 +678,7 @@ public:
 	QMenu *menuGrid = nullptr;
 	QMenu *menuGridContext = nullptr;
 	QMenu *menuShow = nullptr;
+	QAction *actionSetPageOffsetMenu;
 private:
 	QMenu *menuEdit_2;
 

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -9,6 +9,7 @@
 - repair user macro trigger (?highlight-as:...), still not usable for math env detection
 - add new user macro trigger (?inEnv:...)
 - add Grid menu to windowed and embedded pdf-viewer's context menu [#3942](https://github.com/texstudio-org/texstudio/pull/3942)
+- add "Set Column" (sets column of first page, same as Shift+Click) to Grid menu of pdf-viewer's context menu [#3974](https://github.com/texstudio-org/texstudio/pull/3974)
 - fix pdf-viewer's scrollbar with Fit to Width/Window and changing Continuous mode [#3928](https://github.com/texstudio-org/texstudio/pull/3928)
 - fix pdf-viewer's Custom Grid dialog not preset with current Grid settings in Continuous mode [#3929](https://github.com/texstudio-org/texstudio/pull/3929)
 - fix pfd-viewer's page display in non continuous mode [#3952](https://github.com/texstudio-org/texstudio/pull/3952)

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -9,7 +9,7 @@
 - repair user macro trigger (?highlight-as:...), still not usable for math env detection
 - add new user macro trigger (?inEnv:...)
 - add Grid menu to windowed and embedded pdf-viewer's context menu [#3942](https://github.com/texstudio-org/texstudio/pull/3942)
-- add "Set Column" (sets column of first page, same as Shift+Click) to Grid menu of pdf-viewer's context menu [#3974](https://github.com/texstudio-org/texstudio/pull/3974)
+- add "Start Column" (sets column of first page, same as Shift+Click) to Grid menu of pdf-viewer's context menu [#3974](https://github.com/texstudio-org/texstudio/pull/3974)
 - fix pdf-viewer's scrollbar with Fit to Width/Window and changing Continuous mode [#3928](https://github.com/texstudio-org/texstudio/pull/3928)
 - fix pdf-viewer's Custom Grid dialog not preset with current Grid settings in Continuous mode [#3929](https://github.com/texstudio-org/texstudio/pull/3929)
 - fix pfd-viewer's page display in non continuous mode [#3952](https://github.com/texstudio-org/texstudio/pull/3952)


### PR DESCRIPTION
@benibela Here it is:

![setPageOffsetAnimation](https://github.com/user-attachments/assets/15fe9c4c-45d7-493a-8382-16fc8accb4f2)

This works independent from the row (as with `Shift+LeftClick`). Maybe someone can update the manual?