### PR TITLE
use same strings as  used for menu actions

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -10695,15 +10695,15 @@ void Texstudio::findWordRepetions()
 		<< QStringList( {tr("Word Repetition"), "wordRepetition"} )
 		<< QStringList( {tr("Long-range Word Repetition"), "wordRepetitionLongRange"} )
 		<< QStringList( {tr("Bad words"), "badWord"} )
-		<< QStringList( {tr("Grammar Mistake"), "grammarMistake"} )
-		<< QStringList( {tr("Grammar Mistake Special 1"), "grammarMistakeSpecial1"} )
-		<< QStringList( {tr("Grammar Mistake Special 2"), "grammarMistakeSpecial2"} )
-		<< QStringList( {tr("Grammar Mistake Special 3"), "grammarMistakeSpecial3"} )
-		<< QStringList( {tr("Grammar Mistake Special 4"), "grammarMistakeSpecial4"} );
+		<< QStringList( {tr("Grammar Mistake"), "grammarMistake"} );
 	for (int i=0; i<types.size(); i++) {
 		QStringList type = types.at(i);
 		cb->addItem(type.at(0));
 		cb->setItemData(i, QVariant(type.at(1)));
+	}
+	for (int i=1; i<5; i++) {
+		cb->addItem(tr("Grammar Mistake Special %1").arg(i));
+		cb->setItemData(i, QVariant(tr("grammarMistakeSpecial%1").arg(i)));
 	}
 
 	cb->setCurrentIndex(1);


### PR DESCRIPTION
looking into latest changes of the  translation files (538e49b51ef2c7123bbc938fdef69c29ae07060d) showed that two of four new translations were merged with existing ones. This PR will allow to also merge the remaining two (red underlines) with the existing translations:

`texstudio.cpp`:
existing:
<img width="895" height="66" alt="grafik" src="https://github.com/user-attachments/assets/04656d69-7554-41df-be83-f31e853e31a8" />
introduced recently:
<img width="692" height="79" alt="grafik" src="https://github.com/user-attachments/assets/b7d19cd3-b7e7-4038-b915-7eac44e06798" />
