### PR TITLE
show tooltip only for specific checkbox cbAIRecordConversation

### DIFF
--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -3578,9 +3578,6 @@ them here.</string>
                </item>
                <item>
                 <widget class="QGroupBox" name="groupBox_AIChat">
-                 <property name="toolTip">
-                  <string>Store the conversation with AI provider on disk to allow later retrieval</string>
-                 </property>
                  <property name="title">
                   <string>AI chat assistant</string>
                  </property>
@@ -3664,6 +3661,9 @@ Examples:
                   </item>
                   <item row="4" column="0">
                    <widget class="QCheckBox" name="cbAIRecordConversation">
+                    <property name="toolTip">
+                     <string>Store the conversation with AI provider on disk to allow later retrieval</string>
+                    </property>
                     <property name="text">
                      <string>Record Conversation</string>
                     </property>


### PR DESCRIPTION
The tooltip shown here

<img width="524" height="186" alt="grafik" src="https://github.com/user-attachments/assets/57a5702d-cab3-429e-a1a7-d283edfe9671" />

shows everywhere in the AI-groupbox. But the specific text fits best to the checkbox at the end of the group.