### PR TITLE
Clearer ai options and small fix in recorded conversations

### DIFF
--- a/src/aichatassistant.cpp
+++ b/src/aichatassistant.cpp
@@ -323,9 +323,16 @@ void AIChatAssistant::slotOptions()
     QDialog dlg;
     auto *ly=new QVBoxLayout();
     auto *leSystemPrompt=new QTextEdit();
-    leSystemPrompt->setText(config->ai_systemPrompt);
-    if(config->ai_systemPrompt.isEmpty()){
-        leSystemPrompt->setPlaceholderText(tr("System prompt"));
+    if(!ja_messages.isEmpty()){
+        leSystemPrompt->setEnabled(false);
+        if(ja_messages.first()["role"]=="system")
+            leSystemPrompt->setText(ja_messages.first()["content"].toString());
+        leSystemPrompt->setToolTip(tr("System prompt can't be altered mid-conversation"));
+    }else{
+        leSystemPrompt->setText(config->ai_systemPrompt);
+        if(config->ai_systemPrompt.isEmpty()){
+            leSystemPrompt->setPlaceholderText(tr("System prompt"));
+        }
     }
     ly->addWidget(leSystemPrompt);
     auto *leTemp=new QLineEdit();
@@ -337,9 +344,15 @@ void AIChatAssistant::slotOptions()
         maxTemp=2.0;
         rx.setPattern("[01]\\.[0-9]*|2");
     }
-    auto *validator=new QRegularExpressionValidator(rx);
-    leTemp->setValidator(validator);
-    leTemp->setToolTip(tr("Values between 0 and %1").arg(maxTemp));
+    if(config->ai_provider==2){
+        leTemp->setEnabled(false);
+        leTemp->setText(tr("-"));
+        leTemp->setToolTip(tr("Temperature not supported for local models"));
+    }else{
+        auto *validator=new QRegularExpressionValidator(rx);
+        leTemp->setValidator(validator);
+        leTemp->setToolTip(tr("Values between 0 and %1").arg(maxTemp));
+    }
     // add label in front of slider
     auto *lblTemp=new QLabel(tr("Temperature"));
     auto *hl=new QHBoxLayout();

--- a/src/aichatassistant.cpp
+++ b/src/aichatassistant.cpp
@@ -367,8 +367,10 @@ void AIChatAssistant::slotOptions()
                                      | QDialogButtonBox::Cancel);
 
     connect(buttonBox, &QDialogButtonBox::accepted,[&](){
-        config->ai_systemPrompt=leSystemPrompt->toPlainText();
-        config->ai_temperature=leTemp->text();
+        if(ja_messages.isEmpty())
+            config->ai_systemPrompt=leSystemPrompt->toPlainText();
+        if(config->ai_provider!=2)
+            config->ai_temperature=leTemp->text();
         config->ai_streamResults=cbStream->isChecked();
         dlg.close();
     });

--- a/src/aichatassistant.cpp
+++ b/src/aichatassistant.cpp
@@ -478,6 +478,7 @@ void AIChatAssistant::onTreeViewClicked(const QModelIndex &index)
         }
     }else{
         // no query sent yet
+        ja_messages=QJsonArray();
         textBrowser->clear();
     }
 }


### PR DESCRIPTION
### Small fix
Switching from a non-empty conversation to an empty one would not clear the `ja_messages` variable, so they would appear empty, but actually contain text when a query was made. This probably what caused the "fake empty" conversations I mentioned in #4052. Now the variable resets together with the text browser.

---

### Clearer options
Made the ai options clearer by:
- showing the system prompt that's being used in the selected conversation.
- showing that the system prompt can't be changed mid-conversation.
- showing that the temperature can't be changed for local models.