### PR TITLE
remove new compiler warnings

### DIFF
--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1742,7 +1742,7 @@ void BuildManager::killCurrentProcess()
 QString BuildManager::createTemporaryFileName()
 {
 	QTemporaryFile *temp = new QTemporaryFile(QDir::tempPath () + "/texstudio_XXXXXX.tex");
-	temp->open();
+	bool rc = temp->open();
 	temp->setAutoRemove(false);
 	QString tempName = temp->fileName();
 	delete temp;
@@ -1848,7 +1848,7 @@ void BuildManager::preview(const QString &preamble, const PreviewSource &source,
 				//write preamble
 				QTemporaryFile *tf = new QTemporaryFile(tempPath + "hXXXXXX.tex");
 				REQUIRE(tf);
-				tf->open();
+				bool rc = tf->open();
 				QTextStream out(tf);
                 if (outputCodec) {
                     out << outputCodec->fromUnicode(preamble_mod);
@@ -1904,7 +1904,7 @@ void BuildManager::preview(const QString &preamble, const PreviewSource &source,
 	// (place /./ after the temporary directory because it fails otherwise with qt4.3 on win and the tempdir "t:")
 	QTemporaryFile *tf = new QTemporaryFile(tempPath + "XXXXXX.tex");
 	if (!tf) return;
-	tf->open();
+	bool rc = tf->open();
 
 	QTextStream out(tf);
     if (outputCodec) {

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -2906,7 +2906,7 @@ void ConfigManager::setInterfaceStyle()
 #endif
     if(newStyle=="Orion Dark"){
         QFile file(":/utilities/stylesheet_francesco.qss");
-        file.open(QFile::ReadOnly);
+        bool rc = file.open(QFile::ReadOnly);
         QString styleSheet = QString::fromLatin1(file.readAll());
         qApp->setStyleSheet(styleSheet);
         darkMode=true;

--- a/src/latexstyleparser.cpp
+++ b/src/latexstyleparser.cpp
@@ -821,7 +821,7 @@ QStringList LatexStyleParser::readPackageTracing(QString fn) const
 	QString tempPath = QDir::tempPath() + QDir::separator() + "." + QDir::separator();
 	QTemporaryFile *tf = new QTemporaryFile(tempPath + "XXXXXX.tex");
 	if (!tf) return QStringList();
-	tf->open();
+	bool rc = tf->open();
 
 	QTextStream out(tf);
 	out << "\\documentclass{article}\n";

--- a/src/pdfsplittool.cpp
+++ b/src/pdfsplittool.cpp
@@ -327,7 +327,7 @@ QString joinEscape(const QStringList &sl)
 QString MultiProcessX::createTemporaryFileName(const QString &extension)
 {
 	QTemporaryFile *temp = new QTemporaryFile(QDir::tempPath () + "/texstudio_XXXXXX" + extension);
-	temp->open();
+	bool rc = temp->open();
 	temp->setAutoRemove(false);
 	QString tempName = temp->fileName();
 	delete temp;

--- a/src/searchquery.cpp
+++ b/src/searchquery.cpp
@@ -113,7 +113,7 @@ QString SearchQuery::searchFolder() const
 
 SearchInfo SearchQuery::searchInFile(QString file, const QRegularExpression &regex){
     QFile f(file);
-    f.open(QIODevice::ReadOnly);
+    bool rc = f.open(QIODevice::ReadOnly);
     QTextStream textStream(&f);
     SearchInfo result;
     int lineNr=0;

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -7738,7 +7738,7 @@ void Texstudio::generateAddtionalTranslations()
     QRegularExpression rxCommandOnly("^\\\\['`^\"~=.^]?[a-zA-Z]*(\\{\\})* *$"); //latex command
 	//copy menu item text
 	QFile xmlFile(":/uiconfig.xml");
-	xmlFile.open(QIODevice::ReadOnly);
+	bool rc = xmlFile.open(QIODevice::ReadOnly);
 	QDomDocument xml;
 	xml.setContent(&xmlFile);
 
@@ -7768,7 +7768,7 @@ void Texstudio::generateAddtionalTranslations()
 	}
         // default formats
 	QFile xmlFile2(":/qxs/defaultFormats.qxf");
-	xmlFile2.open(QIODevice::ReadOnly);
+	rc = xmlFile2.open(QIODevice::ReadOnly);
 	xml.setContent(&xmlFile2);
 	QDomNodeList formats = xml.documentElement().elementsByTagName("format");
 	for (int i = 0; i < formats.size(); i++)
@@ -7782,7 +7782,7 @@ void Texstudio::generateAddtionalTranslations()
         QStringList l_fn=dir.entryList({"*.xml"});
         for(const QString &fn: l_fn){
             QFile xmlFile3("tags/"+fn);
-            xmlFile3.open(QIODevice::ReadOnly);
+            rc = xmlFile3.open(QIODevice::ReadOnly);
             xml.setContent(&xmlFile3);
 
             QStringList tagNames = QStringList() << "section" << "item";


### PR DESCRIPTION
```
C:/msys64/home/WDAG/texstudio-org/texstudio/src/buildmanager.cpp:1745:19: warning: ignoring return value of 'bool QTemporaryFile::open()', declared with attribute 'nodiscard' [-Wunused-result]
 1745 |         temp->open();
      |         ~~~~~~~~~~^~
C:/msys64/home/WDAG/texstudio-org/texstudio/src/buildmanager.cpp:1851:41: warning: ignoring return value of 'bool QTemporaryFile::open()', declared with attribute 'nodiscard' [-Wunused-result]
 1851 |                                 tf->open();
      |                                 ~~~~~~~~^~
C:/msys64/home/WDAG/texstudio-org/texstudio/src/buildmanager.cpp:1907:17: warning: ignoring return value of 'bool QTemporaryFile::open()', declared with attribute 'nodiscard' [-Wunused-result]
 1907 |         tf->open();
      |         ~~~~~~~~^~
C:/msys64/home/WDAG/texstudio-org/texstudio/src/configmanager.cpp:2910:18: warning: ignoring return value of 'virtual bool QFile::open(QIODeviceBase::OpenMode)', declared with attribute 'nodiscard' [-Wunused-result]
 2910 |         file.open(QFile::ReadOnly);
      |         ~~~~~~~~~^~~~~~~~~~~~~~~~~
C:/msys64/home/WDAG/texstudio-org/texstudio/src/latexstyleparser.cpp:824:17: warning: ignoring return value of 'bool QTemporaryFile::open()', declared with attribute 'nodiscard' [-Wunused-result]
  824 |         tf->open();
      |         ~~~~~~~~^~
C:/msys64/home/WDAG/texstudio-org/texstudio/src/pdfsplittool.cpp:330:19: warning: ignoring return value of 'bool QTemporaryFile::open()', declared with attribute 'nodiscard' [-Wunused-result]
  330 |         temp->open();
      |         ~~~~~~~~~~^~
C:/msys64/home/WDAG/texstudio-org/texstudio/src/searchquery.cpp:116:11: warning: ignoring return value of 'virtual bool QFile::open(QIODeviceBase::OpenMode)', declared with attribute 'nodiscard' [-Wunused-result]
  116 |     f.open(QIODevice::ReadOnly);
      |     ~~~~~~^~~~~~~~~~~~~~~~~~~~~
C:/msys64/home/WDAG/texstudio-org/texstudio/src/texstudio.cpp:7744:21: warning: ignoring return value of 'virtual bool QFile::open(QIODeviceBase::OpenMode)', declared with attribute 'nodiscard' [-Wunused-result]
 7744 |         xmlFile.open(QIODevice::ReadOnly);
      |         ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
C:/msys64/home/WDAG/texstudio-org/texstudio/src/texstudio.cpp:7774:22: warning: ignoring return value of 'virtual bool QFile::open(QIODeviceBase::OpenMode)', declared with attribute 'nodiscard' [-Wunused-result]
 7774 |         xmlFile2.open(QIODevice::ReadOnly);
      |         ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
C:/msys64/home/WDAG/texstudio-org/texstudio/src/texstudio.cpp:7788:26: warning: ignoring return value of 'virtual bool QFile::open(QIODeviceBase::OpenMode)', declared with attribute 'nodiscard' [-Wunused-result]
 7788 |             xmlFile3.open(QIODevice::ReadOnly);
      |             ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
```