### PR TITLE
debughelper: remove compiler warning

### DIFF
--- a/src/debug/debughelper.cpp
+++ b/src/debug/debughelper.cpp
@@ -319,8 +319,8 @@ bool initDebugHelp()
 
 	LOAD_FUNCTIONREQRET(SymInitialize, "SymInitialize", false);
 
-    if (!(*SymInitialize)(true ? GetCurrentProcess() : (HANDLE)GetCurrentProcessId(), 0, true))
-        return false;
+	if (!(*SymInitialize)(GetCurrentProcess(), 0, true))
+		return false;
 	return true;
 }
 


### PR DESCRIPTION
This PR resolves #4440 . There is no change in functionality. Removing unnecessary code simply prevents the compiler from issuing a message.
if you like braces to enclose the `then` path, please let me know.