### PR TITLE
Update nicematrix.cwl

### DIFF
--- a/completion/nicematrix.cwl
+++ b/completion/nicematrix.cwl
@@ -508,8 +508,6 @@ extra-margin=##L
 parallelize-diags#true,false
 delimiters/max-width
 vlines-in-sub-matrix=%<letter%>
-colortbl-like
-color-inside
 rounded-corners
 rounded-corners=##L
 #endkeyvals


### PR DESCRIPTION
The keys `color-inside` and  `colortbl-like` are now deprecated in `nicematrix`. 