### PR TITLE
Allow multiple independent keyval args for commands

### DIFF
--- a/completion/tcolorbox.cwl
+++ b/completion/tcolorbox.cwl
@@ -134,59 +134,59 @@ library/all
 \newtcolorbox{envname}{options%keyvals}#N
 \newtcolorbox{envname}[args]{options%keyvals}#N
 \newtcolorbox{envname}[args][default]{options%keyvals}#N
-\newtcolorbox[init options]{envname}{options%keyvals}#N
-\newtcolorbox[init options]{envname}[args]{options%keyvals}#*N
-\newtcolorbox[init options]{envname}[args][default]{options%keyvals}#*N
+\newtcolorbox[init options%keyvals]{envname}{options%keyvals}#N
+\newtcolorbox[init options%keyvals]{envname}[args]{options%keyvals}#*N
+\newtcolorbox[init options%keyvals]{envname}[args][default]{options%keyvals}#*N
 \renewtcolorbox{envname}{options%keyvals}
 \renewtcolorbox{envname}[args]{options%keyvals}
 \renewtcolorbox{envname}[args][default]{options%keyvals}
-\renewtcolorbox[init options]{envname}{options%keyvals}
-\renewtcolorbox[init options]{envname}[args]{options%keyvals}#*
-\renewtcolorbox[init options]{envname}[args][default]{options%keyvals}#*
+\renewtcolorbox[init options%keyvals]{envname}[args]{options%keyvals}#*
+\renewtcolorbox[init options%keyvals]{envname}{options%keyvals}
+\renewtcolorbox[init options%keyvals]{envname}[args][default]{options%keyvals}#*
 \DeclareTColorBox{envname}{xargs}{options%keyvals}#N
-\DeclareTColorBox[init options]{envname}{xargs}{options%keyvals}#N
+\DeclareTColorBox[init options%keyvals]{envname}{xargs}{options%keyvals}#N
 \NewTColorBox{envname}{xargs}{options%keyvals}#N
-\NewTColorBox[init options]{envname}{xargs}{options%keyvals}#N
+\NewTColorBox[init options%keyvals]{envname}{xargs}{options%keyvals}#N
 \RenewTColorBox{envname}{xargs}{options%keyvals}
-\RenewTColorBox[init options]{envname}{xargs}{options%keyvals}
+\RenewTColorBox[init options%keyvals]{envname}{xargs}{options%keyvals}
 \ProvideTColorBox{envname}{xargs}{options%keyvals}#N
-\ProvideTColorBox[init options]{envname}{xargs}{options%keyvals}#N
+\ProvideTColorBox[init options%keyvals]{envname}{xargs}{options%keyvals}#N
 \DeclareTotalTColorBox{cmd}{xargs}{options%keyvals}{content}#d
-\DeclareTotalTColorBox[init options]{cmd}{xargs}{options%keyvals}{content}#d
+\DeclareTotalTColorBox[init options%keyvals]{cmd}{xargs}{options%keyvals}{content}#d
 \NewTotalTColorBox{cmd}{xargs}{options%keyvals}{content}#d
-\NewTotalTColorBox[init options]{cmd}{xargs}{options%keyvals}{content}#d
+\NewTotalTColorBox[init options%keyvals]{cmd}{xargs}{options%keyvals}{content}#d
 \RenewTotalTColorBox{cmd}{xargs}{options%keyvals}{content}
-\RenewTotalTColorBox[init options]{cmd}{xargs}{options%keyvals}{content}
+\RenewTotalTColorBox[init options%keyvals]{cmd}{xargs}{options%keyvals}{content}
 \ProvideTotalTColorBox{cmd}{xargs}{options%keyvals}{content}#d
-\ProvideTotalTColorBox[init options]{cmd}{xargs}{options%keyvals}{content}#d
+\ProvideTotalTColorBox[init options%keyvals]{cmd}{xargs}{options%keyvals}{content}#d
 \newtcbox{cmd}{options%keyvals}#d1
 \newtcbox{cmd}[args]{options%keyvals}#d1
 \newtcbox{cmd}[args][default]{options%keyvals}#d1
-\newtcbox[init options]{cmd}{options%keyvals}#d1
-\newtcbox[init options]{cmd}[args]{options%keyvals}#*d1
-\newtcbox[init options]{cmd}[args][default]{options%keyvals}#*d1
+\newtcbox[init options%keyvals]{cmd}{options%keyvals}#d1
+\newtcbox[init options%keyvals]{cmd}[args]{options%keyvals}#*d1
+\newtcbox[init options%keyvals]{cmd}[args][default]{options%keyvals}#*d1
 \renewtcbox{cmd}{options%keyvals}
 \renewtcbox{cmd}[args]{options%keyvals}
 \renewtcbox{cmd}[args][default]{options%keyvals}
-\renewtcbox[init options]{cmd}{options%keyvals}
-\renewtcbox[init options]{cmd}[args]{options%keyvals}#*
-\renewtcbox[init options]{cmd}[args][default]{options%keyvals}#*
+\renewtcbox[init options%keyvals]{cmd}{options%keyvals}
+\renewtcbox[init options%keyvals]{cmd}[args]{options%keyvals}#*
+\renewtcbox[init options%keyvals]{cmd}[args][default]{options%keyvals}#*
 \DeclareTCBox{cmd}{xargs}{options%keyvals}#d1
-\DeclareTCBox[init options]{cmd}{xargs}{options%keyvals}#d1
+\DeclareTCBox[init options%keyvals]{cmd}{xargs}{options%keyvals}#d1
 \NewTCBox{cmd}{xargs}{options%keyvals}#d1
-\NewTCBox[init options]{cmd}{xargs}{options%keyvals}#d1
+\NewTCBox[init options%keyvals]{cmd}{xargs}{options%keyvals}#d1
 \RenewTCBox{cmd}{xargs}{options%keyvals}
-\RenewTCBox[init options]{cmd}{xargs}{options%keyvals}
+\RenewTCBox[init options%keyvals]{cmd}{xargs}{options%keyvals}
 \ProvideTCBox{cmd}{xargs}{options%keyvals}#d1
-\ProvideTCBox[init options]{cmd}{xargs}{options%keyvals}#d1
+\ProvideTCBox[init options%keyvals]{cmd}{xargs}{options%keyvals}#d1
 \DeclareTotalTCBox{cmd}{xargs}{options%keyvals}{content}#d
-\DeclareTotalTCBox[init options]{cmd}{xargs}{options%keyvals}{content}#d
+\DeclareTotalTCBox[init options%keyvals]{cmd}{xargs}{options%keyvals}{content}#d
 \NewTotalTCBox{cmd}{xargs}{options%keyvals}{content%text}#d
-\NewTotalTCBox[init options]{cmd}{xargs}{options%keyvals}{content%text}#d
+\NewTotalTCBox[init options%keyvals]{cmd}{xargs}{options%keyvals}{content%text}#d
 \RenewTotalTCBox{cmd}{xargs}{options%keyvals}{content%text}
-\RenewTotalTCBox[init options]{cmd}{xargs}{options%keyvals}{content%text}
+\RenewTotalTCBox[init options%keyvals]{cmd}{xargs}{options%keyvals}{content%text}
 \ProvideTotalTCBox{cmd}{xargs}{options%keyvals}{content%text}#d
-\ProvideTotalTCBox[init options]{cmd}{xargs}{options%keyvals}{content%text}#d
+\ProvideTotalTCBox[init options%keyvals]{cmd}{xargs}{options%keyvals}{content%text}#d
 \tcboxverb{verbatim box content%definition}
 \tcboxverb[options%keyvals]{verbatim box content%definition}
 \tcolorboxenvironment{envname}{options%keyvals}
@@ -642,33 +642,22 @@ tcbox width=#auto,auto limited,forced center,forced left,forced right,minimum ce
 # commented.
 
 # # NOTE: this is not a valid syntax of #keyvals.
-# #keyvals:\newtcolorbox,\renewtcolorbox,\newtcbox,\renewtcbox,
-# \newtcblisting,\renewtcblisting,\newtcbinputlisting,\renewtcbinputlisting,
-# \newtcbtheorem,\renewtcbtheorem,
-# \newtcboxfit,\renewtcboxfit,
-# \DeclareTColorBox,\NewTColorBox,\RenewTColorBox,\ProvideTColorBox,
-# \DeclareTotalTColorBox,\NewTotalTColorBox,\RenewTotalTColorBox,\ProvideTotalTColorBox,
-# \DeclareTCBox,\NewTCBox,\RenewTCBox,\ProvideTCBox,
-# \DeclareTotalTCBox,\NewTotalTCBox,\RenewTotalTCBox,\ProvideTotalTCBox,
-# \DeclareTCBListing,\NewTCBListing,\RenewTCBListing,\ProvideTCBListing,
-# \DeclareTCBInputListing,\NewTCBInputListing,\RenewTCBInputListing,\ProvideTCBInputListing,
-# \DeclareTCBoxFit,\NewTCBoxFit,\RenewTCBoxFit,\ProvideTCBoxFit,
-# \DeclareTotalTCBoxFit,\NewTotalTCBoxFit,\RenewTotalTCBoxFit,\ProvideTotalTCBoxFit
-# auto counter
-# use counter from=%<tcolorbox%>
-# use counter=%<counter%>
-# use counter*=%<counter%>
-# no counter
-# reset counter on overlays#true,false
-# number within=%<counter%>
-# number within from=%<tcolorbox%>
-# number format=%<format macro%>
-# number freestyle=%<code%>
-# crefname={%<singular%>}{%<plural%>}
-# Crefname={%<singular%>}{%<plural%>}
-# blend into=#figures,tables,listings
-# blend before title=#colon,dash,colon hang,dash hang#c
-# blend before title code=%<code%>
-# list inside=%<name%>
-# list type=%<type%>
-# #endkeyvals
+#keyvals:\newtcolorbox#o1,\renewtcolorbox#o1,\newtcbox#o1,\renewtcbox#o1,\newtcblisting#o1,\renewtcblisting#o1,\newtcbinputlisting#o1,\renewtcbinputlisting#o1,\newtcbtheorem#o1,\renewtcbtheorem#o1,\newtcboxfit#o1,\renewtcboxfit#o1,\DeclareTColorBox#o1,\NewTColorBox#o1,\RenewTColorBox#o1,\ProvideTColorBox#o1,\DeclareTotalTColorBox#o1,\NewTotalTColorBox#o1,\RenewTotalTColorBox#o1,\ProvideTotalTColorBox#o1,\DeclareTCBox#o1,\NewTCBox#o1,\RenewTCBox#o1,\ProvideTCBox#o1,\DeclareTotalTCBox#o1,\NewTotalTCBox#o1,\RenewTotalTCBox#o1,\ProvideTotalTCBox#o1,\DeclareTCBListing#o1,\NewTCBListing#o1,\RenewTCBListing#o1,\ProvideTCBListing#o1,\DeclareTCBInputListing#o1,\NewTCBInputListing#o1,\RenewTCBInputListing#o1,\ProvideTCBInputListing#o1,\DeclareTCBoxFit#o1,\NewTCBoxFit#o1,\RenewTCBoxFit#o1,\ProvideTCBoxFit#o1,\DeclareTotalTCBoxFit#o1,\NewTotalTCBoxFit#o1,\RenewTotalTCBoxFit#o1,\ProvideTotalTCBoxFit
+auto counter
+use counter from=%<tcolorbox%>
+use counter=%<counter%>
+use counter*=%<counter%>
+no counter
+reset counter on overlays#true,false
+number within=%<counter%>
+number within from=%<tcolorbox%>
+number format=%<format macro%>
+number freestyle=%<code%>
+crefname={%<singular%>}{%<plural%>}
+Crefname={%<singular%>}{%<plural%>}
+blend into=#figures,tables,listings
+blend before title=#colon,dash,colon hang,dash hang#c
+blend before title code=%<code%>
+list inside=%<name%>
+list type=%<type%>
+#endkeyvals

--- a/src/latexparser/latexparsing.cpp
+++ b/src/latexparser/latexparsing.cpp
@@ -421,6 +421,13 @@ bool latexDetermineContexts2(QDocumentLineHandle *dlh, TokenStack &stack, Comman
                     if (!cd.arguments.isEmpty() && cd.arguments.first().type == ArgumentDescription::MANDATORY) {
                         ArgumentDescription ad= cd.arguments.takeFirst();
                         tk.subtype = ad.tokenType;
+                        // special treatment for keyval
+                        if(tk.subtype==Token::keyValArg){
+                            int indexOfKeyValArg=determineKeyValIndex(cd);
+                            if(indexOfKeyValArg>0){
+                                tk.optionalCommandName=cd.optionalCommandName+QString("#o%1").arg(indexOfKeyValArg);
+                            }
+                        }
                     } else {
                         // handle as independet braces, like commandless brace below
                         // e.g. \hline {... (\hline accepts optional arguments, but no braces)
@@ -469,6 +476,13 @@ bool latexDetermineContexts2(QDocumentLineHandle *dlh, TokenStack &stack, Comman
                         ArgumentDescription ad= cd.arguments.takeFirst();
                         tk.subtype = ad.tokenType;
                         handled=true;
+                        // special treatment for keyval
+                        if(tk.subtype==Token::keyValArg){
+                            int indexOfKeyValArg=determineKeyValIndex(cd);
+                            if(indexOfKeyValArg>0){
+                                tk.optionalCommandName=cd.optionalCommandName+QString("#o%1").arg(indexOfKeyValArg);
+                            }
+                        }
                     }
                     if(!handled){
                         // unexpected optional argument
@@ -486,6 +500,13 @@ bool latexDetermineContexts2(QDocumentLineHandle *dlh, TokenStack &stack, Comman
                     if (!cd.arguments.isEmpty() && cd.arguments.first().type == ArgumentDescription::BRACKET) {
                         ArgumentDescription ad= cd.arguments.takeFirst();
                         tk.subtype = ad.tokenType;
+                        // special treatment for keyval
+                        if(tk.subtype==Token::keyValArg){
+                            int indexOfKeyValArg=determineKeyValIndex(cd);
+                            if(indexOfKeyValArg>0){
+                                tk.optionalCommandName=cd.optionalCommandName+QString("#o%1").arg(indexOfKeyValArg);
+                            }
+                        }
                     } else {
                         lexed << tk;
                         continue;

--- a/src/latexparser/latexparsing.cpp
+++ b/src/latexparser/latexparsing.cpp
@@ -759,7 +759,12 @@ bool latexDetermineContexts2(QDocumentLineHandle *dlh, TokenStack &stack, Comman
                 tk.type = Token::keyVal_key;
                 if(!commandStack.isEmpty()){
                     const CommandDescription &cd = commandStack.top();
-                    tk.optionalCommandName=cd.optionalCommandName;
+                    int indexOfKeyValArg=determineKeyValIndex(cd);
+                    if(indexOfKeyValArg>0){
+                        tk.optionalCommandName=cd.optionalCommandName+QString("#o%1").arg(indexOfKeyValArg);
+                    }else{
+                        tk.optionalCommandName=cd.optionalCommandName;
+                    }
                 }
                 keyName = line.mid(tk.start, tk.length);
                 lexed << tk;
@@ -1579,6 +1584,22 @@ TokenList findRestArgTL(QDocumentLineHandle *dlh, Token::TokenType type, int hin
         }
     }
     return tl + findRestArgTL(dlh, type, index+1, count - 1);
+}
+/*!
+ * \brief determine the number of available keyval arguments
+ * In case more than 1 is defined
+ * \param cd
+ * \return number of keyval arguments
+ */
+int determineKeyValIndex(const CommandDescription &cd)
+{
+    int cnt=0;
+    for(int i=0;i<cd.arguments.length();++i){
+        if(cd.arguments.at(i).tokenType==Token::keyValArg){
+            ++cnt;
+        }
+    }
+    return cnt;
 }
 
 

--- a/src/latexparser/latexparsing.h
+++ b/src/latexparser/latexparsing.h
@@ -31,6 +31,7 @@ QString getCommandFromToken(Token tk); ///< get command name from Token \a tk wh
 Token getCommandTokenFromToken(TokenList tl, Token tk);
 Token::TokenType getCompleterContext(QDocumentLineHandle *dlh, int column);
 
+int determineKeyValIndex(const CommandDescription &cd);
 }
 
 #endif // LATEXPARSING_H

--- a/src/tests/syntaxcheck_t.cpp
+++ b/src/tests/syntaxcheck_t.cpp
@@ -270,6 +270,12 @@ void SyntaxCheckTest::checkkeyval_data(){
              <<"\\usepackage{hyperref} \\hypersetup{pdfpagemode=FullScreen}"<<false;
      QTest::newRow("hypersetup, val in argument 2")
              <<"\\usepackage{hyperref} \\hypersetup{pdfpagemode=test}"<<true;
+     QTest::newRow("tcolorbox, different values in 2 args")
+         <<"\\usepackage{tcolorbox} \\newtcbox[auto counter]{cmd}{after skip balanced=glue}"<<false;
+     QTest::newRow("tcolorbox, different values in 2 args, error in 2nd")
+         <<"\\usepackage{tcolorbox} \\newtcbox[auto counter]{cmd}{after kip balanced=glue}"<<true;
+     QTest::newRow("tcolorbox, different values in 2 args, error in 1st")
+         <<"\\usepackage{tcolorbox} \\newtcbox[aut counter]{cmd}{after skip balanced=glue}"<<true;
 
 }
 


### PR DESCRIPTION
Extend txs to handle multiple keyValArg within one command
the keyvals need to be defined for command#o1 etc
Starting from index 0 as the right most.

Example: init option in tcolorbox.cwl