### PR TITLE
Fix the bundled QuaZIP/zlib build path on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,12 +216,21 @@ else()
         if(WIN32)
             set(ZLIB_BUILD_EXAMPLES OFF)
             set(SKIP_INSTALL_LIBRARIES ON)
+            # Link zlib statically like the other bundled dependencies, so that
+            # no zlib DLL has to be deployed next to the executable.
+            set(ZLIB_BUILD_SHARED OFF)
             add_subdirectory(src/zlib-1.3.2)
             set(ZLIB_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/src/zlib-1.3.2)
-            if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-                set(ZLIB_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/src/zlib-1.3.2/libzlibd.dll)
-            else()
-                set(ZLIB_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/src/zlib-1.3.2/libzlib.dll)
+            # Let CMake resolve the library: the vendored zlib target sets
+            # OUTPUT_NAME z and CMAKE_DEBUG_POSTFIX d, so the file name cannot
+            # be spelled out here without going out of sync.
+            set(ZLIB_LIBRARY zlibstatic)
+            # QuaZIP calls find_package(ZLIB) and links ZLIB::ZLIB. Without the
+            # shared library that alias is not defined by zlib itself, and
+            # FindZLIB would create an imported target pointing at a file that
+            # does not exist.
+            if(NOT TARGET ZLIB::ZLIB)
+                add_library(ZLIB::ZLIB ALIAS zlibstatic)
             endif()
         endif()
 		set(BUILD_SHARED_LIBS OFF)


### PR DESCRIPTION
## Problem

When CMake finds neither `QuaZip-Qt6` nor `QuaZip` on the system, `CMakeLists.txt`
falls back to the bundled QuaZIP and zlib (the `else()` branch at `CMakeLists.txt:196`).
That fallback — the path a first-time contributor on Windows hits, before installing
any system dependencies — does not build:

```
-- Using internal QuaZIP and internal zlib
ninja: error: 'src/zlib-1.3.2/libzlibd.dll', needed by 'texstudio.exe',
       missing and no known rule to make it
```

It fails during generation, before a single file is compiled.

### Two independent defects

**1. The zlib library name is spelled out by hand and is wrong.**
`CMakeLists.txt:222,224` hardcoded `libzlibd.dll` / `libzlib.dll`, but the bundled
zlib target sets `OUTPUT_NAME z` (`src/zlib-1.3.2/CMakeLists.txt:186`, with no platform
condition) and `CMAKE_DEBUG_POSTFIX` is `"d"` (`CMakeLists.txt:5`). The file actually
produced is `libzd.dll`:

```
[19/19] Linking CXX shared library src\zlib-1.3.2\libzd.dll
```

**2. Even with the name corrected, the executable does not start.**
`0xC0000135` (DLL not found): nothing deploys the zlib DLL next to `texstudio.exe`.
zlib was the only bundled dependency built as a shared library — hunspell and QuaZIP
are already static. `set(BUILD_SHARED_LIBS OFF)` at `CMakeLists.txt:226` sits *after*
`add_subdirectory(src/zlib-1.3.2)`, so it only ever applied to QuaZIP; and moving it
would not help either, since zlib has its own `ZLIB_BUILD_SHARED` option, `ON` by
default and independent of `BUILD_SHARED_LIBS`.

## Fix

Build the bundled zlib statically, like the other bundled dependencies. That removes
both problems at once: the file name no longer has to be guessed, and there is no DLL
left to deploy.

The explicit `ZLIB::ZLIB` alias is required, not decorative. QuaZIP links `ZLIB::ZLIB`
(`src/quazip/CMakeLists.txt:128`), an alias zlib defines only in its shared branch.
Without it, `FindZLIB` creates an imported target whose `IMPORTED_LOCATION` is the
*target name*, and the link fails with `ld.exe: cannot find zlibstatic`. In the shared
configuration this worked by luck: the alias came from zlib's own `CMakeLists.txt` and
`find_package(ZLIB)` simply did nothing.

## How to reproduce and verify

The fallback branch can be forced on a machine that does have a system QuaZIP:

```
cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug \
      -DCMAKE_DISABLE_FIND_PACKAGE_QuaZip-Qt6=ON \
      -DCMAKE_DISABLE_FIND_PACKAGE_QuaZip=ON
cmake --build build
```

| | before | after |
|---|---|---|
| build | stops in generation, as quoted above | completes, 274/274 |
| zlib DLLs in the build tree | 1, in the wrong place | 0 |
| `texstudio.exe --version` | never reached | `TeXstudio 4.9.7`, exit 0 |

Verified from clean build directories, MSYS2 UCRT64, GCC 16.1.0, Qt 6.11.1, CMake 4.4.2.

Builds that find a system QuaZIP are unaffected: this branch is not taken there, which
is presumably why the breakage went unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)