### PR TITLE
fix enlarge/shrink not available when windowed and embedded viewer exist

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -6217,10 +6217,9 @@ void Texstudio::runInternalPdfViewer(const QFileInfo &master, const QString &opt
 			viewer->setStateEnlarged(true);
             centralVSplitter->hide();
 		}
-		setEnabledMenusEnlargeShrink(viewer->embeddedMode && !configManager.viewerEnlarged, viewer->embeddedMode && configManager.viewerEnlarged);
-
 		if (preserveDuplicates) break;
 	}
+	setEnabledMenusEnlargeShrink(embedded && !configManager.viewerEnlarged, embedded && configManager.viewerEnlarged);
 #if defined Q_OS_MAC
 	if (embedded)
 		setMenuBar(configManager.menuParentsBar);
@@ -11371,10 +11370,15 @@ void Texstudio::enlargeEmbeddedPDFViewer()
 {
 #ifndef NO_POPPLER_PREVIEW
 	QList<PDFDocument *> oldPDFs = PDFDocument::documentList();
-	if (oldPDFs.isEmpty())
-		return;
-	PDFDocument *viewer = oldPDFs.first();
-	if (!viewer->embeddedMode)
+	PDFDocument *viewer;
+	bool foundEmbedded = false;
+	foreach(viewer, oldPDFs) {
+		if (viewer->embeddedMode) {
+			foundEmbedded = true;
+			break;
+		}
+	}
+	if (!foundEmbedded)
 		return;
     centralVSplitter->hide();
     configManager.viewerEnlarged = true;
@@ -11399,10 +11403,15 @@ void Texstudio::shrinkEmbeddedPDFViewer(bool preserveConfig)
     if (!preserveConfig)
 		configManager.viewerEnlarged = false;
 	QList<PDFDocument *> oldPDFs = PDFDocument::documentList();
-	if (oldPDFs.isEmpty())
-		return;
-	PDFDocument *viewer = oldPDFs.first();
-	if (!viewer->embeddedMode)
+	PDFDocument *viewer;
+	bool foundEmbedded = false;
+	foreach(viewer, oldPDFs) {
+		if (viewer->embeddedMode) {
+			foundEmbedded = true;
+			break;
+		}
+	}
+	if (!foundEmbedded)
 		return;
 	if(enlargedViewer){
 		PDFDocumentConfig *pdfConfig=configManager.pdfDocumentConfig;


### PR DESCRIPTION
Explanation of the PR:

old line 6220: The line was executed for each pdf in the loop. If the first viewer opened is imbedded the menu actions are set correctly. If now a windowed viewer is opened (with option preserve-existing) then the second execution of the line will disable both options. It is not necessary to use the embeddedMode of the embedded viewer. Variable embedded reflects the state.

old lines 11374ff and 11402ff: To set the viewers stateEnlarged icons we need to now the viewer. The code relies on the fact that the embedded viewer is the first viewer opened. If you open a windowed viewer and then the embedded viewer (with option preserve-existing) then this is not true.  Even so the enlarge menu action is enabled, clicking it can not set the splitter hidden, so nothing happens. When you click on the enlarge icon, it changes state but again the enlarge method fails. Therefore we need to search the embedded viewer in the list. The foreach loop can detect if the list is empty or that there is no embedded viewer.