### PR TITLE
Execute external commands completely asynchronously

### DIFF
--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1721,6 +1721,14 @@ void BuildManager::runCommandInternalAsync(const ExpandedCommands &expandedComma
     m_remainingReRunCount = autoRerunLatex;
     runNextCommandInternalAsync();
 }
+/*!
+ * \brief check if any command is currently running
+ * \return
+ */
+bool BuildManager::busyRunningCommands() const
+{
+    return !m_expandedCommands.commands.isEmpty();
+}
 
 void BuildManager::emitEndRunningSubCommandFromProcessX(int)
 {
@@ -1755,7 +1763,7 @@ void BuildManager::runNextCommandInternalAsync()
 
     ProcessX *p = newProcessInternal(cur.command, m_mainFile, singleInstance);
     if(p==nullptr){
-        //TODO: notify error
+        m_expandedCommands.commands.clear();
         return;
     }
     p->subCommandName = cur.parentCommand;
@@ -1773,7 +1781,10 @@ void BuildManager::runNextCommandInternalAsync()
     connect(p, SIGNAL(finished(int,QProcess::ExitStatus)), this, SLOT(runNextCommandInternalAsyncFinished(int,QProcess::ExitStatus)));
 
     p->startCommand();
-    if (!p->waitForStarted(1000)) return;
+    if (!p->waitForStarted(1000)){
+        m_expandedCommands.commands.clear();
+        return;
+    }
 }
 /*!
  * \brief continue after process finished, check if rerun is needed and run next command
@@ -1820,6 +1831,7 @@ void BuildManager::runNextCommandInternalAsyncFinished(int exitCode, QProcess::E
         if(m_returnCmdObj && m_returnCmd){
             QMetaObject::invokeMethod(m_returnCmdObj, m_returnCmd,Q_ARG(int,exitCode),Q_ARG(QProcess::ExitStatus,exitStatus));
         }
+        m_expandedCommands.commands.clear();
         return;
     }
     runNextCommandInternalAsync();

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1637,7 +1637,7 @@ bool BuildManager::checkExpandedCommands(const ExpandedCommands &expansion)
 bool BuildManager::runCommandInternal(const ExpandedCommands &expandedCommands, const QFileInfo &mainFile, QString *buffer, QTextCodec *codecForBuffer, QString *errorMsg)
 {
 	const QList<CommandToRun> &commands = expandedCommands.commands;
-    internalCommands << CMD_VIEW_PDF_INTERNAL << CMD_CONDITIONALLY_RECOMPILE_BIBLIOGRAPHY << CMD_VIEW_LOG; // set to default
+    internalCommands = { CMD_VIEW_PDF_INTERNAL,CMD_CONDITIONALLY_RECOMPILE_BIBLIOGRAPHY, CMD_VIEW_LOG}; // set to default
 
 	int remainingReRunCount = autoRerunLatex;
 	for (int i = 0; i < commands.size(); i++) {
@@ -1743,7 +1743,7 @@ void BuildManager::runNextCommandInternalAsync()
         m_expandedCommands.commands.removeFirst();
         cur = m_expandedCommands.commands.first();
     }
-    internalCommands << CMD_VIEW_PDF_INTERNAL  << CMD_VIEW_LOG; // remove conditional precompile/bibliography
+    internalCommands = { CMD_VIEW_PDF_INTERNAL, CMD_VIEW_LOG}; // set to reduced
     while (testAndRunInternalCommand(cur.command, m_mainFile)){
         m_expandedCommands.commands.removeFirst();
         if(m_expandedCommands.commands.isEmpty()) {

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1744,7 +1744,7 @@ void BuildManager::runNextCommandInternalAsync()
         cur = m_expandedCommands.commands.first();
     }
     internalCommands = { CMD_VIEW_PDF_INTERNAL, CMD_VIEW_LOG}; // set to reduced
-    while (testAndRunInternalCommand(cur.command, m_mainFile)){
+    while (cur.command.isEmpty() || testAndRunInternalCommand(cur.command, m_mainFile)){
         m_expandedCommands.commands.removeFirst();
         if(m_expandedCommands.commands.isEmpty()) {
             emit endRunningCommands(m_expandedCommands.primaryCommand, false, false, false);

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1637,7 +1637,7 @@ bool BuildManager::checkExpandedCommands(const ExpandedCommands &expansion)
 bool BuildManager::runCommandInternal(const ExpandedCommands &expandedCommands, const QFileInfo &mainFile, QString *buffer, QTextCodec *codecForBuffer, QString *errorMsg)
 {
 	const QList<CommandToRun> &commands = expandedCommands.commands;
-    internalCommands = { CMD_VIEW_PDF_INTERNAL,CMD_CONDITIONALLY_RECOMPILE_BIBLIOGRAPHY, CMD_VIEW_LOG}; // set to default
+    internalCommands = QStringList{ CMD_VIEW_PDF_INTERNAL,CMD_CONDITIONALLY_RECOMPILE_BIBLIOGRAPHY, CMD_VIEW_LOG}; // set to default
 
 	int remainingReRunCount = autoRerunLatex;
 	for (int i = 0; i < commands.size(); i++) {
@@ -1743,7 +1743,7 @@ void BuildManager::runNextCommandInternalAsync()
         m_expandedCommands.commands.removeFirst();
         cur = m_expandedCommands.commands.first();
     }
-    internalCommands = { CMD_VIEW_PDF_INTERNAL, CMD_VIEW_LOG}; // set to reduced
+    internalCommands = QStringList{ CMD_VIEW_PDF_INTERNAL, CMD_VIEW_LOG}; // set to reduced
     while (cur.command.isEmpty() || testAndRunInternalCommand(cur.command, m_mainFile)){
         m_expandedCommands.commands.removeFirst();
         if(m_expandedCommands.commands.isEmpty()) {

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1637,6 +1637,7 @@ bool BuildManager::checkExpandedCommands(const ExpandedCommands &expansion)
 bool BuildManager::runCommandInternal(const ExpandedCommands &expandedCommands, const QFileInfo &mainFile, QString *buffer, QTextCodec *codecForBuffer, QString *errorMsg)
 {
 	const QList<CommandToRun> &commands = expandedCommands.commands;
+    internalCommands << CMD_VIEW_PDF_INTERNAL << CMD_CONDITIONALLY_RECOMPILE_BIBLIOGRAPHY << CMD_VIEW_LOG; // set to default
 
 	int remainingReRunCount = autoRerunLatex;
 	for (int i = 0; i < commands.size(); i++) {
@@ -1742,6 +1743,7 @@ void BuildManager::runNextCommandInternalAsync()
         m_expandedCommands.commands.removeFirst();
         cur = m_expandedCommands.commands.first();
     }
+    internalCommands << CMD_VIEW_PDF_INTERNAL  << CMD_VIEW_LOG; // remove conditional precompile/bibliography
     while (testAndRunInternalCommand(cur.command, m_mainFile)){
         m_expandedCommands.commands.removeFirst();
         if(m_expandedCommands.commands.isEmpty()) {

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1657,7 +1657,6 @@ bool BuildManager::runCommandInternal(const ExpandedCommands &expandedCommands, 
 		p->subCommandFlags = cur.flags;
         connect(p, SIGNAL(finished(int,QProcess::ExitStatus)), SLOT(emitEndRunningSubCommandFromProcessX(int)));
 
-
 		p->setStdoutBuffer(buffer);
         p->setStderrBuffer(errorMsg);
 		p->setStdoutCodec(codecForBuffer);
@@ -1669,16 +1668,8 @@ bool BuildManager::runCommandInternal(const ExpandedCommands &expandedCommands, 
 		p->startCommand();
 		if (!p->waitForStarted(1000)) return false;
 
-		if (latexCompiler || (!lastCommandToRun && !singleInstance) )
-			if (!waitForProcess(p)) {
-				p->deleteLater();
-				return false;
-			}
-
-		if (waitForCommand) { //what is this? does not really make any sense (waiting is done in the block above) and breaks multiple single-instance pdf viewer calls (30 sec delay)
-			p->waitForFinished();
-			p->deleteLater();
-		}
+        p->waitForFinished();
+        p->deleteLater();
 
 		bool rerunnable = (cur.flags & RCF_RERUN) && (cur.flags & RCF_RERUNNABLE);
 		if (rerunnable || latexCompiler) {
@@ -1746,6 +1737,11 @@ void BuildManager::runNextCommandInternalAsync()
         return;
     }
     CommandToRun cur = m_expandedCommands.commands.first();
+    if(cur.command.contains("conditional")){
+        //TODO: fix, work.around for now
+        m_expandedCommands.commands.removeFirst();
+        cur = m_expandedCommands.commands.first();
+    }
     while (testAndRunInternalCommand(cur.command, m_mainFile)){
         m_expandedCommands.commands.removeFirst();
         if(m_expandedCommands.commands.isEmpty()) {
@@ -1877,28 +1873,6 @@ ProcessX *BuildManager::newProcessInternal(const QString &cmd, const QFileInfo &
 
 	updatePathSettings(proc, resolvePaths(additionalSearchPaths));
 	return proc;
-}
-
-bool BuildManager::waitForProcess(ProcessX *p)
-{
-	REQUIRE_RET(p, false);
-	REQUIRE_RET(!processWaitedFor, false);
-	// Waiting on a Qt event loop avoids spinlock and high CPU usage, and allows user interaction
-	// and UI responsiveness while compiling.
-	// We have to check the process running state before we start waiting for processFinished
-	// because it is possible that the process has already ended and we would wait forever.
-	// We have to start listening for processFinished before we check the running state in
-	// order to avoid a race condition.
-	QEventLoop loop;
-	connect(p, SIGNAL(processFinished()), &loop, SLOT(quit()));
-	if (p->isRunning()) {
-		processWaitedFor = p;
-		emit buildRunning(true);
-		loop.exec(); //exec will delay execution until the signal has arrived
-		emit buildRunning(false);
-		processWaitedFor = nullptr;
-	}
-	return true;
 }
 
 bool BuildManager::waitingForProcess() const

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1529,6 +1529,43 @@ void BuildManager::checkLatexConfiguration(bool &noWarnAgain)
 		UtilsUi::txsWarning(message, noWarnAgain);
 	}
 }
+/*! \brief prepend command for asynchronous execution
+ * \param unparsedCommandLine
+ * \param mainFile
+ * \param currentFile
+ * \param currentLine
+ * \return true if command was started, false if not (e.g. no command given)
+ */
+bool BuildManager::prependCommandAsync(const QString &unparsedCommandLine, const QFileInfo &mainFile, const QFileInfo &currentFile, int currentLine)
+{
+    if (unparsedCommandLine.isEmpty()) {
+        emit processNotification(tr("Error: No command given"));
+        return false;
+    }
+    ExpandingOptions options(mainFile, currentFile, currentLine);
+    ExpandedCommands expansion = expandCommandLine(unparsedCommandLine, options);
+    if (options.canceled) return false;
+    if (!checkExpandedCommands(expansion)) return false;
+
+    // purge top command as this is basically its replacement
+    if(m_expandedCommands.commands.size()>0){
+        m_expandedCommands.commands.removeFirst();
+    }
+    // prepend the commands to the queue
+    for (int i = expansion.commands.size()-1; i>=0; --i) {
+        if(i==expansion.commands.size()-1){
+            // skip it is the same command as the top command in the queue
+            if(m_expandedCommands.commands.size()>0 && m_expandedCommands.commands.first().command==expansion.commands.value(i).command){
+                continue;
+            }
+        }
+        m_expandedCommands.commands.prepend(expansion.commands.value(i));
+    }
+    // prepend dummy command to allow top command removal in testAndRunInternalCommand
+    m_expandedCommands.commands.prepend(QString());
+
+    return true;
+}
 /*!
  * \brief run command asynchronously, i.e. return immediately and emit signals when finished
  * \param unparsedCommandLine
@@ -1637,7 +1674,6 @@ bool BuildManager::checkExpandedCommands(const ExpandedCommands &expansion)
 bool BuildManager::runCommandInternal(const ExpandedCommands &expandedCommands, const QFileInfo &mainFile, QString *buffer, QTextCodec *codecForBuffer, QString *errorMsg)
 {
 	const QList<CommandToRun> &commands = expandedCommands.commands;
-    internalCommands = QStringList{ CMD_VIEW_PDF_INTERNAL,CMD_CONDITIONALLY_RECOMPILE_BIBLIOGRAPHY, CMD_VIEW_LOG}; // set to default
 
 	int remainingReRunCount = autoRerunLatex;
 	for (int i = 0; i < commands.size(); i++) {
@@ -1738,13 +1774,8 @@ void BuildManager::runNextCommandInternalAsync()
         return;
     }
     CommandToRun cur = m_expandedCommands.commands.first();
-    if(cur.command.contains("conditional")){
-        //TODO: fix, work.around for now
-        m_expandedCommands.commands.removeFirst();
-        cur = m_expandedCommands.commands.first();
-    }
-    internalCommands = QStringList{ CMD_VIEW_PDF_INTERNAL, CMD_VIEW_LOG}; // set to reduced
-    while (cur.command.isEmpty() || testAndRunInternalCommand(cur.command, m_mainFile)){
+
+    while (cur.command.isEmpty() || testAndRunInternalCommandAsync(cur.command, m_mainFile)){
         m_expandedCommands.commands.removeFirst();
         if(m_expandedCommands.commands.isEmpty()) {
             emit endRunningCommands(m_expandedCommands.primaryCommand, false, false, false);
@@ -2427,6 +2458,28 @@ bool BuildManager::testAndRunInternalCommand(const QString &cmd, const QFileInfo
 		return true;
 	}
 	return false;
+}
+/*!
+ * \brief call txs for internal commands
+ * Special variant to run commands asynchronously, this basically only affects conditionally recompile bibliography
+ * \param cmd
+ * \param mainFile
+ * \return
+ */
+bool BuildManager::testAndRunInternalCommandAsync(const QString &cmd, const QFileInfo &mainFile)
+{
+    int space = cmd.indexOf(' ');
+    QString cmdId, options;
+    if (space == -1 ) cmdId = cmd;
+    else {
+        cmdId = cmd.left(space);
+        options = cmd.mid(space + 1);
+    }
+    if (internalCommands.contains(cmdId)) {
+        emit runInternalCommandAsync(cmdId, mainFile, options);
+        return true;
+    }
+    return false;
 }
 
 QString BuildManager::findCompiledFile(const QString &compiledFilename, const QFileInfo &mainFile)

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1529,6 +1529,48 @@ void BuildManager::checkLatexConfiguration(bool &noWarnAgain)
 		UtilsUi::txsWarning(message, noWarnAgain);
 	}
 }
+/*!
+ * \brief run command asynchronously, i.e. return immediately and emit signals when finished
+ * \param unparsedCommandLine
+ * \param mainFile
+ * \param currentFile
+ * \param currentLine
+ * \param buffer
+ * \param errorMsg
+ * \param returnCmd
+ * \return
+ */
+bool BuildManager::runCommandAsync(const QString &unparsedCommandLine, const QFileInfo &mainFile, const QFileInfo &currentFile, int currentLine, QString *buffer, QString *errorMsg, QObject *returnObj, const char *returnCmd)
+{
+    emit clearLogs();
+
+    if (unparsedCommandLine.isEmpty()) {
+        emit processNotification(tr("Error: No command given"));
+        return false;
+    }
+    ExpandingOptions options(mainFile, currentFile, currentLine);
+    ExpandedCommands expansion = expandCommandLine(unparsedCommandLine, options);
+    if (options.canceled) return false;
+    if (!checkExpandedCommands(expansion)) return false;
+
+    bool latexCompiled = false, pdfChanged = false;
+    for (int i = 0; i < expansion.commands.size(); i++) {
+        latexCompiled |= expansion.commands[i].flags & RCF_COMPILES_TEX;
+        pdfChanged |= expansion.commands[i].flags & RCF_CHANGE_PDF;
+        if (buffer || i != expansion.commands.size() - 1)
+            expansion.commands[i].flags |= RCF_WAITFORFINISHED; // don't let buffer be destroyed before command is finished
+    }
+    if (latexCompiled) {
+        ExpandedCommands temp = expandCommandLine(CMD_INTERNAL_PRE_COMPILE, options);
+        for (int i = temp.commands.size() - 1; i >= 0; i--) expansion.commands.prepend(temp.commands[i]);
+    }
+
+    bool asyncPdf = !(expansion.commands.last().flags & RCF_WAITFORFINISHED) && (expansion.commands.last().flags & RCF_CHANGE_PDF);
+
+    emit beginRunningCommands(expansion.primaryCommand, latexCompiled, pdfChanged, asyncPdf);
+    runCommandInternalAsync(expansion, mainFile, buffer, errorMsg,returnObj,returnCmd);
+    return true;
+}
 
 bool BuildManager::runCommand(const QString &unparsedCommandLine, const QFileInfo &mainFile, const QFileInfo &currentFile, int currentLine, QString *buffer, QTextCodec *codecForBuffer , QString *errorMsg)
 {
@@ -1659,12 +1701,128 @@ bool BuildManager::runCommandInternal(const ExpandedCommands &expandedCommands, 
 	}
 	return true;
 }
+/*!
+ * \brief run internally commands asynchronously, i.e. return immediately and emit signals when finished
+ * \param expandedCommands
+ * \param mainFile
+ * \param buffer
+ * \param errorMsg
+ * \param returnCmd
+ * \return
+ */
+void BuildManager::runCommandInternalAsync(const ExpandedCommands &expandedCommands, const QFileInfo &mainFile, QString *buffer, QString *errorMsg, QObject *returnObject,const char *returnCmd)
+{
+    m_expandedCommands=expandedCommands;
+    m_mainFile=mainFile;
+    m_buffer=buffer;
+    m_errorMsg=errorMsg;
+    m_returnCmdObj=returnObject;
+    m_returnCmd=returnCmd;
+    m_remainingReRunCount = autoRerunLatex;
+    runNextCommandInternalAsync();
+}
 
 void BuildManager::emitEndRunningSubCommandFromProcessX(int)
 {
 	ProcessX *p = qobject_cast<ProcessX *>(sender());
 	REQUIRE(p); //p can be NULL (although sender() is not null) ! If multiple single instance viewers are in a command. Why? should not happen
 	emit endRunningSubCommand(p, p->subCommandPrimary, p->subCommandName, p->subCommandFlags);
+}
+/*!
+ * \brief run next command in queue
+ */
+void BuildManager::runNextCommandInternalAsync()
+{
+    if(m_expandedCommands.commands.isEmpty()) {
+        emit endRunningCommands(m_expandedCommands.primaryCommand, false, false, false);
+        return;
+    }
+    CommandToRun cur = m_expandedCommands.commands.first();
+    while (testAndRunInternalCommand(cur.command, m_mainFile)){
+        m_expandedCommands.commands.removeFirst();
+        if(m_expandedCommands.commands.isEmpty()) {
+            emit endRunningCommands(m_expandedCommands.primaryCommand, false, false, false);
+            return;
+        }
+        cur = m_expandedCommands.commands.first();
+    }
+
+    bool singleInstance = cur.flags & RCF_SINGLE_INSTANCE;
+    if (singleInstance && runningCommands.contains(cur.command)) return; //TODO checkout
+    bool latexCompiler = cur.flags & RCF_COMPILES_TEX;
+    bool lastCommandToRun = (m_expandedCommands.commands.size() == 1);
+    bool waitForCommand = latexCompiler || (!lastCommandToRun && !singleInstance) || cur.flags & RCF_WAITFORFINISHED;
+
+    ProcessX *p = newProcessInternal(cur.command, m_mainFile, singleInstance);
+    if(p==nullptr){
+        //TODO: notify error
+        return;
+    }
+    p->subCommandName = cur.parentCommand;
+    p->subCommandPrimary = m_expandedCommands.primaryCommand;
+    p->subCommandFlags = cur.flags;
+    connect(p, SIGNAL(finished(int,QProcess::ExitStatus)), SLOT(emitEndRunningSubCommandFromProcessX(int)));
+
+
+    p->setStdoutBuffer(m_buffer);
+    p->setStderrBuffer(m_errorMsg);
+
+    emit beginRunningSubCommand(p, m_expandedCommands.primaryCommand, cur.parentCommand, cur.flags);
+
+    connect(p, SIGNAL(finished(int,QProcess::ExitStatus)), p, SLOT(deleteLater()));
+    connect(p, SIGNAL(finished(int,QProcess::ExitStatus)), this, SLOT(runNextCommandInternalAsyncFinished(int,QProcess::ExitStatus)));
+
+    p->startCommand();
+    if (!p->waitForStarted(1000)) return;
+}
+/*!
+ * \brief continue after process finished, check if rerun is needed and run next command
+ * \param exitCode
+ * \param exitStatus
+ */
+void BuildManager::runNextCommandInternalAsyncFinished(int exitCode, QProcess::ExitStatus exitStatus)
+{
+    if(exitCode!=0 || exitStatus != QProcess::NormalExit){
+        emit processNotification(tr("Error: Command failed with error code %1").arg(exitCode));
+        //return;
+    }
+    if(m_expandedCommands.commands.isEmpty()){
+        return;
+    }
+    CommandToRun cur = m_expandedCommands.commands.first();
+    bool latexCompiler = cur.flags & RCF_COMPILES_TEX;
+    bool lastCommandToRun = (m_expandedCommands.commands.size() == 1);
+    bool rerunnable = (cur.flags & RCF_RERUN) && (cur.flags & RCF_RERUNNABLE);
+    bool runNext=!lastCommandToRun;
+    if (m_remainingReRunCount>0 && (rerunnable || latexCompiler)) {
+        LatexCompileResult result = LCR_NORMAL;
+        emit latexCompiled(&result);
+        if (result == LCR_ERROR) return;
+        if (result == LCR_RERUN_WITH_BIBLIOGRAPHY) {
+            ExpandingOptions options(m_mainFile, m_mainFile, 0);
+            ExpandedCommands expansion = expandCommandLine(CMD_BIBLIOGRAPHY, options);
+            if (!checkExpandedCommands(expansion)) return;
+            // prepend commands
+            for (int i = expansion.commands.size() - 1; i >= 0; i--) m_expandedCommands.commands.prepend(expansion.commands[i]);
+        }
+        if(result == LCR_RERUN || result == LCR_RERUN_WITH_BIBLIOGRAPHY){
+            m_remainingReRunCount--;
+            if(m_remainingReRunCount>0){
+                runNext=false;
+            }
+        }
+    }
+    if(runNext){
+        m_expandedCommands.commands.removeFirst();
+    }
+    if(lastCommandToRun){
+        emit endRunningCommands(m_expandedCommands.primaryCommand, latexCompiler, cur.flags & RCF_CHANGE_PDF, false);
+        if(m_returnCmdObj && m_returnCmd){
+            QMetaObject::invokeMethod(m_returnCmdObj, m_returnCmd,Q_ARG(int,exitCode),Q_ARG(QProcess::ExitStatus,exitStatus));
+        }
+        return;
+    }
+    runNextCommandInternalAsync();
 }
 
 

--- a/src/buildmanager.cpp
+++ b/src/buildmanager.cpp
@@ -1778,9 +1778,12 @@ void BuildManager::runNextCommandInternalAsync()
     connect(p, SIGNAL(finished(int,QProcess::ExitStatus)), p, SLOT(deleteLater()));
     connect(p, SIGNAL(finished(int,QProcess::ExitStatus)), this, SLOT(runNextCommandInternalAsyncFinished(int,QProcess::ExitStatus)));
 
+    processWaitedFor=p;
+
     p->startCommand();
     if (!p->waitForStarted(1000)){
         m_expandedCommands.commands.clear();
+        processWaitedFor=nullptr;
         return;
     }
 }
@@ -1791,6 +1794,7 @@ void BuildManager::runNextCommandInternalAsync()
  */
 void BuildManager::runNextCommandInternalAsyncFinished(int exitCode, QProcess::ExitStatus exitStatus)
 {
+    processWaitedFor = nullptr;
     if(exitCode!=0 || exitStatus != QProcess::NormalExit){
         emit processNotification(tr("Error: Command failed with error code %1").arg(exitCode));
         //return;
@@ -1887,6 +1891,8 @@ void BuildManager::killCurrentProcess()
 	if (!processWaitedFor) return;
 	processWaitedFor->kill();
     processWaitedFor = nullptr;
+    m_expandedCommands.commands.clear();
+    emit endRunningCommands("", false, false, false);
 }
 
 QString BuildManager::createTemporaryFileName()

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -165,7 +165,6 @@ public:
 
 	Q_INVOKABLE ProcessX *newProcessInternal(const QString &fullCommandLine, const QFileInfo &mainFile, bool singleInstance = false);
 public:
-	Q_INVOKABLE bool waitForProcess(ProcessX *p);
 	Q_INVOKABLE bool waitingForProcess() const;
 
 	static QString createTemporaryFileName(); //don't forget to remove the file!

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -140,7 +140,7 @@ public:
     void resetDefaultCommands(const QString texPath);
 
 	void checkLatexConfiguration(bool &noWarnAgain);
-
+    bool runCommandAsync(const QString &unparsedCommandLine, const QFileInfo &mainFile, const QFileInfo &currentFile = QFileInfo(), int currentLine = 0, QString *buffer = nullptr, QString *errorMsg = nullptr, QObject *returnObj=nullptr,const char * returnCmd = nullptr);
 
 public slots:
     bool runCommand(const QString &unparsedCommandLine, const QFileInfo &mainFile, const QFileInfo &currentFile = QFileInfo(), int currentLine = 0, QString *buffer = nullptr, QTextCodec *codecForBuffer = nullptr, QString *errorMsg = nullptr);
@@ -148,6 +148,14 @@ public slots:
 private:
 	bool checkExpandedCommands(const ExpandedCommands &expandedCommands);
     bool runCommandInternal(const ExpandedCommands &expandedCommands, const QFileInfo &mainFile, QString *buffer = nullptr, QTextCodec *codecForBuffer = nullptr, QString *errorMsg = nullptr);
+    void runCommandInternalAsync(const ExpandedCommands &expandedCommands, const QFileInfo &mainFile, QString *buffer = nullptr, QString *errorMsg = nullptr, QObject *returnObject = nullptr, const char * returnCmd = nullptr);
+
+    ExpandedCommands m_expandedCommands;
+    int m_remainingReRunCount;
+    QFileInfo m_mainFile;
+    QString *m_buffer, *m_errorMsg;
+    QObject *m_returnCmdObj;
+    const char *m_returnCmd;
 public:
 	//creates a process object with the given command line (after it is changed by an implcit call to parseExtendedCommandLine)
 	//ProcessX* newProcess(const QString &unparsedCommandLine, const QString &mainFile, const QString &currentFile, int currentLine=0, bool singleInstance = false);
@@ -198,6 +206,8 @@ private slots:
 	void commandLineRequestedDefault(const QString &cmdId, QString *result, bool *user);
 	void runInternalCommandThroughProcessX();
 	void emitEndRunningSubCommandFromProcessX(int);
+    void runNextCommandInternalAsync();
+    void runNextCommandInternalAsyncFinished(int exitCode,QProcess::ExitStatus exitStatus);
 private:
 	bool testAndRunInternalCommand(const QString &cmd, const QFileInfo &mainFile);
 signals:

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -140,6 +140,7 @@ public:
     void resetDefaultCommands(const QString texPath);
 
 	void checkLatexConfiguration(bool &noWarnAgain);
+    bool prependCommandAsync(const QString &unparsedCommandLine, const QFileInfo &mainFile, const QFileInfo &currentFile = QFileInfo(), int currentLine = 0);
     bool runCommandAsync(const QString &unparsedCommandLine, const QFileInfo &mainFile, const QFileInfo &currentFile = QFileInfo(), int currentLine = 0, QString *buffer = nullptr, QString *errorMsg = nullptr, QObject *returnObj=nullptr,const char * returnCmd = nullptr);
     bool busyRunningCommands() const;
 
@@ -210,6 +211,7 @@ private slots:
     void runNextCommandInternalAsyncFinished(int exitCode,QProcess::ExitStatus exitStatus);
 private:
 	bool testAndRunInternalCommand(const QString &cmd, const QFileInfo &mainFile);
+    bool testAndRunInternalCommandAsync(const QString &cmd, const QFileInfo &mainFile);
 signals:
 	void processNotification(const QString &message);
     void clearLogs();
@@ -217,6 +219,7 @@ signals:
 
     void commandLineRequested(const QString &cmdId, QString *result, bool *user = nullptr);
 	void runInternalCommand(const QString &cmdId, const QFileInfo &mainfile, const QString &options);
+    void runInternalCommandAsync(const QString &cmdId, const QFileInfo &mainfile, const QString &options);
 
 	void latexCompiled(LatexCompileResult *rerun);
 	void beginRunningCommands(const QString &commandMain, bool latex, bool pdf, bool asyncPdf);

--- a/src/buildmanager.h
+++ b/src/buildmanager.h
@@ -141,6 +141,7 @@ public:
 
 	void checkLatexConfiguration(bool &noWarnAgain);
     bool runCommandAsync(const QString &unparsedCommandLine, const QFileInfo &mainFile, const QFileInfo &currentFile = QFileInfo(), int currentLine = 0, QString *buffer = nullptr, QString *errorMsg = nullptr, QObject *returnObj=nullptr,const char * returnCmd = nullptr);
+    bool busyRunningCommands() const;
 
 public slots:
     bool runCommand(const QString &unparsedCommandLine, const QFileInfo &mainFile, const QFileInfo &currentFile = QFileInfo(), int currentLine = 0, QString *buffer = nullptr, QTextCodec *codecForBuffer = nullptr, QString *errorMsg = nullptr);

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -6411,7 +6411,7 @@ bool Texstudio::runCommand(const QString &commandline, QString *buffer, QTextCod
 
 	int ln = currentEditorView() ? currentEditorView()->editor->cursor().lineNumber() + 1 : 0;
     // unified error/stdout into *buffer
-    return buildManager.runCommand(commandline, QFileInfo(finame), QFileInfo(getCurrentFileName()), ln, buffer, codecForBuffer,buffer);
+    return buildManager.runCommandAsync(commandline, QFileInfo(finame), QFileInfo(getCurrentFileName()), ln, buffer, buffer);
 }
 
 /*!

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -6412,6 +6412,10 @@ bool Texstudio::runCommand(const QString &commandline, QString *buffer, QTextCod
 		UtilsUi::txsWarning(tr("Can't detect the file name"));
 		return false;
 	}
+    // disable buttons
+    if(commandline==BuildManager::CMD_COMPILE || commandline== BuildManager::CMD_QUICK){
+        setBuildButtonsDisabled(true);
+    }
 
 	int ln = currentEditorView() ? currentEditorView()->editor->cursor().lineNumber() + 1 : 0;
     // unified error/stdout into *buffer
@@ -6818,6 +6822,7 @@ void Texstudio::endRunningCommand(const QString &commandMain, bool latex, bool p
 	setStatusMessageProcess(QString(" %1 ").arg(tr("Ready")));
 	if (latex) emit infoAfterTypeset();
 	previewIsAutoCompiling = false;
+    setBuildButtonsDisabled(false);
 }
 
 void Texstudio::processNotification(const QString &message)

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -820,6 +820,7 @@ void Texstudio::setupDockWidgets()
         connect(&buildManager, SIGNAL(endRunningCommands(QString,bool,bool,bool)), SLOT(endRunningCommand(QString,bool,bool,bool)));
         connect(&buildManager, SIGNAL(latexCompiled(LatexCompileResult*)), SLOT(viewLogOrReRun(LatexCompileResult*)));
         connect(&buildManager, SIGNAL(runInternalCommand(QString,QFileInfo,QString)), SLOT(runInternalCommand(QString,QFileInfo,QString)));
+        connect(&buildManager, SIGNAL(runInternalCommandAsync(QString,QFileInfo,QString)), SLOT(runInternalCommandAsync(QString,QFileInfo,QString))); // variant for async exec
         connect(&buildManager, SIGNAL(commandLineRequested(QString,QString*,bool*)), SLOT(commandLineRequested(QString,QString*,bool*)));
     }else{
         outputView->updateIcon();
@@ -6631,40 +6632,50 @@ bool Texstudio::checkProgramPermission(const QString &program, const QString &cm
 
 void Texstudio::runBibliographyIfNecessary(const QFileInfo &mainFile)
 {
-	if (!configManager.runLaTeXBibTeXLaTeX) return;
-	if (runBibliographyIfNecessaryEntered) return;
-
-	LatexDocument *rootDoc = documents.getRootDocumentForDoc();
-	REQUIRE(rootDoc);
-
-	QList<LatexDocument *> docs = rootDoc->getListOfDocs();
-	QSet<QString> bibFiles;
-	foreach (const LatexDocument *doc, docs) {
-		foreach (const FileNamePair &bf, doc->mentionedBibTeXFiles()) {
-			bibFiles.insert(bf.absolute);
-		}
-	}
-	if(bibFiles.isEmpty()) {
-		return; // don't try to compile bibtex files if there none
-	}
-	if (bibFiles == rootDoc->lastCompiledBibTeXFiles) {
-		QDateTime bblLastModified = GetBblLastModified();
-		if (bblLastModified.isValid()) {
-			bool bibFilesChanged = false;
-			foreach (const QString &bf, bibFiles) {
-				//qDebug() << bf << ": "<<QFileInfo(bf).lastModified()<<" "<<bblLastModified;
-                if (QFileInfo::exists(bf) && QFileInfo(bf).lastModified() > bblLastModified) {
-					bibFilesChanged = true;
-					break;
-				}
-			}
-			if (!bibFilesChanged) return;
-		}
-	} else rootDoc->lastCompiledBibTeXFiles = bibFiles;
+    if(!checkRunBibliographyIfNecessary(mainFile)) return;
 
 	runBibliographyIfNecessaryEntered = true;
 	buildManager.runCommand(BuildManager::CMD_RECOMPILE_BIBLIOGRAPHY, mainFile);
 	runBibliographyIfNecessaryEntered = false;
+}
+/*!
+ * \brief check if bibliography needs to be run
+ * \param cmd
+ * \return recompilation is necessary
+ */
+bool Texstudio::checkRunBibliographyIfNecessary(const QFileInfo &cmd)
+{
+    if (!configManager.runLaTeXBibTeXLaTeX) return false;
+    if (runBibliographyIfNecessaryEntered) return false;
+
+    LatexDocument *rootDoc = documents.getRootDocumentForDoc();
+    REQUIRE_RET(rootDoc,false);
+
+    QList<LatexDocument *> docs = rootDoc->getListOfDocs();
+    QSet<QString> bibFiles;
+    foreach (const LatexDocument *doc, docs) {
+        foreach (const FileNamePair &bf, doc->mentionedBibTeXFiles()) {
+            bibFiles.insert(bf.absolute);
+        }
+    }
+    if(bibFiles.isEmpty()) {
+        return false; // don't try to compile bibtex files if there none
+    }
+    if (bibFiles == rootDoc->lastCompiledBibTeXFiles) {
+        QDateTime bblLastModified = GetBblLastModified();
+        if (bblLastModified.isValid()) {
+            bool bibFilesChanged = false;
+            foreach (const QString &bf, bibFiles) {
+                //qDebug() << bf << ": "<<QFileInfo(bf).lastModified()<<" "<<bblLastModified;
+                if (QFileInfo::exists(bf) && QFileInfo(bf).lastModified() > bblLastModified) {
+                    bibFilesChanged = true;
+                    break;
+                }
+            }
+            if (!bibFilesChanged) return false;
+        }
+    } else rootDoc->lastCompiledBibTeXFiles = bibFiles;
+    return true;
 }
 
 QDateTime Texstudio::GetBblLastModified(void)
@@ -6691,6 +6702,26 @@ void Texstudio::runInternalCommand(const QString &cmd, const QFileInfo &mainfile
         loadLog();
         viewLog();
 	} else UtilsUi::txsWarning(tr("Unknown internal command: %1").arg(cmd));
+}
+/*!
+ * \brief call internal commands in txs
+ * Special variant for asynchronous execution, especially for conditionally recompiling bibliography
+ * \param cmd
+ * \param mainFile
+ * \param options
+ */
+void Texstudio::runInternalCommandAsync(const QString &cmd, const QFileInfo &mainfile, const QString &options)
+{
+    if (cmd == BuildManager::CMD_VIEW_PDF_INTERNAL || (cmd.startsWith(BuildManager::CMD_VIEW_PDF_INTERNAL) && cmd[BuildManager::CMD_VIEW_PDF_INTERNAL.length()] == ' '))
+        runInternalPdfViewer(mainfile, options);
+    else if (cmd == BuildManager::CMD_CONDITIONALLY_RECOMPILE_BIBLIOGRAPHY){
+        if(checkRunBibliographyIfNecessary(mainfile)){
+            buildManager.prependCommandAsync(BuildManager::CMD_RECOMPILE_BIBLIOGRAPHY, mainfile);
+        }
+    } else if (cmd == BuildManager::CMD_VIEW_LOG) {
+        loadLog();
+        viewLog();
+    } else UtilsUi::txsWarning(tr("Unknown internal command: %1").arg(cmd));
 }
 
 void Texstudio::runInternalCommand(const QString &cmd, const QString &mainfile, const QString &options){

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -6387,6 +6387,11 @@ void Texstudio::addMagicProgram()
 ///////////////TOOLS////////////////////
 bool Texstudio::runCommand(const QString &commandline, QString *buffer, QTextCodec *codecForBuffer, bool saveAll)
 {
+    if(buildManager.busyRunningCommands()){
+        //TODO non-blocking message box
+        UtilsUi::txsWarning(tr("A command is already running. Please wait until the current command stops."));
+        return false;
+    }
     if(saveAll){
         fileSaveAll(buildManager.saveFilesBeforeCompiling == BuildManager::SFBC_ALWAYS, buildManager.saveFilesBeforeCompiling == BuildManager::SFBC_ONLY_CURRENT_OR_NAMED);
     }

--- a/src/texstudio.cpp
+++ b/src/texstudio.cpp
@@ -6388,8 +6388,7 @@ void Texstudio::addMagicProgram()
 bool Texstudio::runCommand(const QString &commandline, QString *buffer, QTextCodec *codecForBuffer, bool saveAll)
 {
     if(buildManager.busyRunningCommands()){
-        //TODO non-blocking message box
-        UtilsUi::txsWarning(tr("A command is already running. Please wait until the current command stops."));
+        setStatusMessageProcess(QString(" %1 ").arg(tr("A command is already running. Please wait until the current command stops.")));
         return false;
     }
     if(saveAll){

--- a/src/texstudio.h
+++ b/src/texstudio.h
@@ -503,6 +503,7 @@ protected slots:
 	bool checkProgramPermission(const QString &program, const QString &cmdId, LatexDocument *master);
 	void runInternalPdfViewer(const QFileInfo &master, const QString &options);
 	void runBibliographyIfNecessary(const QFileInfo &cmd);
+    bool checkRunBibliographyIfNecessary(const QFileInfo &cmd);
 	QDateTime GetBblLastModified(void);
 
 	void showExtendedSearch();
@@ -516,6 +517,7 @@ public slots:
 	void connectSubCommand(ProcessX *p, bool showStdoutLocallyDefault);
 private slots:
     void runInternalCommand(const QString &cmd, const QFileInfo &master, const QString &options);
+    void runInternalCommandAsync(const QString &cmd, const QFileInfo &mainfile, const QString &options);
 	void commandLineRequested(const QString &cmdId, QString *result, bool *);
 	void beginRunningCommand(const QString &commandMain, bool latex, bool pdf, bool async);
 	void beginRunningSubCommand(ProcessX *p, const QString &commandMain, const QString &subCommand, const RunCommandFlags &flags);


### PR DESCRIPTION
This avoids the use of an extra QEventLoop which complicates flow control.

The new solution just collects all commands in m_expandedCommands and executes the next one when the former is finished.

There have been several issue reports, all centering on `waitForProcess` which is not needed any more, see #4554, #4496 and #4490.

