### PR TITLE
Add checkbox to reset stored answer for large‑file confirmation

### DIFF
--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -2242,11 +2242,24 @@ LatexEditorView *Texstudio::load(const QString &f , bool asProject, bool recheck
     }
 #endif
 
-    if (f_real.endsWith(".log", Qt::CaseInsensitive) &&
-            UtilsUi::txsConfirm(QString("Do you want to load file %1 as LaTeX log file?").arg(QFileInfo(f).completeBaseName()))) {
-        outputView->getLogWidget()->loadLogFile(f, documents.getTemporaryCompileFileName(), QTextCodec::codecForName(configManager.logFileEncoding.toLatin1()));
-        setLogMarksVisible(true);
-        return nullptr;
+    if (f_real.endsWith(".log", Qt::CaseInsensitive)) {
+        UtilsUi::txsWarningState rememberChoice=static_cast<UtilsUi::txsWarningState>(configManager.getOption("LogView/RememberChoiceLargeFile",0).toInt());
+        bool result;
+        QString question=tr("Do you want to load file %1 as LaTeX log file?").arg(QFileInfo(f).completeBaseName());
+        if (rememberChoice==UtilsUi::DontRemember) {
+            result=UtilsUi::txsConfirm(question);
+        } else {
+            rememberChoice=UtilsUi::DontRemember;
+            result=UtilsUi::txsConfirmWarning(question,rememberChoice,tr("Clear remembered size confirmation"),QMessageBox::Question);
+            if (!rememberChoice==UtilsUi::DontRemember) {
+                configManager.setOption("LogView/RememberChoiceLargeFile",static_cast<int>(UtilsUi::DontRemember));
+            }
+        }
+        if (result) {
+            outputView->getLogWidget()->loadLogFile(f, documents.getTemporaryCompileFileName(), QTextCodec::codecForName(configManager.logFileEncoding.toLatin1()));
+            setLogMarksVisible(true);
+            return nullptr;
+        }
     }
 
     raise();

--- a/src/utilsUI.cpp
+++ b/src/utilsUI.cpp
@@ -37,15 +37,15 @@ bool txsConfirmWarning(const QString &message)
  * \param rememberChoice if true, return true and avoid Msg. rememberChoice is overwritten by checkbox result.
  * \return yes=true
  */
-bool txsConfirmWarning(const QString &message,txsWarningState &rememberChoice)
+bool txsConfirmWarning(const QString &message,txsWarningState &rememberChoice, const QString cbLabel, const QMessageBox::Icon icon)
 {
     switch (rememberChoice){
         case RememberFalse: return false ;
         case RememberTrue: return true ;
         default: ;
     }
-    QMessageBox msg(QMessageBox::Warning,TEXSTUDIO,message,QMessageBox::Yes | QMessageBox::No,QApplication::activeWindow());
-    QCheckBox *cb=new QCheckBox(QApplication::tr("Remember choice ?"));
+    QMessageBox msg(icon,TEXSTUDIO,message,QMessageBox::Yes | QMessageBox::No,QApplication::activeWindow());
+    QCheckBox *cb=new QCheckBox(cbLabel);
     msg.setCheckBox(cb);
     bool result=(msg.exec()==QMessageBox::Yes);
     if(msg.checkBox()->checkState()==Qt::Checked){

--- a/src/utilsUI.h
+++ b/src/utilsUI.h
@@ -10,7 +10,7 @@ enum txsWarningState {DontRemember,RememberFalse,RememberTrue};
 
 bool txsConfirm(const QString &message);
 bool txsConfirmWarning(const QString &message);
-bool txsConfirmWarning(const QString &message,txsWarningState &rememberChoice);
+bool txsConfirmWarning(const QString &message,txsWarningState &rememberChoice, const QString cbLabel=QApplication::tr("Remember choice ?"),const QMessageBox::Icon icon=QMessageBox::Warning);
 QMessageBox::StandardButton txsConfirmWarning(const QString &message, QMessageBox::StandardButtons buttons);
 void txsInformation(const QString &message);
 void txsWarning(const QString &message);


### PR DESCRIPTION
This PR resolves #4389 

When you load a large log file, an additional size confirmation dialog is shown. This dialog includes a checkbox that allows txs to remember whether you selected Yes or No. If No is selected and remembered, you will no longer be able to load large log files. In such cases, users previously had to open an issue and manually edit a value in the .ini file.

To avoid this situation, the first confirmation dialog (asking whether you want to load the log as a LaTeX log file) has been enhanced. If the size confirmation is no longer shown, an option is now provided that allows the user to restore the original behavior:

<img width="400" height="134" alt="grafik" src="https://github.com/user-attachments/assets/d11716a2-362c-4bc3-8a9a-d05ad844b53b" />