### PR TITLE
Fix: made it so there is only one system prompt per conversation with chatbot

### DIFF
--- a/src/aichatassistant.cpp
+++ b/src/aichatassistant.cpp
@@ -203,16 +203,12 @@ void AIChatAssistant::slotSend()
         m_timer->setInterval(100);
         connect(m_timer,&QTimer::timeout,this,&AIChatAssistant::slotUpdateResults);
     }
-    if(!config->ai_systemPrompt.isEmpty()){
+    if(ja_messages.isEmpty() and !config->ai_systemPrompt.isEmpty()){
         // add system prompt to query
         QJsonObject ja_message;
         ja_message["role"]="system";
         ja_message["content"]=config->ai_systemPrompt;
-        // overwrites if there's already a system prompt
-        if(!ja_messages.isEmpty() and ja_messages.first()["role"]=="system")
-            ja_messages.replace(0, ja_message);
-        else
-            ja_messages.prepend(ja_message);
+        ja_messages.append(ja_message);
     }
     QJsonObject ja_message;
     ja_message["role"]="user";

--- a/src/aichatassistant.cpp
+++ b/src/aichatassistant.cpp
@@ -203,19 +203,16 @@ void AIChatAssistant::slotSend()
         m_timer->setInterval(100);
         connect(m_timer,&QTimer::timeout,this,&AIChatAssistant::slotUpdateResults);
     }
-    if(ja_messages.isEmpty()){
-        // set first message as system prompt. Empty at first
-        QJsonObject ja_message;
-        ja_message["role"]="system";
-        ja_message["content"]="";
-        ja_messages.append(ja_message);
-    }
     if(!config->ai_systemPrompt.isEmpty()){
         // add system prompt to query
         QJsonObject ja_message;
         ja_message["role"]="system";
         ja_message["content"]=config->ai_systemPrompt;
-        ja_messages.replace(0, ja_message);
+        // overwrites if there's already a system prompt
+        if(!ja_messages.isEmpty() and ja_messages.first()["role"]=="system")
+            ja_messages.replace(0, ja_message);
+        else
+            ja_messages.prepend(ja_message);
     }
     QJsonObject ja_message;
     ja_message["role"]="user";

--- a/src/aichatassistant.cpp
+++ b/src/aichatassistant.cpp
@@ -203,12 +203,19 @@ void AIChatAssistant::slotSend()
         m_timer->setInterval(100);
         connect(m_timer,&QTimer::timeout,this,&AIChatAssistant::slotUpdateResults);
     }
+    if(ja_messages.isEmpty()){
+        // set first message as system prompt. Empty at first
+        QJsonObject ja_message;
+        ja_message["role"]="system";
+        ja_message["content"]="";
+        ja_messages.append(ja_message);
+    }
     if(!config->ai_systemPrompt.isEmpty()){
         // add system prompt to query
         QJsonObject ja_message;
         ja_message["role"]="system";
         ja_message["content"]=config->ai_systemPrompt;
-        ja_messages.append(ja_message);
+        ja_messages.replace(0, ja_message);
     }
     QJsonObject ja_message;
     ja_message["role"]="user";


### PR DESCRIPTION
LLMs work best when provided a single system prompt, usually as the first message. The previous code was adding a new system prompt message for every query in a conversation, which would probably cause issues and increase token count.

So I added code to ensure there's always a system prompt, which can be empty, at the start of the conversation. Then, every new query with a system prompt updates this one message.