### PR TITLE
Fix thesaurus dialog freeze on empty search input (#4629)

### DIFF
--- a/src/thesaurusdialog.cpp
+++ b/src/thesaurusdialog.cpp
@@ -318,6 +318,7 @@ void ThesaurusDialog::containsClicked()
 	if (!thesaurus) return;
 	QString word = replaceWrdLe->text().trimmed().toLower();
     word.replace(QRegularExpression(" \\(.*"), "");
+	if (word.isEmpty()) return; // empty needle matches every key -> O(n^2) freeze
 	classlistWidget->clear();
 	replacelistWidget->clear();
     QMultiMap<QString, ThesaurusDatabaseType::TinyStringRef>::const_iterator i = thesaurus->thesaurus.constBegin();
@@ -334,6 +335,7 @@ void ThesaurusDialog::startsWithClicked()
 	if (!thesaurus) return;
 	QString word = replaceWrdLe->text().trimmed().toLower();
     word.replace(QRegularExpression(" \\(.*"), "");
+	if (word.isEmpty()) return; // empty prefix matches every key -> O(n^2) freeze
 	classlistWidget->clear();
 	replacelistWidget->clear();
     QMultiMap<QString, ThesaurusDatabaseType::TinyStringRef>::const_iterator i = thesaurus->thesaurus.lowerBound(word);


### PR DESCRIPTION
Closes #4629

### Problem

In the Thesaurus dialog, clicking "Starts With ..." or "Contains ..." with an
empty search field freezes the whole application (see #4629).

An empty `word` makes `skey.startsWith("")` / `skey.contains("")` true for
every key, so the loop never breaks and iterates the entire thesaurus map.
Each match is additionally deduplicated via `replacelistWidget->findItems(...)`
which is O(n) per item — O(n^2) over the dictionary size, effectively a
permanent freeze with large dictionaries.

### Fix

Return early on empty input in `startsWithClicked()` and `containsClicked()`,
right after the regex cleanup:

```cpp
if (word.isEmpty()) return; // empty prefix matches every key -> O(n^2) freeze
```

### Testing                                                                                                                            
- Empty input + "Starts With ..." / "Contains ...": returns immediately, no freeze                                                     
- Non-empty input: prefix/contains search works as before