### PR TITLE
Fix a command name in xeCJK.cwl

### DIFF
--- a/completion/xeCJK.cwl
+++ b/completion/xeCJK.cwl
@@ -137,7 +137,7 @@ LoadFandol#true,false
 \xeCJKResetCharClass#*
 \xeCJKResetPunctClass#*
 
-\normalspacechars{char list}#*
+\normalspacedchars{char list}#*
 
 ## 3.5
 \xeCJKsetwidth{punct list}{length}#*


### PR DESCRIPTION
Add the missing d: space -> spaced,

The original xeCJK doc (in Chinese), sec. 3.4.
<img width="1099" height="96" alt="image" src="https://github.com/user-attachments/assets/a33fbcda-04a8-4cc5-a87b-774e85b2a318" />

In English: No spaces are automatically added to the beginning and end of characters appearing in `⟨char list⟩`. The initial settings are `/`, `\`, and `-` (U+002D).