### PR TITLE
Cleanup dialog should not constantly add a dot to given extensions

### DIFF
--- a/src/cleandialog.cpp
+++ b/src/cleandialog.cpp
@@ -18,7 +18,7 @@ CleanDialog::CleanDialog(QWidget *parent) :
 	UtilsUi::resizeInFontHeight(this, 38, 22);
 
 	ConfigManagerInterface *config = ConfigManager::getInstance();
-	config->registerOption("CleanDialog/Extensions", &currentExtensions, defaultExtensions);
+	config->registerOption("CleanDialog/ExtensionsWithDot", &currentExtensions, defaultExtensions);
 	config->registerOption("CleanDialog/Scope", &scopeID, 0);
 	if (scopeID < 0 || scopeID >= MAX_SCOPE) scopeID = 0;
 

--- a/src/cleandialog.cpp
+++ b/src/cleandialog.cpp
@@ -28,7 +28,7 @@ CleanDialog::CleanDialog(QWidget *parent) :
 	if (rxValExtensionList->validate(currentExtensions, dummyPos) == QValidator::Acceptable) {
 		ui->leExtensions->setText(currentExtensions);
 	} else {
-		UtilsUi::txsWarning("Invalid extension list found. Resetting to default.");
+		UtilsUi::txsWarning(tr("Invalid extension list %1 found. Resetting to default.").arg(currentExtensions));
 		currentExtensions = defaultExtensions;
 		ui->leExtensions->setText(currentExtensions);
 	}

--- a/src/cleandialog.cpp
+++ b/src/cleandialog.cpp
@@ -22,8 +22,8 @@ CleanDialog::CleanDialog(QWidget *parent) :
 	config->registerOption("CleanDialog/Scope", &scopeID, 0);
 	if (scopeID < 0 || scopeID >= MAX_SCOPE) scopeID = 0;
 
-	QString allowedChars = "[^\\\\/\\?\\%\\*:|\"<>\\s,;\\{\\}\\[\\]\\(\\)]";
-    QRegularExpressionValidator *rxValExtensionList = new QRegularExpressionValidator(QRegularExpression(QString("(%1+\\.)*%1+(,(%1+\\.)*%1+)*").arg(allowedChars)), this);
+	QString disallowedChars = "[^\\\\/\\?\\%\\*:|\"<>\\s,;\\{\\}\\[\\]\\(\\)]";
+    QRegularExpressionValidator *rxValExtensionList = new QRegularExpressionValidator(QRegularExpression(QString("(%1+\\.)*%1+(,(%1+\\.)*%1+)*").arg(disallowedChars)), this);
 	int dummyPos;
 	if (rxValExtensionList->validate(currentExtensions, dummyPos) == QValidator::Acceptable) {
 		ui->leExtensions->setText(currentExtensions);

--- a/src/cleandialog.cpp
+++ b/src/cleandialog.cpp
@@ -15,7 +15,7 @@ CleanDialog::CleanDialog(QWidget *parent) :
 	ui(new Ui::CleanDialog)
 {
 	ui->setupUi(this);
-	UtilsUi::resizeInFontHeight(this, 38, 22);
+	UtilsUi::resizeInFontHeight(this, 40, 22);
 
 	ConfigManagerInterface *config = ConfigManager::getInstance();
 	config->registerOption("CleanDialog/ExtensionsWithDot", &currentExtensions, defaultExtensions);

--- a/src/cleandialog.cpp
+++ b/src/cleandialog.cpp
@@ -4,7 +4,7 @@
 #include "configmanager.h"
 #include "utilsUI.h"
 
-QString CleanDialog::defaultExtensions = "log,aux,dvi,lof,lot,bit,idx,glo,bbl,bcf,ilg,toc,ind,out,blg,fdb_latexmk,fls,run.xml";
+QString CleanDialog::defaultExtensions = ".log,.aux,.dvi,.lof,.lot,.bit,.idx,.glo,.bbl,.bcf,.ilg,.toc,.ind,.out,.blg,.fdb_latexmk,.fls,.run.xml";
 QString CleanDialog::currentExtensions = CleanDialog::defaultExtensions;
 int CleanDialog::scopeID = 0;
 
@@ -104,7 +104,7 @@ void CleanDialog::updateFilesToRemove() {
 #else
     QStringList extList(ui->leExtensions->text().split(',', QString::SkipEmptyParts));
 #endif
-	QStringList forbiddenExtensions = QStringList() << "tex" << "lytex";
+	QStringList forbiddenExtensions = QStringList() << ".tex" << ".lytex";
 	QStringList found;
 	foreach (const QString &ext, forbiddenExtensions) {
 		if (extList.contains(ext))
@@ -137,7 +137,7 @@ QStringList CleanDialog::filesToRemove(CleanDialog::Scope scope, const QStringLi
 	case Project:
 		{
 			QStringList filterList;
-			foreach (const QString &ext, extensionFilter) filterList << "*." + ext;
+			foreach (const QString &ext, extensionFilter) filterList << "*" + ext;
 			files << filesToRemoveFromDir(QFileInfo(masterFile).absoluteDir(), filterList);
 		}
 		break;
@@ -146,7 +146,7 @@ QStringList CleanDialog::filesToRemove(CleanDialog::Scope scope, const QStringLi
 			QFileInfo fi(currentTexFile);
 			QString basename=fi.absolutePath()+"/"+fi.completeBaseName();
 			foreach(const QString& ext, extensionFilter) {
-				QFileInfo f(basename + "." + ext);
+				QFileInfo f(basename + ext);
 				if (f.exists())
 					files << f.absoluteFilePath();
 			}
@@ -155,7 +155,7 @@ QStringList CleanDialog::filesToRemove(CleanDialog::Scope scope, const QStringLi
 	case CurrentFileFolder:
 		{
 			QStringList filterList;
-			foreach (const QString &ext, extensionFilter) filterList << "*." + ext;
+			foreach (const QString &ext, extensionFilter) filterList << "*" + ext;
 			files << filesToRemoveFromDir(QFileInfo(currentTexFile).absoluteDir(), filterList);
 		}
 		break;
@@ -165,7 +165,7 @@ QStringList CleanDialog::filesToRemove(CleanDialog::Scope scope, const QStringLi
 				QFileInfo fi(finame);
 				QString basename=fi.absolutePath()+"/"+fi.completeBaseName();
 				foreach(const QString& ext, extensionFilter) {
-					QFileInfo f(basename + "." + ext);
+					QFileInfo f(basename + ext);
 					if (f.exists())
 						files << f.absoluteFilePath();
 				}

--- a/src/cleandialog.cpp
+++ b/src/cleandialog.cpp
@@ -28,7 +28,7 @@ CleanDialog::CleanDialog(QWidget *parent) :
 	if (rxValExtensionList->validate(currentExtensions, dummyPos) == QValidator::Acceptable) {
 		ui->leExtensions->setText(currentExtensions);
 	} else {
-		UtilsUi::txsWarning(tr("Invalid extension list %1 found. Resetting to default.").arg(currentExtensions));
+		UtilsUi::txsWarning("Invalid extension list found. Resetting to default.");
 		currentExtensions = defaultExtensions;
 		ui->leExtensions->setText(currentExtensions);
 	}

--- a/src/cleandialog.cpp
+++ b/src/cleandialog.cpp
@@ -22,7 +22,7 @@ CleanDialog::CleanDialog(QWidget *parent) :
 	config->registerOption("CleanDialog/Scope", &scopeID, 0);
 	if (scopeID < 0 || scopeID >= MAX_SCOPE) scopeID = 0;
 
-	QString allowedChars = "[^\\\\/\\?\\%\\*:|\"<>\\s,;]";
+	QString allowedChars = "[^\\\\/\\?\\%\\*:|\"<>\\s,;\\{\\}\\[\\]\\(\\)]";
     QRegularExpressionValidator *rxValExtensionList = new QRegularExpressionValidator(QRegularExpression(QString("(%1+\\.)*%1+(,(%1+\\.)*%1+)*").arg(allowedChars)), this);
 	int dummyPos;
 	if (rxValExtensionList->validate(currentExtensions, dummyPos) == QValidator::Acceptable) {

--- a/src/cleandialog.cpp
+++ b/src/cleandialog.cpp
@@ -23,7 +23,7 @@ CleanDialog::CleanDialog(QWidget *parent) :
 	if (scopeID < 0 || scopeID >= MAX_SCOPE) scopeID = 0;
 
 	QString disallowedChars = "[^\\\\/\\?\\%\\*:|\"<>\\s,;\\{\\}\\[\\]\\(\\)]";
-    QRegularExpressionValidator *rxValExtensionList = new QRegularExpressionValidator(QRegularExpression(QString("(%1+\\.)*%1+(,(%1+\\.)*%1+)*").arg(disallowedChars)), this);
+	QRegularExpressionValidator *rxValExtensionList = new QRegularExpressionValidator(QRegularExpression(QString("(%1+\\.)*%1+(,(%1+\\.)*%1+)*").arg(disallowedChars)), this);
 	int dummyPos;
 	if (rxValExtensionList->validate(currentExtensions, dummyPos) == QValidator::Acceptable) {
 		ui->leExtensions->setText(currentExtensions);
@@ -100,9 +100,9 @@ void CleanDialog::updateFilesToRemove() {
 	scopeID = ui->cbScope->itemData(ui->cbScope->currentIndex()).toInt();
 	Scope scope = (Scope) scopeID;
 #if (QT_VERSION>=QT_VERSION_CHECK(5,14,0))
-    QStringList extList(ui->leExtensions->text().split(',', Qt::SkipEmptyParts));
+	QStringList extList(ui->leExtensions->text().split(',', Qt::SkipEmptyParts));
 #else
-    QStringList extList(ui->leExtensions->text().split(',', QString::SkipEmptyParts));
+	QStringList extList(ui->leExtensions->text().split(',', QString::SkipEmptyParts));
 #endif
 	QStringList forbiddenExtensions = QStringList() << ".tex" << ".lytex";
 	QStringList found;
@@ -174,8 +174,8 @@ QStringList CleanDialog::filesToRemove(CleanDialog::Scope scope, const QStringLi
 		break;
 	case None:
 		break;
-    default:
-        break;
+	default:
+		break;
 	}
 	return files;
 }
@@ -187,8 +187,8 @@ QStringList CleanDialog::filesToRemoveFromDir(const QDir &dir, const QStringList
 	}
 	if (recursive) {
 		foreach (const QFileInfo &fi, dir.entryInfoList(QDir::AllDirs | QDir::NoDotAndDotDot)) {
-            if(fi.fileName().startsWith("."))
-                continue; // filter directories starting with . (e.g. .git) since they are not automatiocally hidden on windows
+			if(fi.fileName().startsWith("."))
+				continue; // filter directories starting with . (e.g. .git) since they are not automatiocally hidden on windows
 			files << filesToRemoveFromDir(fi.absoluteFilePath(), extensionFilter, recursive);
 		}
 	}

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -4631,6 +4631,18 @@ void Texstudio::readSettings(bool reread)
     tobemaximized = config->value("MainWindow/Maximized", false).toBool();
     tobefullscreen = config->value("MainWindow/FullScreen", false).toBool();
 
+    // convert to file extensions with dot for cleanup-dialog (#4419)
+    if (!config->contains("CleanDialog/ExtensionsWithDot") && config->contains("CleanDialog/Extensions")) {
+        QString oldExtensions = config->value("CleanDialog/Extensions").toString();
+        QStringList oldExtList = oldExtensions.split(',', Qt::SkipEmptyParts);
+        QStringList convertedList;
+        for (const QString &extension : oldExtList) {
+            convertedList << "." + extension;
+        }
+        QString convertedExtensions = convertedList.join(",");
+        config->setValue("CleanDialog/ExtensionsWithDot", convertedExtensions);
+    }
+
     //dark mode menu
     if(darkMode && ignoreSystemPalette){
         QString ownStyle;

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -4632,7 +4632,7 @@ void Texstudio::readSettings(bool reread)
     tobefullscreen = config->value("MainWindow/FullScreen", false).toBool();
 
     // convert to file extensions with dot for cleanup-dialog (#4419)
-    if (!config->contains("CleanDialog/ExtensionsWithDot") && config->contains("CleanDialog/Extensions")) {
+    if (config->contains("CleanDialog/Extensions")) {
         QString oldExtensions = config->value("CleanDialog/Extensions").toString();
         QStringList oldExtList = oldExtensions.split(',', Qt::SkipEmptyParts);
         QStringList convertedList;
@@ -4641,6 +4641,7 @@ void Texstudio::readSettings(bool reread)
         }
         QString convertedExtensions = convertedList.join(",");
         config->setValue("CleanDialog/ExtensionsWithDot", convertedExtensions);
+        config->remove("CleanDialog/Extensions");
     }
 
     //dark mode menu


### PR DESCRIPTION
This PR resolves #4418 
a new option `ExtensionsWithDot` is introduced which replaces option `Extensions`