### PR TITLE
cwl: include tagpdf pkg in latex-dev.cwl

### DIFF
--- a/completion/axessibility.cwl
+++ b/completion/axessibility.cwl
@@ -4,7 +4,6 @@
 #include:amsmath
 #include:amssymb
 #include:xstring
-#include:tagpdf
 
 #ifOption:accsupp
 #include:accsupp

--- a/completion/latex-dev.cwl
+++ b/completion/latex-dev.cwl
@@ -4,6 +4,7 @@
 # Matthew Bertucci 2025/11/01 release
 
 #include:expl3-commands
+#include:tagpdf
 
 # commands with big Letters and others
 \ActivateGenericHook{hook}#*


### PR DESCRIPTION
According to its doc and with  my testing, the `tagpdf` package

> (This package) is not meant for direct use in document preambles. It is loaded automatically if `\DocumentMetadata` is used.

Since TeXstudio doesn't support such fine-grained control on cwl loading, this PR makes the cwl for `tagpdf` included by `latex-dev.cwl`, where the `\DocumentMetadata` was listed.

_Update:_ `tagpdf.cwl` only lists a few LaTeX2e commands, so this won't pollute the completion list for documents not using `\DocumentMetadata` too much. Though it does list more than 40 expl3 commands.