### PR TITLE
Support custom AI providers fully (remote and local)

### DIFF
--- a/src/aichatassistant.cpp
+++ b/src/aichatassistant.cpp
@@ -198,7 +198,7 @@ void AIChatAssistant::slotSend()
         }
     }
     if(config->ai_streamResults){
-        dd["stream"] = "True";
+        dd["stream"] = true;
         m_timer=new QTimer();
         m_timer->setInterval(100);
         connect(m_timer,&QTimer::timeout,this,&AIChatAssistant::slotUpdateResults);

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -727,7 +727,6 @@ void ConfigDialog::retrieveModels()
         QString provider=ui.cbAIProvider->currentText();
         QString key=ui.leAIAPIKey->text();
         QString url;
-        bool supportsModelListing = true;
         
         switch(ui.cbAIProvider->currentIndex()){
         case 0:

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -3587,6 +3587,14 @@ them here.</string>
                  <layout class="QGridLayout" name="gl_AIChat" columnstretch="0,0,0,0,0">
                   <item row="3" column="3">
                    <widget class="QComboBox" name="cbAIPreferredModel">
+                    <property name="toolTip">
+                     <string>AI model to use for responses. You can type custom model names for any provider.
+Examples:
+• Perplexity: sonar, sonar-pro, sonar-deep-research  
+• Gemini: gemini-2.5-pro, gemini-2.5-flash
+• Claude: claude-opus-4-0, claude-sonnet-4-0	
+• Local: deepseek-r1, llama3.3</string>
+                    </property>
                     <item>
                      <property name="text">
                       <string>open-mistral-7b</string>
@@ -3649,7 +3657,7 @@ them here.</string>
                     </item>
                     <item>
                      <property name="text">
-                      <string>Local Model</string>
+                      <string>Custom Provider (Remote or Local)</string>
                      </property>
                     </item>
                    </widget>
@@ -3672,7 +3680,16 @@ them here.</string>
                    <widget class="QLineEdit" name="leAIAPIKey"/>
                   </item>
                   <item row="2" column="3">
-                   <widget class="QLineEdit" name="leAIAPIURL"/>
+                   <widget class="QLineEdit" name="leAIAPIURL">
+                    <property name="toolTip">
+                     <string>API endpoint URL for custom providers
+Examples:
+• Perplexity: https://api.perplexity.ai/chat/completions
+• Gemini: https://generativelanguage.googleapis.com/v1beta/openai/chat/completions
+• Claude: https://api.anthropic.com/v1/chat/completions
+• Local: http://localhost:8080/v1/chat/completions</string>
+                    </property>
+                   </widget>
                   </item>
                   <item row="2" column="0">
                    <widget class="QLabel" name="label_91">


### PR DESCRIPTION
- Added support for custom AI providers in the model selection dropdown
- Updated the AI model selection combo box to be editable for endpoints without `/v1/models`
- Improved handling of previously selected custom models after model retrieval

Main issue was you could only use either OpenAI or Mistral models (and at that, only specific ones  in the combo box such as `open-mistral-7b` and `gpt-4o-mini`, so you could not use `gpt-4.1` for example)