### PR TITLE
fix -Wreturn-type

### DIFF
--- a/src/git.cpp
+++ b/src/git.cpp
@@ -129,7 +129,7 @@ QStringList GIT::log(QString filename)
  * \brief create a GIT repository
  * \param filename
  */
-QString GIT::createRepository(QString filename)
+void GIT::createRepository(QString filename)
 {
     const QString path = QFileInfo(filename).absolutePath();
     createRepositoryInFolder(path);

--- a/src/git.h
+++ b/src/git.h
@@ -45,7 +45,7 @@ public:
     QList<GraphEntry> getRepoLogGraph(const QString &path, int maxEntries = 200, const QString &fileFilter = QString());
     QString getCommitStat(const QString &path, const QString &hash);
     QString getCommitFileNames(const QString &path, const QString &hash);
-    QString createRepository(QString filename);
+    void createRepository(QString filename);
     QString createRepositoryInFolder(QString folder);
     QList<FileEntry> getChangedFiles(QString path);
     QString getCurrentBranch(QString path);


### PR DESCRIPTION
compiler warning
```
/texstudio/src/git.cpp:136:1: warning: no return statement in function returning non-void [-Wreturn-type]
  136 | }
```

code in `texstudio.cpp`:
```cpp
            if(configManager.useVCS==0){
                svn.createRepository(fn);
            }else{
                git.createRepository(fn);
            }
```
should be same as in `svn.h` where we find:
```cpp
 void createRepository(QString filename);
```