### PR TITLE
use same cmd for build and preview

### DIFF
--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1801,6 +1801,16 @@ BuildManager::Dvi2PngMode BuildManager::guessDvi2PngMode() {
 	return dvi2pngModeDerived;
 }
 
+int BuildManager::index(BuildManager::Dvi2PngMode dvi2pngMode) {
+	if (dvi2pngMode==DPM_BUILD_COMPILER) return 0;
+	return static_cast <int>(dvi2pngMode) + 1;
+}
+
+BuildManager::Dvi2PngMode BuildManager::dvi2PngMode(int index) {
+	if (index==0) return DPM_BUILD_COMPILER;
+	return static_cast <BuildManager::Dvi2PngMode>(index - 1);
+}
+
 //there are 3 ways to generate a preview png:
 //1. latex is called => dvipng is called after latex finished and converts the dvi
 //2. latex is called and dvipng --follow is called at the same time, and will manage the wait time on its own

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1775,8 +1775,8 @@ void addLaTeXInputPaths(ProcessX *p, const QStringList &paths)
 /*!
  * \brief find a Preview Mode which uses the Build Compiler (Default or by Magic Comment)
  * it was reported (#3851) that external storage was filled up when running a preview with a different compiler than the Build Compiler
- * from the Build setup. To prevent this check option autoPreviewCmd. This is also usefull when you switch between documents which can't
- * be compiled with the same compiler and a manuell switch would also be necessary for previews.
+ * from the Build setup. To prevent this check option autoPreviewCmd. This is also useful when you switch between documents which can't
+ * be compiled with the same compiler and a manual switch would also be necessary for previews.
  */
 BuildManager::Dvi2PngMode BuildManager::guessDvi2PngMode() {
 	bool user;

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1453,7 +1453,7 @@ void BuildManager::readSettings(QSettings &settings)
 
 	int md = dvi2pngMode;
 #ifdef NO_POPPLER_PREVIEW
-	if (md == DPM_EMBEDDED_PDF || md == DPM_LUA_EMBEDDED_PDF || md == DPM_XE_EMBEDDED_PDF)
+	if (modifyHeader.contains(static_cast<Dvi2PngMode>(md)))
 		md = -1;
 #endif
 	if (md < 0) {

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1801,16 +1801,6 @@ BuildManager::Dvi2PngMode BuildManager::guessDvi2PngMode() {
 	return dvi2pngModeDerived;
 }
 
-int BuildManager::index(BuildManager::Dvi2PngMode dvi2pngMode) {
-	if (dvi2pngMode==DPM_BUILD_COMPILER) return 0;
-	return static_cast <int>(dvi2pngMode) + 1;
-}
-
-BuildManager::Dvi2PngMode BuildManager::dvi2PngMode(int index) {
-	if (index==0) return DPM_BUILD_COMPILER;
-	return static_cast <BuildManager::Dvi2PngMode>(index - 1);
-}
-
 //there are 3 ways to generate a preview png:
 //1. latex is called => dvipng is called after latex finished and converts the dvi
 //2. latex is called and dvipng --follow is called at the same time, and will manage the wait time on its own

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1341,7 +1341,7 @@ void BuildManager::registerOptions(ConfigManagerInterface &cmi)
 	cmi.registerOption("Tools/Quick Mode", &deprecatedQuickmode, -1);
 	cmi.registerOption("Tools/Max Expanding Nesting Deep", &maxExpandingNestingDeep, 10);
 	Q_ASSERT(sizeof(dvi2pngMode) == sizeof(int));
-	cmi.registerOption("Tools/Dvi2Png Mode", reinterpret_cast<int *>(&dvi2pngMode), 6);
+	cmi.registerOption("Tools/Dvi2Png Mode", reinterpret_cast<int *>(&dvi2pngMode), static_cast<int>(DPM_BUILD_COMPILER));
     cmi.registerOption("Files/Save Files Before Compiling", reinterpret_cast<int *>(&saveFilesBeforeCompiling), static_cast<int>(SFBC_ONLY_NAMED));
 	cmi.registerOption("Preview/Remove Beamer Class", &previewRemoveBeamer, true);
 	cmi.registerOption("Preview/Precompile Preamble", &previewPrecompilePreamble, true);

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1453,7 +1453,7 @@ void BuildManager::readSettings(QSettings &settings)
 
 	int md = dvi2pngMode;
 #ifdef NO_POPPLER_PREVIEW
-	if (modifyHeader.contains(static_cast<Dvi2PngMode>(md)))
+    if (static_cast<Dvi2PngMode>(md)>=DPM_EMBEDDED_PDF)
 		md = -1;
 #endif
 	if (md < 0) {

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -180,13 +180,12 @@ public:
 	int deprecatedQuickmode;
 	QStringList deprecatedUserToolCommands, deprecatedUserToolNames;
 	QStringList userToolOrder, userToolDisplayNames;
-	enum Dvi2PngMode { DPM_DVIPNG, DPM_DVIPNG_FOLLOW, DPM_DVIPS_GHOSTSCRIPT, DPM_EMBEDDED_PDF, DPM_LUA_EMBEDDED_PDF, DPM_XE_EMBEDDED_PDF};
-	// following Dvi2PngModes add tight page modifications for to the document preamble preview
+	enum Dvi2PngMode { DPM_DVIPNG, DPM_DVIPNG_FOLLOW, DPM_DVIPS_GHOSTSCRIPT, DPM_EMBEDDED_PDF, DPM_LUA_EMBEDDED_PDF, DPM_XE_EMBEDDED_PDF, DPM_BUILD_COMPILER};
+	// following Dvi2PngModes add tight page modifications to the document preamble for preview
 	const QList<Dvi2PngMode> modifyHeader = {DPM_EMBEDDED_PDF, DPM_LUA_EMBEDDED_PDF, DPM_XE_EMBEDDED_PDF};
 
 	Dvi2PngMode dvi2pngMode;
 	BuildManager::Dvi2PngMode guessDvi2PngMode();
-	bool autoPreviewCmd;
 	enum SaveFilesBeforeCompiling {SFBC_ALWAYS, SFBC_ONLY_CURRENT_OR_NAMED, SFBC_ONLY_NAMED};
 	SaveFilesBeforeCompiling saveFilesBeforeCompiling;
 	bool previewRemoveBeamer, previewPrecompilePreamble;

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -181,13 +181,9 @@ public:
 	QStringList deprecatedUserToolCommands, deprecatedUserToolNames;
 	QStringList userToolOrder, userToolDisplayNames;
 	enum Dvi2PngMode { DPM_DVIPNG, DPM_DVIPNG_FOLLOW, DPM_DVIPS_GHOSTSCRIPT, DPM_EMBEDDED_PDF, DPM_LUA_EMBEDDED_PDF, DPM_XE_EMBEDDED_PDF, DPM_BUILD_COMPILER};
-	// following Dvi2PngModes add tight page modifications to the document preamble for preview
-	const QList<Dvi2PngMode> modifyHeader = {DPM_EMBEDDED_PDF, DPM_LUA_EMBEDDED_PDF, DPM_XE_EMBEDDED_PDF};
 
 	Dvi2PngMode dvi2pngMode;
-	BuildManager::Dvi2PngMode guessDvi2PngMode();
-	BuildManager::Dvi2PngMode dvi2PngMode(int index);
-	int index(BuildManager::Dvi2PngMode dvi2pngMode);
+    BuildManager::Dvi2PngMode guessDvi2PngMode();
 
 	enum SaveFilesBeforeCompiling {SFBC_ALWAYS, SFBC_ONLY_CURRENT_OR_NAMED, SFBC_ONLY_NAMED};
 	SaveFilesBeforeCompiling saveFilesBeforeCompiling;

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -181,7 +181,12 @@ public:
 	QStringList deprecatedUserToolCommands, deprecatedUserToolNames;
 	QStringList userToolOrder, userToolDisplayNames;
 	enum Dvi2PngMode { DPM_DVIPNG, DPM_DVIPNG_FOLLOW, DPM_DVIPS_GHOSTSCRIPT, DPM_EMBEDDED_PDF, DPM_LUA_EMBEDDED_PDF, DPM_XE_EMBEDDED_PDF};
+	// following Dvi2PngModes add tight page modifications for to the document preamble preview
+	const QList<Dvi2PngMode> modifyHeader = {DPM_EMBEDDED_PDF, DPM_LUA_EMBEDDED_PDF, DPM_XE_EMBEDDED_PDF};
+
 	Dvi2PngMode dvi2pngMode;
+	BuildManager::Dvi2PngMode guessDvi2PngMode();
+	bool autoPreviewCmd;
 	enum SaveFilesBeforeCompiling {SFBC_ALWAYS, SFBC_ONLY_CURRENT_OR_NAMED, SFBC_ONLY_NAMED};
 	SaveFilesBeforeCompiling saveFilesBeforeCompiling;
 	bool previewRemoveBeamer, previewPrecompilePreamble;

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -186,6 +186,9 @@ public:
 
 	Dvi2PngMode dvi2pngMode;
 	BuildManager::Dvi2PngMode guessDvi2PngMode();
+	BuildManager::Dvi2PngMode dvi2PngMode(int index);
+	int index(BuildManager::Dvi2PngMode dvi2pngMode);
+
 	enum SaveFilesBeforeCompiling {SFBC_ALWAYS, SFBC_ONLY_CURRENT_OR_NAMED, SFBC_ONLY_NAMED};
 	SaveFilesBeforeCompiling saveFilesBeforeCompiling;
 	bool previewRemoveBeamer, previewPrecompilePreamble;

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -592,14 +592,6 @@ ConfigDialog::ConfigDialog(QWidget *parent): QDialog(parent,Qt::Dialog|Qt::Windo
 	ui.lineEditMetaFilter->setPlaceholderText(tr("(option filter)"));
 	connect(ui.lineEditMetaFilter, SIGNAL(textChanged(QString)), SLOT(metaFilterChanged(QString)));
 
-	// poppler preview
-#ifdef NO_POPPLER_PREVIEW
-	int l = ui.comboBoxDvi2PngMode->count();
-	ui.comboBoxDvi2PngMode->removeItem(l - 1);
-	l = ui.comboBoxPreviewMode->count();
-	ui.comboBoxPreviewMode->removeItem(l - 1);
-	// maybe add some possibility to disable some preview modes in poppler mode
-#endif
 	ui.labelScreenResolution->setText(labelSystemdpi);
 
 	// set-up GUI scaling

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -443,7 +443,7 @@ ConfigDialog::ConfigDialog(QWidget *parent): QDialog(parent,Qt::Dialog|Qt::Windo
 	connect(UpdateChecker::instance(), SIGNAL(checkCompleted()), this, SLOT(refreshLastUpdateTime()));
 	refreshLastUpdateTime();
 
-	//pageditor
+	//pageEditor
 	populateComboBoxFont(false);
 	connect(ui.checkBoxShowOnlyMonospacedFonts, SIGNAL(toggled(bool)), this, SLOT(populateComboBoxFont(bool)));
 
@@ -489,7 +489,8 @@ ConfigDialog::ConfigDialog(QWidget *parent): QDialog(parent,Qt::Dialog|Qt::Windo
             .arg("<a href=\"https://extensions.openoffice.org/de/search?f[0]=field_project_tags%3A157\">OpenOffice</a>",
                  "<a href=\"https://extensions.libreoffice.org/?Tag%5B0%5D=50&q=&Tags%5B%5D=50\">LibreOffice</a>"));
 	ui.labelGetDic->setOpenExternalLinks(true);
-	//pagequick
+
+	//pageQuick
 	connect(ui.pushButtonGrammarWordlists, SIGNAL(clicked()), this, SLOT(browseGrammarWordListsDir()));
 	connect(ui.pushButtonGrammarLTPath, SIGNAL(clicked()), this, SLOT(browseGrammarLTPath()));
 	connect(ui.pushButtonGrammarLTJava, SIGNAL(clicked()), this, SLOT(browseGrammarLTJavaPath()));

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -4046,7 +4046,23 @@ them here.</string>
                     </item>
                    </widget>
                   </item>
-                  <item row="1" column="0">
+                  <item row="1" column="1">
+                   <widget class="QCheckBox" name="checkBoxAutoPreviewCmd">
+                    <property name="text">
+                     <string notr="true">Preferre Preview with Build Compiler</string>
+                    </property>
+                    <property name="toolTip">
+                     <string>The option applys when the build compiler is pdflatex, lualatex, xelatex, or latex.</string>
+                    </property>
+                    <property name="checked">
+                     <bool>true</bool>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>false</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
                    <widget class="QLabel" name="label_32">
                     <property name="text">
                      <string>Display Mode:</string>
@@ -4056,7 +4072,7 @@ them here.</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="1">
+                  <item row="2" column="1">
                    <widget class="QComboBox" name="comboBoxPreviewMode">
                     <property name="toolTip">
                      <string>When the mode is changed, the preview on formulas is displayed accordingly (but for Inline it's still a tooltip).</string>
@@ -4097,82 +4113,6 @@ them here.</string>
                    </widget>
                   </item>
                   <item row="3" column="0">
-                   <widget class="QLabel" name="label_35">
-                    <property name="toolTip">
-                     <string>Update the preview on text change</string>
-                    </property>
-                    <property name="text">
-                     <string>Auto Update:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="1">
-                   <widget class="QComboBox" name="comboBoxAutoPreview">
-                    <item>
-                     <property name="text">
-                      <string>Never</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Previously previewed text</string>
-                     </property>
-                    </item>
-                   </widget>
-                  </item>
-                  <item row="4" column="0">
-                   <widget class="QLabel" name="label_36">
-                    <property name="text">
-                     <string>Auto Update Delay:</string>
-                    </property>
-                    <property name="advancedOption" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="4" column="1">
-                   <widget class="QSpinBox" name="spinBoxAutoPreviewDelay">
-                    <property name="suffix">
-                     <string> ms</string>
-                    </property>
-                    <property name="minimum">
-                     <number>40</number>
-                    </property>
-                    <property name="maximum">
-                     <number>3000</number>
-                    </property>
-                    <property name="advancedOption" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="5" column="0" colspan="2">
-                   <widget class="QCheckBox" name="checkBoxReplaceBeamer">
-                    <property name="text">
-                     <string>Replace beamer class by article</string>
-                    </property>
-                    <property name="checked">
-                     <bool>true</bool>
-                    </property>
-                    <property name="advancedOption" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="0" colspan="2">
-                   <widget class="QCheckBox" name="checkBoxPrecompilePreamble">
-                    <property name="text">
-                     <string>Precompile Preamble</string>
-                    </property>
-                    <property name="checked">
-                     <bool>true</bool>
-                    </property>
-                    <property name="advancedOption" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
                    <widget class="QLabel" name="label_75">
                     <property name="toolTip">
                      <string/>
@@ -4182,7 +4122,7 @@ them here.</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="2" column="1">
+                  <item row="3" column="1">
                    <widget class="QSpinBox" name="spinBoxSegmentPreviewScalePercent">
                     <property name="toolTip">
                      <string/>
@@ -4201,6 +4141,82 @@ them here.</string>
                     </property>
                     <property name="singleStep">
                      <number>10</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="0">
+                   <widget class="QLabel" name="label_35">
+                    <property name="toolTip">
+                     <string>Update the preview on text change</string>
+                    </property>
+                    <property name="text">
+                     <string>Auto Update:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="1">
+                   <widget class="QComboBox" name="comboBoxAutoPreview">
+                    <item>
+                     <property name="text">
+                      <string>Never</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Previously previewed text</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="5" column="0">
+                   <widget class="QLabel" name="label_36">
+                    <property name="text">
+                     <string>Auto Update Delay:</string>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="1">
+                   <widget class="QSpinBox" name="spinBoxAutoPreviewDelay">
+                    <property name="suffix">
+                     <string> ms</string>
+                    </property>
+                    <property name="minimum">
+                     <number>40</number>
+                    </property>
+                    <property name="maximum">
+                     <number>3000</number>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="0" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxReplaceBeamer">
+                    <property name="text">
+                     <string>Replace beamer class by article</string>
+                    </property>
+                    <property name="checked">
+                     <bool>true</bool>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="7" column="0" colspan="2">
+                   <widget class="QCheckBox" name="checkBoxPrecompilePreamble">
+                    <property name="text">
+                     <string>Precompile Preamble</string>
+                    </property>
+                    <property name="checked">
+                     <bool>true</bool>
+                    </property>
+                    <property name="advancedOption" stdset="0">
+                     <bool>true</bool>
                     </property>
                    </widget>
                   </item>

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -4049,10 +4049,10 @@ them here.</string>
                   <item row="1" column="1">
                    <widget class="QCheckBox" name="checkBoxAutoPreviewCmd">
                     <property name="text">
-                     <string notr="true">Preferre Preview with Build Compiler</string>
+                     <string notr="true">Prefer Preview with Build Compiler</string>
                     </property>
                     <property name="toolTip">
-                     <string>The option applys when the build compiler is pdflatex, lualatex, xelatex, or latex.</string>
+                     <string>The option applies when the build compiler is pdflatex, lualatex, xelatex, or latex.</string>
                     </property>
                     <property name="checked">
                      <bool>true</bool>

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -111,7 +111,7 @@
           </size>
          </property>
          <property name="currentIndex">
-          <number>8</number>
+          <number>12</number>
          </property>
          <widget class="QWidget" name="pageGeneral">
           <layout class="QVBoxLayout">
@@ -143,7 +143,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>1132</width>
+                <width>825</width>
                 <height>731</height>
                </rect>
               </property>
@@ -744,7 +744,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>1132</width>
+                <width>872</width>
                 <height>629</height>
                </rect>
               </property>
@@ -1590,7 +1590,7 @@ Then you can select a new shortcut by one of the following ways:
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>1132</width>
+                <width>953</width>
                 <height>568</height>
                </rect>
               </property>
@@ -2048,7 +2048,7 @@ Then you can select a new shortcut by one of the following ways:
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>-1395</y>
+                <y>0</y>
                 <width>1132</width>
                 <height>1853</height>
                </rect>
@@ -4016,7 +4016,7 @@ them here.</string>
                     </property>
                     <item>
                      <property name="text">
-                      <string>Default Compiler as set up in Build configuration</string>
+                      <string>Preview with default compiler</string>
                      </property>
                     </item>
                     <item>
@@ -4258,7 +4258,7 @@ them here.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>1132</width>
+                <width>556</width>
                 <height>645</height>
                </rect>
               </property>
@@ -4761,8 +4761,8 @@ Note: Changing this setting will only affect documents that are opened afterward
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>1146</width>
-                <height>458</height>
+                <width>413</width>
+                <height>204</height>
                </rect>
               </property>
               <layout class="QGridLayout">

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -4016,6 +4016,11 @@ them here.</string>
                     </property>
                     <item>
                      <property name="text">
+                      <string>Default Compiler as set up in Build configuration</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
                       <string>Preview with dvipng</string>
                      </property>
                     </item>
@@ -4042,11 +4047,6 @@ them here.</string>
                     <item>
                      <property name="text">
                       <string>Preview with xelatex</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Default Compiler as set up in Build configuration</string>
                      </property>
                     </item>
                    </widget>

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -4002,14 +4002,14 @@ them here.</string>
                   <string>Preview</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_5" columnstretch="0,1">
-                  <item row="0" column="0">
+                  <item row="1" column="0">
                    <widget class="QLabel" name="label_31">
                     <property name="text">
                      <string>Command:</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="1">
+                  <item row="1" column="1">
                    <widget class="QComboBox" name="comboBoxDvi2PngMode">
                     <property name="advancedOption" stdset="0">
                      <bool>false</bool>
@@ -4044,22 +4044,11 @@ them here.</string>
                       <string>Preview with xelatex</string>
                      </property>
                     </item>
-                   </widget>
-                  </item>
-                  <item row="1" column="1">
-                   <widget class="QCheckBox" name="checkBoxAutoPreviewCmd">
-                    <property name="text">
-                     <string notr="true">Prefer Preview with Build Compiler</string>
-                    </property>
-                    <property name="toolTip">
-                     <string>The option applies when the build compiler is pdflatex, lualatex, xelatex, or latex.</string>
-                    </property>
-                    <property name="checked">
-                     <bool>true</bool>
-                    </property>
-                    <property name="advancedOption" stdset="0">
-                     <bool>false</bool>
-                    </property>
+                    <item>
+                     <property name="text">
+                      <string>Default Compiler as set up in Build configuration</string>
+                     </property>
+                    </item>
                    </widget>
                   </item>
                   <item row="2" column="0">

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -1465,7 +1465,7 @@ bool ConfigManager::execConfigDialog(QWidget *parentToDialog)
 		else  item->setCheckState(Qt::Unchecked);
 	}
 	//preview
-	confDlg->ui.comboBoxDvi2PngMode->setCurrentIndex(buildManager->dvi2pngMode);
+	confDlg->ui.comboBoxDvi2PngMode->setCurrentIndex(buildManager->index(buildManager->dvi2pngMode));
 
 	//Autosave
 	if (autosaveEveryMinutes == 0) confDlg->ui.comboBoxAutoSave->setCurrentIndex(0);
@@ -1763,7 +1763,7 @@ bool ConfigManager::execConfigDialog(QWidget *parentToDialog)
 		completerConfig->setFiles(newFiles);
 		//preview
         previewMode = static_cast<PreviewMode>(confDlg->ui.comboBoxPreviewMode->currentIndex());
-        buildManager->dvi2pngMode = static_cast<BuildManager::Dvi2PngMode>(confDlg->ui.comboBoxDvi2PngMode->currentIndex());
+        buildManager->dvi2pngMode = buildManager->dvi2PngMode(confDlg->ui.comboBoxDvi2PngMode->currentIndex());
 #ifdef NO_POPPLER_PREVIEW
 		if (buildManager->modifyHeader.contains(buildManager->dvi2pngMode)) {
 			buildManager->dvi2pngMode = BuildManager::DPM_DVIPNG; //fallback when poppler is not included

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -1465,11 +1465,15 @@ bool ConfigManager::execConfigDialog(QWidget *parentToDialog)
 		else  item->setCheckState(Qt::Unchecked);
 	}
 	//preview
-	confDlg->ui.comboBoxDvi2PngMode->setCurrentIndex(buildManager->index(buildManager->dvi2pngMode));
+    int m_dvi2pngModeIndex = 0;
+    if (buildManager->dvi2pngMode!=BuildManager::DPM_BUILD_COMPILER){
+        m_dvi2pngModeIndex = static_cast <int>(buildManager->dvi2pngMode) + 1;
+    }
+    confDlg->ui.comboBoxDvi2PngMode->setCurrentIndex(m_dvi2pngModeIndex);
 #ifdef NO_POPPLER_PREVIEW
 	int l = confDlg->ui.comboBoxDvi2PngMode->count();
 	for (int index=l-1; index>=0; index--) {
-		if (buildManager->modifyHeader.contains(buildManager->dvi2PngMode(index)))
+        if (buildManager->dvi2PngMode(index)>=BuildManager::DPM_EMBEDDED_PDF)
 			confDlg->ui.comboBoxDvi2PngMode->removeItem(index);
 	}
 #endif
@@ -1770,9 +1774,14 @@ bool ConfigManager::execConfigDialog(QWidget *parentToDialog)
 		completerConfig->setFiles(newFiles);
 		//preview
         previewMode = static_cast<PreviewMode>(confDlg->ui.comboBoxPreviewMode->currentIndex());
-        buildManager->dvi2pngMode = buildManager->dvi2PngMode(confDlg->ui.comboBoxDvi2PngMode->currentIndex());
+        int m_dvi2pngModeIndex=confDlg->ui.comboBoxDvi2PngMode->currentIndex();
+        if (m_dvi2pngModeIndex==0){
+            buildManager->dvi2pngMode = BuildManager::DPM_BUILD_COMPILER;
+        }else{
+            buildManager->dvi2pngMode = static_cast <BuildManager::Dvi2PngMode>(m_dvi2pngModeIndex - 1);
+        }
 #ifdef NO_POPPLER_PREVIEW
-		if (buildManager->modifyHeader.contains(buildManager->dvi2pngMode)) {
+        if (buildManager->dvi2pngMode>=BuildManager::DPM_EMBEDDED_PDF){
 			buildManager->dvi2pngMode = BuildManager::DPM_DVIPNG; //fallback when poppler is not included
 		}
 #endif

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -1767,7 +1767,7 @@ bool ConfigManager::execConfigDialog(QWidget *parentToDialog)
         buildManager->dvi2pngMode = static_cast<BuildManager::Dvi2PngMode>(confDlg->ui.comboBoxDvi2PngMode->currentIndex());
         buildManager->autoPreviewCmd = confDlg->ui.checkBoxAutoPreviewCmd->isChecked();
 #ifdef NO_POPPLER_PREVIEW
-		if (buildManager.modifyHeader.contains(dvi2pngMode)) {
+		if (buildManager->modifyHeader.contains(buildManager->dvi2pngMode)) {
 			buildManager->dvi2pngMode = BuildManager::DPM_DVIPNG; //fallback when poppler is not included
 			buildManager->autoPreviewCmd = false;
 		}

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -1466,7 +1466,6 @@ bool ConfigManager::execConfigDialog(QWidget *parentToDialog)
 	}
 	//preview
 	confDlg->ui.comboBoxDvi2PngMode->setCurrentIndex(buildManager->dvi2pngMode);
-	confDlg->ui.checkBoxAutoPreviewCmd->setChecked(buildManager->autoPreviewCmd);
 
 	//Autosave
 	if (autosaveEveryMinutes == 0) confDlg->ui.comboBoxAutoSave->setCurrentIndex(0);
@@ -1765,11 +1764,9 @@ bool ConfigManager::execConfigDialog(QWidget *parentToDialog)
 		//preview
         previewMode = static_cast<PreviewMode>(confDlg->ui.comboBoxPreviewMode->currentIndex());
         buildManager->dvi2pngMode = static_cast<BuildManager::Dvi2PngMode>(confDlg->ui.comboBoxDvi2PngMode->currentIndex());
-        buildManager->autoPreviewCmd = confDlg->ui.checkBoxAutoPreviewCmd->isChecked();
 #ifdef NO_POPPLER_PREVIEW
 		if (buildManager->modifyHeader.contains(buildManager->dvi2pngMode)) {
 			buildManager->dvi2pngMode = BuildManager::DPM_DVIPNG; //fallback when poppler is not included
-			buildManager->autoPreviewCmd = false;
 		}
 #endif
 

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -1466,6 +1466,13 @@ bool ConfigManager::execConfigDialog(QWidget *parentToDialog)
 	}
 	//preview
 	confDlg->ui.comboBoxDvi2PngMode->setCurrentIndex(buildManager->index(buildManager->dvi2pngMode));
+#ifdef NO_POPPLER_PREVIEW
+	int l = confDlg->ui.comboBoxDvi2PngMode->count();
+	for (int index=l-1; index>=0; index--) {
+		if (buildManager->modifyHeader.contains(buildManager->dvi2PngMode(index)))
+			confDlg->ui.comboBoxDvi2PngMode->removeItem(index);
+	}
+#endif
 
 	//Autosave
 	if (autosaveEveryMinutes == 0) confDlg->ui.comboBoxAutoSave->setCurrentIndex(0);

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -1473,7 +1473,7 @@ bool ConfigManager::execConfigDialog(QWidget *parentToDialog)
 #ifdef NO_POPPLER_PREVIEW
 	int l = confDlg->ui.comboBoxDvi2PngMode->count();
 	for (int index=l-1; index>=0; index--) {
-        if (buildManager->dvi2PngMode(index)>=BuildManager::DPM_EMBEDDED_PDF)
+        if (static_cast <BuildManager::Dvi2PngMode>(index)>=BuildManager::DPM_EMBEDDED_PDF || index==0)
 			confDlg->ui.comboBoxDvi2PngMode->removeItem(index);
 	}
 #endif

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -1466,6 +1466,7 @@ bool ConfigManager::execConfigDialog(QWidget *parentToDialog)
 	}
 	//preview
 	confDlg->ui.comboBoxDvi2PngMode->setCurrentIndex(buildManager->dvi2pngMode);
+	confDlg->ui.checkBoxAutoPreviewCmd->setChecked(buildManager->autoPreviewCmd);
 
 	//Autosave
 	if (autosaveEveryMinutes == 0) confDlg->ui.comboBoxAutoSave->setCurrentIndex(0);
@@ -1764,9 +1765,11 @@ bool ConfigManager::execConfigDialog(QWidget *parentToDialog)
 		//preview
         previewMode = static_cast<PreviewMode>(confDlg->ui.comboBoxPreviewMode->currentIndex());
         buildManager->dvi2pngMode = static_cast<BuildManager::Dvi2PngMode>(confDlg->ui.comboBoxDvi2PngMode->currentIndex());
+        buildManager->autoPreviewCmd = confDlg->ui.checkBoxAutoPreviewCmd->isChecked();
 #ifdef NO_POPPLER_PREVIEW
-		if (buildManager->dvi2pngMode == BuildManager::DPM_EMBEDDED_PDF || buildManager->dvi2pngMode == BuildManager::DPM_LUA_EMBEDDED_PDF || buildManager->dvi2pngMode == BuildManager::DPM_XE_EMBEDDED_PDF) {
+		if (buildManager.modifyHeader.contains(dvi2pngMode)) {
 			buildManager->dvi2pngMode = BuildManager::DPM_DVIPNG; //fallback when poppler is not included
+			buildManager->autoPreviewCmd = false;
 		}
 #endif
 

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -8992,7 +8992,7 @@ void Texstudio::showPreview(const QString &text)
 	for (int l = 0; l < m_endingLine; l++)
 		header << edView->editor->document()->line(l).text();
 	BuildManager::Dvi2PngMode dvi2pngModeDerived = buildManager.guessDvi2PngMode();
-	if (buildManager.modifyHeader.contains(dvi2pngModeDerived)) {
+    if (dvi2pngModeDerived>=BuildManager::DPM_EMBEDDED_PDF) {
 		header << "\\usepackage[active,tightpage]{preview}"
 		       << "\\usepackage{varwidth}"
 		       << "\\AtBeginDocument{\\begin{preview}\\begin{varwidth}{\\linewidth}}"
@@ -9093,7 +9093,7 @@ QStringList Texstudio::makePreviewHeader(const LatexDocument *rootDoc)
 		}
 	}
 	BuildManager::Dvi2PngMode dvi2pngModeDerived = buildManager.guessDvi2PngMode();
-	if (buildManager.modifyHeader.contains(dvi2pngModeDerived) && configManager.previewMode != ConfigManager::PM_EMBEDDED) {
+    if (dvi2pngModeDerived>=BuildManager::DPM_EMBEDDED_PDF && configManager.previewMode != ConfigManager::PM_EMBEDDED) {
 		header << "\\usepackage[active,tightpage]{preview}"
 			<< "\\usepackage{varwidth}"
 			<< "\\AtBeginDocument{\\begin{preview}\\begin{varwidth}{\\linewidth}}"

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -8991,13 +8991,14 @@ void Texstudio::showPreview(const QString &text)
 	QStringList header;
 	for (int l = 0; l < m_endingLine; l++)
 		header << edView->editor->document()->line(l).text();
-	if (buildManager.dvi2pngMode == BuildManager::DPM_EMBEDDED_PDF || buildManager.dvi2pngMode == BuildManager::DPM_LUA_EMBEDDED_PDF || buildManager.dvi2pngMode == BuildManager::DPM_XE_EMBEDDED_PDF) {
+	BuildManager::Dvi2PngMode dvi2pngModeDerived = buildManager.guessDvi2PngMode();
+	if (buildManager.modifyHeader.contains(dvi2pngModeDerived)) {
 		header << "\\usepackage[active,tightpage]{preview}"
 		       << "\\usepackage{varwidth}"
 		       << "\\AtBeginDocument{\\begin{preview}\\begin{varwidth}{\\linewidth}}"
 		       << "\\AtEndDocument{\\end{varwidth}\\end{preview}}";
 	}
-	header << "\\pagestyle{empty}";// << "\\begin{document}";
+	header << "\\pagestyle{empty}";
 	buildManager.preview(header.join("\n"), PreviewSource(text, -1, -1, true), documents.getCompileFileName(), edView->editor->document()->codec());
 }
 
@@ -9091,14 +9092,14 @@ QStringList Texstudio::makePreviewHeader(const LatexDocument *rootDoc)
 			header << newLine;
 		}
 	}
-	if ((buildManager.dvi2pngMode == BuildManager::DPM_EMBEDDED_PDF || buildManager.dvi2pngMode == BuildManager::DPM_LUA_EMBEDDED_PDF || buildManager.dvi2pngMode == BuildManager::DPM_XE_EMBEDDED_PDF)
-			&& configManager.previewMode != ConfigManager::PM_EMBEDDED) {
+	BuildManager::Dvi2PngMode dvi2pngModeDerived = buildManager.guessDvi2PngMode();
+	if (buildManager.modifyHeader.contains(dvi2pngModeDerived) && configManager.previewMode != ConfigManager::PM_EMBEDDED) {
 		header << "\\usepackage[active,tightpage]{preview}"
 			<< "\\usepackage{varwidth}"
 			<< "\\AtBeginDocument{\\begin{preview}\\begin{varwidth}{\\linewidth}}"
 			<< "\\AtEndDocument{\\end{varwidth}\\end{preview}}";
 	}
-	header << "\\pagestyle{empty}";// << "\\begin{document}";
+	header << "\\pagestyle{empty}";
 	return header;
 }
 


### PR DESCRIPTION
A new selection available in the Command combobox (s. Config/Preview and images below) tells the build system that the compiler used for previews should be the one used for builds. This includes the Default Compiler setup in Config/Build or given in a magic comment in the document. For this the build system tries to figure out which dvi2pngMode (i.e. one of the other selections available in the combobox) should be used internally. If this is not possible then a default selection from the combobox list is used (Preview with dvipng).

![previewCmdComboboxAnimation](https://github.com/user-attachments/assets/3672487f-dc2d-4f9b-9c9f-49da246e0d7b)

This PR closes #3851.

Note: Comment updated