### PR TITLE
Fix assertion failure when an accessibility client is attached

### DIFF
--- a/src/qcodeedit/lib/qeditor.cpp
+++ b/src/qcodeedit/lib/qeditor.cpp
@@ -6513,7 +6513,7 @@ void QEditor::updateContent (int i, int n)
 
 	// Notify AT tools that the document content has changed.
 	if (QAccessible::isActive())
-		QAccessible::updateAccessibility(new QAccessibleEvent(this, QAccessible::ValueChanged));
+		QAccessible::updateAccessibility(new QAccessibleValueChangeEvent(this, QVariant()));
 }
 
 /*!


### PR DESCRIPTION
`QEditor::updateContent()` posts a `QAccessibleEvent` built with the
`QAccessible::ValueChanged` type. Qt does not allow that type with the plain
`QAccessibleEvent` constructor: it asserts `m_type != QAccessible::ValueChanged`
and expects the dedicated `QAccessibleValueChangeEvent` subclass instead.

**How to reproduce** (debug build): run TeXstudio with a screen reader or any
UI-automation client attached, so that `QAccessible::isActive()` returns true,
then type in the editor. It aborts on the first modification:

    Assert failure: m_type != QAccessible::ValueChanged

Without an assistive client the branch is never taken, which is why this goes
unnoticed in ordinary use.

The empty `QVariant` preserves the original intent: signal that the content
changed, without carrying the new value. A text-specific event such as
`QAccessibleTextUpdateEvent` would be more informative, but it needs the
position and the replaced text, which are not available at that point.

Introduced by #4557 (Accessibility: screen reader support via
QAccessibleTextInterface). The cursor notification a few lines above
correctly uses QAccessibleTextCursorEvent; this is the only remaining
plain QAccessibleEvent in the tree. The bug is invisible to CI: the call sits behind
`QAccessible::isActive()`, which is false unless an assistive client is
attached, so no CI run can reach it. In practice the crash affects only
users who actually run a screen reader — the audience the feature was
written for.

Found while working on TikZ syntax highlighting, with an AI assistant;
the crash surfaced because the editor was being driven by a UI-automation
client. Patch reviewed and tested locally.