### PR TITLE
Fix deprecated enum-to-floating‑point conversion in Adwaita style code

### DIFF
--- a/src/adwaita-qt/style/adwaitahelper.cpp
+++ b/src/adwaita-qt/style/adwaitahelper.cpp
@@ -1334,7 +1334,7 @@ void Helper::renderSliderGroove(QPainter *painter, const QRect &rect, const QCol
     painter->setRenderHint(QPainter::Antialiasing, true);
 
     QRectF baseRect(rect);
-    qreal radius(0.5 * Metrics::Slider_GrooveThickness);
+    qreal radius(0.5 * static_cast<qreal>(Metrics::Slider_GrooveThickness));
 
     // content
     if (color.isValid()) {
@@ -1522,7 +1522,7 @@ void Helper::renderProgressBarBusyContents(QPainter *painter, const QRect &rect,
     painter->setRenderHint(QPainter::Antialiasing, true);
 
     QRectF baseRect(rect);
-    qreal radius(0.25 * Metrics::ProgressBar_Thickness);
+    qreal radius(0.25 * static_cast<qreal>(Metrics::ProgressBar_Thickness));
     QRectF contentRect;
     if (horizontal) {
         contentRect = QRect(baseRect.left(), baseRect.top(), Metrics::ProgressBar_BusyIndicatorSize, baseRect.height());


### PR DESCRIPTION
This PR fixes a C++20 deprecation warning in the embedded Adwaita style code.
Clang emits the following warning during build:
```
warning: arithmetic between floating-point type 'double' and enumeration type 'Adwaita::Metrics' is deprecated [-Wdeprecated-enum-float-conversion]
```
The issue is caused by an implicit conversion of the enum value Metrics::ProgressBar_Thickness (an int) to double. This PR removes the warning and makes the code future‑proof without changing behavior.