### PR TITLE
Expand volatile increment to avoid C++20 deprecation warning

### DIFF
--- a/src/debug/debughelper.cpp
+++ b/src/debug/debughelper.cpp
@@ -1484,7 +1484,7 @@ void Guardian::summon()
 
 void Guardian::calm()
 {
-	mainEventLoopTicks++;
+	mainEventLoopTicks = mainEventLoopTicks + 1;
 }
 
 void Guardian::shutdown()


### PR DESCRIPTION
C++20 deprecates compound operations such as `++` on volatile types. Clang emits the following warning during build:
```
texstudio/src/debug/debughelper.cpp: In static member function 'static void Guardian::calm()':
texstudio/src/debug/debughelper.cpp:1487:9: warning: '++' expression of 'volatile'-qualified type is deprecated [-Wvolatile]
 1487 |         mainEventLoopTicks++;
      |         ^~~~~~~~~~~~~~~~~~
```
This patch updates the increment of `mainEventLoopTicks` to use `mainEventLoopTicks = mainEventLoopTicks + 1;` to ensure standards‑compliant behavior.