### PR TITLE
clarify indentation of an if statement

### DIFF
--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1848,7 +1848,7 @@ void BuildManager::preview(const QString &preamble, const PreviewSource &source,
 				//write preamble
 				QTemporaryFile *tf = new QTemporaryFile(tempPath + "hXXXXXX.tex");
 				REQUIRE(tf);
-                if(!tf->open()) return; // opening file failed
+				if(!tf->open()) return; // opening file failed
 				QTextStream out(tf);
                 if (outputCodec) {
                     out << outputCodec->fromUnicode(preamble_mod);


### PR DESCRIPTION
One of the builds shows this message:
```
D:/a/texstudio/texstudio/src/buildmanager.cpp:1851:17: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
 1851 |                 if(!tf->open()) return; // opening file failed
      |                 ^~
D:/a/texstudio/texstudio/src/buildmanager.cpp:1852:33: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
 1852 |                                 QTextStream out(tf);
```
Here, indentation is done with blanks while tabs are used in the following line. Depending on the size of tabs this might lead to an effective indentation that is larger than the one of the `if`. This could lead to the assumption that the line (1852) is part of the `then` path. The image shows the fixed part:

<img width="530" height="146" alt="image" src="https://github.com/user-attachments/assets/af7b8cdb-892e-4b9d-9c5f-26fefc402662" />
