### PR TITLE
set inital model on switch between Mistral and Open AI

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -608,7 +608,7 @@ ConfigDialog::ConfigDialog(QWidget *parent): QDialog(parent,Qt::Dialog|Qt::Windo
     // fill in the known models
     aiFillInKnownModels();
     // enable/disable custom URL depending on aiProvider
-    aiProviderChanged(ui.cbAIProvider->currentIndex());
+    aiProviderChanged(ui.cbAIProvider->currentIndex(),ui.cbAIPreferredModel->currentIndex());
 
 }
 
@@ -687,7 +687,7 @@ void ConfigDialog::revertClicked()
  * 1: openai
  * 2: custom provider
  */
-void ConfigDialog::aiProviderChanged(int provider)
+void ConfigDialog::aiProviderChanged(int provider, int modelIndex)
 {
     bool activateCustomURL=false;
     ui.cbAIPreferredModel->setEditable(true);
@@ -700,6 +700,7 @@ void ConfigDialog::aiProviderChanged(int provider)
         ui.cbAIPreferredModel->addItem("mistral-small-latest");
         ui.cbAIPreferredModel->addItem("mistral-medium-latest");
         ui.cbAIPreferredModel->addItem("mistral-large-latest");
+        ui.cbAIPreferredModel->setCurrentIndex(modelIndex);
         ui.cbAIPreferredModel->setPlaceholderText("Enter model name (e.g., open-mistral-7b)");
         break;
     case 1:
@@ -708,6 +709,7 @@ void ConfigDialog::aiProviderChanged(int provider)
         ui.cbAIPreferredModel->addItem("gpt-3.5-turbo");
         ui.cbAIPreferredModel->addItem("gpt-4");
         ui.cbAIPreferredModel->addItem("gpt-4o");
+        ui.cbAIPreferredModel->setCurrentIndex(modelIndex);
         ui.cbAIPreferredModel->setPlaceholderText("Enter model name (e.g., gpt-4o)");
         break;
     default:

--- a/src/configdialog.h
+++ b/src/configdialog.h
@@ -143,7 +143,7 @@ private slots:
 
 	void revertClicked();
 
-    void aiProviderChanged(int provider);
+    void aiProviderChanged(int provider, int modelIndex=0);
     void retrieveModels();
     void resetAIURL();
     void modelsRetrieved(QNetworkReply *reply);


### PR DESCRIPTION
Starting txs with empty profile sets default provider Mistral and a default model (`open-mistral-7b`). Since txs doesn't know which model to choose when the user switches between those providers, txs should also set a default here. Currently, txs leaves the field blank. With this PR, the first entry in the model list of the provider is set as default.

<img width="457" height="143" alt="grafik" src="https://github.com/user-attachments/assets/aee31706-bd34-4396-b2fd-0edb0194da36" />

<img width="457" height="143" alt="grafik" src="https://github.com/user-attachments/assets/64dac651-e972-4854-b81e-e137b3a8b0b9" />
