### PR TITLE
signal checkStateChanged replaces stateChanged which is depricated for Qt 6.9

### DIFF
--- a/src/texdocdialog.cpp
+++ b/src/texdocdialog.cpp
@@ -28,7 +28,11 @@ TexdocDialog::TexdocDialog(QWidget *parent,Help *obj) :
 	connect(ui->tbPackages, SIGNAL(currentItemChanged(QTableWidgetItem *, QTableWidgetItem *)), SLOT(itemChanged(QTableWidgetItem *)));
 	connect(help, SIGNAL(texdocAvailableReply(QString, bool, QString)), SLOT(updateDocAvailableInfo(QString, bool, QString)));
 	connect(ui->buttonCTAN, SIGNAL(clicked()), SLOT(openCtanUrl()));
+#if (QT_VERSION<QT_VERSION_CHECK(6,9,0))
 	connect(ui->cbShowAllPackages,&QCheckBox::stateChanged,this,&TexdocDialog::regenerateTable);
+#else
+	connect(ui->cbShowAllPackages,&QCheckBox::checkStateChanged,this,&TexdocDialog::regenerateTable);
+#endif
 }
 
 TexdocDialog::~TexdocDialog()


### PR DESCRIPTION
From [here](https://wiki.qt.io/QtReleasing) I conclude that txs will be built with Qt 6.8 regardless of the OS.

[QCheckbox signals](https://doc.qt.io/qt-6/qcheckbox.html#signals)
[checkStateChanged](https://doc.qt.io/qt-6/qcheckbox.html#checkStateChanged)
[stateChanged](https://doc.qt.io/qt-6/qcheckbox.html#stateChanged)

I found the only place in the code that uses this in `texdocdialog.cpp`.

Qt 6.8.3 and 6.9 are planned to be released in March 2025.