### PR TITLE
Title option

### DIFF
--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -353,6 +353,7 @@ bool ManagedProperty::readFromObject(const QObject *w)
 const int ConfigManager::MAX_NUM_MACROS;
 QTextCodec *ConfigManager::newFileEncoding = nullptr;
 QString ConfigManager::configDirOverride;
+QString ConfigManager::winttlExtension="";
 bool ConfigManager::dontRestoreSession=false;
 int ConfigManager::RUNAWAYLIMIT=50;
 

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -265,6 +265,7 @@ public:
 	void triggerManagedAction(const QString &id);
 
 	static QString configDirOverride;
+	static QString winttlExtension;
     static bool dontRestoreSession;
     static int RUNAWAYLIMIT;
 private:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,6 +149,8 @@ QStringList parseArguments(const QStringList &args, bool &outStartAlways)
 			else if ((cmdArgument == "--debug-logfile") && (++i < args.count()))
 				debugLoggerStart(args[i]);
 #endif
+			else if ((cmdArgument == "--titleExt") && (++i < args.count()))
+				ConfigManager::winttlExtension = args[i];
 			else
 				cmdLine << cmdArgument;
         } else {
@@ -179,6 +181,7 @@ bool handleCommandLineOnly(const QStringList &cmdLine) {
                             << "  --no-session              do not load/save the session at startup/close\n"
                             << "  --texpath PATH            force resetting command defaults with PATH as first search path\n"
                             << "  --version                 show version number\n"
+                            << "  --titleExt TEXT           adds TEXT to the title of the TXS window\n"
 #ifdef DEBUG_LOGGER
 							<< "  --debug-logfile pathname  write debug messages to pathname\n"
 #endif

--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -4522,7 +4522,8 @@ void PDFDocument::setCurrentFile(const QString &fileName)
 	curFileUnnormalized = fileName;
 	curFile = QFileInfo(fileName).canonicalFilePath();
 	QString niceFile = QFileInfo(curFile).fileName();
-    setWindowTitle(tr("%1[*] - %2").arg(niceFile,tr(TEXSTUDIO)));
+	QString winttlExt = (ConfigManager::winttlExtension.isEmpty() ? "" : " " + ConfigManager::winttlExtension);
+    setWindowTitle(tr("%1[*] - %2").arg(niceFile,tr(TEXSTUDIO)) + winttlExt);
 }
 
 PDFDocument *PDFDocument::findDocument(const QString &fileName)

--- a/src/pdfviewer/PDFDocument.cpp
+++ b/src/pdfviewer/PDFDocument.cpp
@@ -3067,6 +3067,10 @@ PDFDocument::PDFDocument(PDFDocumentConfig *const pdfConfig, bool embedded)
         if (!globalConfig->windowState.isEmpty()) restoreState(globalConfig->windowState);
         toolBar->setVisible(globalConfig->toolbarVisible);
         statusbar->setVisible(true);
+        QString title = TEXSTUDIO;
+        if (!ConfigManager::winttlExtension.isEmpty())
+            title += " " + ConfigManager::winttlExtension;
+        setWindowTitle(title);
     }
     if (embeddedMode && globalConfig->autoHideToolbars) {
         setAutoHideToolbars(true);

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -1879,6 +1879,8 @@ void Texstudio::updateCaption()
 		updateOpenDocumentMenu(true);
 		newDocumentLineEnding();
 	}
+	if (!ConfigManager::winttlExtension.isEmpty())
+		title += " " + ConfigManager::winttlExtension;
 	setWindowTitle(title);
 	updateUndoRedoStatus();
 	cursorPositionChanged();


### PR DESCRIPTION
A recent question (#4013) asked for ways to change the window title. In particular one wish is that it should be possible that the title shows a 'project name'.

This PR adds an option to the command line inteface of txs which allows the user to pass a string which will be appended to the text in the window title of 1) txs main window and 2) of the  windowed pdf-viewer. As an example, the name `Project Alpha` can be seen in the following screenshot:

<img width="386" height="316" alt="grafik" src="https://github.com/user-attachments/assets/00a7add8-93b3-4c57-bc40-eb6776f746ae" />

The option given in the current implementation (other suggestions?) would be `--titleExt "Project Alpha"`. The `--help` option shows this:

<img width="646" height="203" alt="grafik" src="https://github.com/user-attachments/assets/9af06166-56ca-4d24-a0c7-9074ea137375" />

Me too uses several instances of txs. So the idea of changing the window title came in mind a long time ago. Ever since I used the simple way of changing the title string in the code because I build my own versions anyway. But this is not suitable for general users.