### PR TITLE
workaround for editor border lines missing

### DIFF
--- a/src/qcodeedit/lib/document/qdocument.cpp
+++ b/src/qcodeedit/lib/document/qdocument.cpp
@@ -3605,7 +3605,7 @@ void QDocumentLineHandle::drawBorders(QPainter *p, qreal yStart, qreal yEnd) con
 	if (d->hardLineWrap() || d->lineWidthConstraint()) {
 		QColor linescolor = QDocumentPrivate::m_formatScheme->format("background").linescolor;
 		if (!linescolor.isValid()) {
-			return;
+			linescolor = QColor("lightGray").rgb();
 		}
 		p->save();
 		p->setPen(linescolor);


### PR DESCRIPTION
When some options are in effect left or right border lines should surround the editor. According to my investigations this is not always the case.

Setup:
Win10: Configure App Color to light/dark
txs: set up a fixed text width, optionally activate option center editor, deactivate Ignore most system colors

| Style   | Color Scheme | App/Win Setup | border |
|---------|--------------|---------------|--------|
| windowsista   | any          | n.a.          | no     |
| Windows | any          | light         | no     |
|         |              | dark          | yes    |
| Fusion  | any          | light         | no     |
|         |              | dark          | yes    |
| Adwaita | any          | n.a.          | no     |
| Adwaita dark  | any          | n.a.          | yes    |
| Orion   | any          | n.a.          | yes    |
| default | any          | n.a.          | no     |

In `QDocumentLineHandle::drawBorders`  following code is executed:
```
QColor linescolor = QDocumentPrivate::m_formatScheme->format("background").linescolor;
if (!linescolor.isValid()) {
   return;
```
It isn't clear to me, why the condition is true. I suggest to set lightGray as a fallback instead of leaving with return.

Example of a fixed case:

![grafik](https://github.com/user-attachments/assets/34455332-a619-4bb0-9ab5-e3fa73473b5c)
(click to enlarge)