### PR TITLE
single menu checkbox action enlarges or normalizes (shrinks) embedded pdf-viewer

### DIFF
--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -3917,13 +3917,13 @@ void PDFDocument::jumpToPage()
 void PDFDocument::shrink()
 {
 	setStateEnlarged(false);
-	emit triggeredShrink();
+	emit triggeredEnlarge(false);
 }
 
 void PDFDocument::enlarge()
 {
 	setStateEnlarged(true);
-	emit triggeredEnlarge();
+	emit triggeredEnlarge(true);
 }
 
 void PDFDocument::setStateEnlarged(bool state)

--- a/src/pdfviewer/PDFDocument.h
+++ b/src/pdfviewer/PDFDocument.h
@@ -553,8 +553,7 @@ signals:
 	void triggeredQuit();
 	void triggeredPlaceOnLeft();
 	void triggeredConfigure();
-	void triggeredEnlarge();
-	void triggeredShrink();
+	void triggeredEnlarge(bool);
 
 	void triggeredClone();
 

--- a/src/texstudio.h
+++ b/src/texstudio.h
@@ -235,6 +235,7 @@ private:
 	LatexEditorView *getEditorViewFromHandle(const QDocumentLineHandle *dlh);
 
 	QAction *fullscreenModeAction;
+	QAction *enlargePdfAction;
 
 	int runningPDFCommands, runningPDFAsyncCommands;
 	QEditor *previewEditorPending; bool previewIsAutoCompiling;
@@ -558,9 +559,7 @@ protected slots:
 
 	void focusEditor();
 	void focusViewer();
-	void enlargeEmbeddedPDFViewer();
-	void shrinkEmbeddedPDFViewer(bool preserveConfig = false);
-	void setEnabledMenusEnlargeShrink(bool enabledEnlarge, bool enabledShrink);
+	void toggleEnlargeEmbeddedPDFViewer(bool stateEnlarged = false, bool preserveConfig = false);
 
 	void showStatusbar();
 	void viewCloseElement();

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -4,6 +4,8 @@
 - add "Start Column" (sets column of first page, same as Shift+Click) to Grid menu of pdf-viewer's context menu [#3974](https://github.com/texstudio-org/texstudio/pull/3974)
 - add preview with default compiler option [#3978](https://github.com/texstudio-org/texstudio/pull/3978)
 - shrink embedded pdf-viewer when an item of the Structure or TOC tree view is selected [#3989](https://github.com/texstudio-org/texstudio/pull/3989)
+- checkable menu action switches between enlarged and normal (shrinked) embedded pdf-viewer [#3991](https://github.com/texstudio-org/texstudio/pull/3991)
+- fix small issues when a windowed pdf-viewer exists and a second viewer is added embedded [#3991](https://github.com/texstudio-org/texstudio/pull/3991)
 
 ## TeXstudio 4.8.6
 


### PR DESCRIPTION
This PR addresses following two mutually exclusive menu actions:

![grafik](https://github.com/user-attachments/assets/d944529f-357a-4458-a553-7507a345b109)

As you can see, my personal settings use two shortcuts for enlarging and shrinking the embedded viewer added in the Shortcut config:

![grafik](https://github.com/user-attachments/assets/ab81a503-0f3e-4832-9c2a-4fd12297347a)

But this has the disadvantages that you waste one shortcut and your hand needs to switch between two positions on the keybord for toggling the size of the viewer. If we agree that the pdf-viewer has a normal size which can be enlarged (maximized to the left), a checkbox should be enough to do the job:

![grafik](https://github.com/user-attachments/assets/a817cde8-9be4-46bd-b334-6c3b5c15cd09)

As long as there is no embedded pdf-viewer the action is not enabled. So txs needs to know if there is an embedded viewer. This brings me to the next point.

The PR also fixes small issues. Under specific conditions enabling and disabling the action(s) or switching between enlarged and normal size of the viewer works not correctly. The reason for this is the not so well known fact that it is possible creating first a windowed pdf-viewer and then the embedded one. This means that there are two viewers. To do so one needs some changes to the Build Meta and User Commands. In this case an internal PDFDocument list holds two pdf-viewer items. But the code may fail if it relies on the assumption that the embedded viewer (if available) is the first one in the list. It is necessary to search through the list.