### PR TITLE
avoid crash when last editor is moved from 2. to 1. split

### DIFF
--- a/src/editors.cpp
+++ b/src/editors.cpp
@@ -262,7 +262,9 @@ QList<LatexEditorView *> Editors::topEditors()
 {
     QList<LatexEditorView *> editors;
     foreach (TxsTabWidget *tabGroup, tabGroups) {
-        editors.append(qobject_cast<LatexEditorView *>(tabGroup->currentWidget()));
+        if (tabGroup->count() > 0) {
+            editors.append(qobject_cast<LatexEditorView *>(tabGroup->currentWidget()));
+        }
     }
     return editors;
 }


### PR DESCRIPTION
This PR fixes #4436. The issue describes the reason for the crash. Now the code checks whether the tabGroup is empty.