### PR TITLE
improve error message in update checker

### DIFF
--- a/src/updatechecker.cpp
+++ b/src/updatechecker.cpp
@@ -65,8 +65,19 @@ void UpdateChecker::onRequestError(QNetworkReply::NetworkError )
 {
 	QNetworkReply *reply = qobject_cast<QNetworkReply *>(sender());
 	if (!reply) return;
-
-	UtilsUi::txsCritical(tr("Update check failed with error:\n") + reply->errorString());
+	QString errorMessage = reply->errorString();
+#if QT_VERSION_MAJOR>5
+	QByteArray data = reply->readAll();
+	QJsonParseError err;
+	QJsonDocument doc = QJsonDocument::fromJson(data, &err);
+	if (err.error == QJsonParseError::NoError && doc.isObject()) {
+		QJsonObject obj = doc.object();
+		if (obj.contains("message")) {
+			errorMessage += "\n" + obj.value("message").toString();
+		}
+	}
+#endif
+	UtilsUi::txsCritical(tr("Update check failed with error:\n") + errorMessage);
 
     networkManager->deleteLater();
     networkManager=nullptr;


### PR DESCRIPTION
I opened Config dialog/General to check for new updates. When I pressed button `Check Now` I faced following message:

<img width="502" height="133" alt="image" src="https://github.com/user-attachments/assets/528fc442-1037-4100-8fa8-20ae89af2fb4" />

I wondered what it could be. I changed the code such that the message shows more details.

<img width="502" height="175" alt="image" src="https://github.com/user-attachments/assets/e2637452-cdb1-4d94-b89c-49fa88f7b93e" />

Then I understood what's going on. This may be usefull in similar cases.

Not all messages have extended information attached:

<img width="241" height="127" alt="image" src="https://github.com/user-attachments/assets/466f5252-2a1f-4002-ad68-bcdab9b7a84b" />
