### PR TITLE
shrink embedded PDF-viewer on clicking a structure view item

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -8253,6 +8253,7 @@ void Texstudio::gotoLine(LatexDocument *doc, int line, int col)
  */
 void Texstudio::gotoLine(QTreeWidgetItem *item, int)
 {
+    shrinkEmbeddedPDFViewer();
     StructureEntry *se=item->data(0,Qt::UserRole).value<StructureEntry *>();
     if(!se){
         // sepcial treatment for doc header


### PR DESCRIPTION
If the embedded PDF-viewer is enlarged, you can't see the tex document. A click on the pdf shrinks the embedded viewer, so you can see the line to which txs syncted from the pdf. This PR implements a similar behavior when you click an item in the strucure or TOC view.

![structureViewClickShrinksEmbeddedPDF](https://github.com/user-attachments/assets/1d88c82a-0134-4d7e-88c1-06a0780cce92)
