### PR TITLE
fix "Can't find internal action" for quote macros when quote replacing is active

### DIFF
--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -2150,7 +2150,7 @@ void ConfigManager::updateUserMacroShortcuts(){
     // if the macro shortcuts have been changed via options, the macros needs to be updated to reflect that shortcuts
     int i=0;
     for(auto &m : completerConfig->userMacros){
-        if (!m.document){
+        if (!m.document && m.name != TXS_AUTO_REPLACE_QUOTE_OPEN && m.name != TXS_AUTO_REPLACE_QUOTE_CLOSE){
             QString mn=m.menu;
             if(!mn.isEmpty()){
                 mn.append('/');


### PR DESCRIPTION
Open Config dialog. In Editor options choose a method for `Replace Double Quotes`. This will add internal macros
`TXS_AUTO_REPLACE_QUOTE_OPEN` and `TXS_AUTO_REPLACE_QUOTE_CLOSE`
to the userMacros list but only after actions have been setup for the (usual) user macros (c.f. `ConfigManager::updateUserMacroMenu`).

When Config dialog is closed with ok `ConfigManager::updateUserMacroShortcuts` is executed. It selects each macro from the userMacros list and calls getManagedAction. Obviously this needs to fail for the internal macros mentioned above. Debug messages `Can't find internal action` are written for both macros.

Also abbreviations come in mind. But debugging `LatexCompleter::updateAbbreviations` shows that macros are skipped when
`macro.abbrev.isEmpty() || macro.snippet().isEmpty()` is true. Indeed, this holds for the internal macros because they don't use abbreviations. Since this may not be obvious, it might be reasonable extending the condition in a similar way as this PR does for the shortcuts. Let me know when I should do so.