### PR TITLE
replace \AtBeginDocument and \AtEndDocument in extra LaTeX code used in documents to be previewed

### DIFF
--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -161,7 +161,7 @@ public:
 
 	static QString createTemporaryFileName(); //don't forget to remove the file!
 
-    void preview(const QString &preamble, const PreviewSource &source, const QString &masterFile, QTextCodec *outputCodec = nullptr);
+    void preview(const QString &preamble, const PreviewSource &source, const QString &masterFile, QTextCodec *outputCodec = nullptr, const QString &atBeginDocument = QString(), const QString &atEndDocument = QString());
 	void clearPreviewPreambleCache();
 
 	Q_INVOKABLE bool isCommandDirectlyDefined(const QString &id) const;

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -9426,15 +9426,17 @@ void Texstudio::showPreview(const QString &text)
 	QStringList header;
 	for (int l = 0; l < m_endingLine; l++)
 		header << edView->editor->document()->line(l).text();
+	QString atBeginDocument = "\n";
+	QString atEndDocument = "\n";
 	BuildManager::Dvi2PngMode dvi2pngModeDerived = buildManager.guessDvi2PngMode();
     if (dvi2pngModeDerived>=BuildManager::DPM_EMBEDDED_PDF) {
 		header << "\\usepackage[active,tightpage]{preview}"
-		       << "\\usepackage{varwidth}"
-		       << "\\AtBeginDocument{\\begin{preview}\\begin{varwidth}{\\linewidth}}"
-		       << "\\AtEndDocument{\\end{varwidth}\\end{preview}}";
+		       << "\\usepackage{varwidth}";
+		atBeginDocument = "\n\\begin{preview}\\begin{varwidth}{\\linewidth}\n";
+		atEndDocument = "\n\\end{varwidth}\\end{preview}\n";
 	}
 	header << "\\pagestyle{empty}";
-	buildManager.preview(header.join("\n"), PreviewSource(text, -1, -1, true), documents.getCompileFileName(), edView->editor->document()->codec());
+	buildManager.preview(header.join("\n"), PreviewSource(text, -1, -1, true), documents.getCompileFileName(), edView->editor->document()->codec(), atBeginDocument, atEndDocument);
 }
 
 void Texstudio::showPreview(const QDocumentCursor &previewc)
@@ -9466,8 +9468,18 @@ void Texstudio::showPreview(const QDocumentCursor &previewc, bool addToList)
 	if (!rootDoc) return;
 	QStringList header = makePreviewHeader(rootDoc);
 	if (header.isEmpty()) return;
+	QString atBeginDocument = "\n";
+	QString atEndDocument = "\n";
+	BuildManager::Dvi2PngMode dvi2pngModeDerived = buildManager.guessDvi2PngMode();
+	if (dvi2pngModeDerived>=BuildManager::DPM_EMBEDDED_PDF && configManager.previewMode != ConfigManager::PM_EMBEDDED) {
+		header << "\\usepackage[active,tightpage]{preview}"
+			<< "\\usepackage{varwidth}";
+		atBeginDocument = "\n\\begin{preview}\\begin{varwidth}{\\linewidth}\n";
+		atEndDocument = "\n\\end{varwidth}\\end{preview}\n";
+	}
+	header << "\\pagestyle{empty}";
 	PreviewSource ps(originalText, previewc.selectionStart().lineNumber(), previewc.selectionEnd().lineNumber(), false);
-	buildManager.preview(header.join("\n"), ps,  documents.getCompileFileName(), rootDoc->codec());
+	buildManager.preview(header.join("\n"), ps,  documents.getCompileFileName(), rootDoc->codec(), atBeginDocument, atEndDocument);
 
 	if (!addToList)
 		return;
@@ -9527,14 +9539,6 @@ QStringList Texstudio::makePreviewHeader(const LatexDocument *rootDoc)
 			header << newLine;
 		}
 	}
-	BuildManager::Dvi2PngMode dvi2pngModeDerived = buildManager.guessDvi2PngMode();
-    if (dvi2pngModeDerived>=BuildManager::DPM_EMBEDDED_PDF && configManager.previewMode != ConfigManager::PM_EMBEDDED) {
-		header << "\\usepackage[active,tightpage]{preview}"
-			<< "\\usepackage{varwidth}"
-			<< "\\AtBeginDocument{\\begin{preview}\\begin{varwidth}{\\linewidth}}"
-			<< "\\AtEndDocument{\\end{varwidth}\\end{preview}}";
-	}
-	header << "\\pagestyle{empty}";
 	return header;
 }
 


### PR DESCRIPTION
This PR resolves #4320. The problem described arises because the document class being used and TeXstudio’s PDF-preview both attempt to use the same LaTeX mechanism to achieve certain modifications, and in doing so they interfere with each other. They use the commands `\AtBeginDocument` and `\AtEndDocument` to allow code to be specified in the document preamble that should be inserted at the beginning or end of the text written or selected for preview. The issue is resolved by having TeXstudio place the required modifications directly at the start and end of a temporary text used for preview, in exactly the same way these commands would.

Description of the changes (line numbers from changed files):
`buildmanager.cpp` builds up the `document` env. But here it's not clear if any changes should be added. This is well known in `texstudio.cpp` (l. 9432 and 9474). Thus we build necessary changes there and pass them as new parameters to `buildmanager.cpp` (s. `buildmanager.h`). The code in l. 9474 in fact was the final chapter of `Texstudio::makePreviewHeader` which is moved to `Texstudio::showPreview`.

Special behavior for Beamer class is not changed in any way.

Note: The discussion in comments below may appear somewhat outdated, as the description above has changed quite a lot (including PR's title).

<details open>
<summary>Example of LaTeX document</summary>

```Latex
\documentclass[aip,apl,amsmath,amssymb,reprint,linenumbers]{revtex4-2}
\begin{document}
Several mechanisms can lead to significant Doppler broadening of hydrogen Balmer
\end{document}
```
</details>

Assume that the whole text line has been selected for preview.

<details open>
<summary>Code finally compiled for **inline** preview</summary>

```Latex
\documentclass[aip,apl,amsmath,amssymb,reprint,linenumbers]{revtex4-2}
\usepackage[active,tightpage]{preview}
\usepackage{varwidth}
\pagestyle{empty}
\begin{document}
\begin{preview}\begin{varwidth}{\linewidth}
Several mechanisms can lead to significant Doppler broadening of hydrogen Balmer
\end{varwidth}\end{preview}
\end{document}
```
</details>

<details open>
<summary>Code finally compiled for preview in embedded PDF-viewer</summary>

```Latex
\documentclass[aip,apl,amsmath,amssymb,reprint,linenumbers]{revtex4-2}
\pagestyle{empty}
\begin{document}
Several mechanisms can lead to significant Doppler broadening of hydrogen Balmer
\end{document}
```
</details>