### PR TITLE
set API Url for Mistral, OpenAI, and Custom

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -713,6 +713,7 @@ void ConfigDialog::aiProviderChanged(int provider)
     default:
         ui.cbAIPreferredModel->clear();
         ui.cbAIPreferredModel->setPlaceholderText("Enter model name (e.g., llama-3.3-8B-Instruct)");
+        ui.leAIAPIURL->setText("http://localhost:8080/v1/chat/completions");
         activateCustomURL=true;
         break;
     }


### PR DESCRIPTION
Choosing Mistral or OpenAI should set the API Url to the appropriate value. Currently the same value as for Custom provider (localhost) ist used. The PR fixes #4150 (s. screenshots there).