### PR TITLE
offer "Clear stored answer" action when loading large logs

### DIFF
--- a/src/latexlogwidget.cpp
+++ b/src/latexlogwidget.cpp
@@ -167,11 +167,11 @@ bool LatexLogWidget::loadLogFile(const QString &logname, const QString &compiled
                 config->setOption("LogView/RememberChoiceLargeFile",static_cast<int>(rememberChoice));
             }
             if(!result){
-                if(skipLoadRememberChoice){
-                    setInfo(tr("Log not loaded because of size constraint (%1 MB). User chose not to load it and set it as default option !\nTo revoke that choice, see [manual](%2)").arg(fileSizeMB, 0, 'f', 2).arg("https://texstudio-org.github.io/configuration.html#hidden-settings"));
-                }else{
+                if(rememberChoice==UtilsUi::DontRemember){
                     setInfo(tr("Log not loaded because of size constraint (%1 MB). User chose not to load it !").arg(fileSizeMB, 0, 'f', 2));
                     m_lastIgnoredFilename=logname;
+                }else{
+                    setInfo(tr("Log not loaded because of size constraint (%1 MB). User chose not to load it and set it as default option ! [Clear stored answer](%2)").arg(fileSizeMB, 0, 'f', 2).arg("setToUtilsUi::txsWarningState::RememberFalse"));
                 }
                 return false;
             }

--- a/src/latexlogwidget.cpp
+++ b/src/latexlogwidget.cpp
@@ -129,12 +129,12 @@ void LatexLogWidget::onInfoLinkActivated(const QString &link)
     config->setOption("LogView/RememberChoiceLargeFile",static_cast<int>(rememberChoice));
 
     if (link==QLatin1String("setToUtilsUi::txsWarningState::RememberFalse")) {
-        setInfo(tr("Your remembered answer has been cleared. Please reopen the log to load it."));
+        setInfo(QString());
     }else if (link==QLatin1String("setToUtilsUi::txsWarningState::RememberTrue")) {
-        setInfo(tr("Your remembered answer has been cleared."));
+        setInfo(QString());
     }else{
         m_lastIgnoredFilename.clear();
-        setInfo(tr("Reset done."));
+        setInfo(QString());
     }
 }
 
@@ -169,14 +169,17 @@ bool LatexLogWidget::loadLogFile(const QString &logname, const QString &compiled
             }
             if(!m_answer){
                 if(rememberChoice==UtilsUi::DontRemember){
-                    setInfo(tr("Log not loaded because of size constraint (%1 MB). User chose not to load it ! [reset](%2)").arg(fileSizeMB, 0, 'f', 2).arg("resetName"));
+                    QString text=tr("Log not loaded because of size constraint (%1 MB). User chose not to load it !").arg(fileSizeMB, 0, 'f', 2);
+                    setInfo(("["+text+"](%1)").arg("resetName"));
                     m_lastIgnoredFilename=logname;
                 }else{
-                    setInfo(tr("Log not loaded because of size constraint (%1 MB). User chose not to load it and set it as default option ! [Clear stored answer](%2)").arg(fileSizeMB, 0, 'f', 2).arg("setToUtilsUi::txsWarningState::RememberFalse"));
+                    QString text=tr("Log not loaded because of size constraint (%1 MB). User chose not to load it and set it as default option !").arg(fileSizeMB, 0, 'f', 2);
+                    setInfo(("["+text+"](%1)").arg("setToUtilsUi::txsWarningState::RememberFalse"));
                 }
                 return false;
             }else if(rememberChoice==UtilsUi::RememberTrue) {
-                setInfo(tr("Log file size (%1 MB) above limit; loading performed due to your remembered choice. [Clear stored answer](%2)").arg(fileSizeMB, 0, 'f', 2).arg("setToUtilsUi::txsWarningState::RememberTrue"));
+                QString text=tr("Log file size (%1 MB) above limit; loading performed due to your remembered choice.").arg(fileSizeMB, 0, 'f', 2);
+                setInfo(("["+text+"](%1)").arg("setToUtilsUi::txsWarningState::RememberTrue"));
             }
         }
         m_lastIgnoredFilename.clear();

--- a/src/latexlogwidget.cpp
+++ b/src/latexlogwidget.cpp
@@ -174,6 +174,8 @@ bool LatexLogWidget::loadLogFile(const QString &logname, const QString &compiled
                     setInfo(tr("Log not loaded because of size constraint (%1 MB). User chose not to load it and set it as default option ! [Clear stored answer](%2)").arg(fileSizeMB, 0, 'f', 2).arg("setToUtilsUi::txsWarningState::RememberFalse"));
                 }
                 return false;
+            }else if(rememberChoice==UtilsUi::RememberTrue) {
+                setInfo(tr("Log file size (%1 MB) above limit; loading performed due to your remembered choice. [Clear stored answer](%2)").arg(fileSizeMB, 0, 'f', 2).arg("setToUtilsUi::txsWarningState::RememberTrue"));
             }
         }
         m_lastIgnoredFilename.clear();

--- a/src/latexlogwidget.cpp
+++ b/src/latexlogwidget.cpp
@@ -130,8 +130,11 @@ void LatexLogWidget::onInfoLinkActivated(const QString &link)
 
     if (link==QLatin1String("setToUtilsUi::txsWarningState::RememberFalse")) {
         setInfo(tr("Your remembered answer has been cleared. Please reopen the log to load it."));
-    }else{
+    }else if (link==QLatin1String("setToUtilsUi::txsWarningState::RememberTrue")) {
         setInfo(tr("Your remembered answer has been cleared."));
+    }else{
+        m_lastIgnoredFilename.clear();
+        setInfo(tr("Reset done."));
     }
 }
 
@@ -156,19 +159,17 @@ bool LatexLogWidget::loadLogFile(const QString &logname, const QString &compiled
 	QFile f(logname);
 	if (f.open(QIODevice::ReadOnly)) {
         ConfigManagerInterface *config=ConfigManagerInterface::getInstance();
-        double fileSizeLimitMB = config->getOption("LogView/WarnIfFileSizeLargerMB").toDouble();
         UtilsUi::txsWarningState rememberChoice=static_cast<UtilsUi::txsWarningState>(config->getOption("LogView/RememberChoiceLargeFile",0).toInt());
+        double fileSizeLimitMB = config->getOption("LogView/WarnIfFileSizeLargerMB").toDouble();
         double fileSizeMB = double(f.size()) / 1024 / 1024;
         if (fileSizeMB > fileSizeLimitMB){
-            bool skipLoadRememberChoice=(rememberChoice==UtilsUi::txsWarningState::RememberFalse);
-            bool result=false;
-            if(m_lastIgnoredFilename!=logname){
-                result=UtilsUi::txsConfirmWarning(tr("The logfile is very large (%1 MB) are you sure you want to load it?").arg(fileSizeMB, 0, 'f', 2),rememberChoice);
+            if(m_lastIgnoredFilename!=logname) {
+                m_answer=UtilsUi::txsConfirmWarning(tr("The logfile is very large (%1 MB) are you sure you want to load it?").arg(fileSizeMB, 0, 'f', 2),rememberChoice);
                 config->setOption("LogView/RememberChoiceLargeFile",static_cast<int>(rememberChoice));
             }
-            if(!result){
+            if(!m_answer){
                 if(rememberChoice==UtilsUi::DontRemember){
-                    setInfo(tr("Log not loaded because of size constraint (%1 MB). User chose not to load it !").arg(fileSizeMB, 0, 'f', 2));
+                    setInfo(tr("Log not loaded because of size constraint (%1 MB). User chose not to load it ! [reset](%2)").arg(fileSizeMB, 0, 'f', 2).arg("resetName"));
                     m_lastIgnoredFilename=logname;
                 }else{
                     setInfo(tr("Log not loaded because of size constraint (%1 MB). User chose not to load it and set it as default option ! [Clear stored answer](%2)").arg(fileSizeMB, 0, 'f', 2).arg("setToUtilsUi::txsWarningState::RememberFalse"));

--- a/src/latexlogwidget.cpp
+++ b/src/latexlogwidget.cpp
@@ -82,7 +82,8 @@ LatexLogWidget::LatexLogWidget(QWidget *parent) :
     infoLabel->setTextFormat(Qt::MarkdownText);
 	infoLabel->setMargin(2);
     infoLabel->setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::LinksAccessibleByMouse);
-    infoLabel->setOpenExternalLinks(true);
+    infoLabel->setOpenExternalLinks(false);
+    connect(infoLabel, &QLabel::linkActivated, this, &LatexLogWidget::onInfoLinkActivated);
 
 	QVBoxLayout *vLayout = new QVBoxLayout(); //contains the widgets for the normal mode (OutputTable + OutputLogTextEdit)
 	vLayout->setSpacing(0);
@@ -119,6 +120,19 @@ LatexLogWidget::LatexLogWidget(QWidget *parent) :
 	errorTable->setVisible(true);
 	displayLogAction->setChecked(false);
 	log->setVisible(false);
+}
+
+void LatexLogWidget::onInfoLinkActivated(const QString &link)
+{
+    ConfigManagerInterface *config=ConfigManagerInterface::getInstance();
+    UtilsUi::txsWarningState rememberChoice = UtilsUi::txsWarningState::DontRemember;
+    config->setOption("LogView/RememberChoiceLargeFile",static_cast<int>(rememberChoice));
+
+    if (link==QLatin1String("setToUtilsUi::txsWarningState::RememberFalse")) {
+        setInfo(tr("Your remembered answer has been cleared. Please reopen the log to load it."));
+    }else{
+        setInfo(tr("Your remembered answer has been cleared."));
+    }
 }
 
 void LatexLogWidget::resizeRows()

--- a/src/latexlogwidget.cpp
+++ b/src/latexlogwidget.cpp
@@ -173,13 +173,13 @@ bool LatexLogWidget::loadLogFile(const QString &logname, const QString &compiled
                     setInfo(("["+text+"](%1)").arg("resetName"));
                     m_lastIgnoredFilename=logname;
                 }else{
-                    QString text=tr("Log not loaded because of size constraint (%1 MB). User chose not to load it and set it as default option !").arg(fileSizeMB, 0, 'f', 2);
-                    setInfo(("["+text+"](%1)").arg("setToUtilsUi::txsWarningState::RememberFalse"));
+                    QString text=tr("Log not loaded because of size constraint (%1 MB). User chose not to load it and set it as default option ! [Clear stored answer](%2)");
+                    setInfo(text.arg(fileSizeMB, 0, 'f', 2).arg("setToUtilsUi::txsWarningState::RememberFalse"));
                 }
                 return false;
             }else if(rememberChoice==UtilsUi::RememberTrue) {
-                QString text=tr("Log file size (%1 MB) above limit; loading performed due to your remembered choice.").arg(fileSizeMB, 0, 'f', 2);
-                setInfo(("["+text+"](%1)").arg("setToUtilsUi::txsWarningState::RememberTrue"));
+                QString text=tr("Log file size (%1 MB) above limit; loading performed due to your remembered choice. [Clear stored answer](%2)");
+                setInfo(text.arg(fileSizeMB, 0, 'f', 2).arg("setToUtilsUi::txsWarningState::RememberTrue"));
             }
         }
         m_lastIgnoredFilename.clear();

--- a/src/latexlogwidget.h
+++ b/src/latexlogwidget.h
@@ -57,7 +57,8 @@ private:
 	QLabel *infoLabel;
 	QAction *displayTableAction, *displayLogAction, *filterErrorAction, *filterWarningAction, *filterBadBoxAction;
 
-    QString m_lastIgnoredFilename; // remember logname which the user did not load to avoid asking again
+	QString m_lastIgnoredFilename; // remember logname which the user did not load to avoid asking again
+	bool m_answer; // remember dialog answer
 
 	void copyRowsWithColumnRange(int firstRow, int rows, int first, int last);
 	void onInfoLinkActivated(const QString &link);

--- a/src/latexlogwidget.h
+++ b/src/latexlogwidget.h
@@ -60,6 +60,7 @@ private:
     QString m_lastIgnoredFilename; // remember logname which the user did not load to avoid asking again
 
 	void copyRowsWithColumnRange(int firstRow, int rows, int first, int last);
+	void onInfoLinkActivated(const QString &link);
 };
 
 #endif // LATEXLOGWIDGET_H

--- a/utilities/manual/source/CHANGELOG.md
+++ b/utilities/manual/source/CHANGELOG.md
@@ -17,6 +17,7 @@
 - show progress dialog when restoring files takes longer
 - clean-up dialog allows arbitrary file endings [#4419](https://github.com/texstudio-org/texstudio/pull/4419)
 - completion of user constructs can be disabled (options/completer). This may speed up file restore for large projects
+- response after opening large log files can now be reverted by clicking the message [#4416](https://github.com/texstudio-org/texstudio/pull/4416)
 
 ## TeXstudio 4.9.3
 


### PR DESCRIPTION
Based on the recently introduced info messages in the log panel, this PR aims to provide more convenience to the user. For reference s. #4389.

In cases where the file‑size confirmation dialog was automatically answered with Yes or No based on the last remembered choice, the info message now includes a link. This link allows the user to quickly and easily clear the stored answer with a single click. This gives them back full control in all possible situations. They no longer need to look up in the manual how to modify the ini file accordingly. The section about hidden options is still not obsolete, though.